### PR TITLE
Allow editing of public link shared single files

### DIFF
--- a/apps/files_sharing/lib/Controller/Share20OcsController.php
+++ b/apps/files_sharing/lib/Controller/Share20OcsController.php
@@ -532,6 +532,7 @@ class Share20OcsController extends OCSController {
 				);
 			} elseif ($permissions === Constants::PERMISSION_CREATE ||
 				$permissions === (Constants::PERMISSION_READ | Constants::PERMISSION_CREATE | Constants::PERMISSION_UPDATE | Constants::PERMISSION_DELETE) ||
+				$permissions === (Constants::PERMISSION_READ | Constants::PERMISSION_UPDATE) ||
 				$permissions === (Constants::PERMISSION_READ | Constants::PERMISSION_CREATE)) {
 				$share->setPermissions($permissions);
 			} else {
@@ -878,6 +879,7 @@ class Share20OcsController extends OCSController {
 			if ($newPermissions !== null &&
 				$newPermissions !== Constants::PERMISSION_READ &&
 				$newPermissions !== Constants::PERMISSION_CREATE &&
+				$newPermissions !== (Constants::PERMISSION_READ | Constants::PERMISSION_UPDATE) &&
 				$newPermissions !== (Constants::PERMISSION_READ | Constants::PERMISSION_CREATE) &&
 				// legacy
 				$newPermissions !== (Constants::PERMISSION_READ | Constants::PERMISSION_CREATE | Constants::PERMISSION_UPDATE) &&

--- a/changelog/unreleased/40264
+++ b/changelog/unreleased/40264
@@ -1,0 +1,6 @@
+Enhancement: Allow editing of public link shared single files
+
+It is now possible to create a public link share of a single file with
+Download/View/Edit permissions.
+
+https://github.com/owncloud/core/pull/40264

--- a/core/js/sharedialoglinkshareview.js
+++ b/core/js/sharedialoglinkshareview.js
@@ -34,7 +34,7 @@
 				'<p><em>{{publicReadWriteDescription}}</em></p>' +
 			'</div>' +
 			'{{/if}}' +
-			'{{#if publicFolderUploadPossible}}' +
+			'{{#if publicUploadFolderPossible}}' +
 			'<div id="allowpublicUploadWrite-{{cid}}" class="public-link-modal--item">' +
 				'<input type="radio" value="{{publicUploadWriteValue}}" name="publicPermissions" id="sharingDialogAllowpublicUploadWrite-{{cid}}" class="checkbox publicPermissions" {{#if publicUploadWriteSelected}}checked{{/if}} />' +
 				'<label class="bold" for="sharingDialogAllowpublicUploadWrite-{{cid}}">{{publicUploadWriteLabel}}</label>' +

--- a/core/js/sharedialoglinkshareview.js
+++ b/core/js/sharedialoglinkshareview.js
@@ -27,7 +27,14 @@
 				'<label class="bold" for="sharingDialogAllowPublicRead-{{cid}}">{{publicReadLabel}}</label>' +
 				'<p><em>{{publicReadDescription}}</em></p>' +
 			'</div>' +
-			'{{#if publicUploadPossible}}' +
+			'{{#if publicUploadFilePossible}}' +
+			'<div id="allowPublicRead-{{cid}}" class="public-link-modal--item">' +
+				'<input type="radio" value="{{publicReadWriteValue}}" name="publicPermissions" id="sharingDialogAllowPublicReadWrite-{{cid}}" class="checkbox publicPermissions" {{#if publicReadWriteSelected}}checked{{/if}} />' +
+				'<label class="bold" for="sharingDialogAllowPublicReadWrite-{{cid}}">{{publicReadWriteLabel}}</label>' +
+				'<p><em>{{publicReadWriteDescription}}</em></p>' +
+			'</div>' +
+			'{{/if}}' +
+			'{{#if publicFolderUploadPossible}}' +
 			'<div id="allowpublicUploadWrite-{{cid}}" class="public-link-modal--item">' +
 				'<input type="radio" value="{{publicUploadWriteValue}}" name="publicPermissions" id="sharingDialogAllowpublicUploadWrite-{{cid}}" class="checkbox publicPermissions" {{#if publicUploadWriteSelected}}checked{{/if}} />' +
 				'<label class="bold" for="sharingDialogAllowpublicUploadWrite-{{cid}}">{{publicUploadWriteLabel}}</label>' +
@@ -230,9 +237,18 @@
 			this.model.destroy();
 		},
 
-		_isPublicUploadPossible: function() {
-			// TODO: in the future to read directly from the FileInfoModel
-			return this.itemModel.isFolder() && this.itemModel.createPermissionPossible() && this.configModel.isPublicUploadEnabled();
+		_isPublicFolderUploadPossible: function() {
+			if (this.itemModel.isFolder()) {
+				return this.itemModel.createPermissionPossible() && this.configModel.isPublicUploadEnabled();
+			}
+			return false;
+		},
+
+		_isPublicFileUploadPossible: function() {
+			if (this.itemModel.isFolder()) {
+				return false;
+			}
+			return this.itemModel.updatePermissionPossible() && this.configModel.isPublicUploadEnabled();
 		},
 
 		render: function () {
@@ -252,7 +268,8 @@
 				fileNameLabel              : t('core', 'Filename'),
 				passwordLabel              : t('core', 'Password'),
 
-				publicUploadPossible       : this._isPublicUploadPossible(),
+				publicUploadFolderPossible : this._isPublicFolderUploadPossible(),
+				publicUploadFilePossible   : this._isPublicFileUploadPossible(),
 
 				publicUploadLabel          : t('core', 'Upload only') + ' (File Drop)',
 				publicUploadDescription    : t('core', 'Receive files from multiple recipients without revealing the contents of the folder.'),

--- a/core/js/sharedialoglinkshareview.js
+++ b/core/js/sharedialoglinkshareview.js
@@ -28,22 +28,22 @@
 				'<p><em>{{publicReadDescription}}</em></p>' +
 			'</div>' +
 			'{{#if publicUploadFilePossible}}' +
-			'<div id="allowPublicRead-{{cid}}" class="public-link-modal--item">' +
-				'<input type="radio" value="{{publicReadWriteValue}}" name="publicPermissions" id="sharingDialogAllowPublicReadWrite-{{cid}}" class="checkbox publicPermissions" {{#if publicReadWriteSelected}}checked{{/if}} />' +
-				'<label class="bold" for="sharingDialogAllowPublicReadWrite-{{cid}}">{{publicReadWriteLabel}}</label>' +
-				'<p><em>{{publicReadWriteDescription}}</em></p>' +
+			'<div id="allowPublicFileReadWrite-{{cid}}" class="public-link-modal--item">' +
+				'<input type="radio" value="{{publicFileReadWriteValue}}" name="publicPermissions" id="sharingDialogAllowPublicFileReadWrite-{{cid}}" class="checkbox publicPermissions" {{#if publicFileReadWriteSelected}}checked{{/if}} />' +
+				'<label class="bold" for="sharingDialogAllowPublicFileReadWrite-{{cid}}">{{publicFileReadWriteLabel}}</label>' +
+				'<p><em>{{publicFileReadWriteDescription}}</em></p>' +
 			'</div>' +
 			'{{/if}}' +
 			'{{#if publicUploadFolderPossible}}' +
-			'<div id="allowpublicUploadWrite-{{cid}}" class="public-link-modal--item">' +
+			'<div id="allowPublicUploadWrite-{{cid}}" class="public-link-modal--item">' +
 				'<input type="radio" value="{{publicUploadWriteValue}}" name="publicPermissions" id="sharingDialogAllowpublicUploadWrite-{{cid}}" class="checkbox publicPermissions" {{#if publicUploadWriteSelected}}checked{{/if}} />' +
 				'<label class="bold" for="sharingDialogAllowpublicUploadWrite-{{cid}}">{{publicUploadWriteLabel}}</label>' +
 				'<p><em>{{publicUploadWriteDescription}}</em></p>' +
 			'</div>' +
-			'<div id="allowPublicRead-{{cid}}" class="public-link-modal--item">' +
-				'<input type="radio" value="{{publicReadWriteValue}}" name="publicPermissions" id="sharingDialogAllowPublicReadWrite-{{cid}}" class="checkbox publicPermissions" {{#if publicReadWriteSelected}}checked{{/if}} />' +
-				'<label class="bold" for="sharingDialogAllowPublicReadWrite-{{cid}}">{{publicReadWriteLabel}}</label>' +
-				'<p><em>{{publicReadWriteDescription}}</em></p>' +
+			'<div id="allowPublicFolderReadWrite-{{cid}}" class="public-link-modal--item">' +
+				'<input type="radio" value="{{publicFolderReadWriteValue}}" name="publicPermissions" id="sharingDialogAllowPublicFolderReadWrite-{{cid}}" class="checkbox publicPermissions" {{#if publicFolderReadWriteSelected}}checked{{/if}} />' +
+				'<label class="bold" for="sharingDialogAllowPublicFolderReadWrite-{{cid}}">{{publicFolderReadWriteLabel}}</label>' +
+				'<p><em>{{publicFolderReadWriteDescription}}</em></p>' +
 			'</div>' +
 			'<div id="allowPublicUploadWrapper-{{cid}}" class="public-link-modal--item">' +
 				'<input type="radio" value="{{publicUploadValue}}" name="publicPermissions" id="sharingDialogAllowPublicUpload-{{cid}}" class="checkbox publicPermissions" {{#if publicUploadSelected}}checked{{/if}} />' +
@@ -286,10 +286,15 @@
 				publicUploadWriteValue       : OC.PERMISSION_READ | OC.PERMISSION_CREATE,
 				publicUploadWriteSelected    : this.model.get('permissions') === (OC.PERMISSION_READ | OC.PERMISSION_CREATE),
 
-				publicReadWriteLabel       : t('core', 'Download / View / Edit'),
-				publicReadWriteDescription : t('core', 'Recipients can view, download, edit, delete and upload contents.'),
-				publicReadWriteValue       : OC.PERMISSION_READ | OC.PERMISSION_UPDATE | OC.PERMISSION_CREATE | OC.PERMISSION_DELETE,
-				publicReadWriteSelected    : this.model.get('permissions') >= (OC.PERMISSION_READ | OC.PERMISSION_UPDATE | OC.PERMISSION_CREATE | OC.PERMISSION_DELETE),
+				publicFolderReadWriteLabel       : t('core', 'Download / View / Upload / Edit'),
+				publicFolderReadWriteDescription : t('core', 'Recipients can view, download, edit, delete and upload contents.'),
+				publicFolderReadWriteValue       : OC.PERMISSION_READ | OC.PERMISSION_UPDATE | OC.PERMISSION_CREATE | OC.PERMISSION_DELETE,
+				publicFolderReadWriteSelected    : this.model.get('permissions') >= (OC.PERMISSION_READ | OC.PERMISSION_UPDATE | OC.PERMISSION_CREATE | OC.PERMISSION_DELETE),
+
+				publicFileReadWriteLabel       : t('core', 'Download / View / Edit'),
+				publicFileReadWriteDescription : t('core', 'Recipients can view, download and edit contents.'),
+				publicFileReadWriteValue       : OC.PERMISSION_READ | OC.PERMISSION_UPDATE,
+				publicFileReadWriteSelected    : this.model.get('permissions') >= (OC.PERMISSION_READ | OC.PERMISSION_UPDATE),
 
 				isMailEnabled: showEmailField
 			}));

--- a/core/js/tests/specs/sharedialoglinkshareviewSpec.js
+++ b/core/js/tests/specs/sharedialoglinkshareviewSpec.js
@@ -144,6 +144,9 @@ describe('OC.Share.ShareDialogLinkShareView', function() {
 				expireDate: '2017-10-12',
 				permissions: OC.PERMISSION_CREATE
 			});
+			expect(view._isPublicFolderUploadPossible()).toEqual(true)
+			expect(view._isPublicFileUploadPossible()).toEqual(false)
+
 			view.render();
 
 			expect(parseInt(view.$('.publicPermissions:checked').val())).toBe(OC.PERMISSION_CREATE);

--- a/lib/private/Share20/Manager.php
+++ b/lib/private/Share20/Manager.php
@@ -322,7 +322,7 @@ class Manager implements IManager {
 		if ($shareNode instanceof \OCP\Files\File) {
 			// Single file shares should never have delete or create permissions
 			$share->setPermissions($share->getPermissions() & ~\OCP\Constants::PERMISSION_DELETE);
-			$share->setPermissions($share->getPermissions() & ~\OCP\Constants::PERMISSION_CREATE);
+#			$share->setPermissions($share->getPermissions() & ~\OCP\Constants::PERMISSION_CREATE);
 		}
 
 		/*
@@ -341,6 +341,9 @@ class Manager implements IManager {
 
 		/* Use share node permission as default $maxPermissions */
 		$maxPermissions = $shareNode->getPermissions();
+		if ($shareNode instanceof \OCP\Files\File) {
+			$maxPermissions |= \OCP\Constants::PERMISSION_CREATE;
+		}
 
 		/* By default, there are no required attributes to be set on a file */
 		$requiredAttributes = $this->newShare()->newAttributes();

--- a/lib/private/Share20/Manager.php
+++ b/lib/private/Share20/Manager.php
@@ -341,9 +341,6 @@ class Manager implements IManager {
 
 		/* Use share node permission as default $maxPermissions */
 		$maxPermissions = $shareNode->getPermissions();
-		if ($shareNode instanceof \OCP\Files\File) {
-			$maxPermissions |= \OCP\Constants::PERMISSION_CREATE;
-		}
 
 		/* By default, there are no required attributes to be set on a file */
 		$requiredAttributes = $this->newShare()->newAttributes();
@@ -403,6 +400,10 @@ class Manager implements IManager {
 					$maxPermissions |= $shareNode->getPermissions();
 				}
 			}
+		}
+
+		if ($shareNode instanceof \OCP\Files\File) {
+			$maxPermissions |= \OCP\Constants::PERMISSION_CREATE;
 		}
 
 		/**

--- a/lib/private/Share20/Manager.php
+++ b/lib/private/Share20/Manager.php
@@ -322,7 +322,7 @@ class Manager implements IManager {
 		if ($shareNode instanceof \OCP\Files\File) {
 			// Single file shares should never have delete or create permissions
 			$share->setPermissions($share->getPermissions() & ~\OCP\Constants::PERMISSION_DELETE);
-#			$share->setPermissions($share->getPermissions() & ~\OCP\Constants::PERMISSION_CREATE);
+			$share->setPermissions($share->getPermissions() & ~\OCP\Constants::PERMISSION_CREATE);
 		}
 
 		/*

--- a/tests/acceptance/features/apiSharePublicLink1/createPublicLinkShare.feature
+++ b/tests/acceptance/features/apiSharePublicLink1/createPublicLinkShare.feature
@@ -106,12 +106,12 @@ Feature: create a public link share
       | 2               | 200             |
 
 
-  Scenario Outline: Trying to create a new public link share of a file with edit permissions only grants read access using the public WebDAV API
+  Scenario Outline: Create a new public link share of a file with edit permissions
     Given using OCS API version "<ocs_api_version>"
     And user "Alice" has uploaded file with content "Random data" to "/randomfile.txt"
     When user "Alice" creates a public link share using the sharing API with settings
-      | path        | randomfile.txt |
-      | permissions | all            |
+      | path        | randomfile.txt            |
+      | permissions | read,update,create,delete |
     Then the OCS status code should be "<ocs_status_code>"
     And the HTTP status code should be "200"
     And the fields of the last response to user "Alice" should include
@@ -119,7 +119,7 @@ Feature: create a public link share
       | mimetype               | text/plain      |
       | file_target            | /randomfile.txt |
       | path                   | /randomfile.txt |
-      | permissions            | read            |
+      | permissions            | read,update     |
       | share_type             | public_link     |
       | displayname_file_owner | %displayname%   |
       | displayname_owner      | %displayname%   |
@@ -127,7 +127,7 @@ Feature: create a public link share
       | uid_owner              | %username%      |
       | name                   |                 |
     And the public should be able to download the last publicly shared file using the <public-webdav-api-version> public WebDAV API without a password and the content should be "Random data"
-    And the public upload to the last publicly shared file using the <public-webdav-api-version> public WebDAV API should fail with HTTP status code "403"
+    And uploading content to a public link shared file should work using the <public-webdav-api-version> public WebDAV API
 
     @notToImplementOnOCIS @issue-ocis-2079
     Examples:

--- a/tests/acceptance/features/apiSharePublicLink1/createPublicLinkShare.feature
+++ b/tests/acceptance/features/apiSharePublicLink1/createPublicLinkShare.feature
@@ -105,7 +105,7 @@ Feature: create a public link share
       | 1               | 100             |
       | 2               | 200             |
 
-
+  @skipOnOcV10.9 @skipOnOcV10.10
   Scenario Outline: Create a new public link share of a file with edit permissions
     Given using OCS API version "<ocs_api_version>"
     And user "Alice" has uploaded file with content "Random data" to "/randomfile.txt"

--- a/tests/acceptance/features/bootstrap/PublicWebDavContext.php
+++ b/tests/acceptance/features/bootstrap/PublicWebDavContext.php
@@ -55,7 +55,14 @@ class PublicWebDavContext implements Context {
 	 */
 	public function downloadPublicFileWithRange(string $range, string $publicWebDAVAPIVersion, ?string $password = ""):void {
 		if ($publicWebDAVAPIVersion === "new") {
-			$path = $this->featureContext->getLastPublicSharePath();
+			// In this case a single file has been shared as a public link.
+			// Even if that file is somewhere down inside a folder(s), when
+			// accessing it as a public link using the "new" public webDAV API
+			// the client needs to provide the public link share token followed
+			// by just the name of the file - not the full path.
+			$fullPath = $this->featureContext->getLastPublicSharePath();
+			$fullPathParts = \explode("/", $fullPath);
+			$path = \end($fullPathParts);
 		} else {
 			$path = "";
 		}

--- a/tests/acceptance/features/bootstrap/PublicWebDavContext.php
+++ b/tests/acceptance/features/bootstrap/PublicWebDavContext.php
@@ -55,7 +55,7 @@ class PublicWebDavContext implements Context {
 	 */
 	public function downloadPublicFileWithRange(string $range, string $publicWebDAVAPIVersion, ?string $password = ""):void {
 		if ($publicWebDAVAPIVersion === "new") {
-			$path = (string)$this->featureContext->getLastPublicShareData()->data->file_target;
+			$path = $this->featureContext->getLastPublicSharePath();
 		} else {
 			$path = "";
 		}
@@ -1225,6 +1225,70 @@ class PublicWebDavContext implements Context {
 	}
 
 	/**
+	 * @Then /^uploading content to a public link shared file should (not|)\s?work using the (old|new) public WebDAV API$/
+	 *
+	 * @param string $shouldOrNot (not|)
+	 * @param string $publicWebDAVAPIVersion
+	 *
+	 * @return void
+	 * @throws Exception
+	 */
+	public function publiclyUploadingToPublicLinkSharedFileShouldWork(
+		string $shouldOrNot,
+		string $publicWebDAVAPIVersion
+	):void {
+		$content = "test $publicWebDAVAPIVersion";
+		$should = ($shouldOrNot !== "not");
+
+		if ($publicWebDAVAPIVersion === "new") {
+			$techPreviewHadToBeEnabled = $this->occContext->enableDAVTechPreview();
+			$path = $this->featureContext->getLastPublicSharePath();
+		} else {
+			$techPreviewHadToBeEnabled = false;
+			$path = "";
+		}
+
+		$this->publicUploadContent(
+			$path,
+			'',
+			$content,
+			false,
+			[],
+			$publicWebDAVAPIVersion
+		);
+		$response = $this->featureContext->getResponse();
+		if ($should) {
+			Assert::assertTrue(
+				($response->getStatusCode() == 204),
+				"upload should have passed but failed with code " .
+				$response->getStatusCode()
+			);
+
+			$this->downloadPublicFileWithRange(
+				"",
+				$publicWebDAVAPIVersion,
+				""
+			);
+
+			$this->featureContext->checkDownloadedContentMatches(
+				$content,
+				"Checking the content of the last public shared file after downloading with the $publicWebDAVAPIVersion public WebDAV API"
+			);
+		} else {
+			$expectedCode = 403;
+			Assert::assertTrue(
+				($response->getStatusCode() == $expectedCode),
+				"upload should have failed with HTTP status $expectedCode but passed with code " .
+				$response->getStatusCode()
+			);
+		}
+
+		if ($techPreviewHadToBeEnabled) {
+			$this->occContext->disableDAVTechPreview();
+		}
+	}
+
+	/**
 	 * @When the public uploads file :fileName to the last public link shared folder with mtime :mtime using the :davVersion public WebDAV API
 	 *
 	 * @param String $fileName
@@ -1447,6 +1511,10 @@ class PublicWebDavContext implements Context {
 			\array_map('rawurlencode', \explode('/', $filename))
 		);
 		$url .= \ltrim($filename, '/');
+		// Trim any "/" from the end. For example, if we are putting content to a
+		// single file that has been shared with a link, then the URL should end
+		// with the link token and no "/" at the end.
+		$url = \rtrim($url, "/");
 		$headers = ['X-Requested-With' => 'XMLHttpRequest'];
 
 		if ($autoRename) {

--- a/tests/acceptance/features/bootstrap/WebUISharingContext.php
+++ b/tests/acceptance/features/bootstrap/WebUISharingContext.php
@@ -863,7 +863,7 @@ class WebUISharingContext extends RawMinkContext implements Context {
 		$linkTab = $this->sharingDialog->openPublicShareTab($this->getSession());
 		$linkName = $linkTab->getNameOfFirstPublicLink($this->getSession());
 		$linkUrl = $linkTab->getLinkUrl($linkName);
-		$this->featureContext->addToListOfCreatedPublicLinks($linkName, $linkUrl);
+		$this->featureContext->addToListOfCreatedPublicLinks($linkName, $linkUrl, $name);
 	}
 
 	/**
@@ -930,7 +930,7 @@ class WebUISharingContext extends RawMinkContext implements Context {
 			);
 		}
 		$this->featureContext->setLastPublicLinkShareId($shareId);
-		$this->featureContext->addToListOfCreatedPublicLinks($linkName, $linkUrl);
+		$this->featureContext->addToListOfCreatedPublicLinks($linkName, $linkUrl, $name);
 	}
 
 	/**
@@ -1224,12 +1224,11 @@ class WebUISharingContext extends RawMinkContext implements Context {
 	 * @throws Exception
 	 */
 	public function thePublicAccessesTheLastCreatedPublicLinkUsingTheWebUI():void {
-		$createdPublicLinks = $this->featureContext->getCreatedPublicLinks();
-		$lastCreatedLink = \end($createdPublicLinks);
+		$lastCreatedLinkUrl = $this->featureContext->getLastCreatedPublicLinkUrl();
 		$path = \str_replace(
 			$this->featureContext->getBaseUrl(),
 			"",
-			$lastCreatedLink['url']
+			$lastCreatedLinkUrl
 		);
 		$this->publicLinkFilesPage->setPagePath($path);
 		$this->publicLinkFilesPage->open();

--- a/tests/acceptance/features/webUISharingPublic1/permissionsShareFileByPublicLink.feature
+++ b/tests/acceptance/features/webUISharingPublic1/permissionsShareFileByPublicLink.feature
@@ -1,0 +1,32 @@
+@webUI @insulated @disablePreviews @mailhog @public_link_share-feature-required @files_sharing-app-required
+Feature: Share a file by public link
+  As a user
+  I want to share files through a publicly accessible link
+  So that users who do not have an account on my ownCloud server can access them
+
+  Background:
+    Given user "Alice" has been created with default attributes and without skeleton files
+
+  Scenario: creating a public link of a file with read permissions
+    Given user "Alice" has uploaded file with content "text to test public links" to "/lorem.txt"
+    And user "Alice" has logged in using the webUI
+    When the user creates a new public link for file "lorem.txt" using the webUI with
+      | permission | read |
+    And the public accesses the last created public link using the webUI
+    Then the text preview of the public link should contain "text to test public links"
+    And the public should be able to download the last publicly shared file using the old public WebDAV API without a password and the content should be "text to test public links"
+    And the public should be able to download the last publicly shared file using the new public WebDAV API without a password and the content should be "text to test public links"
+    And uploading content to a public link shared file should not work using the old public WebDAV API
+    And uploading content to a public link shared file should not work using the new public WebDAV API
+
+  Scenario: creating a public link with read & write permissions
+    Given user "Alice" has uploaded file with content "text to test public links" to "/lorem.txt"
+    And user "Alice" has logged in using the webUI
+    When the user creates a new public link for file "lorem.txt" using the webUI with
+      | permission | read-write |
+    And the public accesses the last created public link using the webUI
+    Then the text preview of the public link should contain "text to test public links"
+    And the public should be able to download the last publicly shared file using the old public WebDAV API without a password and the content should be "text to test public links"
+    And the public should be able to download the last publicly shared file using the new public WebDAV API without a password and the content should be "text to test public links"
+    And uploading content to a public link shared file should work using the old public WebDAV API
+    And uploading content to a public link shared file should work using the new public WebDAV API

--- a/tests/acceptance/features/webUISharingPublic1/permissionsShareFileByPublicLink.feature
+++ b/tests/acceptance/features/webUISharingPublic1/permissionsShareFileByPublicLink.feature
@@ -19,6 +19,7 @@ Feature: Share a file by public link
     And uploading content to a public link shared file should not work using the old public WebDAV API
     And uploading content to a public link shared file should not work using the new public WebDAV API
 
+  @skipOnOcV10.9 @skipOnOcV10.10
   Scenario: creating a public link with read & write permissions
     Given user "Alice" has uploaded file with content "text to test public links" to "/lorem.txt"
     And user "Alice" has logged in using the webUI

--- a/tests/acceptance/features/webUISharingPublic1/permissionsShareFolderByPublicLink.feature
+++ b/tests/acceptance/features/webUISharingPublic1/permissionsShareFolderByPublicLink.feature
@@ -1,7 +1,7 @@
 @webUI @insulated @disablePreviews @mailhog @public_link_share-feature-required @files_sharing-app-required
-Feature: Share by public link
+Feature: Share a folder by public link
   As a user
-  I want to share files through a publicly accessible link
+  I want to share folders through a publicly accessible link
   So that users who do not have an account on my ownCloud server can access them
 
   Background:

--- a/tests/lib/Share20/ManagerTest.php
+++ b/tests/lib/Share20/ManagerTest.php
@@ -930,9 +930,9 @@ class ManagerTest extends \Test\TestCase {
 		$this->assertSame($exception, $thrown);
 	}
 
-	public function dataShareNotEnoughPermissions() {
+	public function dataShareNotEnoughPermissions(): array {
 		$file = $this->createMock(File::class);
-		$file->method('getPermissions')->willReturn(17);
+		$file->method('getPermissions')->willReturn(16);
 		$file->method('getName')->willReturn('sharedfile');
 		$file->method('getPath')->willReturn('/user1/sharedfile');
 
@@ -998,7 +998,7 @@ class ManagerTest extends \Test\TestCase {
 	 * @param $exceptionMessage
 	 * @param $exception
 	 */
-	public function testShareNotEnoughPermissions($share, $superShareNode, $exceptionMessage, $exception) {
+	public function testShareNotEnoughPermissions($share, $superShareNode, $exceptionMessage, $exception): void {
 		$sharer = $this->createMock(IUser::class);
 		$sharer->method('getUID')->willReturn($share->getSharedBy());
 		$this->userSession->method('getUser')->willReturn($sharer);
@@ -1008,7 +1008,7 @@ class ManagerTest extends \Test\TestCase {
 		$this->rootFolder->method('getUserFolder')->willReturn($userFolder);
 
 		try {
-			$this->invokePrivate($this->manager, 'validatePermissions', [$share]);
+			self::invokePrivate($this->manager, 'validatePermissions', [$share]);
 			$thrown = false;
 		} catch (\OCP\Share\Exceptions\GenericShareException $e) {
 			$this->assertEquals($exceptionMessage, $e->getHint());


### PR DESCRIPTION
## Description
This feature was initially in PR #40264 which was merged to master. It was reverted in PR #40312 because it is not yet for release.
PR #40283 also made some minor adjustments to skip tags on new/changed acceptance tests.

This PR is a cherry-pick of the commits from #40264 and #40283 - I will leave the PR in draft mode until after 10.11.0 release.

## Related Issue
https://github.com/owncloud/enterprise/issues/5274

## How Has This Been Tested?
CI

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Database schema changes (next release will require increase of minor version instead of patch)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [ ] Tests only (no source changes)

## Checklist:
- [ ] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 
- [ ] Changelog item, see [TEMPLATE](https://github.com/owncloud/core/blob/master/changelog/TEMPLATE)
