### PR TITLE
[tests-only][full-ci]Remove `/Shares` related scenarios from core

### DIFF
--- a/tests/acceptance/features/apiWebdavProperties1/createFileFolderWhenSharesExist.feature
+++ b/tests/acceptance/features/apiWebdavProperties1/createFileFolderWhenSharesExist.feature
@@ -31,13 +31,6 @@ Feature: create file or folder named similar to Shares folder
       | new         | /shares     |
       | new         | /Shares1    |
 
-    @skipOnOcV10 @personalSpace
-    Examples:
-      | dav_version | folder_name |
-      | spaces      | /Share      |
-      | spaces      | /shares     |
-      | spaces      | /Shares1    |
-
 
   Scenario Outline: create a file with a name similar to Shares
     Given using <dav_version> DAV path
@@ -54,13 +47,6 @@ Feature: create file or folder named similar to Shares folder
       | new         | /shares   |
       | new         | /Shares1  |
 
-    @skipOnOcV10 @personalSpace
-    Examples:
-      | dav_version | file_name |
-      | spaces      | /Share    |
-      | spaces      | /shares   |
-      | spaces      | /Shares1  |
-
 
   Scenario Outline: try to create a folder named Shares
     Given using <dav_version> DAV path
@@ -73,11 +59,6 @@ Feature: create file or folder named similar to Shares folder
       | old         |
       | new         |
 
-    @skipOnOcV10 @personalSpace
-    Examples:
-      | dav_version |
-      | spaces      |
-
 
   Scenario Outline: try to create a file named Shares
     Given using <dav_version> DAV path
@@ -89,8 +70,3 @@ Feature: create file or folder named similar to Shares folder
       | dav_version |
       | old         |
       | new         |
-
-    @skipOnOcV10 @personalSpace
-    Examples:
-      | dav_version |
-      | spaces      |


### PR DESCRIPTION
## Description
These scenarios always fails since in core `Shares` related code is not implemented. So these scenarios can be implemented rather in ocis and can be removed from expected to failure.

## Related Issue
https://github.com/owncloud/ocis/issues/4154
https://github.com/owncloud/ocis/issues/3033

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
- test environment:
- Locally
- CI

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Database schema changes (next release will require increase of minor version instead of patch)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [ ] Tests only (no source changes)

## Checklist:
<!-- Tick the checkboxes when done. -->
<!-- Raise documentation ticket in https://github.com/owncloud/documentation -->
- [ ] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 
- [ ] Changelog item, see [TEMPLATE](https://github.com/owncloud/core/blob/master/changelog/TEMPLATE)
