### PR TITLE
[10.11] Show users only once when repeated for batch sharing

### DIFF
--- a/changelog/10.11.0_2022-08-23/40155
+++ b/changelog/10.11.0_2022-08-23/40155
@@ -5,4 +5,5 @@ via the following format: user1, user2, user3.
 
 https://github.com/owncloud/core/pull/40155
 https://github.com/owncloud/core/pull/40199
+https://github.com/owncloud/core/pull/40347
 https://github.com/owncloud/enterprise/issues/2865

--- a/core/js/sharedialogview.js
+++ b/core/js/sharedialogview.js
@@ -616,7 +616,7 @@
 			var foundUsers = [];
 			var notFound = [];
 			var promises = [];
-			var users = Array.from(new Set(search.split(this.batchActionSeparator)));
+			var users = Array.from(new Set(search.replace(new RegExp(this.batchActionSeparator + '\\s+', 'g'), this.batchActionSeparator).split(this.batchActionSeparator)));
 
 			for (var i = 0; i < users.length; i++) {
 				if (!users[i] || users[i] === OC.currentUser) {


### PR DESCRIPTION
## Description
If users for batch sharing are listed in a comma-separated list with varying amounts of white-space after the commas, then the usernames can be repeated in the suggested list to add - even though they are the same user.

Enter: `brian,carol, brian, carol` and all 4 "users" are suggested.

This PR fixes the problem by removing and white-space after commas in the list of users, before splitting the list into and array.

Note: the fixes only does this when generating the list of unique users. This must not be done generally to the string before this point, because group names can have white-space in them. For example, we still need to be able to share with a group called `brian, carol` ! And a different group called `brian,carol` ! So space matters for group names.

## Related Issue
- Fixes #40344 

## How Has This Been Tested?
I manually tried some combinations with 2 users like `bbbb`and `cccc` and having groups called `bbbb,cccc` and `bbbb, cccc`. I can share with the 2 users, or either group (depending on if I type the space or not after the comma)

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Database schema changes (next release will require increase of minor version instead of patch)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [ ] Tests only (no source changes)

## Checklist:
- [ ] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 
- [ ] Changelog item, see [TEMPLATE](https://github.com/owncloud/core/blob/master/changelog/TEMPLATE)
