### PR TITLE
[tests-only] ApiTest. add the option to send a blank expireDate

### DIFF
--- a/tests/acceptance/features/bootstrap/Sharing.php
+++ b/tests/acceptance/features/bootstrap/Sharing.php
@@ -994,7 +994,9 @@ trait Sharing {
 		$bodyRows = $body->getRowsHash();
 		if (\array_key_exists('expireDate', $bodyRows)) {
 			$dateModification = $bodyRows['expireDate'];
-			$bodyRows['expireDate'] = \date('Y-m-d', \strtotime($dateModification));
+			if (!empty($bodyRows['expireDate'])) {
+				$bodyRows['expireDate'] = \date('Y-m-d', \strtotime($dateModification));
+			} else $bodyRows['expireDate'] = '';
 		}
 		if (\array_key_exists('password', $bodyRows)) {
 			$bodyRows['password'] = $this->getActualPassword($bodyRows['password']);

--- a/tests/acceptance/features/bootstrap/Sharing.php
+++ b/tests/acceptance/features/bootstrap/Sharing.php
@@ -996,7 +996,9 @@ trait Sharing {
 			$dateModification = $bodyRows['expireDate'];
 			if (!empty($bodyRows['expireDate'])) {
 				$bodyRows['expireDate'] = \date('Y-m-d', \strtotime($dateModification));
-			} else $bodyRows['expireDate'] = '';
+			} else {
+				$bodyRows['expireDate'] = '';
+			}
 		}
 		if (\array_key_exists('password', $bodyRows)) {
 			$bodyRows['password'] = $this->getActualPassword($bodyRows['password']);


### PR DESCRIPTION
I have not found any tests where we remove the password and expiration date of the public link

- I added option to send PUT request with `expireDate: `

related: https://github.com/owncloud/ocis/pull/4263