### PR TITLE
fix: CORS on WebDAV is not working

### DIFF
--- a/changelog/unreleased/40204
+++ b/changelog/unreleased/40204
@@ -1,0 +1,8 @@
+Bugfix: CORS on WebDAV is not working
+
+The list of allowed domains was not being correctly decoded, resulting in failure
+to recognise a valid domain, and thus failure to send the relevant CORS headers.
+The decoding of the domains list has been corrected.
+
+https://github.com/owncloud/core/pull/40204
+https://github.com/owncloud/core/issues/40203

--- a/lib/private/legacy/response.php
+++ b/lib/private/legacy/response.php
@@ -294,7 +294,7 @@ class OC_Response {
 		$isCorsRequest = (\is_array($globalAllowedDomains) && \in_array($domain, $globalAllowedDomains, true));
 		if (!$isCorsRequest && $userId !== null) {
 			// check if any of the user specific CORS domains matches
-			$allowedDomains = \json_decode($config->getUserValue($userId, 'core', 'domains'));
+			$allowedDomains = \json_decode($config->getUserValue($userId, 'core', 'domains'), true);
 			$isCorsRequest = (\is_array($allowedDomains) && \in_array($domain, $allowedDomains, true));
 		}
 		if ($isCorsRequest) {


### PR DESCRIPTION
WebDAV is not working at all when used by on browser Javascript because the CORS headers are only present in the OPTION request, but not in the subsequent WebDAV methods.

## Description

This behavior is caused by a erroneous json_decode call while retriving the user's domains whitelist. It return an object, so the is_array always fails and no header are sent.

## Related Issue

- Fixes https://github.com/owncloud/core/issues/40203

## Types of changes

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Database schema changes (next release will require increase of minor version instead of patch)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [ ] Tests only (no source changes)

## Checklist:
- [X] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 
- [ ] Changelog item, see [TEMPLATE](https://github.com/owncloud/core/blob/master/changelog/TEMPLATE)
