### PR TITLE
[tests-only][full-ci]Refactor code to reuse code in `ocis`

### DIFF
--- a/tests/TestHelpers/WebDavHelper.php
+++ b/tests/TestHelpers/WebDavHelper.php
@@ -40,7 +40,7 @@ class WebDavHelper {
 	public const DAV_VERSION_OLD = 1;
 	public const DAV_VERSION_NEW = 2;
 	public const DAV_VERSION_SPACES = 3;
-	public static $SPACE_ID_FROM_OCIS = null;
+	public static $SPACE_ID_FROM_OCIS = '';
 
 	/**
 	 * @var array of users with their different spaces ids
@@ -577,7 +577,7 @@ class WebDavHelper {
 		}
 
 		// get space id if testing with spaces dav
-		if (self::$SPACE_ID_FROM_OCIS === null && $davPathVersionToUse === self::DAV_VERSION_SPACES) {
+		if (self::$SPACE_ID_FROM_OCIS === '' && $davPathVersionToUse === self::DAV_VERSION_SPACES) {
 			if ($doDavRequestAsUser === null) {
 				$spaceId = self::getPersonalSpaceIdForUser($baseUrl, $user, $password, $xRequestId);
 			} else {
@@ -634,8 +634,8 @@ class WebDavHelper {
 			}
 		}
 
-		//Make the space ID from ocis null after each request
-		self::$SPACE_ID_FROM_OCIS = null;
+		//Clear the space ID from ocis after each request
+		self::$SPACE_ID_FROM_OCIS = '';
 		return HttpRequestHelper::sendRequest(
 			$fullUrl,
 			$xRequestId,

--- a/tests/TestHelpers/WebDavHelper.php
+++ b/tests/TestHelpers/WebDavHelper.php
@@ -40,6 +40,7 @@ class WebDavHelper {
 	public const DAV_VERSION_OLD = 1;
 	public const DAV_VERSION_NEW = 2;
 	public const DAV_VERSION_SPACES = 3;
+	public static $SPACE_ID_FROM_OCIS = null;
 
 	/**
 	 * @var array of users with their different spaces ids
@@ -575,14 +576,15 @@ class WebDavHelper {
 			$path = "";
 		}
 
-		$spaceId = null;
 		// get space id if testing with spaces dav
-		if ($davPathVersionToUse === self::DAV_VERSION_SPACES) {
+		if (self::$SPACE_ID_FROM_OCIS === null && $davPathVersionToUse === self::DAV_VERSION_SPACES) {
 			if ($doDavRequestAsUser === null) {
 				$spaceId = self::getPersonalSpaceIdForUser($baseUrl, $user, $password, $xRequestId);
 			} else {
 				$spaceId = self::getPersonalSpaceIdForUser($baseUrl, $doDavRequestAsUser, $password, $xRequestId);
 			}
+		} else {
+			$spaceId = self::$SPACE_ID_FROM_OCIS;
 		}
 
 		if ($doDavRequestAsUser === null) {
@@ -631,6 +633,9 @@ class WebDavHelper {
 				}
 			}
 		}
+
+		//Make the space ID from ocis null after each request
+		self::$SPACE_ID_FROM_OCIS = null;
 		return HttpRequestHelper::sendRequest(
 			$fullUrl,
 			$xRequestId,

--- a/tests/acceptance/features/bootstrap/FavoritesContext.php
+++ b/tests/acceptance/features/bootstrap/FavoritesContext.php
@@ -48,16 +48,14 @@ class FavoritesContext implements Context {
 	/**
 	 * @param string$user
 	 * @param string $path
-	 * @param string|null $spaceIDFromOcis
 	 *
 	 * @return void
 	 */
-	public function userFavoritesElement(string $user, string $path, ?string $spaceIDFromOcis = null):void {
+	public function userFavoritesElement(string $user, string $path):void {
 		$response = $this->changeFavStateOfAnElement(
 			$user,
 			$path,
-			1,
-			$spaceIDFromOcis
+			1
 		);
 		$this->featureContext->setResponse($response);
 	}
@@ -320,19 +318,14 @@ class FavoritesContext implements Context {
 	 * @param string $user
 	 * @param string $path
 	 * @param int|null $favOrUnfav 1 = favorite, 0 = unfavorite
-	 * @param string|null $spaceIDFromOcis
 	 *
 	 * @return ResponseInterface
 	 */
 	public function changeFavStateOfAnElement(
 		string $user,
 		string $path,
-		?int $favOrUnfav,
-		?string $spaceIDFromOcis = null
+		?int $favOrUnfav
 	):ResponseInterface {
-		if ($spaceIDFromOcis !== null) {
-			WebDavHelper::$SPACE_ID_FROM_OCIS = $spaceIDFromOcis;
-		}
 		$renamedUser = $this->featureContext->getActualUsername($user);
 		return WebDavHelper::proppatch(
 			$this->featureContext->getBaseUrl(),

--- a/tests/acceptance/features/bootstrap/FavoritesContext.php
+++ b/tests/acceptance/features/bootstrap/FavoritesContext.php
@@ -48,14 +48,16 @@ class FavoritesContext implements Context {
 	/**
 	 * @param string$user
 	 * @param string $path
+	 * @param string|null $spaceIDFromOcis
 	 *
 	 * @return void
 	 */
-	public function userFavoritesElement(string $user, string $path):void {
+	public function userFavoritesElement(string $user, string $path, ?string $spaceIDFromOcis = null):void {
 		$response = $this->changeFavStateOfAnElement(
 			$user,
 			$path,
-			1
+			1,
+			$spaceIDFromOcis
 		);
 		$this->featureContext->setResponse($response);
 	}
@@ -318,14 +320,19 @@ class FavoritesContext implements Context {
 	 * @param string $user
 	 * @param string $path
 	 * @param int|null $favOrUnfav 1 = favorite, 0 = unfavorite
+	 * @param string|null $spaceIDFromOcis
 	 *
 	 * @return ResponseInterface
 	 */
 	public function changeFavStateOfAnElement(
 		string $user,
 		string $path,
-		?int $favOrUnfav
+		?int $favOrUnfav,
+		?string $spaceIDFromOcis = null
 	):ResponseInterface {
+		if ($spaceIDFromOcis !== null) {
+			WebDavHelper::$SPACE_ID_FROM_OCIS = $spaceIDFromOcis;
+		}
 		$renamedUser = $this->featureContext->getActualUsername($user);
 		return WebDavHelper::proppatch(
 			$this->featureContext->getBaseUrl(),


### PR DESCRIPTION
### Description
This PR adds some code adjustment (in core) so that the code can be reused in ocis (If any new implementation is done). Since as of now we are duplicating the same code in core as well as in ocis.

We have a `favourite.feature` feature in ocis where we have been duplicating code so for reference i have tried to reduce the code in `ocis` for the feature so that it uses code (resource) already in core (for reducing code duplication). Follow this PR https://github.com/owncloud/ocis/pull/4492

## Related Issue
No related Issue So far since this is a sample PR (After approval) a separate issue is made for refactoring and code reuse from core for ocis implementation.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
- Locally
- CI

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Database schema changes (next release will require increase of minor version instead of patch)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [ ] Tests only (no source changes)

## Checklist:
<!-- Tick the checkboxes when done. -->
<!-- Raise documentation ticket in https://github.com/owncloud/documentation -->
- [x] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 
- [ ] Changelog item, see [TEMPLATE](https://github.com/owncloud/core/blob/master/changelog/TEMPLATE)
