### PR TITLE
Adjust OC_VersionString to more closely match the git tag

### DIFF
--- a/version.php
+++ b/version.php
@@ -27,8 +27,8 @@
 // when updating major/minor version number.
 $OC_Version = [10, 11, 0, 3];
 
-// The human readable string
-$OC_VersionString = '10.11.0 beta 1';
+// The human-readable string
+$OC_VersionString = '10.11.0-beta.1';
 
 $OC_VersionCanBeUpgradedFrom = [[8, 2, 11],[9, 0, 9],[9, 1]];
 


### PR DESCRIPTION
## Description
The git tag is `v10.11.0-beta.1` which matches the pattern at item 9 of https://semver.org/ - good.

IMO we can keep the value in `version.php` in this format also. It is still "human-readable" and also it will get parsed correctly by any automated code that looks at it.

## How Has This Been Tested?
N/A

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Database schema changes (next release will require increase of minor version instead of patch)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [ ] Tests only (no source changes)

## Checklist:
- [ ] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 
- [ ] Changelog item, see [TEMPLATE](https://github.com/owncloud/core/blob/master/changelog/TEMPLATE)
