### PR TITLE
[tests-only][full-ci]Do not run folder-lock related tests on ocis for suit `apiWebdavLocksUnlock`

### DIFF
--- a/tests/acceptance/features/apiWebdavLocksUnlock/unlock.feature
+++ b/tests/acceptance/features/apiWebdavLocksUnlock/unlock.feature
@@ -4,7 +4,7 @@ Feature: UNLOCK locked items
   Background:
     Given user "Alice" has been created with default attributes and without skeleton files
 
-  @smokeTest
+  @smokeTest @notToImplementOnOCIS
   Scenario Outline: unlock a single lock set by the user itself
     Given using <dav-path> DAV path
     And user "Alice" has created folder "PARENT"
@@ -23,12 +23,6 @@ Feature: UNLOCK locked items
       | old      | exclusive  |
       | new      | shared     |
       | new      | exclusive  |
-
-    @personalSpace @skipOnOcV10
-    Examples:
-      | dav-path | lock-scope |
-      | spaces   | shared     |
-      | spaces   | exclusive  |
 
 
   Scenario Outline: unlock one of multiple locks set by the user itself
@@ -51,7 +45,7 @@ Feature: UNLOCK locked items
       | dav-path |
       | spaces   |
 
-
+  @notToImplementOnOCIS
   Scenario Outline: unlocking a file that was locked by the user locking the folder above is not possible
     Given using <dav-path> DAV path
     And user "Alice" has created folder "PARENT"
@@ -70,12 +64,6 @@ Feature: UNLOCK locked items
       | new      | shared     |
       | new      | exclusive  |
 
-    @personalSpace @skipOnOcV10
-    Examples:
-      | dav-path | lock-scope |
-      | spaces   | shared     |
-      | spaces   | exclusive  |
-
   @skipOnOcV10 @issue-34302 @files_sharing-app-required @skipOnOcV10.3
   Scenario Outline: as public unlocking a file in a share that was locked by the file owner is not possible. To unlock use the owners locktoken
     Given user "Alice" has created folder "PARENT"
@@ -91,7 +79,7 @@ Feature: UNLOCK locked items
       | shared     |
       | exclusive  |
 
-
+  @notToImplementOnOCIS
   Scenario Outline: unlocking a file or folder does not unlock another folder with the same name in another part of the file system
     Given using <dav-path> DAV path
     And user "Alice" has created folder "locked"
@@ -117,12 +105,6 @@ Feature: UNLOCK locked items
       | old      | exclusive  |
       | new      | shared     |
       | new      | exclusive  |
-
-    @personalSpace @skipOnOcV10
-    Examples:
-      | dav-path | lock-scope |
-      | spaces   | shared     |
-      | spaces   | exclusive  |
 
 
   Scenario Outline: unlocking a file or folder does not unlock another file with the same name in another part of the file system

--- a/tests/acceptance/features/apiWebdavLocksUnlock/unlockSharingToShares.feature
+++ b/tests/acceptance/features/apiWebdavLocksUnlock/unlockSharingToShares.feature
@@ -68,7 +68,7 @@ Feature: UNLOCK locked items (sharing)
       | spaces   | shared     |
       | spaces   | exclusive  |
 
-
+  @notToImplementOnOCIS
   Scenario Outline: as share receiver unlocking a shared folder locked by the file owner is not possible. To unlock use the owners locktoken
     Given using <dav-path> DAV path
     And user "Alice" has created folder "PARENT/CHILD"
@@ -91,12 +91,6 @@ Feature: UNLOCK locked items (sharing)
       | old      | exclusive  |
       | new      | shared     |
       | new      | exclusive  |
-
-    @personalSpace @skipOnOcV10
-    Examples:
-      | dav-path | lock-scope |
-      | spaces   | shared     |
-      | spaces   | exclusive  |
 
 
   Scenario Outline: as share receiver unlock a shared file
@@ -188,7 +182,7 @@ Feature: UNLOCK locked items (sharing)
       | spaces   | shared     |
       | spaces   | exclusive  |
 
-
+  @notToImplementOnOCIS
   Scenario Outline: as owner unlocking a shared folder locked by the share receiver is not possible. To unlock use the receivers locktoken
     Given using <dav-path> DAV path
     And user "Alice" has created folder "PARENT/CHILD"
@@ -211,9 +205,3 @@ Feature: UNLOCK locked items (sharing)
       | old      | exclusive  |
       | new      | shared     |
       | new      | exclusive  |
-
-    @personalSpace @skipOnOcV10
-    Examples:
-      | dav-path | lock-scope |
-      | spaces   | shared     |
-      | spaces   | exclusive  |


### PR DESCRIPTION
## Description
This PR adds `@notToImplementOnOcis` tag on the tests that locks a folder since folder lock related tests will not be implement on `ocis` near future.

apiSuiteCovered
- `apiWebdavLocksUnlock`

## Related Issue
https://github.com/owncloud/ocis/issues/4526

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
- Locally
- CI

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Database schema changes (next release will require increase of minor version instead of patch)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [ ] Tests only (no source changes)

## Checklist:
<!-- Tick the checkboxes when done. -->
<!-- Raise documentation ticket in https://github.com/owncloud/documentation -->
- [ ] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 
- [ ] Changelog item, see [TEMPLATE](https://github.com/owncloud/core/blob/master/changelog/TEMPLATE)
