### PR TITLE
[tests-only] [full-ci] Check the file content in test step 'uploading a file should work'

### DIFF
--- a/tests/acceptance/features/bootstrap/PublicWebDavContext.php
+++ b/tests/acceptance/features/bootstrap/PublicWebDavContext.php
@@ -1215,9 +1215,9 @@ class PublicWebDavContext implements Context {
 		);
 		$this->shouldBeAbleToDownloadFileInsidePublicSharedFolder(
 			$path,
-			$publicWebDAVAPIVersion,
-			$content
+			$publicWebDAVAPIVersion
 		);
+		$this->featureContext->checkDownloadedContentMatches($content);
 
 		if ($techPreviewHadToBeEnabled) {
 			$this->occContext->disableDAVTechPreview();


### PR DESCRIPTION
## Description
Test method `shouldBeAbleToDownloadFileInsidePublicSharedFolder` actually only takes 2 parameters. The code was trying to pass a 3rd parameter `$content` but that is not used.

Add extra code to `shouldBeAbleToDownloadFileInsidePublicSharedFolder` to check that the downloaded file has the expected new content that was just uploaded.

I noticed this while working on a PR that touches public link uploading.

## How Has This Been Tested?
CI

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Database schema changes (next release will require increase of minor version instead of patch)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [x] Tests only (no source changes)

## Checklist:
- [ ] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 
- [ ] Changelog item, see [TEMPLATE](https://github.com/owncloud/core/blob/master/changelog/TEMPLATE)
