### PR TITLE
Allow usernames to be case-insensitive with app passwords

### DIFF
--- a/changelog/unreleased/40281
+++ b/changelog/unreleased/40281
@@ -1,0 +1,7 @@
+Bugfix: Allow usernames to be case-insensitive with app passwords
+
+When using an app password, the associated username can now be provided in any
+case-insensitive way in requests. Username "Alice" and "alice" will work the same.
+
+https://github.com/owncloud/core/issues/40119
+https://github.com/owncloud/core/pull/40281

--- a/lib/private/User/Session.php
+++ b/lib/private/User/Session.php
@@ -919,7 +919,7 @@ class Session implements IUserSession, Emitter {
 		);
 
 		// Check if login names match
-		if ($user !== null && $dbToken->getLoginName() !== $user) {
+		if ($user !== null && \strcasecmp($dbToken->getLoginName(), $user) !== 0) {
 			// TODO: this makes it impossible to use different login names on browser and client
 			// e.g. login by e-mail 'user@example.com' on browser for generating the token will not
 			//      allow to use the client token with the login name 'user'.

--- a/tests/acceptance/features/apiAuthWebDav/webDavCaseInsensitiveAuth.feature
+++ b/tests/acceptance/features/apiAuthWebDav/webDavCaseInsensitiveAuth.feature
@@ -1,0 +1,35 @@
+@api @notToImplementOnOCIS
+Feature: usernames are case-insensitive in webDAV requests with app passwords
+
+  Background:
+    Given these users have been created with default attributes and without skeleton files:
+      | username |
+      | Alice    |
+    And user "Alice" has uploaded file with content "some data" to "/textfile0.txt"
+    And user "Alice" has uploaded file with content "some data" to "/textfile1.txt"
+    And user "Alice" has created folder "/PARENT"
+    And user "Alice" has created folder "/FOLDER"
+    And user "Alice" has uploaded file with content "some data" to "/PARENT/parent.txt"
+
+
+  Scenario: send PUT requests to webDav endpoints using app password token as password and lowercase of username
+    Given token auth has been enforced
+    And a new browser session for "Alice" has been started
+    And the user has generated a new app password named "my-client"
+    When the user "alice" requests these endpoints with "PUT" with body "doesnotmatter" using basic auth and generated app password about user "Alice"
+      | endpoint                                           |
+      | /remote.php/webdav/textfile0.txt                   |
+      | /remote.php/dav/files/%username%/textfile1.txt     |
+      | /remote.php/dav/files/%username%/PARENT/parent.txt |
+    Then the HTTP status code of responses on all endpoints should be "204"
+    When the user "alice" requests these endpoints with "PUT" with body "doesnotmatter" using basic auth and generated app password about user "Alice"
+      | endpoint                                 |
+      # this folder is created, so gives 201 - CREATED
+      | /remote.php/webdav/PARENS                |
+      | /remote.php/dav/files/%username%/FOLDERS |
+    Then the HTTP status code of responses on all endpoints should be "201"
+    When the user "alice" requests these endpoints with "PUT" with body "doesnotmatter" using basic auth and generated app password about user "Alice"
+      | endpoint                                |
+      # this folder already exists so gives 409 - CONFLICT
+      | /remote.php/dav/files/%username%/FOLDER |
+    Then the HTTP status code of responses on all endpoints should be "409"


### PR DESCRIPTION
## Description
An acceptance test scenario is added that uses an app password generated by user "Alice" but provides user "alice" in the webDAV requests. The scenario fails without the fix, and passes with the fix in Session.php

## Related Issue
- Fixes #40119 

## How Has This Been Tested?
CI

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Database schema changes (next release will require increase of minor version instead of patch)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [ ] Tests only (no source changes)

## Checklist:
- [ ] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 
- [ ] Changelog item, see [TEMPLATE](https://github.com/owncloud/core/blob/master/changelog/TEMPLATE)
