### PR TITLE
Use the displayname of the groups

### DIFF
--- a/changelog/unreleased/40229
+++ b/changelog/unreleased/40229
@@ -1,0 +1,15 @@
+Bugfix: Use group's displayname in the user's profile and user list
+
+Previously, the group id was being used in both the user's profile and
+the user list. This hasn't been important because the local groups have
+matching group id and displayname, the same for ldap groups.
+
+Due to recent changes with the ldap app (version 0.17.0), the group
+id and the displayname could be different, and they'll be different
+by default in the ldap app.
+
+In both the user's profile and the user list, the group id was being used
+instead of the displayname. This is fixed now, and the displayname will
+be used as intended.
+
+https://github.com/owncloud/core/pull/40229

--- a/lib/private/Group/MetaData.php
+++ b/lib/private/Group/MetaData.php
@@ -161,7 +161,7 @@ class MetaData {
 	private function generateGroupMetaData(\OCP\IGroup $group, $userSearch) {
 		return [
 				'id' => $group->getGID(),
-				'name' => $group->getGID(),
+				'name' => $group->getDisplayName(),
 				'usercount' => $this->sorting === self::SORT_USERCOUNT ? $group->count($userSearch) : 0,
 		];
 	}

--- a/settings/Controller/UsersController.php
+++ b/settings/Controller/UsersController.php
@@ -43,6 +43,7 @@ use OCP\AppFramework\Http\TemplateResponse;
 use OCP\AppFramework\Utility\ITimeFactory;
 use OCP\IConfig;
 use OCP\IGroupManager;
+use OCP\IGroup;
 use OCP\IL10N;
 use OCP\ILogger;
 use OCP\InvalidUserTokenException;
@@ -329,7 +330,6 @@ class UsersController extends Controller {
 			$groupManager = $this->groupManager;
 			'@phan-var \OC\Group\Manager $groupManager';
 			$subAdminOfGroups = $groupManager->getSubAdmin()->getSubAdminsGroups($this->userSession->getUser());
-			// New class returns IGroup[] so convert back
 			$gids = [];
 			foreach ($subAdminOfGroups as $group) {
 				$gids[$group->getGID()] = [
@@ -340,7 +340,7 @@ class UsersController extends Controller {
 			$subAdminOfGroups = $gids;
 
 			// Set the $gid parameter to an empty value if the subadmin has no rights to access a specific group
-			if ($gid !== '' && !isset($gids[$gid])) {
+			if ($gid !== '' && !isset($subAdminOfGroups[$gid])) {
 				$gid = '';
 			}
 

--- a/settings/Controller/UsersController.php
+++ b/settings/Controller/UsersController.php
@@ -166,7 +166,7 @@ class UsersController extends Controller {
 
 	/**
 	 * @param IUser $user
-	 * @param array $userGroups
+	 * @param IGroup[]|null $userGroups
 	 * @return array
 	 */
 	private function formatUserForIndex(IUser $user, array $userGroups = null) {
@@ -195,8 +195,12 @@ class UsersController extends Controller {
 
 		'@phan-var \OC\Group\Manager $this->groupManager';
 		$subAdminGroups = $this->groupManager->getSubAdmin()->getSubAdminsGroups($user);
-		foreach ($subAdminGroups as $key => $subAdminGroup) {
-			$subAdminGroups[$key] = $subAdminGroup->getGID();
+		$subAdminGroupsKV = [];
+		foreach ($subAdminGroups as $subAdminGroup) {
+			$subAdminGroupsKV[$subAdminGroup->getGID()] = [
+				'id' => $subAdminGroup->getGID(),
+				'name' => $subAdminGroup->getDisplayName(),
+			];
 		}
 
 		$displayName = $user->getEMailAddress();
@@ -213,11 +217,20 @@ class UsersController extends Controller {
 			}
 		}
 
+		$groups = ($userGroups === null) ? $this->groupManager->getUserGroups($user, 'management') : $userGroups;
+		$groupsKV = [];
+		foreach ($groups as $group) {
+			$groupsKV[$group->getGID()] = [
+				'id' => $group->getGID(),
+				'name' => $group->getDisplayName(),
+			];
+		}
+
 		return [
 			'name' => $user->getUID(),
 			'displayname' => $user->getDisplayName(),
-			'groups' => (empty($userGroups)) ? $this->groupManager->getUserGroupIds($user, 'management') : $userGroups,
-			'subadmin' => $subAdminGroups,
+			'groups' => $groupsKV,
+			'subadmin' => $subAdminGroupsKV,
 			'isEnabled' => $user->isEnabled(),
 			'quota' => $user->getQuota(),
 			'storageLocation' => $user->getHome(),
@@ -319,20 +332,23 @@ class UsersController extends Controller {
 			// New class returns IGroup[] so convert back
 			$gids = [];
 			foreach ($subAdminOfGroups as $group) {
-				$gids[] = $group->getGID();
+				$gids[$group->getGID()] = [
+					'id' => $group->getGID(),
+					'name' => $group->getDisplayName(),
+				];
 			}
 			$subAdminOfGroups = $gids;
 
 			// Set the $gid parameter to an empty value if the subadmin has no rights to access a specific group
-			if ($gid !== '' && !\in_array($gid, $subAdminOfGroups)) {
+			if ($gid !== '' && !isset($gids[$gid])) {
 				$gid = '';
 			}
 
 			// Batch all groups the user is subadmin of when a group is specified
 			$batch = [];
 			if ($gid === '') {
-				foreach ($subAdminOfGroups as $group) {
-					$groupUsers = $this->groupManager->displayNamesInGroup($group, $pattern, $limit, $offset);
+				foreach ($subAdminOfGroups as $groupId => $groupData) {
+					$groupUsers = $this->groupManager->displayNamesInGroup($groupId, $pattern, $limit, $offset);
 
 					foreach ($groupUsers as $uid => $displayName) {
 						$batch[$uid] = $displayName;
@@ -345,11 +361,14 @@ class UsersController extends Controller {
 
 			foreach ($batch as $user) {
 				// Only add the groups, this user is a subadmin of
-				$userGroups = \array_values(\array_intersect(
-					$this->groupManager->getUserGroupIds($user),
-					$subAdminOfGroups
-				));
-				$users[] = $this->formatUserForIndex($user, $userGroups);
+				$userGroupList = $this->groupManager->getUserGroups($user);
+				$finalGroupList = [];
+				foreach ($userGroupList as $userGroup) {
+					if (isset($subAdminOfGroups[$userGroup->getGID()])) {
+						$finalGroupList[] = $userGroup;
+					}
+				}
+				$users[] = $this->formatUserForIndex($user, $finalGroupList);
 			}
 		}
 
@@ -505,7 +524,7 @@ class UsersController extends Controller {
 				}
 			}
 			// fetch users groups
-			$userGroups = $this->groupManager->getUserGroupIds($user);
+			$userGroups = $this->groupManager->getUserGroups($user);
 
 			return new DataResponse(
 				$this->formatUserForIndex($user, $userGroups),

--- a/settings/Panels/Personal/Profile.php
+++ b/settings/Panels/Personal/Profile.php
@@ -103,8 +103,7 @@ class Profile implements ISettings {
 		$tmpl->assign('displayNameChangeSupported', $this->userSession->getUser()->canChangeDisplayName());
 		$tmpl->assign('mailAddressChangeSupported', $this->userSession->getUser()->canChangeMailAddress());
 		$tmpl->assign('passwordChangeSupported', $this->userSession->getUser()->canChangePassword());
-		$groups = $this->groupManager->getUserGroupIds($this->userSession->getUser());
-		\sort($groups);
+		$groups = $this->groupManager->getUserGroups($this->userSession->getUser());
 		$tmpl->assign('groups', $groups);
 		$tmpl->assign('languageSelector', $selector->fetchPage());
 		return $tmpl;

--- a/settings/js/users/users.js
+++ b/settings/js/users/users.js
@@ -56,7 +56,7 @@ var UserList = {
 	 * @returns table row created for this user
 	 */
 	add: function (user, sort) {
-		if (this.currentGid && this.currentGid !== '_everyone' && _.indexOf(user.groups, this.currentGid) < 0) {
+		if (this.currentGid && this.currentGid !== '_everyone' && user.groups[this.currentGid] === undefined) {
 			return;
 		}
 
@@ -94,11 +94,11 @@ var UserList = {
 		 * groups and subadmins
 		 */
 		var $tdGroups = $tr.find('td.groups');
-		this._updateGroupListLabel($tdGroups, user.groups);
+		this._updateGroupListLabel($tdGroups, _.pluck(user.groups, 'name'));
 		$tdGroups.find('.action').tooltip({placement: 'top'});
 
 		var $tdSubadmins = $tr.find('td.subadmins');
-		this._updateGroupListLabel($tdSubadmins, user.subadmin);
+		this._updateGroupListLabel($tdSubadmins, _.pluck(user.subadmin, 'name'));
 		$tdSubadmins.find('.action').tooltip({placement: 'top'});
 
 		/**

--- a/settings/templates/panels/personal/profile.php
+++ b/settings/templates/panels/personal/profile.php
@@ -97,7 +97,9 @@ if ($_['mailAddressChangeSupported']) {
 	?>
 		<p><?php p($l->t('You are member of the following groups:')); ?></p>
 		<p>
-			<?php p(\implode(', ', \array_map(function($group) { return $group->getDisplayName(); }, $_['groups']))); ?>
+			<?php p(\implode(', ', \array_map(function ($group) {
+		return $group->getDisplayName();
+	}, $_['groups']))); ?>
 		</p>
 	<?php
 } else {

--- a/settings/templates/panels/personal/profile.php
+++ b/settings/templates/panels/personal/profile.php
@@ -97,7 +97,7 @@ if ($_['mailAddressChangeSupported']) {
 	?>
 		<p><?php p($l->t('You are member of the following groups:')); ?></p>
 		<p>
-			<?php p(\implode(', ', $_['groups'])); ?>
+			<?php p(\implode(', ', \array_map(function($group) { return $group->getDisplayName(); }, $_['groups']))); ?>
 		</p>
 	<?php
 } else {

--- a/settings/templates/users/part.grouplist.php
+++ b/settings/templates/users/part.grouplist.php
@@ -46,7 +46,7 @@
 
 	<!--List of Groups-->
 	<?php foreach ($_["groups"] as $group): ?>
-		<li data-gid="<?php p($group['name']) ?>" data-usercount="<?php p($group['usercount']) ?>" class="isgroup">
+		<li data-gid="<?php p($group['id']) ?>" data-usercount="<?php p($group['usercount']) ?>" class="isgroup">
 			<a href="#" class="dorename">
 				<span class="groupname" title="<?php p($group['name']); ?>">
 					<?php p($group['name']); ?>

--- a/tests/Settings/Controller/GroupsControllerTest.php
+++ b/tests/Settings/Controller/GroupsControllerTest.php
@@ -60,6 +60,7 @@ class GroupsControllerTest extends \Test\TestCase {
 		$firstGroup
 			->method('getGID')
 			->will($this->returnValue('firstGroup'));
+		$firstGroup->method('getDisplayName')->willReturn('first name');
 		$firstGroup
 			->method('count')
 			->will($this->returnValue(12));
@@ -68,6 +69,7 @@ class GroupsControllerTest extends \Test\TestCase {
 		$secondGroup
 			->method('getGID')
 			->will($this->returnValue('secondGroup'));
+		$secondGroup->method('getDisplayName')->willReturn('second name');
 		$secondGroup
 			->method('count')
 			->will($this->returnValue(25));
@@ -76,6 +78,7 @@ class GroupsControllerTest extends \Test\TestCase {
 		$thirdGroup
 			->method('getGID')
 			->will($this->returnValue('thirdGroup'));
+		$thirdGroup->method('getDisplayName')->willReturn('third name');
 		$thirdGroup
 			->method('count')
 			->will($this->returnValue(14));
@@ -84,6 +87,7 @@ class GroupsControllerTest extends \Test\TestCase {
 		$fourthGroup
 			->method('getGID')
 			->will($this->returnValue('admin'));
+		$fourthGroup->method('getDisplayName')->willReturn('admin name');
 		$fourthGroup
 			->method('count')
 			->will($this->returnValue(18));
@@ -114,7 +118,7 @@ class GroupsControllerTest extends \Test\TestCase {
 				'adminGroups' => [
 					0 => [
 						'id' => 'admin',
-						'name' => 'admin',
+						'name' => 'admin name',
 						'usercount' => 0,//User count disabled 18,
 					]
 				],
@@ -122,17 +126,17 @@ class GroupsControllerTest extends \Test\TestCase {
 					[
 						0 => [
 							'id' => 'firstGroup',
-							'name' => 'firstGroup',
+							'name' => 'first name',
 							'usercount' => 0,//User count disabled 12,
 						],
 						1 => [
 							'id' => 'secondGroup',
-							'name' => 'secondGroup',
+							'name' => 'second name',
 							'usercount' => 0,//User count disabled 25,
 						],
 						2 => [
 							'id' => 'thirdGroup',
-							'name' => 'thirdGroup',
+							'name' => 'third name',
 							'usercount' => 0,//User count disabled 14,
 						],
 					]
@@ -153,6 +157,7 @@ class GroupsControllerTest extends \Test\TestCase {
 		$firstGroup
 			->method('getGID')
 			->will($this->returnValue('firstGroup'));
+		$firstGroup->method('getDisplayName')->willReturn('first name');
 		$firstGroup
 			->method('count')
 			->will($this->returnValue(12));
@@ -161,6 +166,7 @@ class GroupsControllerTest extends \Test\TestCase {
 		$secondGroup
 			->method('getGID')
 			->will($this->returnValue('secondGroup'));
+		$secondGroup->method('getDisplayName')->willReturn('second name');
 		$secondGroup
 			->method('count')
 			->will($this->returnValue(25));
@@ -169,6 +175,7 @@ class GroupsControllerTest extends \Test\TestCase {
 		$thirdGroup
 			->method('getGID')
 			->will($this->returnValue('thirdGroup'));
+		$thirdGroup->method('getDisplayName')->willReturn('third name');
 		$thirdGroup
 			->method('count')
 			->will($this->returnValue(14));
@@ -177,6 +184,7 @@ class GroupsControllerTest extends \Test\TestCase {
 		$fourthGroup
 			->method('getGID')
 			->will($this->returnValue('admin'));
+		$fourthGroup->method('getDisplayName')->willReturn('admin name');
 		$fourthGroup
 			->method('count')
 			->will($this->returnValue(18));
@@ -207,7 +215,7 @@ class GroupsControllerTest extends \Test\TestCase {
 				'adminGroups' => [
 					0 => [
 						'id' => 'admin',
-						'name' => 'admin',
+						'name' => 'admin name',
 						'usercount' => 18,
 					]
 				],
@@ -215,17 +223,17 @@ class GroupsControllerTest extends \Test\TestCase {
 					[
 						0 => [
 							'id' => 'secondGroup',
-							'name' => 'secondGroup',
+							'name' => 'second name',
 							'usercount' => 25,
 						],
 						1 => [
 							'id' => 'thirdGroup',
-							'name' => 'thirdGroup',
+							'name' => 'third name',
 							'usercount' => 14,
 						],
 						2 => [
 							'id' => 'firstGroup',
-							'name' => 'firstGroup',
+							'name' => 'first name',
 							'usercount' => 12,
 						],
 					]

--- a/tests/Settings/Panels/Personal/ProfileTest.php
+++ b/tests/Settings/Panels/Personal/ProfileTest.php
@@ -14,6 +14,7 @@ use OC\Helper\LocaleHelper;
 use OC\Settings\Panels\Personal\Profile;
 use OCP\IConfig;
 use OCP\IGroupManager;
+use OCP\IGroup;
 use OCP\IUser;
 use OCP\IUserSession;
 use OCP\L10N\IFactory;
@@ -59,10 +60,16 @@ class ProfileTest extends \Test\TestCase {
 	}
 
 	public function testGetPanel() {
+		$group1 = $this->createMock(IGroup::class);
+		$group1->method('getGID')->willReturn('abc-def-000-111');
+		$group1->method('getDisplayName')->willReturn('group1');
+		$group2 = $this->createMock(IGroup::class);
+		$group2->method('getGID')->willReturn('bcd-efa-111-222');
+		$group2->method('getDisplayName')->willReturn('group2');
 		$user = $this->createMock(IUser::class);
 		$user->expects($this->once())->method('getEMailAddress')->will($this->returnValue('test@example.com'));
 		$this->userSession->expects($this->exactly(8))->method('getUser')->will($this->returnValue($user));
-		$this->groupManager->expects($this->once())->method('getUserGroupIds')->will($this->returnValue(['group1', 'group2']));
+		$this->groupManager->expects($this->once())->method('getUserGroups')->willReturn([$group1, $group2]);
 		$this->lfactory->expects($this->once())->method('findLanguage')->will($this->returnValue('en'));
 		$this->config->expects($this->once())->method('getUserValue')->will($this->returnValue(''));
 		$this->lfactory->expects($this->once())->method('findAvailableLanguages')->will($this->returnValue([]));

--- a/tests/lib/Group/MetaDataTest.php
+++ b/tests/lib/Group/MetaDataTest.php
@@ -22,6 +22,8 @@
 
 namespace Test\Group;
 
+use OCP\IGroup;
+
 class MetaDataTest extends \Test\TestCase {
 	/** @var \OC\Group\Manager */
 	private $groupManager;
@@ -46,36 +48,21 @@ class MetaDataTest extends \Test\TestCase {
 		);
 	}
 
-	private function getGroupMock($countCallCount = 0) {
-		$group = $this->getMockBuilder('\OC\Group\Group')
-			->disableOriginalConstructor()
-			->getMock();
-
-		$group->expects($this->exactly(9))
-			->method('getGID')
-			->will($this->onConsecutiveCalls(
-				'admin',
-				'admin',
-				'admin',
-				'g2',
-				'g2',
-				'g2',
-				'g3',
-				'g3',
-				'g3'
-			));
-
-		$group->expects($this->exactly($countCallCount))
-			->method('count')
-			->with('')
-			->will($this->onConsecutiveCalls(2, 3, 5));
-
-		return $group;
-	}
-
 	public function testGet() {
-		$group = $this->getGroupMock();
-		$groups = \array_fill(0, 3, $group);
+		$group1 = $this->createMock(IGroup::class);
+		$group1->method('getGID')->willReturn('admin');
+		$group1->method('getDisplayName')->willReturn('admin group');
+		$group1->method('count')->willReturn(2);
+		$group2 = $this->createMock(IGroup::class);
+		$group2->method('getGID')->willReturn('g2');
+		$group2->method('getDisplayName')->willReturn('group 2');
+		$group2->method('count')->willReturn(3);
+		$group3 = $this->createMock(IGroup::class);
+		$group3->method('getGID')->willReturn('g3');
+		$group3->method('getDisplayName')->willReturn('group 3');
+		$group3->method('count')->willReturn(5);
+
+		$groups = [$group1, $group2, $group3];
 
 		$this->groupManager->expects($this->once())
 			->method('search')
@@ -87,15 +74,28 @@ class MetaDataTest extends \Test\TestCase {
 		$this->assertCount(1, $adminGroups);
 		$this->assertCount(2, $ordinaryGroups);
 
-		$this->assertSame('g2', $ordinaryGroups[0]['name']);
+		$this->assertSame('g2', $ordinaryGroups[0]['id']);
 		// user count is not loaded
 		$this->assertSame(0, $ordinaryGroups[0]['usercount']);
 	}
 
 	public function testGetWithSorting() {
+		$group1 = $this->createMock(IGroup::class);
+		$group1->method('getGID')->willReturn('admin');
+		$group1->method('getDisplayName')->willReturn('admin group');
+		$group1->method('count')->willReturn(2);
+		$group2 = $this->createMock(IGroup::class);
+		$group2->method('getGID')->willReturn('g2');
+		$group2->method('getDisplayName')->willReturn('group 2');
+		$group2->method('count')->willReturn(3);
+		$group3 = $this->createMock(IGroup::class);
+		$group3->method('getGID')->willReturn('g3');
+		$group3->method('getDisplayName')->willReturn('group 3');
+		$group3->method('count')->willReturn(5);
+
+		$groups = [$group1, $group2, $group3];
+
 		$this->groupMetadata->setSorting(1);
-		$group = $this->getGroupMock(3);
-		$groups = \array_fill(0, 3, $group);
 
 		$this->groupManager->expects($this->once())
 			->method('search')
@@ -107,13 +107,25 @@ class MetaDataTest extends \Test\TestCase {
 		$this->assertCount(1, $adminGroups);
 		$this->assertCount(2, $ordinaryGroups);
 
-		$this->assertSame('g3', $ordinaryGroups[0]['name']);
+		$this->assertSame('g3', $ordinaryGroups[0]['id']);
 		$this->assertSame(5, $ordinaryGroups[0]['usercount']);
 	}
 
 	public function testGetWithCache() {
-		$group = $this->getGroupMock();
-		$groups = \array_fill(0, 3, $group);
+		$group1 = $this->createMock(IGroup::class);
+		$group1->expects($this->exactly(2))->method('getGID')->willReturn('admin');
+		$group1->method('getDisplayName')->willReturn('admin group');
+		$group1->method('count')->willReturn(2);
+		$group2 = $this->createMock(IGroup::class);
+		$group2->expects($this->exactly(2))->method('getGID')->willReturn('g2');
+		$group2->method('getDisplayName')->willReturn('group 2');
+		$group2->method('count')->willReturn(3);
+		$group3 = $this->createMock(IGroup::class);
+		$group3->expects($this->exactly(2))->method('getGID')->willReturn('g3');
+		$group3->method('getDisplayName')->willReturn('group 3');
+		$group3->method('count')->willReturn(5);
+
+		$groups = [$group1, $group2, $group3];
 
 		$this->groupManager->expects($this->once())
 			->method('search')


### PR DESCRIPTION
<!--
Thanks for submitting a change to ownCloud!

This is the bug tracker for the Server component. Find other components at https://github.com/owncloud/core/blob/master/.github/CONTRIBUTING.md#guidelines

For fixing potential security issues please see https://owncloud.com/security/

To make it possible for us to get your change reviewed and merged please carefully fill out the requested information below.

Please note that any kind of change needs first be submitted to the master branch which holds the next version of ownCloud.

Please set the following labels:

- Set label "3 - To review" for review or "2 - Development" if the PR still has open tasks
- Assignment: assign to self
- Milestone: set the same as the ticket this PR fixes, or "development" by default
- Reviewers: pick at least one
-->

## Description
Use the displayname name of the group instead of the group id in multiple places. Currently checked in the user's list and in the personal settings.

Note that for regular (local) groups, the id and the displayname is the same, so there shouldn't be any noticeable changes.

The LDAP app will rely on this for further functionality (changes for LDAP in progress)

## Related Issue
https://github.com/owncloud/enterprise/issues/5071

## Motivation and Context
The group id must be immutable, as it is the user id. The group displayname should be shown instead, as the displayname can be changed at any point.

## How Has This Been Tested?
Checked along with a specific patch for the user_ldap app.

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Database schema changes (next release will require increase of minor version instead of patch)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [ ] Tests only (no source changes)

## Checklist:
<!-- Tick the checkboxes when done. -->
<!-- Raise documentation ticket in https://github.com/owncloud/documentation -->
- [ ] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 
- [ ] Changelog item, see [TEMPLATE](https://github.com/owncloud/core/blob/master/changelog/TEMPLATE)
