### PR TITLE
[tests-only] [full-ci] Enhance share copy-overwrite test scenarios to demonstrate current behaviour

### DIFF
--- a/tests/acceptance/features/apiWebdavProperties1/copyFile.feature
+++ b/tests/acceptance/features/apiWebdavProperties1/copyFile.feature
@@ -215,10 +215,32 @@ Feature: copy file
     And user "Alice" has accepted share "/BRIAN-Folder" offered by user "Brian"
     When user "Alice" copies file "/textfile1.txt" to "/Shares/BRIAN-Folder" using the WebDAV API
     Then the HTTP status code should be "204"
+    # Alice now sees the content of "her" file in /Shares/BRIAN-Folder
+    # The share that she received from Brian has "automatically" gone into the "declined" state
     And the content of file "/Shares/BRIAN-Folder" for user "Alice" should be "ownCloud test text file 1"
     And as "Alice" folder "/Shares/BRIAN-Folder/sample-folder" should not exist
     And as "Alice" file "/textfile1.txt" should exist
     And user "Alice" should not have any received shares
+    And the sharing API should report to user "Alice" that these shares are in the declined state
+      | path                  |
+      | /Shares/BRIAN-Folder/ |
+    # Brian still has his original BRIAN-Folder and can see that it is shared with Alice
+    And as "Brian" folder "BRIAN-Folder" should exist
+    And as "Brian" folder "BRIAN-Folder/sample-folder" should exist
+    When user "Brian" gets all shares shared by him using the sharing API
+    Then the OCS status code should be "100"
+    And the HTTP status code should be "200"
+    And folder "/Shares/BRIAN-Folder" should be included in the response
+    # Alice can accept the share from Brian again
+    When user "Alice" accepts share "/BRIAN-Folder" offered by user "Brian" using the sharing API
+    Then the OCS status code should be "100"
+    And the HTTP status code should be "200"
+    # now Alice has "her" text file as "/Shares/BRIAN-Folder"
+    # and has the shared folder from Brian as "/Shares/BRIAN-Folder (2)"
+    And as "Alice" file "/Shares/BRIAN-Folder" should exist
+    And the content of file "/Shares/BRIAN-Folder" for user "Alice" should be "ownCloud test text file 1"
+    And as "Alice" folder "/Shares/BRIAN-Folder (2)" should exist
+    And as "Alice" folder "/Shares/BRIAN-Folder (2)/sample-folder" should exist
     Examples:
       | dav_version |
       | old         |
@@ -234,9 +256,30 @@ Feature: copy file
     And user "Alice" has created folder "FOLDER/sample-folder"
     When user "Alice" copies folder "/FOLDER" to "/Shares/sharedfile1.txt" using the WebDAV API
     Then the HTTP status code should be "204"
+    # Alice now sees the content of "her" folder as folder "/Shares/sharedfile1.txt"
+    # The share that she received from Brian has "automatically" gone into the "declined" state
     And as "Alice" folder "/FOLDER/sample-folder" should exist
     And as "Alice" folder "/Shares/sharedfile1.txt/sample-folder" should exist
     And user "Alice" should not have any received shares
+    And the sharing API should report to user "Alice" that these shares are in the declined state
+      | path                    |
+      | /Shares/sharedfile1.txt |
+    # Brian still has his original sharedfile1.txt and can see that it is shared with Alice
+    And as "Brian" file "sharedfile1.txt" should exist
+    And the content of file "sharedfile1.txt" for user "Brian" should be "file to share"
+    When user "Brian" gets all shares shared by him using the sharing API
+    Then the OCS status code should be "100"
+    And the HTTP status code should be "200"
+    And file "/Shares/sharedfile1.txt" should be included in the response
+    When user "Alice" accepts share "/sharedfile1.txt" offered by user "Brian" using the sharing API
+    Then the OCS status code should be "100"
+    And the HTTP status code should be "200"
+    # now Alice has "her" folder as "/Shares/sharedfile1.txt"
+    # and has the shared file from Brian as "/Shares/sharedfile1 (2).txt"
+    And as "Alice" folder "/Shares/sharedfile1.txt" should exist
+    And as "Alice" folder "/Shares/sharedfile1.txt/sample-folder" should exist
+    And as "Alice" file "/Shares/sharedfile1 (2).txt" should exist
+    And the content of file "/Shares/sharedfile1 (2).txt" for user "Alice" should be "file to share"
     Examples:
       | dav_version |
       | old         |

