### PR TITLE
Handle exception when adding mount to existing cache or adding existing lock

### DIFF
--- a/changelog/unreleased/40192
+++ b/changelog/unreleased/40192
@@ -1,0 +1,9 @@
+Bugfix: Handle exception when adding mount to existing cache or lock
+
+In some cases there are can be multiple parallel requests that could in
+their logic attempt to create shared file mountpoint for the file or 
+to create lock, e.g. collaboration software. Exception to add cache or 
+lock that already exists is now handled
+
+https://github.com/owncloud/core/pull/40192
+https://github.com/owncloud/enterprise/issues/5198

--- a/lib/private/Files/Config/UserMountCache.php
+++ b/lib/private/Files/Config/UserMountCache.php
@@ -133,24 +133,26 @@ class UserMountCache implements IUserMountCache {
 				$rows = $this->connection->insertIfNotExist(
 					'*PREFIX*mounts',
 					[
-					'storage_id' => $mount->getStorageId(),
-					'root_id' => $mount->getRootId(),
-					'user_id' => $mount->getUser()->getUID(),
-					'mount_point' => $mount->getMountPoint()
-				],
-				// NOTE: see {ocprefix}mounts/mounts_user_root_index
-				['root_id', 'user_id']
+						'storage_id' => $mount->getStorageId(),
+						'root_id' => $mount->getRootId(),
+						'user_id' => $mount->getUser()->getUID(),
+						'mount_point' => $mount->getMountPoint()
+					],
+					['root_id', 'user_id'] // NOTE: see *PREFIX*mounts/mounts_user_root_index
 				);
-			} catch (UniqueConstraintViolationException $e) {
-				$this->logger->logException($e);
-				$rows = 0;
-			}
 
-			if ($rows === 0) {
+				if ($rows === 0) {
+					// likely to happen when called multiple times
+					$this->logger->debug(
+						"Mount {$mount->getRootId()}/{$mount->getUser()->getUID()} already exists"
+					);
+				}
+			} catch (UniqueConstraintViolationException $e) {
 				// most likely race condition but make sure to log the error in case it is application level error
 				$this->logger->error(
-					"Attempt to add mount to cache where mount {$mount->getRootId()}/{$mount->getUser()->getUID()} already exists"
+					"Attempt to add mount {$mount->getRootId()}/{$mount->getUser()->getUID()} cache failed"
 				);
+				$this->logger->logException($e);
 			}
 		} else {
 			// in some cases this is legitimate, like orphaned shares


### PR DESCRIPTION
## Description

Bugfix: Handle exception when adding mount to existing cache or adding existing lock

In some cases there are can be multiple parallel requests that could in their logic attempt to create shared file mountpoint for the file or to create lock, e.g. collaboration software. Exception to add cache or lock that already exists is now handled

## Related Issue
- Related https://github.com/owncloud/enterprise/issues/5198

## How Has This Been Tested?
- manually in the developer instance attempting to open shared file at the same time
- unit/acceptance tests

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist:
- [x] Base code changes
- [x] Unit tests added
- [x] Acceptance tests added
- [x] Changelog item, see [TEMPLATE](https://github.com/owncloud/core/blob/master/changelog/TEMPLATE)
