### PR TITLE
transifex url update

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,6 +42,6 @@ Learn about the different ways you can get support for ownCloud: https://ownclou
 
 ## Important Notice on Translations
 Please submit translations via Transifex:
-https://www.transifex.com/projects/p/owncloud/
+https://explore.transifex.com/owncloud-org/
 
 See the detailed information about [translations](https://doc.owncloud.com/server/latest/developer_manual/core/translation.html) here.

--- a/settings/templates/panels/personal/profile.php
+++ b/settings/templates/panels/personal/profile.php
@@ -139,7 +139,7 @@ if ($_['passwordChangeSupported']) {
 	</h2>
 	<?php print_unescaped($_['languageSelector']); ?>
 	<?php if (OC_Util::getEditionString() === OC_Util::EDITION_COMMUNITY): ?>
-	<a href="https://www.transifex.com/projects/p/owncloud/"
+	<a href="https://explore.transifex.com/owncloud-org/"
 	  target="_blank" rel="noreferrer">
 		<em><?php p($l->t('Help translate'));?></em>
 	</a>


### PR DESCRIPTION
The old https://www.transifex.com/projects/p/owncloud/ just goes to the generic entry page these days.

Pick something that stays specific to owncloud.
