### PR TITLE
[tests-only] [full-ci] Adjust public link test code

### DIFF
--- a/tests/acceptance/features/apiSharePublicLink1/createPublicLinkShare.feature
+++ b/tests/acceptance/features/apiSharePublicLink1/createPublicLinkShare.feature
@@ -105,30 +105,32 @@ Feature: create a public link share
     And user "Alice" has uploaded file with content "Random data" to "/randomfile.txt"
     When user "Alice" creates a public link share using the sharing API with settings
       | path        | randomfile.txt            |
-      | permissions | read,update,create,delete |
+      | permissions | <requested_permissions>   |
     Then the OCS status code should be "<ocs_status_code>"
     And the HTTP status code should be "200"
     And the fields of the last response to user "Alice" should include
-      | item_type              | file            |
-      | mimetype               | text/plain      |
-      | file_target            | /randomfile.txt |
-      | path                   | /randomfile.txt |
-      | permissions            | read,update     |
-      | share_type             | public_link     |
-      | displayname_file_owner | %displayname%   |
-      | displayname_owner      | %displayname%   |
-      | uid_file_owner         | %username%      |
-      | uid_owner              | %username%      |
-      | name                   |                 |
+      | item_type              | file                  |
+      | mimetype               | text/plain            |
+      | file_target            | /randomfile.txt       |
+      | path                   | /randomfile.txt       |
+      | permissions            | <granted_permissions> |
+      | share_type             | public_link           |
+      | displayname_file_owner | %displayname%         |
+      | displayname_owner      | %displayname%         |
+      | uid_file_owner         | %username%            |
+      | uid_owner              | %username%            |
+      | name                   |                       |
     And the public should be able to download the last publicly shared file using the old public WebDAV API without a password and the content should be "Random data"
     And the public should be able to download the last publicly shared file using the new public WebDAV API without a password and the content should be "Random data"
-    And uploading content to a public link shared file should work using the old public WebDAV API
-    And uploading content to a public link shared file should work using the new public WebDAV API
+    And uploading content to a public link shared file <upload_works_or_not> using the old public WebDAV API
+    And uploading content to a public link shared file <upload_works_or_not> using the new public WebDAV API
 
     Examples:
-      | ocs_api_version | ocs_status_code |
-      | 1               | 100             |
-      | 2               | 200             |
+      | ocs_api_version | ocs_status_code | requested_permissions     | granted_permissions | upload_works_or_not |
+      | 1               | 100             | read,update,create,delete | read,update         | should work         |
+      | 2               | 200             | read,update,create,delete | read,update         | should work         |
+      | 1               | 100             | all                       | read                | should not work     |
+      | 2               | 200             | all                       | read                | should not work     |
 
 
   Scenario Outline: Creating a new public link share of a folder using the default permissions only grants read access and can be accessed with no password or any password using the public WebDAV API


### PR DESCRIPTION
## Description
This is the acceptance test code that was refactored for PR #40264 - a lot of it is good refactoring to do anyway.

The code looks good for current master behavior. But we can keep this PR in Draft until after release 10.11 happens and is merged back. I don't really want to refactor this much test code in master right now.

Note: it seems that we can currently use the API to create a public link of a single file that has write access, and that "the public" can use the link to update the content of the file. So, at the API level, this feature already exists. There is just no UI to do it on the classic web UI.

## How Has This Been Tested?
CI

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Database schema changes (next release will require increase of minor version instead of patch)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [x] Tests only (no source changes)

## Checklist:
- [ ] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 
- [ ] Changelog item, see [TEMPLATE](https://github.com/owncloud/core/blob/master/changelog/TEMPLATE)
