### PR TITLE
Revert "config.apps.sample changes"

### DIFF
--- a/config/config.apps.sample.php
+++ b/config/config.apps.sample.php
@@ -324,6 +324,19 @@ $CONFIG = [
  *
  * token-introspection-endpoint-client-secret::
  * Client secret to be used with the token introspection endpoint.
+ *
+ * use-access-token-payload-for-user-info::
+ * If set to `true` any user information will be read from the access token.
+ * If set to `false` the userinfo endpoint is used (starting app version 1.1.0).
+ *
+ * use-token-introspection-endpoint::
+ * If set to `true`, the token introspection endpoint is used to verify a given access
+ * token - only needed if the access token is not a JWT. If set to `false`, the userinfo
+ * endpoint is used (requires version >= 1.1.0)
+ * Tokens which are not JSON WebToken (JWT) may not have information like the
+ * expiry. In these cases, the OpenID Connect Provider needs to call on the token
+ * introspection endpoint to get this information. The default value is `false`. See
+ * https://datatracker.ietf.org/doc/html/rfc7662 for more information on token introspection.
  */
 
 /**
@@ -402,7 +415,8 @@ $CONFIG = [
 		'token_endpoint_auth_methods_supported' => '...',
 		'userinfo_endpoint' => '...'
 	],
-	'provider-url' => '...'
+	'provider-url' => '...',
+	'use-token-introspection-endpoint' => true
 ],
 
 /**
@@ -417,6 +431,7 @@ $CONFIG = [
 	'loginButtonName' => 'node-oidc-provider',
 	'mode' => 'userid',
 	'search-attribute' => 'sub',
+	'use-token-introspection-endpoint' => true,
 	  // do not verify tls host or peer
 	'insecure' => true
 ],


### PR DESCRIPTION
Reverts owncloud/core#40260

Requested by @DeepDiver1975 because of https://github.com/owncloud/openidconnect/pull/250#issuecomment-1248045724

A config-to-docs run fill follow right after merging

@phil-davis, can this go into 10.11?
@jnweiger fyi