### PR TITLE
[tests-only][full-ci]Adjust test for limit search assertion

### DIFF
--- a/tests/acceptance/features/bootstrap/WebDav.php
+++ b/tests/acceptance/features/bootstrap/WebDav.php
@@ -5054,7 +5054,7 @@ trait WebDav {
 			},
 			$elementRows
 		);
-		$resultEntries = $this->findEntryFromPropfindResponse(null, $user);
+		$resultEntries = $this->findEntryFromPropfindResponse(null, $user, "REPORT");
 		foreach ($resultEntries as $resultEntry) {
 			Assert::assertContains($resultEntry, $expectedEntries);
 		}
@@ -5297,17 +5297,24 @@ trait WebDav {
 			foreach ($multistatusResults as $multistatusResult) {
 				$entryPath = $multistatusResult['value'][0]['value'];
 				if (OcisHelper::isTestingOnOcis() && $method === "REPORT") {
-					$entryName = \rawurldecode($entryPath);
-					if (str_ends_with($entryName, $entryNameToSearch)) {
-						return $multistatusResult;
+					if ($entryNameToSearch !== null && str_ends_with($entryPath, $entryNameToSearch)) {
+						return $multistatusResults;
+					} else {
+						$spaceId = WebDavHelper::getPersonalSpaceIdForUser(
+							$this->getBaseUrl(),
+							$user,
+							$this->getPasswordForUser($user),
+							$this->getStepLineRef()
+						);
+						$splitSpaceID = explode("$", $spaceId);
+						$topWebDavPath = "/dav/spaces/" . $splitSpaceID[0] . "%21" . "$splitSpaceID[1]" . "/";
 					}
-				} else {
-					$entryName = \str_replace($topWebDavPath, "", $entryPath);
-					$entryName = \rawurldecode($entryName);
-					$entryName = \trim($entryName, "/");
-					if ($trimmedEntryNameToSearch === $entryName) {
-						return $multistatusResult;
-					}
+				}
+				$entryName = \str_replace($topWebDavPath, "", $entryPath);
+				$entryName = \rawurldecode($entryName);
+				$entryName = \trim($entryName, "/");
+				if ($trimmedEntryNameToSearch === $entryName) {
+					return $multistatusResult;
 				}
 				\array_push($results, $entryName);
 			}


### PR DESCRIPTION
## Description
This PR adjust the search limit which fails on assertion for the failure on ocis.
Previously while testing on `ocis`, the test code only check for the non-empty `$entryNameToSearch`. But incase of null `$entryNameToSearch` for `new` endpoint whole `url` was pushed to array instead of only the files|folders names causing the test to fail.  

## Related Issue
https://github.com/owncloud/ocis/issues/4017

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
- CI
- Locally

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Database schema changes (next release will require increase of minor version instead of patch)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [ ] Tests only (no source changes)

## Checklist:
<!-- Tick the checkboxes when done. -->
<!-- Raise documentation ticket in https://github.com/owncloud/documentation -->
- [x] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 
- [ ] Changelog item, see [TEMPLATE](https://github.com/owncloud/core/blob/master/changelog/TEMPLATE)
