### PR TITLE
Adjusted the description to refer to the datadirectory parameter

### DIFF
--- a/config/config.sample.php
+++ b/config/config.sample.php
@@ -1259,7 +1259,7 @@ $CONFIG = [
  * Define the DAV chunk base directory
  * Location of the chunk folder, defaults to `<datadirectory>/$user/uploads` where
  * `$user` is the current user and `datadirectory` is the datadirectory described here.
- * When specified, the format will change to `$dav.chunk_base_dir/$user` where 
+ * When specified, the format will change to `$dav.chunk_base_dir/$user` where
  * `$dav.chunk_base_dir` is the configured cache directory here and `$user` is the user.
  */
 'dav.chunk_base_dir' => '',

--- a/config/config.sample.php
+++ b/config/config.sample.php
@@ -1257,10 +1257,10 @@ $CONFIG = [
 
 /**
  * Define the DAV chunk base directory
- * Location of the chunk folder, defaults to `data/$user/uploads` where
- * `$user` is the current user. When specified, the format will change to
- * `$dav.chunk_base_dir/$user` where `$dav.chunk_base_dir` is the configured
- * cache directory and `$user` is the user.
+ * Location of the chunk folder, defaults to `<datadirectory>/$user/uploads` where
+ * `$user` is the current user and `datadirectory` is the datadirectory described here.
+ * When specified, the format will change to `$dav.chunk_base_dir/$user` where 
+ * `$dav.chunk_base_dir` is the configured cache directory here and `$user` is the user.
  */
 'dav.chunk_base_dir' => '',
 


### PR DESCRIPTION
I adjusted the text so it refers to the `datadirectory` parameter as the folder name is not `data` everywhere but rather depends on the `datadirectory` parameter.