--- a/tests/acceptance/features/apiWebdavProperties1/copyFile.feature
+++ b/tests/acceptance/features/apiWebdavProperties1/copyFile.feature
@@ -286,6 +286,91 @@ Feature: copy file
       | new         |
 
 
+  Scenario Outline: copy a file over the top of an existing file received as a user share
+    Given using <dav_version> DAV path
+    And user "Brian" has been created with default attributes and without skeleton files
+    And user "Brian" has uploaded file with content "file to share" to "/sharedfile1.txt"
+    And user "Brian" has shared file "/sharedfile1.txt" with user "Alice"
+    And user "Alice" has accepted share "/sharedfile1.txt" offered by user "Brian"
+    When user "Alice" copies file "/textfile1.txt" to "/Shares/sharedfile1.txt" using the WebDAV API
+    Then the HTTP status code should be "204"
+    # Alice now sees the content of "her" file in /Shares/sharedfile1.txt
+    # The share that she received from Brian has "automatically" gone into the "declined" state
+    And as "Alice" file "/Shares/sharedfile1.txt" should exist
+    And the content of file "/Shares/sharedfile1.txt" for user "Alice" should be "ownCloud test text file 1"
+    And as "Alice" file "/textfile1.txt" should exist
+    And user "Alice" should not have any received shares
+    And the sharing API should report to user "Alice" that these shares are in the declined state
+      | path                    |
+      | /Shares/sharedfile1.txt |
+    # Brian still has his original "/sharedfile1.txt" and can see that it is shared with Alice
+    And as "Brian" file "/sharedfile1.txt" should exist
+    And the content of file "/sharedfile1.txt" for user "Brian" should be "file to share"
+    # Alice can accept the share from Brian again
+    When user "Alice" accepts share "/sharedfile1.txt" offered by user "Brian" using the sharing API
+    Then the OCS status code should be "100"
+    And the HTTP status code should be "200"
+    # now Alice has "her" text file as "/Shares/sharedfile1.txt"
+    # and has the shared folder from Brian as "/Shares/sharedfile1 (2).txt"
+    And as "Alice" file "/Shares/sharedfile1.txt" should exist
+    And the content of file "/Shares/sharedfile1.txt" for user "Alice" should be "ownCloud test text file 1"
+    And as "Alice" file "/Shares/sharedfile1 (2).txt" should exist
+    And the content of file "/Shares/sharedfile1 (2).txt" for user "Alice" should be "file to share"
+    Examples:
+      | dav_version |
+      | old         |
+      | new         |
+
+
+  Scenario Outline: copy a folder over the top of an existing folder received as a user share
+    Given using <dav_version> DAV path
+    And user "Brian" has been created with default attributes and without skeleton files
+    And user "Brian" has created folder "/BRIAN-Folder"
+    And user "Brian" has created folder "BRIAN-Folder/sample-folder"
+    And user "Brian" has shared folder "BRIAN-Folder" with user "Alice"
+    And user "Alice" has accepted share "/BRIAN-Folder" offered by user "Brian"
+    And user "Alice" has created folder "FOLDER/ALICE-folder"
+    When user "Alice" copies folder "/FOLDER" to "/Shares/BRIAN-Folder" using the WebDAV API
+    Then the HTTP status code should be "204"
+    # Alice now sees the content of "her" folder as folder "/Shares/BRIAN-Folder"
+    # The share that she received from Brian has "automatically" gone into the "declined" state
+    And as "Alice" folder "/FOLDER/ALICE-folder" should exist
+    And as "Alice" folder "/Shares/BRIAN-Folder/ALICE-folder" should exist
+    And user "Alice" should not have any received shares
+    And the sharing API should report to user "Alice" that these shares are in the declined state
+      | path                 |
+      | /Shares/BRIAN-Folder |
+    # Brian still has his original BRIAN-Folder and can see that it is shared with Alice
+    And as "Brian" folder "BRIAN-Folder" should exist
+    And as "Brian" folder "BRIAN-Folder/sample-folder" should exist
+    When user "Brian" gets all shares shared by him using the sharing API
+    Then the OCS status code should be "100"
+    And the HTTP status code should be "200"
+    And file "/Shares/BRIAN-Folder" should be included in the response
+    When user "Alice" accepts share "/BRIAN-Folder" offered by user "Brian" using the sharing API
+    Then the OCS status code should be "100"
+    And the HTTP status code should be "200"
+    # now Alice has "her" folder as "/Shares/BRIAN-Folder"
+    # and has the shared file from Brian as "/Shares/BRIAN-Folder (2)"
+    And as "Alice" folder "/Shares/BRIAN-Folder" should exist
+    And as "Alice" folder "/Shares/BRIAN-Folder/ALICE-folder" should exist
+    And as "Alice" folder "/Shares/BRIAN-Folder (2)" should exist
+    And as "Alice" folder "/Shares/BRIAN-Folder (2)/sample-folder" should exist
+    # Alice can add content to both folders
+    # Brian sees what Alice puts into "/Shares/BRIAN-Folder (2)"
+    And user "Alice" has created folder "/Shares/BRIAN-Folder/new-folder1"
+    And user "Alice" has created folder "/Shares/BRIAN-Folder (2)/new-folder2"
+    And user "Alice" has uploaded file with content "new content 1" to "/Shares/BRIAN-Folder/new-folder1/file1.txt"
+    And user "Alice" has uploaded file with content "new content 2" to "/Shares/BRIAN-Folder (2)/new-folder2/file2.txt"
+    And the content of file "/Shares/BRIAN-Folder/new-folder1/file1.txt" for user "Alice" should be "new content 1"
+    And the content of file "/Shares/BRIAN-Folder (2)/new-folder2/file2.txt" for user "Alice" should be "new content 2"
+    And the content of file "/BRIAN-Folder/new-folder2/file2.txt" for user "Brian" should be "new content 2"
+    Examples:
+      | dav_version |
+      | old         |
+      | new         |
+
+
   Scenario Outline: copy a folder into another folder at different level which is received as a user share
     Given using <dav_version> DAV path
     And user "Brian" has been created with default attributes and without skeleton files

