### PR TITLE
[tests-only][full-ci]Adjustment in core so that code can be reused from ocis

### DIFF
--- a/tests/acceptance/features/bootstrap/FavoritesContext.php
+++ b/tests/acceptance/features/bootstrap/FavoritesContext.php
@@ -48,14 +48,16 @@ class FavoritesContext implements Context {
 	/**
 	 * @param string$user
 	 * @param string $path
+	 * @param string|null $spaceIDFromOcis
 	 *
 	 * @return void
 	 */
-	public function userFavoritesElement(string $user, string $path):void {
+	public function userFavoritesElement(string $user, string $path, string $spaceIDFromOcis = null):void {
 		$response = $this->changeFavStateOfAnElement(
 			$user,
 			$path,
-			1
+			1,
+			$spaceIDFromOcis
 		);
 		$this->featureContext->setResponse($response);
 	}
@@ -318,13 +320,15 @@ class FavoritesContext implements Context {
 	 * @param string $user
 	 * @param string $path
 	 * @param int|null $favOrUnfav 1 = favorite, 0 = unfavorite
+	 * @param string|null $spaceIdFromOcis
 	 *
 	 * @return ResponseInterface
 	 */
 	public function changeFavStateOfAnElement(
 		string $user,
 		string $path,
-		?int $favOrUnfav
+		?int $favOrUnfav,
+		?string $spaceIdFromOcis = null
 	):ResponseInterface {
 		$renamedUser = $this->featureContext->getActualUsername($user);
 		return WebDavHelper::proppatch(
@@ -336,7 +340,9 @@ class FavoritesContext implements Context {
 			(string)$favOrUnfav,
 			$this->featureContext->getStepLineRef(),
 			"oc='http://owncloud.org/ns'",
-			$this->featureContext->getDavPathVersion()
+			$this->featureContext->getDavPathVersion(),
+			'files',
+			$spaceIdFromOcis
 		);
 	}
 


### PR DESCRIPTION
### Description
This PR adds some code adjustment (in core) so that the code can be reused in ocis (If any new implementation is done). Since as of now we are duplicating the same code in core as well as in ocis.

We have a `favourite.feature` feature in ocis where we have been duplicating code so for reference i have tried to reduce the code in `ocis` for the feature so that it uses code (resource) already in core (for reducing code duplication). Follow this PR https://github.com/owncloud/ocis/pull/4492

## Related Issue
No related Issue So far since this is a sample PR (After approval) a separate issue is made for refactoring and code reuse from core for ocis implementation.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
- Locally
- CI

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Database schema changes (next release will require increase of minor version instead of patch)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [ ] Tests only (no source changes)

## Checklist:
<!-- Tick the checkboxes when done. -->
<!-- Raise documentation ticket in https://github.com/owncloud/documentation -->
- [x] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 
- [ ] Changelog item, see [TEMPLATE](https://github.com/owncloud/core/blob/master/changelog/TEMPLATE)
