### PR TITLE
[tests-only][full-ci]Remove /Shares related tests from core for copy properties

### DIFF
--- a/tests/acceptance/features/apiWebdavProperties1/copyFile.feature
+++ b/tests/acceptance/features/apiWebdavProperties1/copyFile.feature
@@ -83,11 +83,6 @@ Feature: copy file
       | old         |
       | new         |
 
-    @skipOnOcV10 @personalSpace
-    Examples:
-      | dav_version |
-      | spaces      |
-
   @files_sharing-app-required
   @issue-ocis-reva-11 @skipOnOcV10.6 @skipOnOcV10.7 @skipOnOcV10.8.0
   Scenario Outline: Copying a file to overwrite a file into a folder with no permissions
@@ -109,11 +104,6 @@ Feature: copy file
       | dav_version |
       | old         |
       | new         |
-
-    @skipOnOcV10 @personalSpace
-    Examples:
-      | dav_version |
-      | spaces      |
 
   @issue-ocis-reva-15
   Scenario Outline: Copying file to a path with extension .part should not be possible
@@ -286,11 +276,6 @@ Feature: copy file
       | old         |
       | new         |
 
-    @skipOnOcV10 @personalSpace
-    Examples:
-      | dav_version |
-      | spaces      |
-
   @issue-ocis-1239 @skipOnOcV10.6 @skipOnOcV10.7 @skipOnOcV10.8.0
   Scenario Outline: copy a folder over the top of an existing file received as a user share
     Given using <dav_version> DAV path
@@ -308,11 +293,6 @@ Feature: copy file
       | dav_version |
       | old         |
       | new         |
-
-    @skipOnOcV10 @personalSpace
-    Examples:
-      | dav_version |
-      | spaces      |
 
   @issue-ocis-1239 @skipOnOcV10.6 @skipOnOcV10.7 @skipOnOcV10.8.0
   Scenario Outline: copy a folder into another folder at different level which is received as a user share
@@ -336,11 +316,6 @@ Feature: copy file
       | dav_version |
       | old         |
       | new         |
-
-    @skipOnOcV10 @personalSpace
-    Examples:
-      | dav_version |
-      | spaces      |
 
   @issue-ocis-1239 @skipOnOcV10.6 @skipOnOcV10.7 @skipOnOcV10.8.0
   Scenario Outline: copy a file into a folder at different level received as a user share
@@ -367,11 +342,6 @@ Feature: copy file
       | old         |
       | new         |
 
-    @skipOnOcV10 @personalSpace
-    Examples:
-      | dav_version |
-      | spaces      |
-
   @issue-ocis-1239 @skipOnOcV10.6 @skipOnOcV10.7 @skipOnOcV10.8.0
   Scenario Outline: copy a file into a file at different level received as a user share
     Given using <dav_version> DAV path
@@ -396,11 +366,6 @@ Feature: copy file
       | old         |
       | new         |
 
-    @skipOnOcV10 @personalSpace
-    Examples:
-      | dav_version |
-      | spaces      |
-
   @issue-ocis-1239 @skipOnOcV10.6 @skipOnOcV10.7 @skipOnOcV10.8.0
   Scenario Outline: copy a folder into a file at different level received as a user share
     Given using <dav_version> DAV path
@@ -424,11 +389,6 @@ Feature: copy file
       | dav_version |
       | old         |
       | new         |
-
-    @skipOnOcV10 @personalSpace
-    Examples:
-      | dav_version |
-      | spaces      |
 
   @issue-ocis-1239 @skipOnOcV10.6 @skipOnOcV10.7 @skipOnOcV10.8.0
   Scenario Outline: copy a file over the top of an existing folder received as a group share
@@ -509,11 +469,6 @@ Feature: copy file
       | old         |
       | new         |
 
-    @skipOnOcV10 @personalSpace
-    Examples:
-      | dav_version |
-      | spaces      |
-
   @issue-ocis-1239 @skipOnOcV10.6 @skipOnOcV10.7 @skipOnOcV10.8.0
   Scenario Outline: copy a file into a folder at different level received as a group share
     Given using <dav_version> DAV path
@@ -542,11 +497,6 @@ Feature: copy file
       | old         |
       | new         |
 
-    @skipOnOcV10 @personalSpace
-    Examples:
-      | dav_version |
-      | spaces      |
-
   @issue-ocis-1239 @skipOnOcV10.6 @skipOnOcV10.7 @skipOnOcV10.8.0
   Scenario Outline: copy a file into a file at different level received as a group share
     Given using <dav_version> DAV path
@@ -574,11 +524,6 @@ Feature: copy file
       | old         |
       | new         |
 
-    @skipOnOcV10 @personalSpace
-    Examples:
-      | dav_version |
-      | spaces      |
-
   @issue-ocis-1239 @skipOnOcV10.6 @skipOnOcV10.7 @skipOnOcV10.8.0
   Scenario Outline: copy a folder into a file at different level received as a group share
     Given using <dav_version> DAV path
@@ -605,11 +550,6 @@ Feature: copy file
       | dav_version |
       | old         |
       | new         |
-
-    @skipOnOcV10 @personalSpace
-    Examples:
-      | dav_version |
-      | spaces      |
 
 
   Scenario Outline: copy a file of size zero byte


### PR DESCRIPTION
## Description
The `/Shares` related for the `spaces` WebDAV is removed from core since this is to be implemented and run on ocis.

## Related Issue
https://github.com/owncloud/ocis/issues/4154#issuecomment-1206026045

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
- Locally
- CI

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Database schema changes (next release will require increase of minor version instead of patch)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [ ] Tests only (no source changes)

## Checklist:
<!-- Tick the checkboxes when done. -->
<!-- Raise documentation ticket in https://github.com/owncloud/documentation -->
- [ ] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 
- [ ] Changelog item, see [TEMPLATE](https://github.com/owncloud/core/blob/master/changelog/TEMPLATE)