--- a/tests/acceptance/features/apiWebdavProperties1/copyFile.feature
+++ b/tests/acceptance/features/apiWebdavProperties1/copyFile.feature
@@ -870,3 +870,19 @@ Feature: copy file
       | dav_version |
       | old         |
       | new         |
+
+
+  Scenario Outline: Copying a folder with a file onto another folder
+    Given using <dav_version> DAV path
+    And user "Alice" has created folder "/FOLDER1"
+    And user "Alice" has created folder "/FOLDER2"
+    And user "Alice" has uploaded file with content "Folder 1 text" to "/FOLDER1/textfile1.txt"
+    And user "Alice" has uploaded file with content "Folder 2 text" to "/FOLDER2/textfile2.txt"
+    When user "Alice" copies folder "/FOLDER1" to "/FOLDER2" using the WebDAV API
+    Then the HTTP status code should be "204"
+    And as "Alice" file "/FOLDER2/textfile1.txt" should exist
+    And as "Alice" file "/FOLDER2/textfile2.txt" should not exist
+    Examples:
+      | dav_version |
+      | old         |
+      | new         |

--- a/tests/acceptance/features/apiWebdavProperties1/copyFile.feature
+++ b/tests/acceptance/features/apiWebdavProperties1/copyFile.feature
@@ -285,7 +285,7 @@ Feature: copy file
       | old         |
       | new         |
 
