### PR TITLE
Adjust installation database details

### DIFF
--- a/changelog/unreleased/39871
+++ b/changelog/unreleased/39871
@@ -1,0 +1,7 @@
+Bugfix: Adjust installation database details
+
+The suggested host name and port syntax for the database host on the installation
+has been corrected.
+
+https://github.com/owncloud/core/pull/40348
+https://github.com/owncloud/core/issues/39871

--- a/core/templates/installation.php
+++ b/core/templates/installation.php
@@ -136,7 +136,7 @@ script('core', [
 					autocomplete="off" autocorrect="off">
 			</p>
 			<p class="info">
-				<?php p($l->t('Please specify the port number along with the host name (e.g., localhost: 5432).')); ?>
+				<?php p($l->t('Please specify the port number along with the host name (e.g., localhost:5432).')); ?>
 			</p>
 		</div>
 		</fieldset>


### PR DESCRIPTION
## Description
1) Remove the space from `localhost: 5432` on the installation screen. Note: this changes a translated string, so it can't get into 10.11 - the change needs to go into master and wait a bit for all the language translations to be updated.

2) TBD - improve PostgreSQL hint - this can be done in a next PR when we know what text to write.

## Related Issue

#39871 

## How Has This Been Tested?


## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Database schema changes (next release will require increase of minor version instead of patch)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [ ] Tests only (no source changes)

## Checklist:
- [ ] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 
- [ ] Changelog item, see [TEMPLATE](https://github.com/owncloud/core/blob/master/changelog/TEMPLATE)
