### PR TITLE
Upgrading sabre/http (5.1.4 => 5.1.5)

### DIFF
--- a/changelog/unreleased/PHPdependencies20220523onward
+++ b/changelog/unreleased/PHPdependencies20220523onward
@@ -9,7 +9,7 @@ The following have been updated:
 - laminas/laminas-validator (2.17.0 to 2.19.0)
 - paragonie/constant_time_encoding (v2.5.0 to v2.6.3)
 - sabre/dav (4.3.1 to 4.4.0)
-- sabre/http (5.1.3 to 5.1.4)
+- sabre/http (5.1.3 to 5.1.5)
 - sabre/vobject (4.4.1 to 4.4.2)
 - webmozart/assert (1.10.0 to 1.11.0)
 
@@ -32,3 +32,4 @@ https://github.com/owncloud/core/pull/40151
 https://github.com/owncloud/core/pull/40154
 https://github.com/owncloud/core/pull/40169
 https://github.com/owncloud/core/pull/40171
+https://github.com/owncloud/core/pull/40191

--- a/composer.lock
+++ b/composer.lock
@@ -3112,16 +3112,16 @@
         },
         {
             "name": "sabre/http",
-            "version": "5.1.4",
+            "version": "5.1.5",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sabre-io/http.git",
-                "reference": "84a83642c3b877da9d0e265fba7258157c0bdc37"
+                "reference": "164725c2d2e248384e5b6115510c545e9c47cff9"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sabre-io/http/zipball/84a83642c3b877da9d0e265fba7258157c0bdc37",
-                "reference": "84a83642c3b877da9d0e265fba7258157c0bdc37",
+                "url": "https://api.github.com/repos/sabre-io/http/zipball/164725c2d2e248384e5b6115510c545e9c47cff9",
+                "reference": "164725c2d2e248384e5b6115510c545e9c47cff9",
                 "shasum": ""
             },
             "require": {
@@ -3171,7 +3171,7 @@
                 "issues": "https://github.com/sabre-io/http/issues",
                 "source": "https://github.com/fruux/sabre-http"
             },
-            "time": "2022-06-24T08:39:23+00:00"
+            "time": "2022-07-09T08:38:22+00:00"
         },
         {
             "name": "sabre/uri",


### PR DESCRIPTION
## Description
```
$ composer update
Loading composer repositories with package information
Info from https://repo.packagist.org: #StandWithUkraine
Updating dependencies
Lock file operations: 0 installs, 1 update, 0 removals
  - Upgrading sabre/http (5.1.4 => 5.1.5)
Writing lock file
```

## How Has This Been Tested?
CI

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Database schema changes (next release will require increase of minor version instead of patch)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [ ] Tests only (no source changes)

## Checklist:
- [ ] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 
- [x] Changelog item, see [TEMPLATE](https://github.com/owncloud/core/blob/master/changelog/TEMPLATE)
