### PR TITLE
[tests-only][full-ci]Do not run `folder-lock` related tests on `ocis`

### DIFF
--- a/tests/acceptance/features/apiWebdavLocks/exclusiveLocks.feature
+++ b/tests/acceptance/features/apiWebdavLocks/exclusiveLocks.feature
@@ -26,7 +26,7 @@ Feature: there can be only one exclusive lock on a resource
       | spaces   | shared     |
       | spaces   | exclusive  |
 
-
+  @notToImplementOnOCIS
   Scenario Outline: if a parent resource is exclusively locked a child resource cannot be locked again
     Given using <dav-path> DAV path
     And user "Alice" has created folder "PARENT"
@@ -45,13 +45,7 @@ Feature: there can be only one exclusive lock on a resource
       | new      | shared     |
       | new      | exclusive  |
 
-    @personalSpace @skipOnOcV10
-    Examples:
-      | dav-path | lock-scope |
-      | spaces   | shared     |
-      | spaces   | exclusive  |
-
-
+  @notToImplementOnOCIS
   Scenario Outline: if a parent resource is exclusively locked with depth 0 a child resource can be locked again
     Given using <dav-path> DAV path
     And user "Alice" has created folder "PARENT"
@@ -71,13 +65,7 @@ Feature: there can be only one exclusive lock on a resource
       | new      | shared     |
       | new      | exclusive  |
 
-    @personalSpace @skipOnOcV10
-    Examples:
-      | dav-path | lock-scope |
-      | spaces   | shared     |
-      | spaces   | exclusive  |
-
-  @skipOnOcV10 @issue-34358
+  @skipOnOcV10 @issue-34358 @notToImplementOnOCIS
   Scenario Outline: if a child resource is exclusively locked a parent resource cannot be locked again
     Given using <dav-path> DAV path
     And user "Alice" has created folder "PARENT"
@@ -96,13 +84,7 @@ Feature: there can be only one exclusive lock on a resource
       | new      | shared     |
       | new      | exclusive  |
 
-    @personalSpace
-    Examples:
-      | dav-path | lock-scope |
-      | spaces   | shared     |
-      | spaces   | exclusive  |
-
-
+  @notToImplementOnOCIS
   Scenario Outline: if a child resource is exclusively locked a parent resource can be locked with depth 0
     Given using <dav-path> DAV path
     And user "Alice" has created folder "PARENT"
@@ -121,12 +103,6 @@ Feature: there can be only one exclusive lock on a resource
       | old      | exclusive  |
       | new      | shared     |
       | new      | exclusive  |
-
-    @personalSpace @skipOnOcV10
-    Examples:
-      | dav-path | lock-scope |
-      | spaces   | shared     |
-      | spaces   | exclusive  |
 
   @files_sharing-app-required
   Scenario Outline: a share receiver cannot lock a resource exclusively locked by itself

--- a/tests/acceptance/features/apiWebdavLocks/folder.feature
+++ b/tests/acceptance/features/apiWebdavLocks/folder.feature
@@ -4,7 +4,7 @@ Feature: lock folders
   Background:
     Given user "Alice" has been created with default attributes and without skeleton files
 
-  @smokeTest
+  @smokeTest @notToImplementOnOCIS
   Scenario Outline: upload to a locked folder
     Given using <dav-path> DAV path
     And user "Alice" has created folder "FOLDER"
@@ -20,13 +20,7 @@ Feature: lock folders
       | new      | shared     |
       | new      | exclusive  |
 
-    @personalSpace @skipOnOcV10
-    Examples:
-      | dav-path | lock-scope |
-      | spaces   | shared     |
-      | spaces   | exclusive  |
-
-
+  @notToImplementOnOCIS
   Scenario Outline: upload to a subfolder of a locked folder
     Given using <dav-path> DAV path
     And user "Alice" has created folder "PARENT"
@@ -43,13 +37,7 @@ Feature: lock folders
       | new      | shared     |
       | new      | exclusive  |
 
-    @personalSpace @skipOnOcV10
-    Examples:
-      | dav-path | lock-scope |
-      | spaces   | shared     |
-      | spaces   | exclusive  |
-
-  @smokeTest
+  @smokeTest @notToImplementOnOCIS
   Scenario Outline: create folder in a locked folder
     Given using <dav-path> DAV path
     And user "Alice" has created folder "FOLDER"
@@ -65,13 +53,7 @@ Feature: lock folders
       | new      | shared     |
       | new      | exclusive  |
 
-    @personalSpace @skipOnOcV10
-    Examples:
-      | dav-path | lock-scope |
-      | spaces   | shared     |
-      | spaces   | exclusive  |
-
-
+  @notToImplementOnOCIS
   Scenario Outline: create folder in a subfolder of a locked folder
     Given using <dav-path> DAV path
     And user "Alice" has created folder "PARENT"
