### PR TITLE
[tests-only][full-ci]Add Test for updating (removing) password for a public link

### DIFF
--- a/tests/acceptance/features/apiSharePublicLink3/updatePublicLinkShare.feature
+++ b/tests/acceptance/features/apiSharePublicLink3/updatePublicLinkShare.feature
@@ -147,6 +147,23 @@ Feature: update a public link share
       | 1               | 100             | new                       |
       | 2               | 200             | new                       |
 
+  Scenario Outline: Creating a new public link share with password and removing (updating) it to make the resources accessible without password using public API
+    Given using OCS API version "<ocs_api_version>"
+    And user "Alice" has uploaded file with content "Random data" to "/randomfile.txt"
+    And user "Alice" has created a public link share with settings
+      | path     | randomfile.txt |
+      | password | %public%       |
+    When user "Alice" updates the last public link share using the sharing API with
+    #removing password is basically making password empty
+      | password | %remove% |
+    Then the OCS status code should be "<ocs_status_code>"
+    And the HTTP status code should be "200"
+    And the public should be able to download the last publicly shared file using the <public-webdav-api-version> public WebDAV API without a password and the content should be "Random data"
+    Examples:
+      | ocs_api_version | ocs_status_code | public-webdav-api-version |
+      | 1               | 100             | old                       |
+      | 2               | 200             | new                       |
+
   @issue-ocis-reva-336
   Scenario Outline: Creating a new public link share, updating its expiration date and getting its info (ocis Bug demonstration)
     Given using OCS API version "<ocs_api_version>"

--- a/tests/acceptance/features/apiSharePublicLink3/updatePublicLinkShare.feature
+++ b/tests/acceptance/features/apiSharePublicLink3/updatePublicLinkShare.feature
@@ -147,6 +147,7 @@ Feature: update a public link share
       | 1               | 100             | new                       |
       | 2               | 200             | new                       |
 
+
   Scenario Outline: Creating a new public link share with password and removing (updating) it to make the resources accessible without password using public API
     Given using OCS API version "<ocs_api_version>"
     And user "Alice" has uploaded file with content "Random data" to "/randomfile.txt"

--- a/tests/acceptance/features/bootstrap/FeatureContext.php
+++ b/tests/acceptance/features/bootstrap/FeatureContext.php
@@ -2370,6 +2370,8 @@ class FeatureContext extends BehatVariablesContext {
 			return $this->alternateAdminPassword;
 		} elseif ($functionalPassword === "%public%") {
 			return $this->publicLinkSharePassword;
+		} elseif ($functionalPassword === "%remove%") {
+			return "";
 		} else {
 			return $functionalPassword;
 		}

--- a/tests/acceptance/features/bootstrap/Sharing.php
+++ b/tests/acceptance/features/bootstrap/Sharing.php
@@ -1007,7 +1007,6 @@ trait Sharing {
 				$bodyRows['permissions'] = SharingHelper::getPermissionSum($bodyRows['permissions']);
 			}
 		}
-
 		$this->response = OcsApiHelper::sendRequest(
 			$this->getBaseUrl(),
 			$user,


### PR DESCRIPTION
## Description
This PR adds an API test when a user updates(remove) a `password` from a public link share previously having a certain `password`. As this test scenario was not added previously but now is added since a failure was noticed on this issue https://github.com/owncloud/web/issues/7307 for ocis.

## Related Issue
https://github.com/owncloud/core/issues/40227

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
- CI
- Locally

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Database schema changes (next release will require increase of minor version instead of patch)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [ ] Tests only (no source changes)

## Checklist:
<!-- Tick the checkboxes when done. -->
<!-- Raise documentation ticket in https://github.com/owncloud/documentation -->
- [x] Code changes
- [ ] Unit tests added
- [x] Acceptance tests added
- [ ] Documentation ticket raised: <link> 
- [ ] Changelog item, see [TEMPLATE](https://github.com/owncloud/core/blob/master/changelog/TEMPLATE)
