### PR TITLE
[tests-only] Find duplicate scenarios in expected-failures files

### DIFF
--- a/tests/acceptance/lint-expected-failures.sh
+++ b/tests/acceptance/lint-expected-failures.sh
@@ -12,6 +12,8 @@ log_success() {
 	echo -e "\e[32m$1\e[0m"
 }
 
+declare -A scenarioLines
+
 if [ -n "${EXPECTED_FAILURES_FILE}" ]
 then
 	if [ -f "${EXPECTED_FAILURES_FILE}" ]
@@ -93,6 +95,12 @@ then
 				FINAL_EXIT_STATUS=1
 				continue
 			fi
+			if [[ -n "${scenarioLines[${SUITE_SCENARIO_LINE}]:-}" ]];
+			then
+				log_error "> Line ${LINE_NUMBER}: Scenario line ${SUITE_SCENARIO_LINE} is duplicated"
+				FINAL_EXIT_STATUS=1
+			fi
+			scenarioLines[${SUITE_SCENARIO_LINE}]="exists"
 			OLD_IFS=${IFS}
 			IFS=':'
 			read -ra FEATURE_PARTS <<< "${SUITE_SCENARIO_LINE}"


### PR DESCRIPTION
## Description
Enhance the expected-failures-file linter so that it reports if a scenario is duplicated.

## How Has This Been Tested?
CI and local runs to find existing duplicate lines (see PRs https://github.com/cs3org/reva/pull/3265 https://github.com/cs3org/reva/pull/3264 https://github.com/owncloud/ocis/pull/4649 for the duplicates that were found)

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Database schema changes (next release will require increase of minor version instead of patch)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [x] Tests only (no source changes)

## Checklist:
- [ ] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 
- [ ] Changelog item, see [TEMPLATE](https://github.com/owncloud/core/blob/master/changelog/TEMPLATE)