@@ -88,13 +70,7 @@ Feature: lock folders
       | new      | shared     |
       | new      | exclusive  |
 
-    @personalSpace @skipOnOcV10
-    Examples:
-      | dav-path | lock-scope |
-      | spaces   | shared     |
-      | spaces   | exclusive  |
-
-
+  @notToImplementOnOCIS
   Scenario Outline: Move file out of a locked folder
     Given using <dav-path> DAV path
     And user "Alice" has created folder "PARENT"
@@ -112,13 +88,7 @@ Feature: lock folders
       | new      | shared     |
       | new      | exclusive  |
 
-    @personalSpace @skipOnOcV10
-    Examples:
-      | dav-path | lock-scope |
-      | spaces   | shared     |
-      | spaces   | exclusive  |
-
-
+  @notToImplementOnOCIS
   Scenario Outline: Move file out of a locked sub folder one level higher into locked parent folder
     Given using <dav-path> DAV path
     And user "Alice" has created folder "PARENT"
@@ -137,13 +107,7 @@ Feature: lock folders
       | new      | shared     |
       | new      | exclusive  |
 
-    @personalSpace @skipOnOcV10
-    Examples:
-      | dav-path | lock-scope |
-      | spaces   | shared     |
-      | spaces   | exclusive  |
-
-
+  @notToImplementOnOCIS
   Scenario Outline: lockdiscovery of a locked folder
     Given using <dav-path> DAV path
     And user "Alice" has created folder "PARENT"
@@ -162,9 +126,3 @@ Feature: lock folders
       | old      | exclusive  | /%base_path%\/remote.php\/webdav\/PARENT$/                 |
       | new      | shared     | /%base_path%\/remote.php\/dav\/files\/%username%\/PARENT$/ |
       | new      | exclusive  | /%base_path%\/remote.php\/dav\/files\/%username%\/PARENT$/ |
-
-    @personalSpace @skipOnOcV10
-    Examples:
-      | dav-path | lock-scope | lock-root                                                  |
-      | spaces   | shared     | /%base_path%\/remote.php\/dav\/spaces\/%spaceid%\/PARENT$/ |
-      | spaces   | exclusive  | /%base_path%\/remote.php\/dav\/spaces\/%spaceid%\/PARENT$/ |

--- a/tests/acceptance/features/apiWebdavLocks/publicLink.feature
+++ b/tests/acceptance/features/apiWebdavLocks/publicLink.feature
@@ -1,4 +1,4 @@
-@api @smokeTest @public_link_share-feature-required @files_sharing-app-required @issue-ocis-reva-172
+@api @smokeTest @public_link_share-feature-required @files_sharing-app-required @issue-ocis-reva-172 @notToImplementOnOCIS
 Feature: persistent-locking in case of a public link
 
   Background:
@@ -18,8 +18,6 @@ Feature: persistent-locking in case of a public link
     When the public uploads file "/test.txt" with content "test" using the <public-webdav-api-version> public WebDAV API
     Then the HTTP status code should be "423"
     And as "Alice" file "/FOLDER/test.txt" should not exist
-
-    @notToImplementOnOCIS @issue-ocis-2079
     Examples:
       | dav-path | lock-scope | public-webdav-api-version |
       | old      | shared     | old                       |
@@ -34,14 +32,6 @@ Feature: persistent-locking in case of a public link
       | old      | exclusive  | new                       |
       | new      | shared     | new                       |
       | new      | exclusive  | new                       |
-
-    @skipOnOcV10 @personalSpace
-    Examples:
-      | dav-path | lock-scope | public-webdav-api-version |
-      | spaces   | shared     | old                       |
-      | spaces   | exclusive  | old                       |
-      | spaces   | shared     | new                       |
-      | spaces   | exclusive  | new                       |
 
   @skipOnOcV10.6 @skipOnOcV10.7
   Scenario Outline: Uploading a file into a locked subfolder of a public folder
@@ -103,8 +93,6 @@ Feature: persistent-locking in case of a public link
       | lockscope | <lock-scope> |
     Then the HTTP status code should be "405"
     And the value of the item "//s:message" in the response should be "Locking not allowed from public endpoint"
-
-    @notToImplementOnOCIS @issue-ocis-2079
     Examples:
       | public-webdav-api-version | lock-scope |
       | old                       | shared     |

