### PR TITLE
[tests-only][full-ci]Added test for Sharing resource to user in multiple groups

### DIFF
--- a/tests/acceptance/features/apiShareManagementBasicToShares/createShareToSharesFolder.feature
+++ b/tests/acceptance/features/apiShareManagementBasicToShares/createShareToSharesFolder.feature
@@ -236,18 +236,15 @@ Feature: sharing
       | 2               | 200             |
 
   @smokeTest
-  Scenario Outline: User included in multiple group receives a share from admin
+  Scenario Outline: User included in multiple groups receives a share from the admin
     Given using OCS API version "<ocs_api_version>"
-    And these users have been created with default attributes and without skeleton files:
-      | username   |
-      | admin-user |
-    And user "admin-user" has been added to group "admin"
     And group "grp1" has been created
     And group "grp2" has been created
     And user "Alice" has been added to group "grp1"
-    And user "admin-user" has created folder "/PARENT"
-    When user "admin-user" shares folder "/PARENT" with group "grp1" using the sharing API
-    And user "Alice" accepts share "/PARENT" offered by user "admin-user" using the sharing API
+    And user "Alice" has been added to group "grp2"
+    And admin "admin" has created folder "/PARENT"
+    When user "admin" shares folder "/PARENT" with group "grp1" using the sharing API
+    And user "Alice" accepts share "/PARENT" offered by user "admin" using the sharing API
     Then the OCS status code of responses on all endpoints should be "<ocs_status_code>"
     And the HTTP status code of responses on all endpoints should be "200"
     Examples:
@@ -256,7 +253,7 @@ Feature: sharing
       | 2               | 200             |
 
   @smokeTest
-  Scenario Outline: user included in multiple group share a folder to a group
+  Scenario Outline: user included in multiple groups, shares a folder with a group
     Given using OCS API version "<ocs_api_version>"
     And these users have been created with default attributes and without skeleton files:
       | username |

--- a/tests/acceptance/features/apiShareManagementBasicToShares/createShareToSharesFolder.feature
+++ b/tests/acceptance/features/apiShareManagementBasicToShares/createShareToSharesFolder.feature
@@ -235,6 +235,49 @@ Feature: sharing
       | 1               | 100             |
       | 2               | 200             |
 
+  @smokeTest
+  Scenario Outline: User included in multiple group receives a share from admin
+    Given using OCS API version "<ocs_api_version>"
+    And these users have been created with default attributes and without skeleton files:
+      | username   |
+      | admin-user |
+    And user "admin-user" has been added to group "admin"
+    And group "grp1" has been created
+    And group "grp2" has been created
+    And user "Alice" has been added to group "grp1"
+    And user "admin-user" has created folder "/PARENT"
+    When user "admin-user" shares folder "/PARENT" with group "grp1" using the sharing API
+    And user "Alice" accepts share "/PARENT" offered by user "admin-user" using the sharing API
+    Then the OCS status code of responses on all endpoints should be "<ocs_status_code>"
+    And the HTTP status code of responses on all endpoints should be "200"
+    Examples:
+      | ocs_api_version | ocs_status_code |
+      | 1               | 100             |
+      | 2               | 200             |
+
+  @smokeTest
+  Scenario Outline: user included in multiple group share a folder to a group
+    Given using OCS API version "<ocs_api_version>"
+    And these users have been created with default attributes and without skeleton files:
+      | username |
+      | Brian    |
+    And group "grp1" has been created
+    And group "grp2" has been created
+    And user "Alice" has been added to group "grp1"
+    And user "Alice" has been added to group "grp2"
+    And user "Brian" has been added to group "grp1"
+    And user "Brian" has been added to group "grp2"
+    And user "Alice" has created folder "/PARENT"
+    When user "Alice" shares folder "/PARENT" with group "grp1" using the sharing API
+    And user "Brian" accepts share "/PARENT" offered by user "Alice" using the sharing API
+    Then the OCS status code of responses on all endpoints should be "<ocs_status_code>"
+    And the HTTP status code of responses on all endpoints should be "200"
+    Examples:
+      | ocs_api_version | ocs_status_code |
+      | 1               | 100             |
+      | 2               | 200             |
+
+
   @skipOnOcV10.6 @skipOnOcV10.7 @skipOnOcV10.8.0
   Scenario Outline: sharing again an own file while belonging to a group
     Given using OCS API version "<ocs_api_version>"

--- a/tests/acceptance/features/bootstrap/FeatureContext.php
+++ b/tests/acceptance/features/bootstrap/FeatureContext.php
@@ -3700,6 +3700,17 @@ class FeatureContext extends BehatVariablesContext {
 	}
 
 	/**
+	 * @AfterScenario
+	 *
+	 * @return void
+	 */
+	public function deleteAllResourceCreatedByAdmin():void {
+		foreach ($this->adminResources as $resource) {
+			$this->userDeletesFile("admin", $resource);
+		}
+	}
+
+	/**
 	 * deletes all created storages
 	 *
 	 * @return void

--- a/tests/acceptance/features/bootstrap/WebDav.php
+++ b/tests/acceptance/features/bootstrap/WebDav.php
@@ -94,6 +94,16 @@ trait WebDav {
 	private $responseXml = [];
 
 	/**
+	 * add resource created by admin in an array
+	 * This array is used while cleaning up the resource created by admin during test run
+	 * As of now it tracks only for (files|folder) creation
+	 * This can be expanded and modified to track other actions like (upload, deleted ..)
+	 *
+	 * @var array
+	 */
+	private $adminResources = [];
+
+	/**
 	 * response content parsed into a SimpleXMLElement
 	 *
 	 * @var SimpleXMLElement
@@ -3704,6 +3714,32 @@ trait WebDav {
 			["201", "204"],
 			"HTTP status code was not 201 or 204 while trying to create folder '$destination' for user '$user'"
 		);
+		$this->emptyLastHTTPStatusCodesArray();
+	}
+
+	/**
+	 * @Given admin :admin has created folder :destination
+	 *
+	 * @param string $admin
+	 * @param string $destination
+	 *
+	 * @return void
+	 * @throws JsonException
+	 * @throws GuzzleException
+	 */
+	public function adminHasCreatedFolder(string $admin, string $destination):void {
+		$admin = $this->getActualUsername($admin);
+		Assert::assertEquals(
+			"admin",
+			$admin,
+			__METHOD__ . "The provided user is not admin but '" . $admin . "'"
+		);
+		$this->userCreatesFolder($admin, $destination);
+		$this->theHTTPStatusCodeShouldBe(
+			["201", "204"],
+			"HTTP status code was not 201 or 204 while trying to create folder '$destination' for admin '$admin'"
+		);
+		$this->adminResources[] = $destination;
 		$this->emptyLastHTTPStatusCodesArray();
 	}
 


### PR DESCRIPTION
## Description
This PR adds tests scenarios:
 - User who is in multiple group receiving a share from admin
 - User who is in multiple group shares a folder to other user who are in multiple groups
  
## Related Issue
https://github.com/owncloud/ocis/issues/4671

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
- Locally
- CI

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Database schema changes (next release will require increase of minor version instead of patch)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [ ] Tests only (no source changes)

## Checklist:
<!-- Tick the checkboxes when done. -->
<!-- Raise documentation ticket in https://github.com/owncloud/documentation -->
- [ ] Code changes
- [ ] Unit tests added
- [x] Acceptance tests added
- [ ] Documentation ticket raised: <link> 
- [ ] Changelog item, see [TEMPLATE](https://github.com/owncloud/core/blob/master/changelog/TEMPLATE)