-
+  @skipOnOcV10 @issue-40787 @files_sharing-app-required
   Scenario Outline: copy a file over the top of an existing file received as a user share
     Given using <dav_version> DAV path
     And user "Brian" has been created with default attributes and without skeleton files
@@ -294,34 +294,17 @@ Feature: copy file
     And user "Alice" has accepted share "/sharedfile1.txt" offered by user "Brian"
     When user "Alice" copies file "/textfile1.txt" to "/Shares/sharedfile1.txt" using the WebDAV API
     Then the HTTP status code should be "204"
-    # Alice now sees the content of "her" file in /Shares/sharedfile1.txt
-    # The share that she received from Brian has "automatically" gone into the "declined" state
     And as "Alice" file "/Shares/sharedfile1.txt" should exist
     And the content of file "/Shares/sharedfile1.txt" for user "Alice" should be "ownCloud test text file 1"
     And as "Alice" file "/textfile1.txt" should exist
-    And user "Alice" should not have any received shares
-    And the sharing API should report to user "Alice" that these shares are in the declined state
-      | path                    |
-      | /Shares/sharedfile1.txt |
-    # Brian still has his original "/sharedfile1.txt" and can see that it is shared with Alice
     And as "Brian" file "/sharedfile1.txt" should exist
-    And the content of file "/sharedfile1.txt" for user "Brian" should be "file to share"
-    # Alice can accept the share from Brian again
-    When user "Alice" accepts share "/sharedfile1.txt" offered by user "Brian" using the sharing API
-    Then the OCS status code should be "100"
-    And the HTTP status code should be "200"
-    # now Alice has "her" text file as "/Shares/sharedfile1.txt"
-    # and has the shared folder from Brian as "/Shares/sharedfile1 (2).txt"
-    And as "Alice" file "/Shares/sharedfile1.txt" should exist
-    And the content of file "/Shares/sharedfile1.txt" for user "Alice" should be "ownCloud test text file 1"
-    And as "Alice" file "/Shares/sharedfile1 (2).txt" should exist
-    And the content of file "/Shares/sharedfile1 (2).txt" for user "Alice" should be "file to share"
+    And the content of file "/sharedfile1.txt" for user "Brian" should be "ownCloud test text file 1"
     Examples:
       | dav_version |
       | old         |
       | new         |
 
-
+  @skipOnOcV10 @issue-40788 @files_sharing-app-required
   Scenario Outline: copy a folder over the top of an existing folder received as a user share
     Given using <dav_version> DAV path
     And user "Brian" has been created with default attributes and without skeleton files
@@ -331,40 +314,14 @@ Feature: copy file
     And user "Alice" has accepted share "/BRIAN-Folder" offered by user "Brian"
     And user "Alice" has created folder "FOLDER/ALICE-folder"
     When user "Alice" copies folder "/FOLDER" to "/Shares/BRIAN-Folder" using the WebDAV API
-    Then the HTTP status code should be "204"
-    # Alice now sees the content of "her" folder as folder "/Shares/BRIAN-Folder"
-    # The share that she received from Brian has "automatically" gone into the "declined" state
+    Then the HTTP status code should be "409"
     And as "Alice" folder "/FOLDER/ALICE-folder" should exist
-    And as "Alice" folder "/Shares/BRIAN-Folder/ALICE-folder" should exist
-    And user "Alice" should not have any received shares
-    And the sharing API should report to user "Alice" that these shares are in the declined state
-      | path                 |
-      | /Shares/BRIAN-Folder |
-    # Brian still has his original BRIAN-Folder and can see that it is shared with Alice
+    And as "Alice" folder "/Shares/BRIAN-Folder" should exist
+    And as "Alice" folder "/Shares/BRIAN-Folder/sample-folder" should exist
+    And as "Alice" folder "/Shares/BRIAN-Folder/ALICE-folder" should not exist
     And as "Brian" folder "BRIAN-Folder" should exist
     And as "Brian" folder "BRIAN-Folder/sample-folder" should exist
