### PR TITLE
Don't change the share target if it isn't available

### DIFF
--- a/apps/files_sharing/lib/Helper.php
+++ b/apps/files_sharing/lib/Helper.php
@@ -296,12 +296,13 @@ class Helper {
 			}
 
 			$dirsToCreate = \array_reverse($dirsToCreate);
-			$shareFolder = '/';
 			foreach ($dirsToCreate as $dirToCreate) {
 				if ($view->mkdir($dirToCreate) === false) {
 					break;
 				}
-				$shareFolder = $dirToCreate;
+			}
+			if ($shareFolder !== $dirToCreate) {
+				\OCP\Util::writeLog('files_sharing', "Couldn't create missing share folder $shareFolder. Please choose a different share folder", \OCP\Util::ERROR);
 			}
 		}
 

--- a/apps/files_sharing/lib/Helper.php
+++ b/apps/files_sharing/lib/Helper.php
@@ -285,6 +285,10 @@ class Helper {
 		$shareFolder = Filesystem::normalizePath($shareFolder);
 
 		if (!$view->file_exists($shareFolder)) {
+			// if the share folder doesn't exists, create the folder in order
+			// to place the shares inside it. All the parent folders need to
+			// be created as well. By creating these folders, the shares will
+			// be accessible
 			$currentDir = $shareFolder;
 			$dirsToCreate = [$shareFolder];
 			while (($currentDir = \dirname($currentDir)) !== '/') {
@@ -302,6 +306,7 @@ class Helper {
 				}
 			}
 			if ($shareFolder !== $dirToCreate) {
+				// share folder might fail to be created
 				\OCP\Util::writeLog('files_sharing', "Couldn't create missing share folder $shareFolder. Please choose a different share folder", \OCP\Util::ERROR);
 			}
 		}

--- a/apps/files_sharing/tests/HelperTest.php
+++ b/apps/files_sharing/tests/HelperTest.php
@@ -32,21 +32,21 @@ use OC\Files\View;
  * @group DB
  */
 class HelperTest extends TestCase {
+	public function tearDown(): void {
+		// tests will set this config option. It needs to be removed
+		\OC::$server->getConfig()->deleteSystemValue('share_folder');
+		parent::tearDown();
+	}
 
 	/**
 	 * test set and get share folder
 	 */
 	public function testSetGetShareFolder() {
-		$this->assertSame('/', \OCA\Files_Sharing\Helper::getShareFolder());
-
 		\OCA\Files_Sharing\Helper::setShareFolder('/Shared/Folder');
 
 		$sharedFolder = \OCA\Files_Sharing\Helper::getShareFolder();
 		$this->assertSame('/Shared/Folder', \OCA\Files_Sharing\Helper::getShareFolder());
 		$this->assertTrue(\OC\Files\Filesystem::is_dir($sharedFolder));
-
-		// cleanup
-		\OC::$server->getConfig()->deleteSystemValue('share_folder');
 	}
 
 	/**
@@ -62,9 +62,6 @@ class HelperTest extends TestCase {
 		$viewMock->method('mkdir')
 			->willReturnOnConsecutiveCalls(true, false);
 		$sharedFolder = \OCA\Files_Sharing\Helper::getShareFolder($viewMock);
-		$this->assertSame('/Share', $sharedFolder);
-
-		// cleanup
-		\OC::$server->getConfig()->deleteSystemValue('share_folder');
+		$this->assertSame('/Share/Folder', $sharedFolder);
 	}
 }


### PR DESCRIPTION
<!--
Thanks for submitting a change to ownCloud!

This is the bug tracker for the Server component. Find other components at https://github.com/owncloud/core/blob/master/.github/CONTRIBUTING.md#guidelines

For fixing potential security issues please see https://owncloud.com/security/

To make it possible for us to get your change reviewed and merged please carefully fill out the requested information below.

Please note that any kind of change needs first be submitted to the master branch which holds the next version of ownCloud.

Please set the following labels:

- Set label "3 - To review" for review or "2 - Development" if the PR still has open tasks
- Assignment: assign to self
- Milestone: set the same as the ticket this PR fixes, or "development" by default
- Reviewers: pick at least one
-->

## Description
The share folder we get could be different than the one configured if somehow the target folder isn't available. This might be bad since the shares will be placed in a different place than the one expected, and might be even more confusing if the storage becomes unavailable and the share are magically moved to a different place.

We'll always get the configured share folder now. If the share folder is missing and can't be created, an error will be logged

## Related Issue
https://github.com/owncloud/enterprise/issues/5383

## Motivation and Context
The case where the target folder can't be created, likely due to permissions, seems very rare. In this case, the admin should adjust the configured share folder to a different usable one. Meanwhile, the case where the whole FS becomes unavailable might be more common. If this happens, this PR will keep the shares in the same location after the FS comes back

## How Has This Been Tested?
Tested withe the steps provided in the linked issue. It still needs additional tests for possible side effects

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Database schema changes (next release will require increase of minor version instead of patch)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [ ] Tests only (no source changes)

## Checklist:
<!-- Tick the checkboxes when done. -->
<!-- Raise documentation ticket in https://github.com/owncloud/documentation -->
- [x] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 
- [ ] Changelog item, see [TEMPLATE](https://github.com/owncloud/core/blob/master/changelog/TEMPLATE)
