### PR TITLE
[tests-only] skip new tests from PR 40264 on old oC10

### DIFF
--- a/tests/acceptance/features/apiSharePublicLink1/createPublicLinkShare.feature
+++ b/tests/acceptance/features/apiSharePublicLink1/createPublicLinkShare.feature
@@ -105,7 +105,7 @@ Feature: create a public link share
       | 1               | 100             |
       | 2               | 200             |
 
-
+  @skipOnOcV10.9 @skipOnOcV10.10
   Scenario Outline: Create a new public link share of a file with edit permissions
     Given using OCS API version "<ocs_api_version>"
     And user "Alice" has uploaded file with content "Random data" to "/randomfile.txt"

--- a/tests/acceptance/features/webUISharingPublic1/permissionsShareFileByPublicLink.feature
+++ b/tests/acceptance/features/webUISharingPublic1/permissionsShareFileByPublicLink.feature
@@ -19,6 +19,7 @@ Feature: Share a file by public link
     And uploading content to a public link shared file should not work using the old public WebDAV API
     And uploading content to a public link shared file should not work using the new public WebDAV API
 
+  @skipOnOcV10.9 @skipOnOcV10.10
   Scenario: creating a public link with read & write permissions
     Given user "Alice" has uploaded file with content "text to test public links" to "/lorem.txt"
     And user "Alice" has logged in using the webUI


### PR DESCRIPTION
## Description
These new tests were added by PR #40264 to test writable public link shares of a single file. They will not pass on older oC10 releases, so skip in that case.

## How Has This Been Tested?
CI

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Database schema changes (next release will require increase of minor version instead of patch)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [x] Tests only (no source changes)

## Checklist:
- [ ] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 
- [ ] Changelog item, see [TEMPLATE](https://github.com/owncloud/core/blob/master/changelog/TEMPLATE)