-    When user "Brian" gets all shares shared by him using the sharing API
-    Then the OCS status code should be "100"
-    And the HTTP status code should be "200"
-    And file "/Shares/BRIAN-Folder" should be included in the response
-    When user "Alice" accepts share "/BRIAN-Folder" offered by user "Brian" using the sharing API
-    Then the OCS status code should be "100"
-    And the HTTP status code should be "200"
-    # now Alice has "her" folder as "/Shares/BRIAN-Folder"
-    # and has the shared file from Brian as "/Shares/BRIAN-Folder (2)"
-    And as "Alice" folder "/Shares/BRIAN-Folder" should exist
-    And as "Alice" folder "/Shares/BRIAN-Folder/ALICE-folder" should exist
-    And as "Alice" folder "/Shares/BRIAN-Folder (2)" should exist
-    And as "Alice" folder "/Shares/BRIAN-Folder (2)/sample-folder" should exist
-    # Alice can add content to both folders
-    # Brian sees what Alice puts into "/Shares/BRIAN-Folder (2)"
-    And user "Alice" has created folder "/Shares/BRIAN-Folder/new-folder1"
-    And user "Alice" has created folder "/Shares/BRIAN-Folder (2)/new-folder2"
-    And user "Alice" has uploaded file with content "new content 1" to "/Shares/BRIAN-Folder/new-folder1/file1.txt"
-    And user "Alice" has uploaded file with content "new content 2" to "/Shares/BRIAN-Folder (2)/new-folder2/file2.txt"
-    And the content of file "/Shares/BRIAN-Folder/new-folder1/file1.txt" for user "Alice" should be "new content 1"
-    And the content of file "/Shares/BRIAN-Folder (2)/new-folder2/file2.txt" for user "Alice" should be "new content 2"
-    And the content of file "/BRIAN-Folder/new-folder2/file2.txt" for user "Brian" should be "new content 2"
+    And as "Brian" folder "/Shares/BRIAN-Folder/ALICE-folder" should not exist
     Examples:
       | dav_version |
       | old         |

--- a/tests/acceptance/features/apiWebdavProperties1/copyFileOc10Issue40787.feature
+++ b/tests/acceptance/features/apiWebdavProperties1/copyFileOc10Issue40787.feature
@@ -1,0 +1,51 @@
+@api
+Feature: copy file
+  As a user
+  I want to be able to copy files
+  So that I can manage my files
+
+  # When fixing this issue, delete this bug-demo feature file.
+  # And unskip the corresponding scenario in copyFile.feature and make it pass.
+  Background:
+    Given using OCS API version "1"
+    And the administrator has set the default folder for received shares to "Shares"
+    And auto-accept shares has been disabled
+    And user "Alice" has been created with default attributes and without skeleton files
+    And user "Alice" has uploaded file with content "ownCloud test text file 0" to "/textfile0.txt"
+    And user "Alice" has uploaded file with content "ownCloud test text file 1" to "/textfile1.txt"
+
+  @issue-40787 @files_sharing-app-required
+  Scenario Outline: copy a file over the top of an existing file received as a user share
+    Given using <dav_version> DAV path
+    And user "Brian" has been created with default attributes and without skeleton files
+    And user "Brian" has uploaded file with content "file to share" to "/sharedfile1.txt"
+    And user "Brian" has shared file "/sharedfile1.txt" with user "Alice"
+    And user "Alice" has accepted share "/sharedfile1.txt" offered by user "Brian"
+    When user "Alice" copies file "/textfile1.txt" to "/Shares/sharedfile1.txt" using the WebDAV API
+    Then the HTTP status code should be "204"
+    # Alice now sees the content of "her" file in /Shares/sharedfile1.txt
+    # The share that she received from Brian has "automatically" gone into the "declined" state
+    And as "Alice" file "/Shares/sharedfile1.txt" should exist
+    And the content of file "/Shares/sharedfile1.txt" for user "Alice" should be "ownCloud test text file 1"
+    And as "Alice" file "/textfile1.txt" should exist
+    And user "Alice" should not have any received shares
+    And the sharing API should report to user "Alice" that these shares are in the declined state
+      | path                    |
+      | /Shares/sharedfile1.txt |
+    # Brian still has his original "/sharedfile1.txt" and can see that it is shared with Alice
+    And as "Brian" file "/sharedfile1.txt" should exist
+    And the content of file "/sharedfile1.txt" for user "Brian" should be "file to share"
+    # Alice can accept the share from Brian again
+    When user "Alice" accepts share "/sharedfile1.txt" offered by user "Brian" using the sharing API
+    Then the OCS status code should be "100"
+    And the HTTP status code should be "200"
+    # now Alice has "her" text file as "/Shares/sharedfile1.txt"
+    # and has the shared folder from Brian as "/Shares/sharedfile1 (2).txt"
+    And as "Alice" file "/Shares/sharedfile1.txt" should exist
+    And the content of file "/Shares/sharedfile1.txt" for user "Alice" should be "ownCloud test text file 1"
+    And as "Alice" file "/Shares/sharedfile1 (2).txt" should exist
+    And the content of file "/Shares/sharedfile1 (2).txt" for user "Alice" should be "file to share"
+    Examples:
+      | dav_version |
+      | old         |
+      | new         |

