### PR TITLE
allow specifying available space for objectstorages

### DIFF
--- a/changelog/unreleased/40389
+++ b/changelog/unreleased/40389
@@ -1,0 +1,6 @@
+Change: Allow specifying available space for objectstorages
+
+Before this change, objectstorages were reporting only infinite storage space. This could have caused problems in other apps that rely on this storage method, e.g. metrics app that monitors available space
+
+https://github.com/owncloud/core/pull/40192
+https://github.com/owncloud/enterprise/issues/5384

--- a/lib/private/Files/ObjectStore/ObjectStoreStorage.php
+++ b/lib/private/Files/ObjectStore/ObjectStoreStorage.php
@@ -431,6 +431,16 @@ class ObjectStoreStorage extends \OC\Files\Storage\Common {
 	}
 
 	/**
+	 * overwrite this method if objectstorage supports getting total bucket objects size
+	 *
+	 * @return int
+	 */
+	protected function getTotalUsedStorage() {
+		$rootInfo = Filesystem::getFileInfo('/', false);
+		return $rootInfo->getSize();
+	}
+
+	/**
 	 * get the free space in the object storage as indicated by the objectstore config
 	 *
 	 * NOTE: getting total free space for objectstorage is not possible,
@@ -442,8 +452,7 @@ class ObjectStoreStorage extends \OC\Files\Storage\Common {
 	 */
 	public function free_space($path) {
 		if (isset($this->availableStorage)) {
-			$rootInfo = Filesystem::getFileInfo('/', false);
-			$used = $rootInfo->getSize();
+			$used = $this->getTotalUsedStorage();
 			if ($used < 0) {
 				$used = 0;
 			}

--- a/lib/private/Files/ObjectStore/ObjectStoreStorage.php
+++ b/lib/private/Files/ObjectStore/ObjectStoreStorage.php
@@ -74,8 +74,8 @@ class ObjectStoreStorage extends \OC\Files\Storage\Common {
 		if (isset($params['objectPrefix'])) {
 			$this->objectPrefix = $params['objectPrefix'];
 		}
-		if (isset($params['availablestorage']) && is_int($params['availablestorage'])) {
-			$this->availableStorage = $params['availablestorage'];
+		if (isset($params['availableStorage']) && \is_int($params['availableStorage'])) {
+			$this->availableStorage = $params['availableStorage'];
 		}
 		
 		//initialize cache with root directory in cache
@@ -432,9 +432,9 @@ class ObjectStoreStorage extends \OC\Files\Storage\Common {
 
 	/**
 	 * get the free space in the object storage as indicated by the objectstore config
-	 * 
-	 * NOTE: getting total free space for objectstorage is not possible, 
-	 *       and this can only be set to administrator allowed volume 
+	 *
+	 * NOTE: getting total free space for objectstorage is not possible,
+	 *       and this can only be set to administrator allowed volume
 	 *       e.g. due to billing or monitoring concerns
 	 *
 	 * @param string $path
@@ -449,7 +449,7 @@ class ObjectStoreStorage extends \OC\Files\Storage\Common {
 			}
 
 			$free = $this->availableStorage - $used;
-			if ($free < 0){
+			if ($free < 0) {
 				return 0;
 			}
 			return $free;

--- a/tests/lib/Files/ObjectStore/ObjectStoreTest.php
+++ b/tests/lib/Files/ObjectStore/ObjectStoreTest.php
@@ -3,6 +3,7 @@
  * @author Thomas Müller <thomas.mueller@tmit.eu>
  *
  * @copyright Copyright (c) 2018, ownCloud GmbH
+ * @license AGPL-3.0
  *
  * This code is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License, version 3,
@@ -104,7 +105,7 @@ class ObjectStoreTest extends TestCase {
 		$objectStore = $this->getMockBuilder(ObjectStoreStorage::class)
 			->setConstructorArgs([[
 				'objectstore' => $this->impl,
-				'availablestorage' => 1
+				'availableStorage' => 1
 			]])
 			->getMock();
 		$free = $objectStore->free_space('test');

--- a/tests/lib/Files/ObjectStore/ObjectStoreTest.php
+++ b/tests/lib/Files/ObjectStore/ObjectStoreTest.php
@@ -2,12 +2,7 @@
 /**
  * @author Thomas Müller <thomas.mueller@tmit.eu>
  *
-<<<<<<< HEAD
  * @copyright Copyright (c) 2018, ownCloud GmbH
-=======
- * @copyright Copyright (c) 2017, ownCloud GmbH
->>>>>>> 478c4d51eb... Add versioning to objectstore
- * @license AGPL-3.0
  *
  * This code is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License, version 3,
@@ -29,6 +24,7 @@ use OC\Files\Cache\CacheEntry;
 use OC\Files\Cache\Updater;
 use OC\Files\ObjectStore\NoopScanner;
 use OC\Files\ObjectStore\ObjectStoreStorage;
+use OCP\Files\FileInfo;
 use OCP\Files\NotFoundException;
 use OCP\Files\ObjectStore\IObjectStore;
 use OCP\Files\ObjectStore\IVersionedObjectStorage;
@@ -98,6 +94,21 @@ class ObjectStoreTest extends TestCase {
 
 	public function testGetScanner() {
 		$this->assertInstanceOf(NoopScanner::class, $this->objectStore->getScanner());
+	}
+
+	public function testFreeSpaceDefault() {
+		$this->assertEquals(FileInfo::SPACE_UNLIMITED, $this->objectStore->free_space('test'));
+	}
+
+	public function testFreeSpaceWithAvailableStorageConfig() {
+		$objectStore = $this->getMockBuilder(ObjectStoreStorage::class)
+			->setConstructorArgs([[
+				'objectstore' => $this->impl,
+				'availablestorage' => 1
+			]])
+			->getMock();
+		$free = $objectStore->free_space('test');
+		$this->assertTrue($free >= 0);
 	}
 
 	public function testUnlink() {


### PR DESCRIPTION
## Description

Feature: Allow specifying available space for objectstorages

Before this change, objectstorages were reporting only infinite storage space. This could have caused problems in other apps that rely on this storage method, e.g. metrics app that monitors available space

-  [x] Doc Update https://github.com/owncloud/docs-server/pull/658

## Related Issue
- Fixes https://github.com/owncloud/enterprise/issues/5384
- Related https://github.com/owncloud/enterprise/issues/5006

## How Has This Been Tested?
- manually in the developer instance
- unit/acceptance tests

Add configurations for files primary s3 being ceph, specifying `availableStorage`

```
<?php
$CONFIG = [
	'objectstore' => [
		'class' => 'OCA\Files_Primary_S3\S3Storage',
		'arguments' => [
			// replace with your bucket
			'bucket' => 'owncloud',
			// uncomment to indicate to owncloud available storage size in bytes (in this example 1TB)
			'availableStorage' => 1099511627776,
			// uncomment to enable server side encryption
			//'serversideencryption' => 'AES256',
			'options' => [
				// version and region are required
				'version' => '2006-03-01',
				'region'  => 'us-central-1',
				'credentials' => [
					// replace key and secret with your credentials
					'key' => 'owncloud123456',
					'secret' => 'secret123456',
				],
				'use_path_style_endpoint' => true,
				'endpoint' => 'http://ceph:8009/',
			],
		],
	],
];
```

Start ceph additionaly with owncloud instance
```
  ceph:
    image: ceph/daemon:master-dba849b-pacific-centos-8-aarch64
    command: demo
    restart: always
    environment:
      - NETWORK_AUTO_DETECT=4
      - RGW_NAME=ceph
      - CEPH_DEMO_UID=owncloud
      - CEPH_DEMO_ACCESS_KEY=owncloud123456
      - CEPH_DEMO_SECRET_KEY=secret123456
      - CEPH_DEMO_BUCKET=owncloud
    ports:
      - ${OWNCLOUD_S3_PORT}:8080
      - ${OWNCLOUD_S3_REST_PORT}:5000
```

## Types of changes
- [x] New feature (non-breaking change which adds functionality)

## Checklist:
- [x] Base code changes
- [x] Unit tests added
- [x] Acceptance tests added
- [x] Changelog item, see [TEMPLATE](https://github.com/owncloud/core/blob/master/changelog/TEMPLATE)

## Example

Example use-case: metrics app

Now metric is correctly reported in the app
![Screenshot 2022-09-27 at 23 37 12](https://user-images.githubusercontent.com/13368647/192704818-2e7ddd38-68c1-48dd-ad8a-439dc3f66a1d.png)

