### PR TITLE
[tests-only]Create user without skeleton file

### DIFF
--- a/tests/acceptance/features/apiShareManagementToShares/acceptShares.feature
+++ b/tests/acceptance/features/apiShareManagementToShares/acceptShares.feature
@@ -541,8 +541,8 @@ Feature: accept/decline shares coming from internal users
       | /Shares/textfile0.txt |
 
   @skipOnLDAP @skipOnOcV10.6 @skipOnOcV10.7 @skipOnOcV10.8.0
-  Scenario: user shares folder with matching folder name a user before that user has logged in
-    Given these users have been created with small skeleton files but not initialized:
+  Scenario: user shares folder with matching folder name to  a user before that user has logged in
+    Given these users have been created without skeleton files and not initialized:
       | username |
       | David    |
     And user "Alice" has uploaded file with content "uploaded content" to "/PARENT/abc.txt"
@@ -553,11 +553,6 @@ Feature: accept/decline shares coming from internal users
     And user "David" should see the following elements
       | /Shares/PARENT/        |
       | /Shares/PARENT/abc.txt |
-      | /FOLDER/               |
-      | /textfile0.txt         |
-      | /textfile1.txt         |
-      | /textfile2.txt         |
-      | /textfile3.txt         |
     And user "David" should not see the following elements
       | /PARENT (2)/ |
     And the content of file "/Shares/PARENT/abc.txt" for user "David" should be "uploaded content"

--- a/tests/acceptance/features/apiTrashbin/trashbinFilesFolders.feature
+++ b/tests/acceptance/features/apiTrashbin/trashbinFilesFolders.feature
@@ -232,9 +232,10 @@ Feature: files and folders exist in the trashbin after being deleted
     And user "testtrashbin102" has deleted file "/textfile0.txt"
     And user "testtrashbin102" has deleted file "/textfile2.txt"
     And the administrator has deleted user "testtrashbin102" using the provisioning API
-    And these users have been created with default attributes and small skeleton files but not initialized:
+    And these users have been created without skeleton files and not initialized:
       | username        |
       | testtrashbin102 |
+    And user "testtrashbin102" has uploaded file "filesForUpload/textfile.txt" to "/textfile3.txt"
     And user "testtrashbin102" has deleted file "/textfile3.txt"
     When user "Brian" tries to list the trashbin content for user "testtrashbin102"
     Then the HTTP status code should be "401"


### PR DESCRIPTION
<!--
Thanks for submitting a change to ownCloud!

This is the bug tracker for the Server component. Find other components at https://github.com/owncloud/core/blob/master/.github/CONTRIBUTING.md#guidelines

For fixing potential security issues please see https://owncloud.com/security/

To make it possible for us to get your change reviewed and merged please carefully fill out the requested information below.

Please note that any kind of change needs first be submitted to the master branch which holds the next version of ownCloud.

Please set the following labels:

- Set label "3 - To review" for review or "2 - Development" if the PR still has open tasks
- Assignment: assign to self
- Milestone: set the same as the ticket this PR fixes, or "development" by default
- Reviewers: pick at least one
-->

## Description
This Pr changes the user creation test step so that the related test doesn't depend on `testing-app` for creating small skeleton files 

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
- Fixes:https://github.com/owncloud/ocis/issues/4567

## Motivation and Context
These changes will make it possible to remove the cloning of the testing app in ocis, which is not necessarily needed in oics

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
- CI

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Database schema changes (next release will require increase of minor version instead of patch)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [ ] Tests only (no source changes)

## Checklist:
<!-- Tick the checkboxes when done. -->
<!-- Raise documentation ticket in https://github.com/owncloud/documentation -->
- [ ] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 
- [ ] Changelog item, see [TEMPLATE](https://github.com/owncloud/core/blob/master/changelog/TEMPLATE)
