### PR TITLE
Only call getGroupDetails if the group exists in the backend

### DIFF
--- a/changelog/unreleased/40261
+++ b/changelog/unreleased/40261
@@ -1,0 +1,7 @@
+Bugfix: Only call getGroupDetails when the group exists
+
+When getting a group, the getGroupDetails method could be called for a group
+that does not exist. That is unnecessary and may cause a group backend implementation
+to log an error. The code has been refactored to avoid this happening.
+
+https://github.com/owncloud/core/pull/40261

--- a/lib/private/Group/Manager.php
+++ b/lib/private/Group/Manager.php
@@ -176,17 +176,17 @@ class Manager extends PublicEmitter implements IGroupManager {
 	protected function getGroupObject($gid, $displayName = null) {
 		$backends = [];
 		foreach ($this->backends as $backend) {
-			if ($backend->implementsActions(\OC\Group\Backend::GROUP_DETAILS)) {
-				/* @phan-suppress-next-line PhanUndeclaredMethod */
-				$groupData = $backend->getGroupDetails($gid);
-				if (\is_array($groupData)) {
-					// take the display name from the first backend that has a non-null one
-					if ($displayName === null && isset($groupData['displayName'])) {
-						$displayName = $groupData['displayName'];
+			if ($backend->groupExists($gid)) {
+				if ($backend->implementsActions(\OC\Group\Backend::GROUP_DETAILS)) {
+					/* @phan-suppress-next-line PhanUndeclaredMethod */
+					$groupData = $backend->getGroupDetails($gid);
+					if (\is_array($groupData)) {
+						// take the display name from the first backend that has a non-null one
+						if ($displayName === null && isset($groupData['displayName'])) {
+							$displayName = $groupData['displayName'];
+						}
 					}
-					$backends[] = $backend;
 				}
-			} elseif ($backend->groupExists($gid)) {
 				$backends[] = $backend;
 			}
 		}

--- a/tests/lib/Group/ManagerTest.php
+++ b/tests/lib/Group/ManagerTest.php
@@ -1159,6 +1159,9 @@ class ManagerTest extends \Test\TestCase {
 			GroupInterface::GROUP_DETAILS
 		);
 		$backend->expects($this->any())
+			->method('groupExists')
+			->will($this->returnValue(true));
+		$backend->expects($this->any())
 			->method('getGroupDetails')
 			->will($this->returnValueMap([
 				['group1', ['gid' => 'group1', 'displayName' => 'Group One']],


### PR DESCRIPTION
## Description
When getting a group, the getGroupDetails method could be called for a group that does not exist. That is unnecessary and may cause a group backend implementation to log an error. The code has been refactored to avoid this happening.

This was noticed while developing user_ldap changes related to group display names. See my comment: https://github.com/owncloud/user_ldap/pull/748#issuecomment-1202899346

## Related Issue
None

## How Has This Been Tested?
CI - all existing group-related unit and acceptance tests are passing.

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Database schema changes (next release will require increase of minor version instead of patch)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [ ] Tests only (no source changes)

## Checklist:
- [ ] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 
- [x] Changelog item, see [TEMPLATE](https://github.com/owncloud/core/blob/master/changelog/TEMPLATE)
