### PR TITLE
Validate previews:cleanup chunk_size

### DIFF
--- a/core/Command/Previews/Cleanup.php
+++ b/core/Command/Previews/Cleanup.php
@@ -56,6 +56,17 @@ class Cleanup extends Base {
 	protected function execute(InputInterface $input, OutputInterface $output) {
 		$all = $input->hasOption('all');
 		$chunk_size = $input->getArgument('chunk_size');
+		$chunk_size_valid = false;
+		if (is_numeric($chunk_size)) {
+			$chunk_size = (int) $chunk_size;
+			if ($chunk_size > 0) {
+				$chunk_size_valid = true;
+			}
+		}
+		if (!$chunk_size_valid) {
+			$output->writeln('<error>chunk_size must be a positive integer.</error>');
+			return 1;
+		}
 
 		$pc = new PreviewCleanup($this->connection);
 		$count = $pc->process($all, $chunk_size, static function ($userId, $name, $action) use ($output) {


### PR DESCRIPTION
## Description
Validate the `chunk_size` that is input by the user and give and error message if it is not a positive number.

## Related Issue
https://github.com/owncloud/core/pull/40045#issuecomment-1243721634

## How Has This Been Tested?
```
$ php occ previews:cleanup abc
chunk_size must be a positive integer.
$ php occ previews:cleanup 123
0 orphaned previews deleted
$ php occ previews:cleanup 0
chunk_size must be a positive integer.
```

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Database schema changes (next release will require increase of minor version instead of patch)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [ ] Tests only (no source changes)

## Checklist:
- [ ] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 
- [ ] Changelog item, see [TEMPLATE](https://github.com/owncloud/core/blob/master/changelog/TEMPLATE)

Changelog not needed - this is a fix/enhancement to an unreleased feature.