### PR TITLE
[tests-only][full-ci]Remove spaces related tests with /Shares for checksum from core

### DIFF
--- a/tests/acceptance/features/apiMain/checksums.feature
+++ b/tests/acceptance/features/apiMain/checksums.feature
@@ -205,11 +205,6 @@ Feature: checksums
       | dav_version |
       | new         |
 
-    @skipOnOcV10 @personalSpace
-    Examples:
-      | dav_version |
-      | spaces      |
-
   @files_sharing-app-required
   @issue-ocis-reva-196 @skipOnOcV10
   Scenario Outline: Modifying a shared file should return correct checksum in the propfind using new DAV path
@@ -226,11 +221,6 @@ Feature: checksums
     Examples:
       | dav_version | checksum                                                                                            |
       | new         | SHA1:ce5582148c6f0c1282335b87df5ed4be4b781399 MD5:56e57920c3c8c727bfe7a5288cdf61c4 ADLER32:1048035a |
-
-    @personalSpace
-    Examples:
-      | dav_version | checksum                                                                                            |
-      | spaces      | SHA1:3ee962b839762adb0ad8ba6023a4690be478de6f MD5:d70b40f177b14b470d1756a3c12b963a ADLER32:8ae90960 |
 
   @issue-ocis-reva-56 @notToImplementOnOCIS @newChunking @issue-ocis-1321
   Scenario: Upload new DAV chunked file where checksum matches


### PR DESCRIPTION
## Description
The `/Shares` related for the `spaces` WebDAV is removed from core since this is to be implemented and run on ocis.

## Related Issue
https://github.com/owncloud/ocis/issues/4154#issuecomment-1206026045

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
- Locally
- CI

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Database schema changes (next release will require increase of minor version instead of patch)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [ ] Tests only (no source changes)

## Checklist:
<!-- Tick the checkboxes when done. -->
<!-- Raise documentation ticket in https://github.com/owncloud/documentation -->
- [ ] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 
- [ ] Changelog item, see [TEMPLATE](https://github.com/owncloud/core/blob/master/changelog/TEMPLATE)
