### PR TITLE
[tests-only] Improve test for removing a password from a public link share

### DIFF
--- a/tests/acceptance/features/apiSharePublicLink3/updatePublicLinkShare.feature
+++ b/tests/acceptance/features/apiSharePublicLink3/updatePublicLinkShare.feature
@@ -160,9 +160,17 @@ Feature: update a public link share
     Then the OCS status code should be "<ocs_status_code>"
     And the HTTP status code should be "200"
     And the public should be able to download the last publicly shared file using the <public-webdav-api-version> public WebDAV API without a password and the content should be "Random data"
+
+    @notToImplementOnOCIS @issue-ocis-2079
     Examples:
       | ocs_api_version | ocs_status_code | public-webdav-api-version |
       | 1               | 100             | old                       |
+      | 2               | 200             | old                       |
+
+
+    Examples:
+      | ocs_api_version | ocs_status_code | public-webdav-api-version |
+      | 1               | 100             | new                       |
       | 2               | 200             | new                       |
 
   @issue-ocis-reva-336

--- a/tests/acceptance/features/bootstrap/PublicWebDavContext.php
+++ b/tests/acceptance/features/bootstrap/PublicWebDavContext.php
@@ -724,7 +724,10 @@ class PublicWebDavContext implements Context {
 			$password
 		);
 
-		$this->featureContext->downloadedContentShouldBe($expectedContent);
+		$this->featureContext->checkDownloadedContentMatches(
+			$expectedContent,
+			"Checking the content of the last public shared file after downloading with the $publicWebDAVAPIVersion public WebDAV API"
+		);
 
 		if ($techPreviewHadToBeEnabled) {
 			$this->occContext->disableDAVTechPreview();

--- a/tests/acceptance/features/bootstrap/WebDav.php
+++ b/tests/acceptance/features/bootstrap/WebDav.php
@@ -1147,16 +1147,32 @@ trait WebDav {
 	 * @return void
 	 */
 	public function downloadedContentShouldBe(string $content):void {
+		$this->checkDownloadedContentMatches($content);
+	}
+
+	/**
+	 * @param string $expectedContent
+	 * @param string $extraErrorText
+	 *
+	 * @return void
+	 */
+	public function checkDownloadedContentMatches(
+		string $expectedContent,
+		string $extraErrorText = ""
+	):void {
 		$actualContent = (string) $this->response->getBody();
 		// For this test we really care about the content.
 		// A separate "Then" step can specifically check the HTTP status.
 		// But if the content is wrong (e.g. empty) then it is useful to
 		// report the HTTP status to give some clue what might be the problem.
 		$actualStatus = $this->response->getStatusCode();
+		if ($extraErrorText !== "") {
+			$extraErrorText .= "\n";
+		}
 		Assert::assertEquals(
-			$content,
+			$expectedContent,
 			$actualContent,
-			"The downloaded content was expected to be '$content', but actually is '$actualContent'. HTTP status was $actualStatus"
+			$extraErrorText . "The downloaded content was expected to be '$expectedContent', but actually is '$actualContent'. HTTP status was $actualStatus"
 		);
 	}
 


### PR DESCRIPTION
## Description
See comment https://github.com/owncloud/ocis/issues/4262#issuecomment-1197707639 and old issue https://github.com/owncloud/ocis/issues/2079

We should not be running test steps with the "old" Public WebDAV API against oCIS or reva. The test scenario examples have been adjusted so that that does not happen.

I also added some enhancement to the test error reporting for `checkDownloadedContentMatches` so that it can emit more error text if something goes wrong. When looking in the test output from drone CI in `cs3org/reva` it was not 100% clear exactly what download method was being used when the content check failed.

## Related Issue
https://github.com/owncloud/ocis/issues/4262

## How Has This Been Tested?
CI

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Database schema changes (next release will require increase of minor version instead of patch)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [x] Tests only (no source changes)

## Checklist:
- [ ] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 
- [ ] Changelog item, see [TEMPLATE](https://github.com/owncloud/core/blob/master/changelog/TEMPLATE)
