### PR TITLE
[tests-only] [full-ci]Test against federated 10.9.1

### DIFF
--- a/.drone.star
+++ b/.drone.star
@@ -224,7 +224,7 @@ config = {
                 "apiFederationToShares2",
             ],
             "federatedServerNeeded": True,
-            "federatedServerVersions": ["git", "latest", "10.8.0"],
+            "federatedServerVersions": ["git", "latest", "10.9.1"],
         },
         "cli": {
             "suites": [
@@ -299,7 +299,7 @@ config = {
                 "cliExternalStorage",
             ],
             "federatedServerNeeded": True,
-            "federatedServerVersions": ["git", "latest", "10.8.0"],
+            "federatedServerVersions": ["git", "latest", "10.9.1"],
             "extraApps": {
                 "files_external": "",
             },
@@ -378,7 +378,7 @@ config = {
                 "webUISharingExternal2": "webUISharingExt2",
             },
             "federatedServerNeeded": True,
-            "federatedServerVersions": ["git", "latest", "10.8.0"],
+            "federatedServerVersions": ["git", "latest", "10.9.1"],
         },
         "webUIFirefox": {
             "suites": {


### PR DESCRIPTION
## Description
We run federated acceptance test pipelines with a federated server running current core master, "latest" core, and the version before "latest". That gives us confidence that the federated sharing features are working OK between servers run different recent oC10 core releases.

"latest" is 10.10 these days. So the previous-to-latest is actually 10.9.1. This PR adjusts the test pieleines so that they use 10.9.1 in this case. 

## How Has This Been Tested?
CI

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Database schema changes (next release will require increase of minor version instead of patch)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [x] Tests only (no source changes)

## Checklist:
- [ ] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 
- [ ] Changelog item, see [TEMPLATE](https://github.com/owncloud/core/blob/master/changelog/TEMPLATE)
