### PR TITLE
Init encryption module before calculating unencrypted block-size

### DIFF
--- a/lib/private/Files/Storage/Wrapper/Encryption.php
+++ b/lib/private/Files/Storage/Wrapper/Encryption.php
@@ -572,6 +572,8 @@ class Encryption extends Wrapper {
 			return 0;
 		}
 
+		// initialize encryption module to get the correct unencrypted block-size
+		$encryptionModule->begin($this->getFullPath($path), $this->uid, 'r', $header, [], null);
 		$signed = (isset($header['signed']) && $header['signed'] === 'true') ? true : false;
 		$unencryptedBlockSize = $encryptionModule->getUnencryptedBlockSize($signed);
 
@@ -603,7 +605,6 @@ class Encryption extends Wrapper {
 		\fclose($stream);
 
 		// we have to decrypt the last chunk to get it actual size
-		$encryptionModule->begin($this->getFullPath($path), $this->uid, 'r', $header, [], null);
 		$decryptedLastChunk = $encryptionModule->decrypt($lastChunkContentEncrypted, $lastChunkNr . 'end');
 		$decryptedLastChunk .= $encryptionModule->end($this->getFullPath($path), $lastChunkNr . 'end');
 


### PR DESCRIPTION
<!--
Thanks for submitting a change to ownCloud!

This is the bug tracker for the Server component. Find other components at https://github.com/owncloud/core/blob/master/.github/CONTRIBUTING.md#guidelines

For fixing potential security issues please see https://owncloud.com/security/

To make it possible for us to get your change reviewed and merged please carefully fill out the requested information below.

Please note that any kind of change needs first be submitted to the master branch which holds the next version of ownCloud.

Please set the following labels:

- Set label "3 - To review" for review or "2 - Development" if the PR still has open tasks
- Assignment: assign to self
- Milestone: set the same as the ticket this PR fixes, or "development" by default
- Reviewers: pick at least one
-->

## Description
Fixes a bug where the un-encrypted blocksize was calculated before initializing the encryption-module. This yields the wrong size after a file-scan. The issue is only triggered if encryption.use_legacy_encoding is set to true.

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

Related test PR: https://github.com/owncloud/encryption/pull/360#issue-1318035322

## Motivation and Context
When restoring encrypted files from backup and doing a ``occ file:scan --repair`` and ``encryption:fix-encrypted-version`` the file was still not readable correctly because the size in oc_filecache is wrong. 

The wrong calculation was introduced via https://github.com/owncloud/core/pull/38249 where the size calculation depends on the encoding mode (binary vs base64). The code assumes that the begin method is called before the size is calculated which is not  the case for the call-site which this PR fixes.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
- test environment:
- test case 1:
- test case 2:
- ...


## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Database schema changes (next release will require increase of minor version instead of patch)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [ ] Tests only (no source changes)

## Checklist:
<!-- Tick the checkboxes when done. -->
<!-- Raise documentation ticket in https://github.com/owncloud/documentation -->
- [x] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 
- [ ] Changelog item, see [TEMPLATE](https://github.com/owncloud/core/blob/master/changelog/TEMPLATE)
