### PR TITLE
[tests-only][full-ci]Remove spaces tests with /shares on path from apiShareOperationsToShares2/getWebDAVSharePermissions.feature

### DIFF
--- a/tests/acceptance/features/apiShareOperationsToShares2/getWebDAVSharePermissions.feature
+++ b/tests/acceptance/features/apiShareOperationsToShares2/getWebDAVSharePermissions.feature
@@ -45,11 +45,6 @@ Feature: sharing
       | old      |
       | new      |
 
-    @skipOnOcV10 @personalSpace
-    Examples:
-      | dav-path |
-      | spaces   |
-
 
   Scenario Outline: Correct webdav share-permissions for received group shared file with edit and reshare permissions
     Given using <dav-path> DAV path
@@ -72,11 +67,6 @@ Feature: sharing
       | old      |
       | new      |
 
-    @skipOnOcV10 @personalSpace
-    Examples:
-      | dav-path |
-      | spaces   |
-
   @issue-ocis-2213
   Scenario Outline: Correct webdav share-permissions for received file with edit permissions but no reshare permissions
     Given using <dav-path> DAV path
@@ -91,11 +81,6 @@ Feature: sharing
       | dav-path |
       | old      |
       | new      |
-
-    @skipOnOcV10 @personalSpace
-    Examples:
-      | dav-path |
-      | spaces   |
 
   @issue-ocis-2213
   Scenario Outline: Correct webdav share-permissions for received group shared file with edit permissions but no reshare permissions
@@ -119,11 +104,6 @@ Feature: sharing
       | old      |
       | new      |
 
-    @skipOnOcV10 @personalSpace
-    Examples:
-      | dav-path |
-      | spaces   |
-
   @issue-ocis-2213
   Scenario Outline: Correct webdav share-permissions for received file with reshare permissions but no edit permissions
     Given using <dav-path> DAV path
@@ -138,12 +118,6 @@ Feature: sharing
       | dav-path |
       | old      |
       | new      |
-
-    @skipOnOcV10 @personalSpace
-    Examples:
-      | dav-path |
-      | spaces   |
-
 
   Scenario Outline: Correct webdav share-permissions for received group shared file with reshare permissions but no edit permissions
     Given using <dav-path> DAV path
@@ -165,12 +139,6 @@ Feature: sharing
       | dav-path |
       | old      |
       | new      |
-
-    @skipOnOcV10 @personalSpace
-    Examples:
-      | dav-path |
-      | spaces   |
-
 
   Scenario Outline: Correct webdav share-permissions for owned folder
     Given using <dav-path> DAV path
@@ -206,11 +174,6 @@ Feature: sharing
       | old      |
       | new      |
 
-    @skipOnOcV10 @personalSpace
-    Examples:
-      | dav-path |
-      | spaces   |
-
 
   Scenario Outline: Correct webdav share-permissions for received group shared folder with all permissions
     Given using <dav-path> DAV path
@@ -232,11 +195,6 @@ Feature: sharing
       | old      |
       | new      |
 
-    @skipOnOcV10 @personalSpace
-    Examples:
-      | dav-path |
-      | spaces   |
-
   @issue-ocis-2213
   Scenario Outline: Correct webdav share-permissions for received folder with all permissions but edit
     Given using <dav-path> DAV path
@@ -251,11 +209,6 @@ Feature: sharing
       | dav-path |
       | old      |
       | new      |
-
-    @skipOnOcV10 @personalSpace
-    Examples:
-      | dav-path |
-      | spaces   |
 
 
   Scenario Outline: Correct webdav share-permissions for received group shared folder with all permissions but edit
@@ -279,11 +232,6 @@ Feature: sharing
       | old      |
       | new      |
 
-    @skipOnOcV10 @personalSpace
-    Examples:
-      | dav-path |
-      | spaces   |
-
 
   Scenario Outline: Correct webdav share-permissions for received folder with all permissions but create
     Given using <dav-path> DAV path
@@ -298,11 +246,6 @@ Feature: sharing
       | dav-path |
       | old      |
       | new      |
-
-    @skipOnOcV10 @personalSpace
-    Examples:
-      | dav-path |
-      | spaces   |
 
 
   Scenario Outline: Correct webdav share-permissions for received group shared folder with all permissions but create
@@ -326,11 +269,6 @@ Feature: sharing
       | old      |
       | new      |
 
-    @skipOnOcV10 @personalSpace
-    Examples:
-      | dav-path |
-      | spaces   |
-
 
   Scenario Outline: Correct webdav share-permissions for received folder with all permissions but delete
     Given using <dav-path> DAV path
@@ -345,11 +283,6 @@ Feature: sharing
       | dav-path |
       | old      |
       | new      |
-
-    @skipOnOcV10 @personalSpace
-    Examples:
-      | dav-path |
-      | spaces   |
 
 
   Scenario Outline: Correct webdav share-permissions for received group shared folder with all permissions but delete
@@ -373,11 +306,6 @@ Feature: sharing
       | old      |
       | new      |
 
-    @skipOnOcV10 @personalSpace
-    Examples:
-      | dav-path |
-      | spaces   |
-
 
   Scenario Outline: Correct webdav share-permissions for received folder with all permissions but share
     Given using <dav-path> DAV path
@@ -392,11 +320,6 @@ Feature: sharing
       | dav-path |
       | old      |
       | new      |
-
-    @skipOnOcV10 @personalSpace
-    Examples:
-      | dav-path |
-      | spaces   |
 
 
   Scenario Outline: Correct webdav share-permissions for received group shared folder with all permissions but share
@@ -419,8 +342,3 @@ Feature: sharing
       | dav-path |
       | old      |
       | new      |
-
-    @skipOnOcV10 @personalSpace
-    Examples:
-      | dav-path |
-      | spaces   |


### PR DESCRIPTION

<!--
Thanks for submitting a change to ownCloud!

This is the bug tracker for the Server component. Find other components at https://github.com/owncloud/core/blob/master/.github/CONTRIBUTING.md#guidelines

For fixing potential security issues please see https://owncloud.com/security/

To make it possible for us to get your change reviewed and merged please carefully fill out the requested information below.

Please note that any kind of change needs first be submitted to the master branch which holds the next version of ownCloud.

Please set the following labels:

- Set label "3 - To review" for review or "2 - Development" if the PR still has open tasks
- Assignment: assign to self
- Milestone: set the same as the ticket this PR fixes, or "development" by default
- Reviewers: pick at least one
-->

## Description
This PR removes the tests with `/shares` on path for `spaces` endpoint as there no `shares` there and as spaces will never be implemented in `oc10` these tests don't have any relevance here. The removed tests will be added to ocis as local API tests.

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
- part of: https://github.com/owncloud/ocis/issues/4154

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
- locally 
- ci

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Database schema changes (next release will require increase of minor version instead of patch)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [x] Tests only (no source changes)

## Checklist:
<!-- Tick the checkboxes when done. -->
<!-- Raise documentation ticket in https://github.com/owncloud/documentation -->
- [ ] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 
- [ ] Changelog item, see [TEMPLATE](https://github.com/owncloud/core/blob/master/changelog/TEMPLATE)
