### PR TITLE
Move view versions author setting (config.sample.php)

### DIFF
--- a/config/config.sample.php
+++ b/config/config.sample.php
@@ -705,6 +705,13 @@ $CONFIG = [
 'versions_retention_obligation' => 'auto',
 
 /**
+ * Save and display the author of each version of uploaded and edited files.
+ *
+ * WARNING: This does not work for S3 storage backends.
+ */
+'file_storage.save_version_author' => false,
+
+/**
  * ownCloud Verifications
  *
  * ownCloud performs several verification checks. There are two options,
@@ -1294,13 +1301,6 @@ $CONFIG = [
  * quick action will not be displayed!
  */
 'sharing.showPublicLinkQuickAction' => false,
-
-/**
- * Save and display the author of each version of uploaded and edited files.
- *
- * WARNING: This does not work for S3 storage backends.
- */
-'file_storage.save_version_author' => false,
 
 /**
  * All other configuration options


### PR DESCRIPTION
This is just a small change and moved the config setting `file_storage.save_version_author` to the correct location of Files Versions. No content change, move only.

@jnweiger would be great to get this into 10.11 (if possible)

Referencing: [Add recent core changes](https://github.com/owncloud/docs-server/pull/600#top)

I will do an config-to-docs run post merging.

@pmaier1 fyi