### PR TITLE
[full-ci] Get extended attributes for user for apps

### DIFF
--- a/lib/private/User/DeletedUser.php
+++ b/lib/private/User/DeletedUser.php
@@ -238,4 +238,8 @@ class DeletedUser implements IUser {
 	public function getSearchTerms() {
 		return [];
 	}
+
+	public function getExtendedAttributes($clearCache = false) {
+		return [];
+	}
 }

--- a/lib/private/User/RemoteUser.php
+++ b/lib/private/User/RemoteUser.php
@@ -238,4 +238,12 @@ class RemoteUser implements IUser {
 	public function getAccountId() {
 		return null;
 	}
+
+	/**
+	 * @return array
+	 * @since 10.3.1
+	 */
+	public function getExtendedAttributes($clearCache = false) {
+		return [];
+	}
 }

--- a/lib/private/User/RemoteUser.php
+++ b/lib/private/User/RemoteUser.php
@@ -241,7 +241,7 @@ class RemoteUser implements IUser {
 
 	/**
 	 * @return array
-	 * @since 10.3.1
+	 * @since 10.11.0
 	 */
 	public function getExtendedAttributes($clearCache = false) {
 		return [];

--- a/lib/private/User/User.php
+++ b/lib/private/User/User.php
@@ -680,7 +680,7 @@ class User implements IUser {
 		 * using empty because userExtendedAttributes could either be null or empty array
 		 * or an array of attributes
 		 */
-		if ($clearCache || !isset($this->userExtendedAttributes) || [] === $this->userExtendedAttributes) {
+		if ($clearCache || !isset($this->userExtendedAttributes) || $this->userExtendedAttributes === []) {
 			$userExtendedAttributesEvent = new UserExtendedAttributesEvent($this);
 
 			/**

--- a/lib/private/User/User.php
+++ b/lib/private/User/User.php
@@ -670,7 +670,7 @@ class User implements IUser {
 	 * @param bool $clearCache, set to true if user attributes should be created every time, else false is set to reuse the userExtendedAttributes cache.
 	 * @return array
 	 * @throws NotPermittedActionException
-	 * @since 10.3.1
+	 * @since 10.11.0
 	 */
 	public function getExtendedAttributes($clearCache = false) {
 		if (!$this->allowUserAccountUpdate) {

--- a/lib/public/IUser.php
+++ b/lib/public/IUser.php
@@ -294,7 +294,7 @@ interface IUser {
 	 * @param bool $clearCache, set to true if user attributes should be created every time, else false is set to reuse the userExtendedAttributes cache.
 	 * @return array
 	 * @throws NotPermittedActionException
-	 * @since 10.3.1
+	 * @since 10.11.0
 	 */
 	public function getExtendedAttributes($clearCache = false);
 }

--- a/lib/public/User/NotPermittedActionException.php
+++ b/lib/public/User/NotPermittedActionException.php
@@ -1,0 +1,42 @@
+<?php
+/**
+ * @author Sujith Haridasan <sharidasan@owncloud.com>
+ *
+ * @copyright Copyright (c) 2019, ownCloud GmbH
+ * @license AGPL-3.0
+ *
+ * This code is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License, version 3,
+ * as published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License, version 3,
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>
+ *
+ */
+
+namespace OCP\User;
+
+/**
+ * Class NotPermitUserAccountException
+ *
+ * @package OCP
+ * @since 10.3.1
+ */
+class NotPermittedActionException extends \Exception {
+	/**
+	 * NotPermitUserAccountException constructor.
+	 *
+	 * @param string $message
+	 * @param int $code
+	 * @param \Exception|null $previous
+	 * @since 10.3.1
+	 */
+	public function __construct($message = "", $code = 0, \Exception $previous = null) {
+		parent::__construct($message, $code, $previous);
+	}
+}

--- a/lib/public/User/NotPermittedActionException.php
+++ b/lib/public/User/NotPermittedActionException.php
@@ -25,7 +25,7 @@ namespace OCP\User;
  * Class NotPermitUserAccountException
  *
  * @package OCP
- * @since 10.3.1
+ * @since 10.11.0
  */
 class NotPermittedActionException extends \Exception {
 	/**
@@ -34,7 +34,7 @@ class NotPermittedActionException extends \Exception {
 	 * @param string $message
 	 * @param int $code
 	 * @param \Exception|null $previous
-	 * @since 10.3.1
+	 * @since 10.11.0
 	 */
 	public function __construct($message = "", $code = 0, \Exception $previous = null) {
 		parent::__construct($message, $code, $previous);

--- a/lib/public/User/UserExtendedAttributesEvent.php
+++ b/lib/public/User/UserExtendedAttributesEvent.php
@@ -1,0 +1,98 @@
+<?php
+/**
+ * @author Sujith Haridasan <sharidasan@owncloud.com>
+ *
+ * @copyright Copyright (c) 2019, ownCloud GmbH
+ * @license AGPL-3.0
+ *
+ * This code is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License, version 3,
+ * as published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License, version 3,
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>
+ *
+ */
+
+// use OCP namespace for all classes that are considered public.
+// This means that they should be used by apps instead of the internal ownCloud classes
+namespace OCP\User;
+
+use OCP\IUser;
+use Symfony\Component\EventDispatcher\Event;
+
+/**
+ * Class UserExtendedAttributesEvent
+ *
+ * @package OCP\User
+ * @since 10.3.1
+ */
+class UserExtendedAttributesEvent extends Event {
+	const USER_EXTENDED_ATTRIBUTES = 'UserExtendedAttributesEvent';
+
+	/** @var array */
+	private $attributes = [];
+
+	/** @var IUser */
+	private $user;
+
+	/**
+	 * UserExtendedAttributesEvent constructor.
+	 *
+	 * @param IUser $user
+	 * @since 10.3.1
+	 */
+	public function __construct(IUser $user) {
+		$this->user = $user;
+	}
+
+	/**
+	 * get the user whose attributes are requested from the apps
+	 * This event is triggered from User object so the user object cannot be
+	 * null.
+	 *
+	 * @return IUser
+	 * @since 10.3.1
+	 */
+	public function getUser() {
+		return $this->user;
+	}
+
+	/**
+	 * Get the extended attributes of user
+	 * Returns the attributes array. This means it would return the
+	 * attributes of all apps which were set in this array.
+	 *
+	 * @return array
+	 * @since 10.3.1
+	 */
+	public function getAttributes() {
+		return $this->attributes;
+	}
+
+	/**
+	 * Set the attributes
+	 * Here the attributes of the app with key and value are set.
+	 * If the attributes are already present ( and not null value ), then the method
+	 * returns false. Else true is returned. If $attributeValue is null then false is returned
+	 * We are restricting null value assignment.
+	 *
+	 * @param string $attributeKey
+	 * @param mixed $attributeValue
+	 * @return bool true if the attribute is set by the method, else false if the attribute is already present
+	 * @since 10.3.1
+	 */
+	public function setAttributes($attributeKey, $attributeValue) {
+		if (isset($this->attributes[$attributeKey]) || $attributeValue === null) {
+			return false;
+		}
+
+		$this->attributes[$attributeKey] = $attributeValue;
+		return true;
+	}
+}

--- a/lib/public/User/UserExtendedAttributesEvent.php
+++ b/lib/public/User/UserExtendedAttributesEvent.php
@@ -33,7 +33,7 @@ use Symfony\Component\EventDispatcher\Event;
  * @since 10.3.1
  */
 class UserExtendedAttributesEvent extends Event {
-	const USER_EXTENDED_ATTRIBUTES = 'UserExtendedAttributesEvent';
+	public const USER_EXTENDED_ATTRIBUTES = 'UserExtendedAttributesEvent';
 
 	/** @var array */
 	private $attributes = [];

--- a/lib/public/User/UserExtendedAttributesEvent.php
+++ b/lib/public/User/UserExtendedAttributesEvent.php
@@ -30,7 +30,7 @@ use Symfony\Component\EventDispatcher\Event;
  * Class UserExtendedAttributesEvent
  *
  * @package OCP\User
- * @since 10.3.1
+ * @since 10.11.0
  */
 class UserExtendedAttributesEvent extends Event {
 	public const USER_EXTENDED_ATTRIBUTES = 'UserExtendedAttributesEvent';
@@ -45,7 +45,7 @@ class UserExtendedAttributesEvent extends Event {
 	 * UserExtendedAttributesEvent constructor.
 	 *
 	 * @param IUser $user
-	 * @since 10.3.1
+	 * @since 10.11.0
 	 */
 	public function __construct(IUser $user) {
 		$this->user = $user;
@@ -57,7 +57,7 @@ class UserExtendedAttributesEvent extends Event {
 	 * null.
 	 *
 	 * @return IUser
-	 * @since 10.3.1
+	 * @since 10.11.0
 	 */
 	public function getUser() {
 		return $this->user;
@@ -69,7 +69,7 @@ class UserExtendedAttributesEvent extends Event {
 	 * attributes of all apps which were set in this array.
 	 *
 	 * @return array
-	 * @since 10.3.1
+	 * @since 10.11.0
 	 */
 	public function getAttributes() {
 		return $this->attributes;
@@ -85,7 +85,7 @@ class UserExtendedAttributesEvent extends Event {
 	 * @param string $attributeKey
 	 * @param mixed $attributeValue
 	 * @return bool true if the attribute is set by the method, else false if the attribute is already present
-	 * @since 10.3.1
+	 * @since 10.11.0
 	 */
 	public function setAttributes($attributeKey, $attributeValue) {
 		if (isset($this->attributes[$attributeKey]) || $attributeValue === null) {

--- a/tests/lib/App/ManagerTest.php
+++ b/tests/lib/App/ManagerTest.php
@@ -651,4 +651,15 @@ class ManagerTest extends TestCase {
 			],
 		];
 	}
+
+	/**
+	 * This test is to make sure if the app is not whitelisted then the app will
+	 * not be enabled for the user. The checkAppForUser would return false.
+	 */
+	public function testCheckAppNotForGuestUser() {
+		$user = $this->createMock(IUser::class);
+		$user->method('getExtendedAttributes')
+			->willReturn(['whitelistedAppsForGuests' => ['foo', 'bar']]);
+		$this->assertFalse($this->invokePrivate($this->manager, 'checkAppForUser', [true, 'foobar', $user]));
+	}
 }

--- a/tests/lib/User/UserExtendedAttributesEventTest.php
+++ b/tests/lib/User/UserExtendedAttributesEventTest.php
@@ -32,7 +32,7 @@ class UserExtendedAttributesEventTest extends TestCase {
 	/** @var UserExtendedAttributesEvent | \PHPUnit\Framework\MockObject\MockObject */
 	private $userExtendedAttributesEvent;
 
-	public function setUp() {
+	public function setUp(): void {
 		parent::setUp();
 
 		$this->user = $this->createMock(IUser::class);

--- a/tests/lib/User/UserExtendedAttributesEventTest.php
+++ b/tests/lib/User/UserExtendedAttributesEventTest.php
@@ -1,0 +1,61 @@
+<?php
+/**
+ * @author Sujith Haridasan <sharidasan@owncloud.com>
+ *
+ * @copyright Copyright (c) 2019, ownCloud GmbH
+ * @license AGPL-3.0
+ *
+ * This code is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License, version 3,
+ * as published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License, version 3,
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>
+ *
+ */
+
+namespace Test\User;
+
+use OCP\IUser;
+use OCP\User\UserExtendedAttributesEvent;
+use Test\TestCase;
+
+class UserExtendedAttributesEventTest extends TestCase {
+	/** @var IUser | \PHPUnit\Framework\MockObject\MockObject */
+	private $user;
+
+	/** @var UserExtendedAttributesEvent | \PHPUnit\Framework\MockObject\MockObject */
+	private $userExtendedAttributesEvent;
+
+	public function setUp() {
+		parent::setUp();
+
+		$this->user = $this->createMock(IUser::class);
+		$this->userExtendedAttributesEvent = new UserExtendedAttributesEvent($this->user);
+	}
+
+	/**
+	 * This test is to get the user whose extended attributes are to be fetched
+	 */
+	public function testGetUser() {
+		$this->assertSame($this->userExtendedAttributesEvent->getUser(), $this->user);
+	}
+
+	public function testSetAttributesDuplicateKey() {
+		$this->userExtendedAttributesEvent->setAttributes('one', [1,2,3]);
+		$this->assertFalse($this->userExtendedAttributesEvent->setAttributes('one', [4, 5, 6]));
+	}
+
+	public function testSetGetAttributes() {
+		$this->userExtendedAttributesEvent->setAttributes('one', [1,2]);
+		$this->assertEquals($this->userExtendedAttributesEvent->getAttributes(), ['one' => [1, 2]]);
+
+		$this->userExtendedAttributesEvent->setAttributes('two', 'another test');
+		$this->assertEquals($this->userExtendedAttributesEvent->getAttributes(), ['one' => [1, 2], 'two' => 'another test']);
+	}
+}

--- a/tests/lib/User/UserTest.php
+++ b/tests/lib/User/UserTest.php
@@ -21,6 +21,8 @@ use OC\User\User;
 use OCP\IConfig;
 use OCP\IURLGenerator;
 use OCP\User\IChangePasswordBackend;
+use OCP\User\NotPermittedActionException;
+use OCP\User\UserExtendedAttributesEvent;
 use Symfony\Component\EventDispatcher\EventDispatcher;
 use Symfony\Component\EventDispatcher\GenericEvent;
 use Test\TestCase;
@@ -580,5 +582,180 @@ class UserTest extends TestCase {
 			'normal terms' => [['term1'], ['term1']],
 			'too long terms' => [['term1', \str_repeat(".", 192)], ['term1', \str_repeat(".", 191)]]
 		];
+	}
+
+	public function providesClearCache() {
+		return [
+			[true],
+			[false],
+		];
+	}
+
+	/**
+	 * @dataProvider providesClearCache
+	 * @param bool $clearCache
+	 */
+	public function testGetExtendedAttributes($clearCache) {
+		$userExtendedAttributesEvent = new UserExtendedAttributesEvent($this->user);
+
+		$this->eventDispatcher->expects($this->once())
+			->method('dispatch')
+			->with(UserExtendedAttributesEvent::USER_EXTENDED_ATTRIBUTES, $userExtendedAttributesEvent);
+
+		$this->assertEquals($this->user->getExtendedAttributes($clearCache), []);
+	}
+
+	/**
+	 * @expectedException \OCP\User\NotPermittedActionException
+	 * @throws NotPermittedActionException
+	 */
+	public function testGetExtendedAttributesForException() {
+		$userExtendedAttributesEvent = new UserExtendedAttributesEvent($this->user);
+
+		$this->eventDispatcher->expects($this->once())
+			->method('dispatch')
+			->with(UserExtendedAttributesEvent::USER_EXTENDED_ATTRIBUTES, $userExtendedAttributesEvent)
+			->willThrowException(new NotPermittedActionException());
+
+		$this->user->getExtendedAttributes();
+	}
+
+	/**
+	 * In a normal execution test if the allowUserAccountUpdate is set to true
+	 * after the event is emitted.
+	 *
+	 * @throws NotPermittedActionException
+	 */
+	public function testAllowUserAccountUpdateFlagNormalExecution() {
+		$userExtendedAttributesEvent = new UserExtendedAttributesEvent($this->user);
+		$this->eventDispatcher->expects($this->once())
+			->method('dispatch')
+			->with(UserExtendedAttributesEvent::USER_EXTENDED_ATTRIBUTES, $userExtendedAttributesEvent);
+
+		$this->user->getExtendedAttributes();
+		$value = $this->invokePrivate($this->user, 'allowUserAccountUpdate');
+		$this->assertTrue($value);
+	}
+
+	/**
+	 * Verify the value of allowUserAccountUpdate after NotPermittedActionException is thrown.
+	 * It should be set back to true.
+	 */
+	public function testAllowUserAccountUpdateFlagAfterException() {
+		$userExtendedAttributesEvent = new UserExtendedAttributesEvent($this->user);
+		$this->eventDispatcher->expects($this->once())
+			->method('dispatch')
+			->with(UserExtendedAttributesEvent::USER_EXTENDED_ATTRIBUTES, $userExtendedAttributesEvent)
+			->willThrowException(new NotPermittedActionException());
+
+		try {
+			$this->user->getExtendedAttributes();
+		} catch (NotPermittedActionException $ex) {
+			$value = $this->invokePrivate($this->user, 'allowUserAccountUpdate');
+			$this->assertTrue($value);
+		}
+	}
+
+	/**
+	 * Test for allowUserAccountUpdate when a random exception is thrown, the value
+	 * should be set back to true.
+	 */
+	public function testAllowUserAccountUpdateFlagAfterRandomException() {
+		$userExtendedAttributesEvent = new UserExtendedAttributesEvent($this->user);
+		$this->eventDispatcher->expects($this->once())
+			->method('dispatch')
+			->with(UserExtendedAttributesEvent::USER_EXTENDED_ATTRIBUTES, $userExtendedAttributesEvent)
+			->willThrowException(new \Exception());
+
+		try {
+			$this->user->getExtendedAttributes();
+		} catch (\Exception $ex) {
+			$value = $this->invokePrivate($this->user, 'allowUserAccountUpdate');
+			$this->assertTrue($value);
+		}
+	}
+
+	/**
+	 * Test to check no infinite loop is possible when getExtendedAttributes is called.
+	 * So lets say the listener of the event cannot call getExtendedAttributes again.
+	 */
+	public function testGetExtendedAttributesNoInfiniteLoop() {
+		$userExtendedAttributesEvent = new UserExtendedAttributesEvent($this->user);
+		$this->eventDispatcher->expects($this->once())
+			->method('dispatch')
+			->with(UserExtendedAttributesEvent::USER_EXTENDED_ATTRIBUTES, $userExtendedAttributesEvent)
+			->will($this->returnCallback(function () {
+				$this->user->getExtendedAttributes();
+			}));
+
+		try {
+			$this->user->getExtendedAttributes();
+		} catch (NotPermittedActionException $ex) {
+			$value = $this->invokePrivate($this->user, 'allowUserAccountUpdate');
+			$this->assertTrue($value);
+		}
+	}
+
+	/**
+	 * @expectedException \OCP\User\NotPermittedActionException
+	 * @throws NotPermittedActionException
+	 */
+	public function testSetSearchTermsForException() {
+		$this->invokePrivate($this->user, 'allowUserAccountUpdate', [false]);
+		$this->user->setSearchTerms(['foo']);
+	}
+
+	/**
+	 * @expectedException \OCP\User\NotPermittedActionException
+	 * @throws NotPermittedActionException
+	 */
+	public function testSetQuotaForException() {
+		$this->invokePrivate($this->user, 'allowUserAccountUpdate', [false]);
+		$this->user->setQuota('12M');
+	}
+
+	/**
+	 * @expectedException \OCP\User\NotPermittedActionException
+	 * @throws NotPermittedActionException
+	 */
+	public function testSetEmailAddressForException() {
+		$this->invokePrivate($this->user, 'allowUserAccountUpdate', [false]);
+		$this->user->setEMailAddress('foo@bar.com');
+	}
+
+	/**
+	 * @expectedException \OCP\User\NotPermittedActionException
+	 * @throws NotPermittedActionException
+	 */
+	public function testSetEnabledForException() {
+		$this->invokePrivate($this->user, 'allowUserAccountUpdate', [false]);
+		$this->user->setEnabled(true);
+	}
+
+	/**
+	 * @expectedException \OCP\User\NotPermittedActionException
+	 * @throws NotPermittedActionException
+	 */
+	public function testSetPasswordForException() {
+		$this->invokePrivate($this->user, 'allowUserAccountUpdate', [false]);
+		$this->user->setPassword('foobar');
+	}
+
+	/**
+	 * @expectedException \OCP\User\NotPermittedActionException
+	 * @throws NotPermittedActionException
+	 */
+	public function testSetDisplayNameForException() {
+		$this->invokePrivate($this->user, 'allowUserAccountUpdate', [false]);
+		$this->user->setDisplayName('FooBar');
+	}
+
+	/**
+	 * @expectedException \OCP\User\NotPermittedActionException
+	 * @throws NotPermittedActionException
+	 */
+	public function testSetUserNameForException() {
+		$this->invokePrivate($this->user, 'allowUserAccountUpdate', [false]);
+		$this->user->setUserName('Foo');
 	}
 }

--- a/tests/lib/User/UserTest.php
+++ b/tests/lib/User/UserTest.php
@@ -606,10 +606,11 @@ class UserTest extends TestCase {
 	}
 
 	/**
-	 * @expectedException \OCP\User\NotPermittedActionException
 	 * @throws NotPermittedActionException
 	 */
 	public function testGetExtendedAttributesForException() {
+		$this->expectException(\OCP\User\NotPermittedActionException::class);
+
 		$userExtendedAttributesEvent = new UserExtendedAttributesEvent($this->user);
 
 		$this->eventDispatcher->expects($this->once())
@@ -697,64 +698,71 @@ class UserTest extends TestCase {
 	}
 
 	/**
-	 * @expectedException \OCP\User\NotPermittedActionException
 	 * @throws NotPermittedActionException
 	 */
 	public function testSetSearchTermsForException() {
+		$this->expectException(\OCP\User\NotPermittedActionException::class);
+
 		$this->invokePrivate($this->user, 'allowUserAccountUpdate', [false]);
 		$this->user->setSearchTerms(['foo']);
 	}
 
 	/**
-	 * @expectedException \OCP\User\NotPermittedActionException
 	 * @throws NotPermittedActionException
 	 */
 	public function testSetQuotaForException() {
+		$this->expectException(\OCP\User\NotPermittedActionException::class);
+
 		$this->invokePrivate($this->user, 'allowUserAccountUpdate', [false]);
 		$this->user->setQuota('12M');
 	}
 
 	/**
-	 * @expectedException \OCP\User\NotPermittedActionException
 	 * @throws NotPermittedActionException
 	 */
 	public function testSetEmailAddressForException() {
+		$this->expectException(\OCP\User\NotPermittedActionException::class);
+
 		$this->invokePrivate($this->user, 'allowUserAccountUpdate', [false]);
 		$this->user->setEMailAddress('foo@bar.com');
 	}
 
 	/**
-	 * @expectedException \OCP\User\NotPermittedActionException
 	 * @throws NotPermittedActionException
 	 */
 	public function testSetEnabledForException() {
+		$this->expectException(\OCP\User\NotPermittedActionException::class);
+
 		$this->invokePrivate($this->user, 'allowUserAccountUpdate', [false]);
 		$this->user->setEnabled(true);
 	}
 
 	/**
-	 * @expectedException \OCP\User\NotPermittedActionException
 	 * @throws NotPermittedActionException
 	 */
 	public function testSetPasswordForException() {
+		$this->expectException(\OCP\User\NotPermittedActionException::class);
+
 		$this->invokePrivate($this->user, 'allowUserAccountUpdate', [false]);
 		$this->user->setPassword('foobar');
 	}
 
 	/**
-	 * @expectedException \OCP\User\NotPermittedActionException
 	 * @throws NotPermittedActionException
 	 */
 	public function testSetDisplayNameForException() {
+		$this->expectException(\OCP\User\NotPermittedActionException::class);
+
 		$this->invokePrivate($this->user, 'allowUserAccountUpdate', [false]);
 		$this->user->setDisplayName('FooBar');
 	}
 
 	/**
-	 * @expectedException \OCP\User\NotPermittedActionException
 	 * @throws NotPermittedActionException
 	 */
 	public function testSetUserNameForException() {
+		$this->expectException(\OCP\User\NotPermittedActionException::class);
+
 		$this->invokePrivate($this->user, 'allowUserAccountUpdate', [false]);
 		$this->user->setUserName('Foo');
 	}


### PR DESCRIPTION
## Description

Get extended attributes for user from the apps. A
new method which emits events to get the attributes
for user, which is listened by apps to provide the
attributes for the specific user. Use case for example:
When apps are not whitelisted for guest user
they should not be visible in the personal settings.

Signed-off-by: Sujith H <sharidasan@owncloud.com>

This is a rebase of #36258 - needs review and decision if it is wanted.

## Related Issue

## Motivation
Do not show the apps which are not whitelisted for the guest user.

## How Has This Been Tested?
- Enable customgroups. Make sure its not listed as whitelisted apps in guest configuration.
- As guest user navigate to the settings page.
- The settings page should not show customgroups. And it does not.

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Database schema changes (next release will require increase of minor version instead of patch)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [ ] Tests only (no source changes)

## Checklist:
- [x] Code changes
- [x] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 
- [ ] Changelog item, see [TEMPLATE](https://github.com/owncloud/core/blob/master/changelog/TEMPLATE)
