### PR TITLE
[tests-only][full-ci]Added test for restoring file version after delete and restore from Trashbin

### DIFF
--- a/tests/acceptance/config/behat.yml
+++ b/tests/acceptance/config/behat.yml
@@ -509,6 +509,7 @@ default:
         - WebDavPropertiesContext:
         - OccContext:
         - AppConfigurationContext:
+        - TrashbinContext:
 
     apiWebdavDelete:
       paths:

--- a/tests/acceptance/features/apiVersions/fileVersions.feature
+++ b/tests/acceptance/features/apiVersions/fileVersions.feature
@@ -516,3 +516,19 @@ Feature: dav-versions
       | MTI4NGQyMzgtYWE5Mi00MmNlLWJkYzQtMGIwMDAwMDA5MTU3OGNjZDI3NTEtOTBhNC00MGYyLWI5ZjMtNjFlZGY4NDQyMWY0     | 1284d238-aa92-42ce-bdc4-0b00000091578ccd2751-90a4-40f2-b9f3-61edf84421f4  | no = sign          |
       | c29tZS1yYW5kb20tZmlsZUlkPWFub3RoZXItcmFuZG9tLWZpbGVJZA==                                             | some-random-fileId=another-random-fileId                                  | some random string |
       | MTI4NGQyMzgtYWE5Mi00MmNlLWJkxzQtMGIwMDAwMDA5MTU2OjhjY2QyNzUxLTkwYTQtNDBmMi1iOWYzLTYxZWRmODQ0MjFmNA== | 1284d238-aa92-42ce-bd�4-0b0000009156:8ccd2751-90a4-40f2-b9f3-61edf84421f4 | with : and  � sign |
+
+
+  Scenario: File versions sets back after getting deleted and restored from trashbin
+    Given user "Alice" has uploaded file with content "Old Test Content." to "/davtest.txt"
+    And user "Alice" has uploaded file with content "New Test Content." to "/davtest.txt"
+    And the version folder of file "/davtest.txt" for user "Alice" should contain "1" element
+    And user "Alice" has deleted file "/davtest.txt"
+    And as "Alice" file "/davtest.txt" should exist in the trashbin
+    When user "Alice" restores the file with original path "/davtest.txt" using the trashbin API
+    Then the HTTP status code should be "201"
+    And as "Alice" file "/davtest.txt" should exist
+    And the content of file "/davtest.txt" for user "Alice" should be "New Test Content."
+    And the version folder of file "/davtest.txt" for user "Alice" should contain "1" element
+    When user "Alice" restores version index "1" of file "/davtest.txt" using the WebDAV API
+    Then the HTTP status code should be "200"
+    And the content of file "/davtest.txt" for user "Alice" should be "Old Test Content."


### PR DESCRIPTION
### Description
This PR adds if the files versions are set back when a file with (versions) is deleted and again restored back from the trashbin.

## Related Issue
https://github.com/owncloud/core/issues/40286
https://github.com/owncloud/core/issues/40286#issuecomment-1231402040

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
- test environment:
- Locally
- CI

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Database schema changes (next release will require increase of minor version instead of patch)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [ ] Tests only (no source changes)

## Checklist:
<!-- Tick the checkboxes when done. -->
<!-- Raise documentation ticket in https://github.com/owncloud/documentation -->
- [ ] Code changes
- [ ] Unit tests added
- [x] Acceptance tests added
- [ ] Documentation ticket raised: <link> 
- [ ] Changelog item, see [TEMPLATE](https://github.com/owncloud/core/blob/master/changelog/TEMPLATE)
