### PR TITLE
[tests-only] Skip the flaky etag propagation tests when running with oCIS CI

### DIFF
--- a/tests/acceptance/features/apiWebdavEtagPropagation2/copyFileFolder.feature
+++ b/tests/acceptance/features/apiWebdavEtagPropagation2/copyFileFolder.feature
@@ -107,6 +107,7 @@ Feature: propagation of etags when copying files or folders
     And these etags should not have changed:
       | user  | path             |
       | Alice | /upload/file.txt |
+    @skipOnOcis @issue-ocis-4091
     Examples:
       | dav_version |
       | old         |
@@ -139,6 +140,7 @@ Feature: propagation of etags when copying files or folders
     And these etags should not have changed:
       | user  | path             |
       | Alice | /upload/file.txt |
+    @skipOnOcis @issue-ocis-4091
     Examples:
       | dav_version |
       | old         |


### PR DESCRIPTION
Signed-off-by: Kiran Parajuli <kiranparajuli589@gmail.com>

<!--
Thanks for submitting a change to ownCloud!

This is the bug tracker for the Server component. Find other components at https://github.com/owncloud/core/blob/master/.github/CONTRIBUTING.md#guidelines

For fixing potential security issues please see https://owncloud.com/security/

To make it possible for us to get your change reviewed and merged please carefully fill out the requested information below.

Please note that any kind of change needs first be submitted to the master branch which holds the next version of ownCloud.

Please set the following labels:

- Set label "3 - To review" for review or "2 - Development" if the PR still has open tasks
- Assignment: assign to self
- Milestone: set the same as the ticket this PR fixes, or "development" by default
- Reviewers: pick at least one
-->

## Description
After running the etag propagation tests very often in the CI with this PR https://github.com/owncloud/ocis/pull/4137, the found flaky scenarios are now skipped for the oCIS CI.

## Related Issue
- Part of https://github.com/owncloud/ocis/issues/4091

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
- :robot: 

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Database schema changes (next release will require increase of minor version instead of patch)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [x] Tests only (no source changes)