### PR TITLE
Filter out the current user from batch sharing in the webUI

### DIFF
--- a/changelog/unreleased/40155
+++ b/changelog/unreleased/40155
@@ -4,4 +4,5 @@ It is now possible to share resources with multiple users at once
 via the following format: user1, user2, user3.
 
 https://github.com/owncloud/core/pull/40155
+https://github.com/owncloud/core/pull/40199
 https://github.com/owncloud/enterprise/issues/2865

--- a/core/js/sharedialogview.js
+++ b/core/js/sharedialogview.js
@@ -277,12 +277,27 @@
 						if (isBatch) {
 							return view._getUsersForBatchAction(trimmedSearch).then(function (res) {
 								if (res.found.length) {
+									//Filter out the current user
+									for (i = 0; i < res.found.length; i++) {
+										if (res.found[i].shareWith === OC.currentUser) {
+											res.found.splice(i, 1);
+											continue;
+										}
+									}
+								}
+								if (res.found.length) {
+									// Build the label for the list of users to be batch-added
 									var labelArray = [];
 									for (i = 0; i < res.found.length; i++) {
 										labelArray.push(res.found[i].shareWith)
 									}
 
-									suggestions.push({ batch: res.found, failedBatch: res.notFound, label: labelArray.join(', '), value: {} });
+									suggestions.push({
+										batch: res.found,
+										failedBatch: res.notFound,
+										label: labelArray.join(', '),
+										value: {}
+									});
 								}
 
 								$loading.addClass('hidden');
@@ -604,7 +619,9 @@
 			var users = Array.from(new Set(search.split(this.batchActionSeparator)));
 
 			for (var i = 0; i < users.length; i++) {
-				if (!users[i]) continue;
+				if (!users[i] || users[i] === OC.currentUser) {
+					continue;
+				}
 				var user = users[i].trim();
 				promises.push(
 					$.ajax({


### PR DESCRIPTION
## Description
If I put myself (phil) in the list of users to share with "alice,brian,phil,carol" then the UI keeps my name in the list and still attempts to share with me. An error notification is displayed. That seems unnecessary - the JS code knows who I am, so filter me out of the list before even sending it off to find matches.

If I put my display name in the list - "alice,brian,Phillip Davis,carol" then that does get sent off for checking, returning a list of users like "alice,brian,phil,carol". So also filter the returned list and remove my username from the list, if found.

## Related Issue
Follow-on from PR #40155 

## How Has This Been Tested?
Have users like alice, brian, carol, phil. "phil" has display name "Phillip Davis"

Try to share with "alice,brian,carol,phil"
Try to share with "alice,brian,carol,Phillip Davis"
Switch "phil" around to the start and middle of the list.

Result:
The sharing suggestion is always just to share with multiple users "alice, brian, carol".
Clicking on that sharing suggestion results in shares with those 3 users only, and no error notifications are displayed.

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Database schema changes (next release will require increase of minor version instead of patch)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [ ] Tests only (no source changes)

## Checklist:
- [ ] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 
- [ ] Changelog item, see [TEMPLATE](https://github.com/owncloud/core/blob/master/changelog/TEMPLATE)
