### PR TITLE
[full-ci] [tests-only] Added tests for `MOVE` request to endpoints with body

### DIFF
--- a/tests/acceptance/features/apiAuthWebDav/webDavMOVEAuth.feature
+++ b/tests/acceptance/features/apiAuthWebDav/webDavMOVEAuth.feature
@@ -158,3 +158,24 @@ Feature: MOVE file/folder
       | /remote.php/webdav/PARENT                          |
       | /remote.php/dav/files/%username%/FOLDER            |
     Then the HTTP status code of responses on all endpoints should be "403"
+
+  @skipOnOcV10
+  Scenario: send MOVE requests to webDav endpoints with body as normal user
+    When user "Alice" requests these endpoints with "MOVE" including body "doesnotmatter" about user "Alice"
+      | endpoint                                           |
+      | /remote.php/webdav/textfile0.txt                   |
+      | /remote.php/dav/files/%username%/textfile0.txt     |
+      | /remote.php/webdav/PARENT                          |
+      | /remote.php/dav/files/%username%/PARENT            |
+      | /remote.php/webdav/PARENT/parent.txt               |
+      | /remote.php/dav/files/%username%/PARENT/parent.txt |
+    Then the HTTP status code of responses on all endpoints should be "415"
+
+  @skipOnOcV10 @personalSpace
+  Scenario: send MOVE requests to webDav endpoints with body as normal user using the spaces WebDAV API
+    When user "Alice" requests these endpoints with "MOVE" including body "doesnotmatter" about user "Alice"
+      | endpoint                                           |
+      | /remote.php/dav/spaces/%spaceid%/textfile0.txt     |
+      | /remote.php/dav/spaces/%spaceid%/PARENT            |
+      | /remote.php/dav/spaces/%spaceid%/PARENT/parent.txt |
+    Then the HTTP status code of responses on all endpoints should be "415"

--- a/tests/acceptance/features/apiAuthWebDav/webDavMOVEAuthOC10Issue40144.feature
+++ b/tests/acceptance/features/apiAuthWebDav/webDavMOVEAuthOC10Issue40144.feature
@@ -1,0 +1,24 @@
+@api @notToImplementOnOCIS
+Feature: MOVE file/folder
+
+  Background:
+    Given these users have been created with default attributes and without skeleton files:
+      | username |
+      | Alice    |
+      | Brian    |
+    And user "Alice" has uploaded file with content "some data" to "/textfile0.txt"
+    And user "Alice" has created folder "/PARENT"
+    And user "Alice" has created folder "/FOLDER"
+    And user "Alice" has uploaded file with content "some data" to "/PARENT/parent.txt"
+
+
+  Scenario: send MOVE requests to webDav endpoints with body as normal user
+    When user "Alice" requests these endpoints with "MOVE" including body "doesnotmatter" about user "Alice"
+      | endpoint                                           |
+      | /remote.php/webdav/textfile0.txt                   |
+      | /remote.php/dav/files/%username%/textfile0.txt     |
+      | /remote.php/webdav/PARENT                          |
+      | /remote.php/dav/files/%username%/PARENT            |
+      | /remote.php/webdav/PARENT/parent.txt               |
+      | /remote.php/dav/files/%username%/PARENT/parent.txt |
+    Then the HTTP status code of responses on all endpoints should be "403"


### PR DESCRIPTION
Signed-off-by: Prarup Gurung <grgprarup@gmail.com>

<!--
Thanks for submitting a change to ownCloud!

This is the bug tracker for the Server component. Find other components at https://github.com/owncloud/core/blob/master/.github/CONTRIBUTING.md#guidelines

For fixing potential security issues please see https://owncloud.com/security/

To make it possible for us to get your change reviewed and merged please carefully fill out the requested information below.

Please note that any kind of change needs first be submitted to the master branch which holds the next version of ownCloud.

Please set the following labels:

- Set label "3 - To review" for review or "2 - Development" if the PR still has open tasks
- Assignment: assign to self
- Milestone: set the same as the ticket this PR fixes, or "development" by default
- Reviewers: pick at least one
-->

## Description
This PR adds the test for the `MOVE` request to endpoints with body for `oCIS` backend and bug demonstration for `oC10` backend.

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
- Part of https://github.com/owncloud/core/issues/40144

## Motivation and Context
webDAV DELETE, COPY or MOVE requests should not send a body in the request.
https://datatracker.ietf.org/doc/html/rfc4918#section-8.4
If a body is sent, then the server is supposed to return HTTP status 415 (Unsupported Media Type).

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
- locally
- CI

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Database schema changes (next release will require increase of minor version instead of patch)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [x] Tests only (no source changes)

## Checklist:
<!-- Tick the checkboxes when done. -->
<!-- Raise documentation ticket in https://github.com/owncloud/documentation -->
- [ ] Code changes
- [ ] Unit tests added
- [x] Acceptance tests added
- [ ] Documentation ticket raised: <link> 
- [ ] Changelog item, see [TEMPLATE](https://github.com/owncloud/core/blob/master/changelog/TEMPLATE)
