### PR TITLE
config.apps.sample changes

### DIFF
--- a/config/config.apps.sample.php
+++ b/config/config.apps.sample.php
@@ -324,19 +324,6 @@ $CONFIG = [
  *
  * token-introspection-endpoint-client-secret::
  * Client secret to be used with the token introspection endpoint.
- *
- * use-access-token-payload-for-user-info::
- * If set to `true` any user information will be read from the access token.
- * If set to `false` the userinfo endpoint is used (starting app version 1.1.0).
- *
- * use-token-introspection-endpoint::
- * If set to `true`, the token introspection endpoint is used to verify a given access
- * token - only needed if the access token is not a JWT. If set to `false`, the userinfo
- * endpoint is used (requires version >= 1.1.0)
- * Tokens which are not JSON WebToken (JWT) may not have information like the
- * expiry. In these cases, the OpenID Connect Provider needs to call on the token
- * introspection endpoint to get this information. The default value is `false`. See
- * https://datatracker.ietf.org/doc/html/rfc7662 for more information on token introspection.
  */
 
 /**
@@ -415,8 +402,7 @@ $CONFIG = [
 		'token_endpoint_auth_methods_supported' => '...',
 		'userinfo_endpoint' => '...'
 	],
-	'provider-url' => '...',
-	'use-token-introspection-endpoint' => true
+	'provider-url' => '...'
 ],
 
 /**
@@ -431,7 +417,6 @@ $CONFIG = [
 	'loginButtonName' => 'node-oidc-provider',
 	'mode' => 'userid',
 	'search-attribute' => 'sub',
-	'use-token-introspection-endpoint' => true,
 	  // do not verify tls host or peer
 	'insecure' => true
 ],


### PR DESCRIPTION
## Description
Necessary config.apps.sample changes.
Removed the the keys and description for:
`use-token-introspection-endpoint`
`use-access-token-payload-for-user-info`

## Related Issue
- References [feat: JWT token will always be used for user info, expiry and verification](https://github.com/owncloud/openidconnect/pull/243)

Needs merging of the above PR first.

## Motivation and Context
Completeness of docs

## How Has This Been Tested?
- Text change only

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Database schema changes (next release will require increase of minor version instead of patch)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [ ] Tests only (no source changes)

## Checklist:
<!-- Tick the checkboxes when done. -->
<!-- Raise documentation ticket in https://github.com/owncloud/documentation -->
- [ ] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [x] Documentation ticket raised: 
[config.apps.sample needs an update when openidconnect PR gets merged](https://github.com/owncloud/docs-server/issues/561) 
- [ ] Changelog item, see [TEMPLATE](https://github.com/owncloud/core/blob/master/changelog/TEMPLATE)
