### PR TITLE
[tests-only][full-ci]Remove /Shares related tests for lock properties from core

### DIFF
--- a/tests/acceptance/features/apiWebdavLocks2/setTimeoutSharesToShares.feature
+++ b/tests/acceptance/features/apiWebdavLocks2/setTimeoutSharesToShares.feature
@@ -40,15 +40,6 @@ Feature: set timeouts of LOCKS on shares
       | new      | second--1       | /Second-\d{5}$/ |
       | new      | second-0        | /Second-\d{4}$/ |
 
-    @personalSpace @skipOnOcV10
-    Examples:
-      | dav-path | timeout         | result          |
-      | spaces   | second-999      | /Second-\d{3}$/ |
-      | spaces   | second-99999999 | /Second-\d{5}$/ |
-      | spaces   | infinite        | /Second-\d{5}$/ |
-      | spaces   | second--1       | /Second-\d{5}$/ |
-      | spaces   | second-0        | /Second-\d{4}$/ |
-
 
   Scenario Outline: as share receiver set timeout on folder as owner check it
     Given using <dav-path> DAV path
@@ -73,12 +64,3 @@ Feature: set timeouts of LOCKS on shares
       | new      | infinite        | /Second-\d{5}$/ |
       | new      | second--1       | /Second-\d{5}$/ |
       | new      | second-0        | /Second-\d{4}$/ |
-
-    @personalSpace @skipOnOcV10
-    Examples:
-      | dav-path | timeout         | result          |
-      | spaces   | second-999      | /Second-\d{3}$/ |
-      | spaces   | second-99999999 | /Second-\d{5}$/ |
-      | spaces   | infinite        | /Second-\d{5}$/ |
-      | spaces   | second--1       | /Second-\d{5}$/ |
-      | spaces   | second-0        | /Second-\d{4}$/ |


### PR DESCRIPTION
## Description
The `/Shares` related for the `spaces` WebDAV is removed from core since this is to be implemented and run on ocis.

## Related Issue
https://github.com/owncloud/ocis/issues/4154#issuecomment-1206026045

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
- Locally
- CI

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Database schema changes (next release will require increase of minor version instead of patch)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [ ] Tests only (no source changes)

## Checklist:
<!-- Tick the checkboxes when done. -->
<!-- Raise documentation ticket in https://github.com/owncloud/documentation -->
- [ ] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 
- [ ] Changelog item, see [TEMPLATE](https://github.com/owncloud/core/blob/master/changelog/TEMPLATE)