--- a/tests/acceptance/features/apiWebdavProperties1/copyFileOc10Issue40788.feature
+++ b/tests/acceptance/features/apiWebdavProperties1/copyFileOc10Issue40788.feature
@@ -1,0 +1,64 @@
+@api
+Feature: copy file
+  As a user
+  I want to be able to copy files
+  So that I can manage my files
+
+  # When fixing this issue, delete this bug-demo feature file.
+  # And unskip the corresponding scenario in copyFile.feature and make it pass.
+  Background:
+    Given using OCS API version "1"
+    And the administrator has set the default folder for received shares to "Shares"
+    And auto-accept shares has been disabled
+    And user "Alice" has been created with default attributes and without skeleton files
+    And user "Alice" has uploaded file with content "ownCloud test text file 0" to "/textfile0.txt"
+    And user "Alice" has uploaded file with content "ownCloud test text file 1" to "/textfile1.txt"
+    And user "Alice" has created folder "/FOLDER"
+
+  Scenario Outline: copy a folder over the top of an existing folder received as a user share
+    Given using <dav_version> DAV path
+    And user "Brian" has been created with default attributes and without skeleton files
+    And user "Brian" has created folder "/BRIAN-Folder"
+    And user "Brian" has created folder "BRIAN-Folder/sample-folder"
+    And user "Brian" has shared folder "BRIAN-Folder" with user "Alice"
+    And user "Alice" has accepted share "/BRIAN-Folder" offered by user "Brian"
+    And user "Alice" has created folder "FOLDER/ALICE-folder"
+    When user "Alice" copies folder "/FOLDER" to "/Shares/BRIAN-Folder" using the WebDAV API
+    Then the HTTP status code should be "204"
+    # Alice now sees the content of "her" folder as folder "/Shares/BRIAN-Folder"
+    # The share that she received from Brian has "automatically" gone into the "declined" state
+    And as "Alice" folder "/FOLDER/ALICE-folder" should exist
+    And as "Alice" folder "/Shares/BRIAN-Folder/ALICE-folder" should exist
+    And user "Alice" should not have any received shares
+    And the sharing API should report to user "Alice" that these shares are in the declined state
+      | path                 |
+      | /Shares/BRIAN-Folder |
+    # Brian still has his original BRIAN-Folder and can see that it is shared with Alice
+    And as "Brian" folder "BRIAN-Folder" should exist
+    And as "Brian" folder "BRIAN-Folder/sample-folder" should exist
+    When user "Brian" gets all shares shared by him using the sharing API
+    Then the OCS status code should be "100"
+    And the HTTP status code should be "200"
+    And file "/Shares/BRIAN-Folder" should be included in the response
+    When user "Alice" accepts share "/BRIAN-Folder" offered by user "Brian" using the sharing API
+    Then the OCS status code should be "100"
+    And the HTTP status code should be "200"
+    # now Alice has "her" folder as "/Shares/BRIAN-Folder"
+    # and has the shared file from Brian as "/Shares/BRIAN-Folder (2)"
+    And as "Alice" folder "/Shares/BRIAN-Folder" should exist
+    And as "Alice" folder "/Shares/BRIAN-Folder/ALICE-folder" should exist
+    And as "Alice" folder "/Shares/BRIAN-Folder (2)" should exist
+    And as "Alice" folder "/Shares/BRIAN-Folder (2)/sample-folder" should exist
+    # Alice can add content to both folders
+    # Brian sees what Alice puts into "/Shares/BRIAN-Folder (2)"
+    And user "Alice" has created folder "/Shares/BRIAN-Folder/new-folder1"
+    And user "Alice" has created folder "/Shares/BRIAN-Folder (2)/new-folder2"
+    And user "Alice" has uploaded file with content "new content 1" to "/Shares/BRIAN-Folder/new-folder1/file1.txt"
+    And user "Alice" has uploaded file with content "new content 2" to "/Shares/BRIAN-Folder (2)/new-folder2/file2.txt"
+    And the content of file "/Shares/BRIAN-Folder/new-folder1/file1.txt" for user "Alice" should be "new content 1"
+    And the content of file "/Shares/BRIAN-Folder (2)/new-folder2/file2.txt" for user "Alice" should be "new content 2"
+    And the content of file "/BRIAN-Folder/new-folder2/file2.txt" for user "Brian" should be "new content 2"
+    Examples:
+      | dav_version |
+      | old         |
+      | new         |


