### PR TITLE
[tests-only] Make test-php-style more verbose

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -220,13 +220,13 @@ test-acceptance-webui: $(acceptance_test_deps)
 
 .PHONY: test-php-style
 test-php-style: vendor-bin/owncloud-codestyle/vendor vendor-bin/php_codesniffer/vendor
-	$(PHP_CS_FIXER) fix -v --diff --allow-risky yes --dry-run
+	$(PHP_CS_FIXER) fix -vv --diff --allow-risky yes --dry-run
 	$(PHP_CODESNIFFER) --cache --runtime-set ignore_warnings_on_exit --standard=phpcs.xml tests/acceptance tests/TestHelpers
 	php build/OCPSinceChecker.php
 
 .PHONY: test-php-style-fix
 test-php-style-fix: vendor-bin/owncloud-codestyle/vendor
-	$(PHP_CS_FIXER) fix -v --diff --allow-risky yes
+	$(PHP_CS_FIXER) fix -vv --diff --allow-risky yes
 
 .PHONY: test-php-phan
 test-php-phan: vendor-bin/phan/vendor


### PR DESCRIPTION
## Description
If I have PHP syntax errors, then `make test-php-style` only reports:
```
Files that were not fixed due to errors reported during linting before fixing:
   1) /home/phil/git/owncloud/core/lib/public/Constants.php
make: *** [Makefile:223: test-php-style] Error 4
```
There is not clue about where or what the problem is.

Change to `-vv` so that the output is more verbose, and gives a clue about the line number and what is the problem.

## How Has This Been Tested?
Make a syntax error in some PHP code, then `make test-php-style`
```
Files that were not fixed due to errors reported during linting before fixing:
   1) /home/phil/git/owncloud/core/lib/public/Constants.php

        [PhpCsFixer\Linter\LintingException]                                                         
        Parse error: syntax error, unexpected 'public' (T_PUBLIC), expecting ';' or ',' on line 54.  
```
It now outputs some clue about what the syntax-checker (linter) has found.

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Database schema changes (next release will require increase of minor version instead of patch)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [x] Tests only (no source changes)

## Checklist:
- [ ] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 
- [ ] Changelog item, see [TEMPLATE](https://github.com/owncloud/core/blob/master/changelog/TEMPLATE)
