### PR TITLE
[tests-only] wait for open file action menu to be closed before trying to open it again

### DIFF
--- a/tests/acceptance/features/bootstrap/WebUIFilesContext.php
+++ b/tests/acceptance/features/bootstrap/WebUIFilesContext.php
@@ -1938,7 +1938,7 @@ class WebUIFilesContext extends RawMinkContext implements Context {
 	public function theFilesActionMenuShouldBeCompletelyVisibleAfterOpeningItUsingTheWebUI():void {
 		for ($i = 1; $i <= $this->filesPage->getSizeOfFileFolderList(); $i++) {
 			// wait for the actions menu to be closed if is open already
-			$this->waitTillFileActionsMenuIsClosed($this->getSession());
+			$this->waitTillFileActionsMenuIsClosed();
 
 			$actionMenu = $this->filesPage->openFileActionsMenuByNo(
 				$i,
@@ -1981,7 +1981,12 @@ class WebUIFilesContext extends RawMinkContext implements Context {
 		}
 	}
 
-	public function waitTillFileActionsMenuIsClosed($session) {
+	/**
+	 * waits upto standard ui wait timeout for the file actions menu to be closed
+	 *
+	 * @return void
+	 */
+	public function waitTillFileActionsMenuIsClosed(): void {
 		$timeout_msec = STANDARD_UI_WAIT_TIMEOUT_MILLISEC;
 		$currentTime = \microtime(true);
 		$end = $currentTime + ($timeout_msec / 1000);

--- a/tests/acceptance/features/bootstrap/WebUIFilesContext.php
+++ b/tests/acceptance/features/bootstrap/WebUIFilesContext.php
@@ -1937,6 +1937,9 @@ class WebUIFilesContext extends RawMinkContext implements Context {
 	 */
 	public function theFilesActionMenuShouldBeCompletelyVisibleAfterOpeningItUsingTheWebUI():void {
 		for ($i = 1; $i <= $this->filesPage->getSizeOfFileFolderList(); $i++) {
+			// wait for the actions menu to be closed if is open already
+			$this->waitTillFileActionsMenuIsClosed($this->getSession());
+
 			$actionMenu = $this->filesPage->openFileActionsMenuByNo(
 				$i,
 				$this->getSession()
@@ -1975,6 +1978,19 @@ class WebUIFilesContext extends RawMinkContext implements Context {
 			);
 			//this will close the menu again
 			$this->filesPage->clickFileActionsMenuBtnByNo($i);
+		}
+	}
+
+	public function waitTillFileActionsMenuIsClosed($session) {
+		$timeout_msec = STANDARD_UI_WAIT_TIMEOUT_MILLISEC;
+		$currentTime = \microtime(true);
+		$end = $currentTime + ($timeout_msec / 1000);
+		while ($currentTime <= $end) {
+			if (!$this->filesPage->isFileActionsMenuOpen()) {
+				break;
+			}
+			\usleep(STANDARD_SLEEP_TIME_MICROSEC);
+			$currentTime = \microtime(true);
 		}
 	}
 

--- a/tests/acceptance/features/lib/FilesPageBasic.php
+++ b/tests/acceptance/features/lib/FilesPageBasic.php
@@ -475,12 +475,19 @@ abstract class FilesPageBasic extends OwncloudPage {
 		return $actionMenu;
 	}
 
+	/**
+	 * checks if the file actions menu is open
+	 *
+	 * @return bool
+	 */
 	public function isFileActionsMenuOpen(): bool {
 		try {
 			$openMenu = $this->find('css', $this->fileActionMenuCss);
 			if ($openMenu && $openMenu->isVisible()) {
 				return true;
-			} else return false;
+			} else {
+				return false;
+			}
 		} catch (Exception $e) {
 			return false;
 		}

--- a/tests/acceptance/features/lib/FilesPageBasic.php
+++ b/tests/acceptance/features/lib/FilesPageBasic.php
@@ -56,6 +56,7 @@ abstract class FilesPageBasic extends OwncloudPage {
 	protected $detailsDialogXpath = "//*[contains(@id, 'app-sidebar') and not(contains(@class, 'disappear'))]";
 	protected $newFileFolderButtonXpath = './/*[@id="controls"]//a[@class="button new"]';
 	protected $fileActionsApplicationSelectMenuXpath = ".//div[contains(@class, 'fileActionsApplicationSelectMenu')]";
+	protected $fileActionMenuCss = ".fileActionsMenu.open";
 
 	/**
 	 * @return string
@@ -472,6 +473,17 @@ abstract class FilesPageBasic extends OwncloudPage {
 			$this->getFileActionMenuXpath()
 		);
 		return $actionMenu;
+	}
+
+	public function isFileActionsMenuOpen(): bool {
+		try {
+			$openMenu = $this->find('css', $this->fileActionMenuCss);
+			if ($openMenu && $openMenu->isVisible()) {
+				return true;
+			} else return false;
+		} catch (Exception $e) {
+			return false;
+		}
 	}
 
 	/**

--- a/tests/acceptance/features/lib/FilesPageBasic.php
+++ b/tests/acceptance/features/lib/FilesPageBasic.php
@@ -56,7 +56,7 @@ abstract class FilesPageBasic extends OwncloudPage {
 	protected $detailsDialogXpath = "//*[contains(@id, 'app-sidebar') and not(contains(@class, 'disappear'))]";
 	protected $newFileFolderButtonXpath = './/*[@id="controls"]//a[@class="button new"]';
 	protected $fileActionsApplicationSelectMenuXpath = ".//div[contains(@class, 'fileActionsApplicationSelectMenu')]";
-	protected $fileActionMenuCss = ".fileActionsMenu.open";
+	protected $openFileActionMenuCss = ".fileActionsMenu.open";
 
 	/**
 	 * @return string
@@ -482,7 +482,7 @@ abstract class FilesPageBasic extends OwncloudPage {
 	 */
 	public function isFileActionsMenuOpen(): bool {
 		try {
-			$openMenu = $this->find('css', $this->fileActionMenuCss);
+			$openMenu = $this->find('css', $this->openFileActionMenuCss);
 			if ($openMenu && $openMenu->isVisible()) {
 				return true;
 			} else {


### PR DESCRIPTION
Signed-off-by: Kiran Parajuli <kiranparajuli589@gmail.com>

## Description
<!--- Describe your changes in detail -->
Sometime, the open file actions menu comes in a way while the tests tries to click the `3 dot` button to open file actions menu (for some other resource).

Due to this sometimes we see failures like reported here in https://github.com/owncloud/encryption/issues/333

With this PR, we wait for the open actions menu to not be visible on the screen before attempting a click to open actions menu for some another resource.

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
- https://github.com/owncloud/encryption/issues/333

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
- locally
- :robot:

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Database schema changes (next release will require increase of minor version instead of patch)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [x] Tests only (no source changes)

## Checklist:
<!-- Tick the checkboxes when done. -->
<!-- Raise documentation ticket in https://github.com/owncloud/documentation -->
- [ ] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 
- [ ] Changelog item, see [TEMPLATE](https://github.com/owncloud/core/blob/master/changelog/TEMPLATE)
