### PR TITLE
[tests-only][full-ci]Do not run folder-lock related tests on ocis for suit `apiWebdavLocks3`

### DIFF
--- a/tests/acceptance/features/apiWebdavLocks3/independentLocks.feature
+++ b/tests/acceptance/features/apiWebdavLocks3/independentLocks.feature
@@ -5,7 +5,7 @@ Feature: independent locks
   Background:
     Given user "Alice" has been created with default attributes and without skeleton files
 
-
+  @notToImplementOnOCIS
   Scenario Outline: locking a folder does not lock other items with the same name in other parts of the file system
     Given using <dav-path> DAV path
     And user "Alice" has created folder "locked"
@@ -27,13 +27,7 @@ Feature: independent locks
       | new      | shared     |
       | new      | exclusive  |
 
-    @personalSpace @skipOnOcV10
-    Examples:
-      | dav-path | lock-scope |
-      | spaces   | shared     |
-      | spaces   | exclusive  |
-
-
+  @notToImplementOnOCIS
   Scenario Outline: locking a folder on the root level does not lock other folders with the same name in other parts of the file system
     Given using <dav-path> DAV path
     And user "Alice" has created folder "notlocked"
@@ -52,12 +46,6 @@ Feature: independent locks
       | old      | exclusive  |
       | new      | shared     |
       | new      | exclusive  |
-
-    @personalSpace @skipOnOcV10
-    Examples:
-      | dav-path | lock-scope |
-      | spaces   | shared     |
-      | spaces   | exclusive  |
 
 
   Scenario Outline: locking a file does not lock other items with the same name in other parts of the file system

--- a/tests/acceptance/features/apiWebdavLocks3/independentLocksShareToShares.feature
+++ b/tests/acceptance/features/apiWebdavLocks3/independentLocksShareToShares.feature
@@ -8,7 +8,7 @@ Feature: independent locks
     And user "Alice" has been created with default attributes and without skeleton files
     And user "Brian" has been created with default attributes and without skeleton files
 
-
+  @notToImplementOnOCIS
   Scenario Outline: locking a received share does not lock other shares that had the same name on the sharer side (shares from different users)
     Given using <dav-path> DAV path
     And user "Carol" has been created with default attributes and without skeleton files
@@ -30,13 +30,7 @@ Feature: independent locks
       | new      | shared     |
       | new      | exclusive  |
 
-    @personalSpace @skipOnOcV10
-    Examples:
-      | dav-path | lock-scope |
-      | spaces   | shared     |
-      | spaces   | exclusive  |
-
-
+  @notToImplementOnOCIS
   Scenario Outline: locking a received share does not lock other shares that had the same name on the sharer side (shares from the same user)
     Given using <dav-path> DAV path
     And user "Alice" has created folder "locked/"
@@ -58,12 +52,6 @@ Feature: independent locks
       | old      | exclusive  |
       | new      | shared     |
       | new      | exclusive  |
-
-    @personalSpace @skipOnOcV10
-    Examples:
-      | dav-path | lock-scope |
-      | spaces   | shared     |
-      | spaces   | exclusive  |
 
 
   Scenario Outline: locking a file in a received share does not lock other items with the same name in other received shares (shares from different users)


### PR DESCRIPTION
## Description
This PR adds `@notToImplementOnOcis` tag on the tests that locks a folder since folder lock related tests will not be implement on `ocis` near future.

apiSuiteCovered
- `apiWebdavLocks3`

## Related Issue
https://github.com/owncloud/ocis/issues/4526

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
- Locally
- CI

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Database schema changes (next release will require increase of minor version instead of patch)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [ ] Tests only (no source changes)

## Checklist:
<!-- Tick the checkboxes when done. -->
<!-- Raise documentation ticket in https://github.com/owncloud/documentation -->
- [ ] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 
- [ ] Changelog item, see [TEMPLATE](https://github.com/owncloud/core/blob/master/changelog/TEMPLATE)