### PR DESCRIPTION
## Description
A share receiver can do a COPY webDAV API request to COPY  a resource of theirs "over the top" of a received share. That results in some interesting behavior. This PR expands the existing acceptance tests so that they demonstrate all the "interesting" behavior that I could notice.

1) Brian shares a folder with Alice. Alice copies a file directly over the received folder.
2) Brian shares a file with Alice. Alice copies a folder directly over the received file.
3) Brian shares a file with Alice. Alice copies a file directly over the received file.
4) Brian shares a folder with Alice. Alice copies a folder directly over the received folder.

Let's say that the file or folder is called "resource".

In each case, the share from Brian to Alice switches into the "declined" state. Alice can accept the share again, and the shared resource from Brian is now called "/Shares/resource (2)" The original name "/Shares/resource" is the thing that Alice copied.

For item (3) (file copied to existing shared file) probably the system should copy the content into "/Shares/resource" and Brian will see new content in the file called "resource" that he shared to Alice.

For item (4) (folder copied to existing shared folder) there could be some rules for merging the folder structure from Alice into the folder structure that was shared from Brian. (Some algorithm for that would also apply to when Alice copies a folder "over the top" of one of her own personal folders) Or that sort of COPY could be rejected, probably 409 - Conflict would be a suitable HTTP status

For items (1) and (2), probably the COPY request should be rejected with 409 - Conflict. If Brian shares a file or folder to Alice, giving Alice write access, then I don't think that Brian would be wanting Alice to change the resource from file to folder, or folder to file.

## How Has This Been Tested?
CI

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Database schema changes (next release will require increase of minor version instead of patch)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [x] Tests only (no source changes)

## Checklist:
- [ ] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 
- [ ] Changelog item, see [TEMPLATE](https://github.com/owncloud/core/blob/master/changelog/TEMPLATE)
