### PR TITLE
[tests-only][full-ci]Donot set OCC status code for all steps

### DIFF
--- a/tests/acceptance/features/bootstrap/AppManagementContext.php
+++ b/tests/acceptance/features/bootstrap/AppManagementContext.php
@@ -185,8 +185,10 @@ class AppManagementContext implements Context {
 	 * @throws Exception
 	 */
 	public function adminGetsPathForApp(string $appId):void {
-		$this->featureContext->runOcc(
-			['app:getpath', $appId, '--no-ansi']
+		$this->featureContext->setOccLastCode(
+			$this->featureContext->runOcc(
+				['app:getpath', $appId, '--no-ansi']
+			)
 		);
 		$this->cmdOutput = $this->featureContext->getStdOutOfOccCommand();
 		// check that the command seems to have executed OK, for both When and Given
@@ -207,8 +209,10 @@ class AppManagementContext implements Context {
 	 * @throws Exception
 	 */
 	public function adminListsTheApps():void {
-		$this->featureContext->runOcc(
-			['app:list', '--no-ansi']
+		$this->featureContext->setOccLastCode(
+			$this->featureContext->runOcc(
+				['app:list', '--no-ansi']
+			)
 		);
 	}
 
@@ -219,8 +223,10 @@ class AppManagementContext implements Context {
 	 * @throws Exception
 	 */
 	public function adminListsTheEnabledApps():void {
-		$this->featureContext->runOcc(
-			['app:list', '--enabled', '--no-ansi']
+		$this->featureContext->setOccLastCode(
+			$this->featureContext->runOcc(
+				['app:list', '--enabled', '--no-ansi']
+			)
 		);
 	}
 
@@ -231,8 +237,10 @@ class AppManagementContext implements Context {
 	 * @throws Exception
 	 */
 	public function adminListsTheDisabledApps():void {
-		$this->featureContext->runOcc(
-			['app:list', '--disabled', '--no-ansi']
+		$this->featureContext->setOccLastCode(
+			$this->featureContext->runOcc(
+				['app:list', '--disabled', '--no-ansi']
+			)
 		);
 	}
 
@@ -243,8 +251,10 @@ class AppManagementContext implements Context {
 	 * @throws Exception
 	 */
 	public function adminListsTheEnabledAndDisabledApps():void {
-		$this->featureContext->runOcc(
-			['app:list', '--enabled', '--disabled', '--no-ansi']
+		$this->featureContext->setOccLastCode(
+			$this->featureContext->runOcc(
+				['app:list', '--enabled', '--disabled', '--no-ansi']
+			)
 		);
 	}
 
@@ -255,8 +265,10 @@ class AppManagementContext implements Context {
 	 * @throws Exception
 	 */
 	public function adminListsTheAppsInMinimalFormat():void {
-		$this->featureContext->runOcc(
-			['app:list', '--minimal --no-ansi']
+		$this->featureContext->setOccLastCode(
+			$this->featureContext->runOcc(
+				['app:list', '--minimal --no-ansi']
+			)
 		);
 	}
 

--- a/tests/acceptance/features/bootstrap/CorsContext.php
+++ b/tests/acceptance/features/bootstrap/CorsContext.php
@@ -49,7 +49,7 @@ class CorsContext implements Context {
 	 */
 	public function addDomainToPrivateCORSLists(string $user, string $domain):void {
 		$user = $this->featureContext->getActualUsername($user);
-		$this->featureContext->runOcc(
+		$occStatus = $this->featureContext->runOcc(
 			[
 				'user:setting',
 				$user,
@@ -57,7 +57,7 @@ class CorsContext implements Context {
 				'domains'
 			]
 		);
-		if ($this->featureContext->getExitStatusCodeOfOccCommand() === 0) {
+		if ($occStatus === 0) {
 			$domainsJson = $this->featureContext->getStdOutOfOccCommand();
 			$domains = \json_decode($domainsJson);
 		} else {
@@ -72,8 +72,7 @@ class CorsContext implements Context {
 
 		$domains[] = $domain;
 		$valueString = \json_encode($domains);
-
-		$this->featureContext->runOcc(
+		$occStatus = $this->featureContext->runOcc(
 			[
 				'user:setting',
 				$user,
@@ -82,7 +81,7 @@ class CorsContext implements Context {
 				'--value=\'' . $valueString . '\''
 			]
 		);
-		if ($this->featureContext->getExitStatusCodeOfOccCommand() !== 0) {
+		if ($occStatus !== 0) {
 			throw new \Exception(
 				"could not set CORS domain. " .
 				$this->featureContext->getStdErrOfOccCommand()

--- a/tests/acceptance/features/bootstrap/EncryptionContext.php
+++ b/tests/acceptance/features/bootstrap/EncryptionContext.php
@@ -60,7 +60,7 @@ class EncryptionContext implements Context {
 	 * @throws Exception
 	 */
 	public function adminRecreatesMasterKeyUsingOccCommand():void {
-		$this->featureContext->setOccLastCode($this->recreateMasterKeyUsingOccCommand());	
+		$this->featureContext->setOccLastCode($this->recreateMasterKeyUsingOccCommand());
 	}
 
 	/**
@@ -92,8 +92,9 @@ class EncryptionContext implements Context {
 	 * @throws Exception
 	 */
 	public function setEncryptionTypeUsingTheOccCommand(string $encryptionType):int {
-		return( $this->featureContext->runOcc(
-				["encryption:select-encryption-type", $encryptionType, "-y"])
+		return($this->featureContext->runOcc(
+			["encryption:select-encryption-type", $encryptionType, "-y"]
+		)
 		);
 	}
 

--- a/tests/acceptance/features/bootstrap/EncryptionContext.php
+++ b/tests/acceptance/features/bootstrap/EncryptionContext.php
@@ -166,10 +166,12 @@ class EncryptionContext implements Context {
 	 * @throws Exception
 	 */
 	public function theAdministratorDecryptsUserKeysBasedEncryptionWithKey(string $recoveryKey):void {
-		$this->occContext->invokingTheCommandWithEnvVariable(
-			"encryption:decrypt-all -m recovery -c yes",
-			'OC_RECOVERY_PASSWORD',
-			$recoveryKey
+		$this->featureContext->setOccLastCode(
+			$this->occContext->invokingTheCommandWithEnvVariable(
+				"encryption:decrypt-all -m recovery -c yes",
+				'OC_RECOVERY_PASSWORD',
+				$recoveryKey
+			)
 		);
 	}
 

--- a/tests/acceptance/features/bootstrap/EncryptionContext.php
+++ b/tests/acceptance/features/bootstrap/EncryptionContext.php
@@ -47,8 +47,10 @@ class EncryptionContext implements Context {
 	 * @return void
 	 * @throws Exception
 	 */
-	public function recreateMasterKeyUsingOccCommand():void {
-		$this->featureContext->runOcc(['encryption:recreate-master-key', '-y']);
+	public function recreateMasterKeyUsingOccCommand():int {
+		return(
+			$this->featureContext->runOcc(['encryption:recreate-master-key', '-y'])
+		);
 	}
 
 	/**
@@ -58,7 +60,7 @@ class EncryptionContext implements Context {
 	 * @throws Exception
 	 */
 	public function adminRecreatesMasterKeyUsingOccCommand():void {
-		$this->recreateMasterKeyUsingOccCommand();
+		$this->featureContext->setOccLastCode($this->recreateMasterKeyUsingOccCommand());	
 	}
 
 	/**
@@ -89,9 +91,9 @@ class EncryptionContext implements Context {
 	 * @return void
 	 * @throws Exception
 	 */
-	public function setEncryptionTypeUsingTheOccCommand(string $encryptionType):void {
-		$this->featureContext->runOcc(
-			["encryption:select-encryption-type", $encryptionType, "-y"]
+	public function setEncryptionTypeUsingTheOccCommand(string $encryptionType):int {
+		return( $this->featureContext->runOcc(
+				["encryption:select-encryption-type", $encryptionType, "-y"])
 		);
 	}
 
@@ -104,7 +106,9 @@ class EncryptionContext implements Context {
 	 * @throws Exception
 	 */
 	public function theAdministratorSetsEncryptionTypeToUsingTheOccCommand(string $encryptionType):void {
-		$this->setEncryptionTypeUsingTheOccCommand($encryptionType);
+		$this->featureContext->setOccLastCode(
+			$this->setEncryptionTypeUsingTheOccCommand($encryptionType)
+		);
 	}
 
 	/**
@@ -124,8 +128,10 @@ class EncryptionContext implements Context {
 	 * @return void
 	 * @throws Exception
 	 */
-	public function encryptAllDataUsingTheOccCommand():void {
-		$this->featureContext->runOcc(["encryption:encrypt-all", "-y"]);
+	public function encryptAllDataUsingTheOccCommand():int {
+		return (
+			$this->featureContext->runOcc(["encryption:encrypt-all", "-y"])
+		);
 	}
 
 	/**
@@ -135,7 +141,9 @@ class EncryptionContext implements Context {
 	 * @throws Exception
 	 */
 	public function theAdministratorEncryptsAllDataUsingTheOccCommand():void {
-		$this->encryptAllDataUsingTheOccCommand();
+		$this->featureContext->setOccLastCode(
+			$this->encryptAllDataUsingTheOccCommand()
+		);
 	}
 
 	/**

--- a/tests/acceptance/features/bootstrap/FeatureContext.php
+++ b/tests/acceptance/features/bootstrap/FeatureContext.php
@@ -379,6 +379,13 @@ class FeatureContext extends BehatVariablesContext {
 	}
 
 	/**
+	 * @return void
+	 */
+	public function setOccLastCode(?int $statusCode = null):void {
+		$this->occLastCode = $statusCode;
+	}
+
+	/**
 	 * @param string|null $httpStatusCode
 	 *
 	 * @return void
@@ -4118,8 +4125,8 @@ class FeatureContext extends BehatVariablesContext {
 		);
 		$this->lastStdOut = $return['stdOut'];
 		$this->lastStdErr = $return['stdErr'];
-		$this->occLastCode = (int) $return['code'];
-		return $this->occLastCode;
+		$occStatusCode = (int) $return['code'];
+		return $occStatusCode;
 	}
 
 	/**

--- a/tests/acceptance/features/bootstrap/FeatureContext.php
+++ b/tests/acceptance/features/bootstrap/FeatureContext.php
@@ -379,6 +379,8 @@ class FeatureContext extends BehatVariablesContext {
 	}
 
 	/**
+	 * @param int $statusCode
+	 *
 	 * @return void
 	 */
 	public function setOccLastCode(?int $statusCode = null):void {

--- a/tests/acceptance/features/bootstrap/OccContext.php
+++ b/tests/acceptance/features/bootstrap/OccContext.php
@@ -3672,7 +3672,9 @@ class OccContext implements Context {
 	 */
 	public function theAdministratorListsMigrationStatusOfApp(string $app):void {
 		$this->featureContext->setStdOutOfOccCommand("");
-		$this->featureContext->runOcc(['migrations:status', $app]);
+		$this->featureContext->setOccLastCode(
+			$this->featureContext->runOcc(['migrations:status', $app])
+		);
 	}
 
 	/**

--- a/tests/acceptance/features/bootstrap/OccContext.php
+++ b/tests/acceptance/features/bootstrap/OccContext.php
@@ -126,7 +126,9 @@ class OccContext implements Context {
 	 * @throws Exception
 	 */
 	public function invokingTheCommand(string $cmd):void {
-		$this->featureContext->runOcc([$cmd]);
+		$this->featureContext->setOccLastCode(
+			$this->featureContext->runOcc([$cmd])
+		);
 	}
 
 	/**

--- a/tests/acceptance/features/bootstrap/OccContext.php
+++ b/tests/acceptance/features/bootstrap/OccContext.php
@@ -1499,13 +1499,15 @@ class OccContext implements Context {
 			$action = "$action-group";
 		}
 		$mountId = $this->featureContext->getStorageId($mountName);
-		$this->featureContext->runOcc(
-			[
-				'files_external:applicable',
-				$mountId,
-				"$action ",
-				"$userOrGroupName"
-			]
+		$this->featureContext->setOccLastCode(
+			$this->featureContext->runOcc(
+				[
+					'files_external:applicable',
+					$mountId,
+					"$action ",
+					"$userOrGroupName"
+				]
+			)
 		);
 	}
 
@@ -3401,7 +3403,9 @@ class OccContext implements Context {
 			$extMntSettings['storage_backend'],
 			$extMntSettings['authentication_backend']
 		];
-		$this->featureContext->runOcc($args);
+		$this->featureContext->setOccLastCode(
+			$this->featureContext->runOcc($args)
+		);
 		// add to array of created storageIds
 		$commandOutput = $this->featureContext->getStdOutOfOccCommand();
 		$mountId = \preg_replace('/\D/', '', $commandOutput);

--- a/tests/acceptance/features/bootstrap/OccContext.php
+++ b/tests/acceptance/features/bootstrap/OccContext.php
@@ -158,11 +158,13 @@ class OccContext implements Context {
 		string $cmd,
 		string $envVariableName,
 		string $envVariableValue
-	):void {
+	):int {
 		$args = [$cmd];
-		$this->featureContext->runOccWithEnvVariables(
-			$args,
-			[$envVariableName => $envVariableValue]
+		return(
+			$this->featureContext->runOccWithEnvVariables(
+				$args,
+				[$envVariableName => $envVariableValue]
+			)
 		);
 	}
 
@@ -730,10 +732,12 @@ class OccContext implements Context {
 		string $envVariableName,
 		string $envVariableValue
 	):void {
-		$this->invokingTheCommandWithEnvVariable(
-			$cmd,
-			$envVariableName,
-			$envVariableValue
+		$this->featureContext->setOccLastCode(
+			$this->invokingTheCommandWithEnvVariable(
+				$cmd,
+				$envVariableName,
+				$envVariableValue
+			)
 		);
 	}
 

--- a/tests/acceptance/features/bootstrap/OccUsersGroupsContext.php
+++ b/tests/acceptance/features/bootstrap/OccUsersGroupsContext.php
@@ -88,10 +88,12 @@ class OccUsersGroupsContext implements Context {
 				$password = $this->featureContext->getPasswordForUser($row ['username']);
 			}
 
-			$this->occContext->invokingTheCommandWithEnvVariable(
-				$cmd,
-				'OC_PASS',
-				$password
+			$this->featureContext->setOccLastCode(
+				$this->occContext->invokingTheCommandWithEnvVariable(
+					$cmd,
+					'OC_PASS',
+					$password
+				)
 			);
 
 			if ($checkOccCommandStatus) {
@@ -154,10 +156,12 @@ class OccUsersGroupsContext implements Context {
 	 */
 	public function theAdministratorTriesToCreateAUserUsingTheOccCommand(string $username):void {
 		$user = $this->featureContext->getActualUsername($username);
-		$this->occContext->invokingTheCommandWithEnvVariable(
-			"user:add $user  --password-from-env",
-			'OC_PASS',
-			$this->featureContext->getPasswordForUser($username)
+		$this->featureContext->setOccLastCode(
+			$this->occContext->invokingTheCommandWithEnvVariable(
+				"user:add $user  --password-from-env",
+				'OC_PASS',
+				$this->featureContext->getPasswordForUser($username)
+			)
 		);
 	}
 
@@ -175,10 +179,12 @@ class OccUsersGroupsContext implements Context {
 		$user = $this->featureContext->getActualUsername($username);
 		$cmd = "user:add $user  --password-from-env --group=$group";
 		$actualPassword = $this->featureContext->getActualPassword($password);
-		$this->occContext->invokingTheCommandWithEnvVariable(
-			$cmd,
-			'OC_PASS',
-			$actualPassword
+		$this->featureContext->setOccLastCode(
+			$this->occContext->invokingTheCommandWithEnvVariable(
+				$cmd,
+				'OC_PASS',
+				$actualPassword
+			)
 		);
 		$this->featureContext->addUserToCreatedUsersList(
 			$user,
@@ -229,10 +235,12 @@ class OccUsersGroupsContext implements Context {
 	public function theAdministratorResetsTheirOwnPasswordToUsingTheOccCommand(string $newPassword):void {
 		$password = $this->featureContext->getActualPassword($newPassword);
 		$admin = $this->featureContext->getAdminUsername();
-		$this->occContext->invokingTheCommandWithEnvVariable(
-			"user:resetpassword $admin --password-from-env",
-			'OC_PASS',
-			$password
+		$this->featureContext->setOccLastCode(
+			$this->occContext->invokingTheCommandWithEnvVariable(
+				"user:resetpassword $admin --password-from-env",
+				'OC_PASS',
+				$password
+			)
 		);
 		$this->featureContext->rememberNewAdminPassword($password);
 	}

--- a/tests/acceptance/features/bootstrap/OccUsersGroupsContext.php
+++ b/tests/acceptance/features/bootstrap/OccUsersGroupsContext.php
@@ -816,8 +816,10 @@ class OccUsersGroupsContext implements Context {
 	):void {
 		$actualUsername = $this->featureContext->getActualUsername($username);
 		if ($password === null) {
-			$this->featureContext->runOcc(
-				["user:resetpassword $actualUsername --send-email"]
+			$this->featureContext->setOccLastCode(
+				$this->featureContext->runOcc(
+					["user:resetpassword $actualUsername --send-email"]
+				)
 			);
 		} else {
 			$password = $this->featureContext->getActualPassword($password);
@@ -826,9 +828,11 @@ class OccUsersGroupsContext implements Context {
 			} else {
 				$sendEmailParam = "";
 			}
-			$this->featureContext->runOccWithEnvVariables(
-				["user:resetpassword $actualUsername $sendEmailParam --password-from-env"],
-				['OC_PASS' => $password]
+			$this->featureContext->setOccLastCode(
+				$this->featureContext->runOccWithEnvVariables(
+					["user:resetpassword $actualUsername $sendEmailParam --password-from-env"],
+					['OC_PASS' => $password]
+				)
 			);
 			if ($username === "%admin%") {
 				$this->featureContext->rememberNewAdminPassword($password);

--- a/tests/acceptance/features/bootstrap/TransferOwnershipContext.php
+++ b/tests/acceptance/features/bootstrap/TransferOwnershipContext.php
@@ -67,7 +67,9 @@ class TransferOwnershipContext implements Context {
 	 * @throws Exception
 	 */
 	public function transferringOwnership(string $user1, string $user2):void {
-		if ($this->featureContext->runOcc(['files:transfer-ownership', $user1, $user2]) === 0) {
+		$occStatusCode = $this->featureContext->runOcc(['files:transfer-ownership', $user1, $user2]);
+		$this->featureContext->setOccLastCode($occStatusCode);
+		if ($occStatusCode === 0) {
 			$this->lastTransferPath
 				= $this->featureContext->findLastTransferFolderForUser($user1, $user2);
 		} else {
@@ -142,7 +144,9 @@ class TransferOwnershipContext implements Context {
 		$user1 = $this->featureContext->getActualUsername($user1);
 		$user2 = $this->featureContext->getActualUsername($user2);
 		$path = "--path=$path";
-		if ($this->featureContext->runOcc(['files:transfer-ownership', $path, $user1, $user2]) === 0) {
+		$occStatusCode = $this->featureContext->runOcc(['files:transfer-ownership', $path, $user1, $user2]);
+		$this->featureContext->setOccLastCode($occStatusCode);
+		if ($occStatusCode === 0) {
 			$this->lastTransferPath
 				= $this->featureContext->findLastTransferFolderForUser($user1, $user2);
 		} else {

--- a/tests/acceptance/features/bootstrap/TransferOwnershipContext.php
+++ b/tests/acceptance/features/bootstrap/TransferOwnershipContext.php
@@ -84,8 +84,8 @@ class TransferOwnershipContext implements Context {
 	 */
 	public function troubleshootingTransferOwnership(string $type):void {
 		$this->featureContext->setOccLastCode(
-			$this->featureContext->runOcc(['files:troubleshoot-transfer-ownership', $type, '--fix']);
-		)
+			$this->featureContext->runOcc(['files:troubleshoot-transfer-ownership', $type, '--fix'])
+		);
 	}
 
 	/**

--- a/tests/acceptance/features/bootstrap/TransferOwnershipContext.php
+++ b/tests/acceptance/features/bootstrap/TransferOwnershipContext.php
@@ -83,7 +83,9 @@ class TransferOwnershipContext implements Context {
 	 * @throws Exception
 	 */
 	public function troubleshootingTransferOwnership(string $type):void {
-		$this->featureContext->runOcc(['files:troubleshoot-transfer-ownership', $type, '--fix']);
+		$this->featureContext->setOccLastCode(
+			$this->featureContext->runOcc(['files:troubleshoot-transfer-ownership', $type, '--fix']);
+		)
 	}
 
 	/**


### PR DESCRIPTION
## Description
This PR changes the implementation structure of setting occ status code.

## Related Issue
- #40351 

## Motivation and Context
Instead of trying to reset the occ status code, the implementation structure has been modified such that occ status code is not set for such cases where reset is required.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
- locally
- CI

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Database schema changes (next release will require increase of minor version instead of patch)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [ ] Tests only (no source changes)

## Checklist:
<!-- Tick the checkboxes when done. -->
<!-- Raise documentation ticket in https://github.com/owncloud/documentation -->
- [X] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 
- [ ] Changelog item, see [TEMPLATE](https://github.com/owncloud/core/blob/master/changelog/TEMPLATE)
