### PR TITLE
WIP: add support for public link roles assigned by apps

### DIFF
--- a/apps/files_sharing/lib/Controller/Share20OcsController.php
+++ b/apps/files_sharing/lib/Controller/Share20OcsController.php
@@ -532,6 +532,7 @@ class Share20OcsController extends OCSController {
 				);
 			} elseif ($permissions === Constants::PERMISSION_CREATE ||
 				$permissions === (Constants::PERMISSION_READ | Constants::PERMISSION_CREATE | Constants::PERMISSION_UPDATE | Constants::PERMISSION_DELETE) ||
+				$permissions === (Constants::PERMISSION_READ | Constants::PERMISSION_UPDATE) ||
 				$permissions === (Constants::PERMISSION_READ | Constants::PERMISSION_CREATE)) {
 				$share->setPermissions($permissions);
 			} else {

--- a/apps/files_sharing/lib/Controller/Share20OcsController.php
+++ b/apps/files_sharing/lib/Controller/Share20OcsController.php
@@ -882,6 +882,7 @@ class Share20OcsController extends OCSController {
 				// legacy
 				$newPermissions !== (Constants::PERMISSION_READ | Constants::PERMISSION_CREATE | Constants::PERMISSION_UPDATE) &&
 				// correct
+				$newPermissions !== (Constants::PERMISSION_READ | Constants::PERMISSION_UPDATE) &&
 				$newPermissions !== (Constants::PERMISSION_READ | Constants::PERMISSION_CREATE | Constants::PERMISSION_UPDATE | Constants::PERMISSION_DELETE)
 			) {
 				$share->getNode()->unlock(ILockingProvider::LOCK_SHARED);

--- a/apps/files_sharing/lib/Controller/Share20OcsController.php
+++ b/apps/files_sharing/lib/Controller/Share20OcsController.php
@@ -277,7 +277,7 @@ class Share20OcsController extends OCSController {
 
 		$result['attributes'] = null;
 		if ($attributes = $share->getAttributes()) {
-			$result['attributes'] = \json_encode($attributes->toArray());
+			$result['attributes'] = $attributes->toArray();
 		}
 
 		return $result;

--- a/core/js/sharedialoglinkshareview.js
+++ b/core/js/sharedialoglinkshareview.js
@@ -38,10 +38,10 @@
 				'<p><em>{{publicReadDescription}}</em></p>' +
 			'</div>' +
 			'{{#if publicUploadFilePossible}}' +
-			'<div id="allowPublicReadWrite-{{cid}}" class="public-link-modal--item">' +
-				'<input type="radio" value="allowPublicReadWrite" name="publicLinkRole" id="sharingDialogAllowPublicReadWrite-{{cid}}" class="checkbox publicLinkRole" {{#if publicReadWriteSelected}}checked{{/if}} />' +
-				'<label class="bold" for="sharingDialogAllowPublicReadWrite-{{cid}}">{{publicReadWriteLabel}}</label>' +
-				'<p><em>{{publicReadWriteDescription}}</em></p>' +
+			'<div id="allowPublicFileReadWrite-{{cid}}" class="public-link-modal--item">' +
+				'<input type="radio" value="allowPublicFileReadWrite" name="publicLinkRole" id="sharingDialogAllowPublicFileReadWrite-{{cid}}" class="checkbox publicLinkRole" {{#if publicFileReadWriteSelected}}checked{{/if}} />' +
+				'<label class="bold" for="sharingDialogAllowPublicFileReadWrite-{{cid}}">{{publicFileReadWriteLabel}}</label>' +
+				'<p><em>{{publicFileReadWriteDescription}}</em></p>' +
 			'</div>' +
 			'{{/if}}' +
 			'{{#if publicUploadFolderPossible}}' +
@@ -50,10 +50,10 @@
 				'<label class="bold" for="sharingDialogAllowPublicUploadWrite-{{cid}}">{{publicUploadWriteLabel}}</label>' +
 				'<p><em>{{publicUploadWriteDescription}}</em></p>' +
 			'</div>' +
-			'<div id="allowPublicReadWrite-{{cid}}" class="public-link-modal--item">' +
-				'<input type="radio" value="allowPublicReadWrite" name="publicLinkRole" id="sharingDialogAllowPublicReadWrite-{{cid}}" class="checkbox publicLinkRole" {{#if publicReadWriteSelected}}checked{{/if}} />' +
-				'<label class="bold" for="sharingDialogAllowPublicReadWrite-{{cid}}">{{publicReadWriteLabel}}</label>' +
-				'<p><em>{{publicReadWriteDescription}}</em></p>' +
+			'<div id="allowPublicFolderReadWrite-{{cid}}" class="public-link-modal--item">' +
+				'<input type="radio" value="allowPublicFolderReadWrite" name="publicLinkRole" id="sharingDialogAllowPublicFolderReadWrite-{{cid}}" class="checkbox publicLinkRole" {{#if publicFolderReadWriteSelected}}checked{{/if}} />' +
+				'<label class="bold" for="sharingDialogAllowPublicFolderReadWrite-{{cid}}">{{publicFolderReadWriteLabel}}</label>' +
+				'<p><em>{{publicFolderReadWriteDescription}}</em></p>' +
 			'</div>' +
 			'<div id="allowPublicUpload-{{cid}}" class="public-link-modal--item">' +
 				'<input type="radio" value="allowPublicUpload" name="publicLinkRole" id="sharingDialogAllowPublicUpload-{{cid}}" class="checkbox publicLinkRole" {{#if publicUploadSelected}}checked{{/if}} />' +
@@ -116,7 +116,12 @@
 				attributes: []
 			},
 			{
-				name: "allowPublicReadWrite",
+				name: "allowPublicFileReadWrite",
+				permissions: OC.PERMISSION_READ | OC.PERMISSION_UPDATE,
+				attributes: []
+			},
+			{
+				name: "allowPublicFolderReadWrite",
 				permissions: OC.PERMISSION_READ | OC.PERMISSION_UPDATE | OC.PERMISSION_CREATE | OC.PERMISSION_DELETE,
 				attributes: []
 			}
@@ -386,9 +391,13 @@
 				publicUploadWriteDescription : t('core', 'Recipients can view, download and upload contents.'),
 				publicUploadWriteSelected    : this._checkRoleEnabled('allowPublicUploadWrite'),
 
-				publicReadWriteLabel       : t('core', 'Download / View / Edit'),
-				publicReadWriteDescription : t('core', 'Recipients can view, download, edit, delete and upload contents.'),
-				publicReadWriteSelected    : this._checkRoleEnabled('allowPublicReadWrite'),
+				publicFileReadWriteLabel       : t('core', 'Download / View / Edit'),
+				publicFileReadWriteDescription : t('core', 'Recipients can view, download and edit contents.'),
+				publicFileReadWriteSelected    : this._checkRoleEnabled('allowPublicFileReadWrite'),
+
+				publicFolderReadWriteLabel       : t('core', 'Download / View / Edit / Upload'),
+				publicFolderReadWriteDescription : t('core', 'Recipients can view, download, edit, delete and upload contents.'),
+				publicFolderReadWriteSelected    : this._checkRoleEnabled('allowPublicFolderReadWrite'),
 
 				isMailEnabled: showEmailField
 			}));


### PR DESCRIPTION
## Description

Feature: Add support for public link roles assigned by apps

TODO

## Related Issue
- Related https://github.com/owncloud/enterprise/issues/5277
- Related https://github.com/owncloud/core/pull/40264

## How Has This Been Tested?
- manually in the developer instance
- unit/acceptance tests

## Types of changes
- [x] New feature (non-breaking change which adds functionality)

## Checklist:
- [x] Base code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Changelog item, see [TEMPLATE](https://github.com/owncloud/core/blob/master/changelog/TEMPLATE)

Example use-case: richdocuments preview

![Screenshot 2022-08-15 at 21 52 53](https://user-images.githubusercontent.com/13368647/184707529-5e7d5816-3b68-4bc5-9d90-238279d77ab6.png)

![Screenshot 2022-08-15 at 21 51 56](https://user-images.githubusercontent.com/13368647/184707524-98b763be-6a0b-4a2d-bba4-26357b4df256.png)
