### PR TITLE
Refactor to not have required parameters following an optional parameter

### DIFF
--- a/apps/files_sharing/lib/Controller/Share20OcsController.php
+++ b/apps/files_sharing/lib/Controller/Share20OcsController.php
@@ -621,7 +621,7 @@ class Share20OcsController extends OCSController {
 	 * [Share::SHARE_TYPE_USER => true, Share::SHARE_TYPE_GROUP => false]
 	 * @return Result
 	 */
-	private function getSharedWithMe($node = null, $includeTags, $requestedShareTypes, $stateFilter = 0) {
+	private function getSharedWithMe($node, $includeTags, $requestedShareTypes, $stateFilter = 0) {
 		// sharedWithMe is limited to user and group shares for compatibility.
 		$shares = [];
 		if (isset($requestedShareTypes[Share::SHARE_TYPE_USER]) && $requestedShareTypes[Share::SHARE_TYPE_USER]) {

--- a/changelog/unreleased/40303
+++ b/changelog/unreleased/40303
@@ -1,0 +1,6 @@
+Bugfix: refactor to not have required params following an optional parameter
+
+All required parameters should be listed first in PHP functions. Adjust the code
+to meet this rule.
+
+https://github.com/owncloud/core/pull/40303

--- a/lib/public/UserTokenException.php
+++ b/lib/public/UserTokenException.php
@@ -36,7 +36,7 @@ class UserTokenException extends \Exception {
 	 * @param \Exception|null $previous
 	 * @since 10.0.10
 	 */
-	public function __construct($message = "", $code, \Exception $previous = null) {
+	public function __construct($message = "", $code = 0, \Exception $previous = null) {
 		parent::__construct($message, $code, $previous);
 	}
 }


### PR DESCRIPTION
## Description
All required parameters should be listed first in PHP functions. Adjust the code to meet this rule.

I noticed this when running PHPstan in a different environment, and it told me about these existing invalid/not-useful parameter lists.

## How Has This Been Tested?
CI

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Database schema changes (next release will require increase of minor version instead of patch)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [ ] Tests only (no source changes)

## Checklist:
- [x] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 
- [x] Changelog item, see [TEMPLATE](https://github.com/owncloud/core/blob/master/changelog/TEMPLATE)
