### PR TITLE
[tests-only] check for the links but not a list item in expected failures file

### DIFF
--- a/tests/acceptance/lint-expected-failures.sh
+++ b/tests/acceptance/lint-expected-failures.sh
@@ -66,18 +66,23 @@ then
 			if [[ $FEATURE_FILE_SPEC_LINE_FOUND == "true" ]]; then
 				continue
 			fi
-			# Match lines that have [someSuite/someName.feature:n] - the part inside the
-			# brackets is the suite, feature and line number of the expected failure.
-			# Else ignore the line.
-			if [[ "${INPUT_LINE}" =~ \[([a-zA-Z0-9_-]+/[a-zA-Z0-9_-]+\.feature:[0-9]+)] ]]; then
+			# Match lines that have "- [someSuite/someName.feature:n]" pattern on start
+			# the part inside the brackets is the suite, feature and line number of the expected failure.
+			if [[ "${INPUT_LINE}" =~ ^-[[:space:]]\[([a-zA-Z0-9_-]+/[a-zA-Z0-9_-]+\.feature:[0-9]+)] ]]; then
 				SUITE_SCENARIO_LINE="${BASH_REMATCH[1]}"
-			elif [[ "${INPUT_LINE}" =~ ^[[:space:]]*-[[:space:]][a-zA-Z0-9_-]+/[a-zA-Z0-9_-]+\.feature:[0-9]+[[:space:]]*$ ]]; then
+			elif [[
+			  # report for lines like: " - someSuite/someName.feature:n"
+			  "${INPUT_LINE}" =~ ^[[:space:]]*-[[:space:]][a-zA-Z0-9_-]+/[a-zA-Z0-9_-]+\.feature:[0-9]+[[:space:]]*$ ||
+			  # report for lines starting with: "[someSuite/someName.feature:n]"
+			  "${INPUT_LINE}" =~ ^[[:space:]]*\[([a-zA-Z0-9_-]+/[a-zA-Z0-9_-]+\.feature:[0-9]+)]
+			]]; then
 				log_error "> Line ${LINE_NUMBER}: Not in the correct format."
 				log_error "  + Actual Line     : '${INPUT_LINE}'"
-				log_error "  - Expected Format : '- [suite/scenario.feature:line_number]'"
+				log_error "  - Expected Format : '- [suite/scenario.feature:line_number](scenario_line_url)'"
 				FINAL_EXIT_STATUS=1
 				continue
 			else
+				# otherwise, ignore the line
 				continue
 			fi
 			# Find the link in round-brackets that should be after the SUITE_SCENARIO_LINE


### PR DESCRIPTION
Signed-off-by: Kiran Parajuli <kiranparajuli589@gmail.com>

<!-- Thanks for submitting a change to ownCloud!

This is the bug tracker for the Server component. Find other components at https://github.com/owncloud/core/blob/master/.github/CONTRIBUTING.md#guidelines

For fixing potential security issues please see https://owncloud.com/security/

To make it possible for us to get your change reviewed and merged please carefully fill out the requested information below.

Please note that any kind of change needs first be submitted to the master branch which holds the next version of ownCloud.

Please set the following labels:

- Set label "3 - To review" for review or "2 - Development" if the PR still has open tasks - Assignment: assign to self - Milestone: set the same as the ticket this PR fixes, or "development" by default - Reviewers: pick at least 
one -->

## Description
Generally, Expected Failures files are constructed like:
```
# [issue title](issue link)
  - [suite/scenario1:n](link)
  - [suite/scenario1:n](link)
```

If the expected failure markdown consists of lines like: `[abc/bac.feature:n](some-link)` i.e a link but not a list item, the linter now reports to set it as the expected format.

## Related Issue
<!--- This project only accepts pull requests related to open issues --> <!--- If suggesting a new feature or change, please discuss it in an issue first --> <!--- If fixing a bug, there should be an issue describing it with steps 
to reproduce --> <!--- Please link to the issue here: --> 
- Part of https://github.com/owncloud/QA/issues/716

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. --> <!--- Include details of your testing environment, and the tests you ran to --> <!--- see how your change affects other areas of the code, etc. -->
- :robot: 

