### PR TITLE
Fix case sensitivity for app passwords/tokens

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ ownCloud admins and users.
 Summary
 -------
 
+* Bugfix - Fix case sensitivity for app passwords/tokens - [#40280](https://github.com/owncloud/core/pull/40280)
 * Bugfix - Trigger the right event when the filecache is updated: [#39844](https://github.com/owncloud/core/pull/39844)
 * Bugfix - Replace userid with username in login form: [#39870](https://github.com/owncloud/core/pull/39870)
 * Bugfix - Quota can be exceeded by user: [#40140](https://github.com/owncloud/core/issues/40140)

--- a/lib/private/User/Session.php
+++ b/lib/private/User/Session.php
@@ -919,7 +919,7 @@ class Session implements IUserSession, Emitter {
 		);
 
 		// Check if login names match
-		if ($user !== null && \strcasecmp ($dbToken->getLoginName(), $user) !== 0) {
+		if ($user !== null && \strcasecmp($dbToken->getLoginName(), $user) !== 0) {
 			// TODO: this makes it impossible to use different login names on browser and client
 			// e.g. login by e-mail 'user@example.com' on browser for generating the token will not
 			//      allow to use the client token with the login name 'user'.

--- a/lib/private/User/Session.php
+++ b/lib/private/User/Session.php
@@ -919,7 +919,7 @@ class Session implements IUserSession, Emitter {
 		);
 
 		// Check if login names match
-		if ($user !== null && $dbToken->getLoginName() !== $user) {
+		if ($user !== null && \strcasecmp ($dbToken->getLoginName(), $user) !== 0) {
 			// TODO: this makes it impossible to use different login names on browser and client
 			// e.g. login by e-mail 'user@example.com' on browser for generating the token will not
 			//      allow to use the client token with the login name 'user'.


### PR DESCRIPTION
## Description

Fix case sensitivity for app passwords/tokens

## Related Issue

- https://github.com/owncloud/core/issues/40119
- https://github.com/owncloud/core/issues/29708

## Motivation and Context

Currently, app passwords/tokens are case sensitive. That is, login will be prevented if the entered username has different case as the app password/token's username (which comes from the user's session).

## How Has This Been Tested?

1. Login as user `User1` and create an app password/token --> username will be automatically set to `User1` and saved as the `login_name` in the `oc_authtoken` table. 
2. Try to authenticate by using i.e. the ownCloud desktop client with the newly generated app password/token by using `user1` as username (note the different casing):

Before this fix --> login failed with exception https://github.com/owncloud/core/blob/master/lib/private/User/Session.php#L927

After this fix --> login is correctly allowed, which is consistent with the "normal" login via username/password where usernames are case-insensitive.
 
## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Database schema changes (next release will require increase of minor version instead of patch)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [ ] Tests only (no source changes)

## Checklist:
- [x] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised