### PR TITLE
fix: previews:cleanup with chunk size argument

### DIFF
--- a/core/Command/Previews/Cleanup.php
+++ b/core/Command/Previews/Cleanup.php
@@ -58,7 +58,7 @@ class Cleanup extends Base {
 		$chunk_size = $input->getArgument('chunk_size');
 
 		$pc = new PreviewCleanup($this->connection);
-		$count = $pc->process($all, $chunk_size, static function ($userId, $name, $action) use ($output) {
+		$count = $pc->process($all, (int)$chunk_size, static function ($userId, $name, $action) use ($output) {
 			$output->writeln("$name - $userId: $action");
 		});
 


### PR DESCRIPTION
## Description
Fix previews:cleanup with chunk size argument

## Related Issue
- https://github.com/owncloud/core/pull/40045#issuecomment-1243721634

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Database schema changes (next release will require increase of minor version instead of patch)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [ ] Tests only (no source changes)

## Checklist:
<!-- Tick the checkboxes when done. -->
<!-- Raise documentation ticket in https://github.com/owncloud/documentation -->
- [x] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 
- [ ] Changelog item, see [TEMPLATE](https://github.com/owncloud/core/blob/master/changelog/TEMPLATE)