--- a/tests/acceptance/features/apiWebdavLocks/publicLinkLockdiscovery.feature
+++ b/tests/acceptance/features/apiWebdavLocks/publicLinkLockdiscovery.feature
@@ -1,4 +1,4 @@
-@api @smokeTest @public_link_share-feature-required @files_sharing-app-required @issue-ocis-reva-172
+@api @smokeTest @public_link_share-feature-required @files_sharing-app-required @issue-ocis-reva-172 @notToImplementOnOCIS
 Feature: LOCKDISCOVERY for public links
 
   Background:

--- a/tests/acceptance/features/apiWebdavLocks/requestsWithToken.feature
+++ b/tests/acceptance/features/apiWebdavLocks/requestsWithToken.feature
@@ -4,7 +4,7 @@ Feature: actions on a locked item are possible if the token is sent with the req
   Background:
     Given user "Alice" has been created with default attributes and without skeleton files
 
-  @smokeTest
+  @smokeTest @notToImplementOnOCIS
   Scenario Outline: rename a file in a locked folder
     Given using <dav-path> DAV path
     And user "Alice" has created folder "PARENT"
@@ -22,13 +22,7 @@ Feature: actions on a locked item are possible if the token is sent with the req
       | new      | shared     |
       | new      | exclusive  |
 
-    @personalSpace @skipOnOcV10
-    Examples:
-      | dav-path | lock-scope |
-      | spaces   | shared     |
-      | spaces   | exclusive  |
-
-  @smokeTest
+  @smokeTest @notToImplementOnOCIS
   Scenario Outline: move a file into a locked folder
     Given using <dav-path> DAV path
     And user "Alice" has created folder "FOLDER"
@@ -47,13 +41,7 @@ Feature: actions on a locked item are possible if the token is sent with the req
       | new      | shared     |
       | new      | exclusive  |
 
-    @personalSpace @skipOnOcV10
-    Examples:
-      | dav-path | lock-scope |
-      | spaces   | shared     |
-      | spaces   | exclusive  |
-
-  @smokeTest
+  @smokeTest @notToImplementOnOCIS
   Scenario Outline: move a file into a locked folder is impossible when using the wrong token
     Given using <dav-path> DAV path
     And user "Alice" has created folder "FOLDER"
@@ -75,13 +63,7 @@ Feature: actions on a locked item are possible if the token is sent with the req
       | new      | shared     |
       | new      | exclusive  |
 
-    @personalSpace @skipOnOcV10
-    Examples:
-      | dav-path | lock-scope |
-      | spaces   | shared     |
-      | spaces   | exclusive  |
-
-  @skipOnOcV10 @issue-34338 @files_sharing-app-required
+  @skipOnOcV10 @issue-34338 @files_sharing-app-required @notToImplementOnOCIS
   Scenario Outline: share receiver cannot rename a file in a folder locked by the owner even when sending the locktoken
     Given using <dav-path> DAV path
     And user "Alice" has created folder "PARENT"
@@ -102,13 +84,7 @@ Feature: actions on a locked item are possible if the token is sent with the req
       | new      | shared     |
       | new      | exclusive  |
 
-    @personalSpace
-    Examples:
-      | dav-path | lock-scope |
-      | spaces   | shared     |
-      | spaces   | exclusive  |
-
-  @files_sharing-app-required
+  @files_sharing-app-required @notToImplementOnOCIS
   Scenario Outline: public cannot overwrite a file in a folder locked by the owner even when sending the locktoken
     Given user "Alice" has created folder "PARENT"
     And user "Alice" has uploaded file with content "ownCloud test text file parent" to "PARENT/parent.txt"
@@ -118,8 +94,6 @@ Feature: actions on a locked item are possible if the token is sent with the req
     When the public uploads file "parent.txt" with content "test" sending the locktoken of file "PARENT" of user "Alice" using the <webdav_api_version> public WebDAV API
     Then the HTTP status code should be "<http_status_code>"
     And the content of file "/PARENT/parent.txt" for user "Alice" should be "ownCloud test text file parent"
-
-    @notToImplementOnOCIS @issue-ocis-2079
     Examples:
       | lock-scope | webdav_api_version | http_status_code |
       | shared     | old                | 423              |


### PR DESCRIPTION
## Description
This PR adds `@notToImplementOnOcis` tag on the tests that locks a folder since folder lock related tests will not be implement on `ocis` near future.

apiSuiteCovered
- `apiWebdavLock`

## Related Issue
https://github.com/owncloud/ocis/issues/4526

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
- Locally
- CI

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Database schema changes (next release will require increase of minor version instead of patch)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [ ] Tests only (no source changes)

## Checklist:
<!-- Tick the checkboxes when done. -->
<!-- Raise documentation ticket in https://github.com/owncloud/documentation -->
- [ ] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 
- [ ] Changelog item, see [TEMPLATE](https://github.com/owncloud/core/blob/master/changelog/TEMPLATE)
