### PR TITLE
[tests-only][full-ci]Added `api` test to upload empty file to a shared folder

### DIFF
--- a/tests/acceptance/features/apiShareOperationsToShares2/uploadToShare.feature
+++ b/tests/acceptance/features/apiShareOperationsToShares2/uploadToShare.feature
@@ -289,3 +289,19 @@ Feature: sharing
       | dav-path | permissions |
       | old      | change      |
       | new      | create      |
+
+
+  Scenario Outline: upload an empty file (size zero byte) to a shared folder
+    Given using <dav_version> DAV path
+    And user "Brian" has been created with default attributes and without skeleton files
+    And user "Brian" has created folder "/folder-to-share"
+    And user "Brian" has shared folder "/folder-to-share" with user "Alice"
+    And user "Alice" has accepted share "/folder-to-share" offered by user "Brian"
+    When user "Alice" uploads file "filesForUpload/zerobyte.txt" to "/Shares/folder-to-share/zerobyte.txt" using the WebDAV API
+    Then the HTTP status code should be "201"
+    And as "Alice" file "/Shares/folder-to-share/zerobyte.txt" should exist
+    And the content of file "/Shares/folder-to-share/zerobyte.txt" for user "Alice" should be ""
+    Examples:
+      | dav_version |
+      | old         |
+      | new         |

--- a/tests/acceptance/features/apiWebdavUpload1/uploadFile.feature
+++ b/tests/acceptance/features/apiWebdavUpload1/uploadFile.feature
@@ -318,7 +318,17 @@ Feature: upload file
       | spaces      |
 
 
-  Scenario: upload a file of size zero byte
+  Scenario Outline: upload a file of size zero byte
+    Given using <dav_version> DAV path
     When user "Alice" uploads file "filesForUpload/zerobyte.txt" to "/zerobyte.txt" using the WebDAV API
     Then the HTTP status code should be "201"
     And as "Alice" file "zerobyte.txt" should exist
+    Examples:
+      | dav_version |
+      | old         |
+      | new         |
+
+    @skipOnOcV10 @personalSpace
+    Examples:
+      | dav_version |
+      | spaces      |


### PR DESCRIPTION
## Description
This PR adds API tests to upload an empty (size zero byte) file to a shared folder. 

## Related Issue
https://github.com/owncloud/ocis/issues/4383

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
- Locally
- CI

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Database schema changes (next release will require increase of minor version instead of patch)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [ ] Tests only (no source changes)

## Checklist:
<!-- Tick the checkboxes when done. -->
<!-- Raise documentation ticket in https://github.com/owncloud/documentation -->
- [ ] Code changes
- [ ] Unit tests added
- [x] Acceptance tests added
- [ ] Documentation ticket raised: <link> 
- [ ] Changelog item, see [TEMPLATE](https://github.com/owncloud/core/blob/master/changelog/TEMPLATE)
