### PR TITLE
[tests-only] Update vendor-bin tool versions to current minor versions

### DIFF
--- a/vendor-bin/behat/composer.json
+++ b/vendor-bin/behat/composer.json
@@ -4,15 +4,15 @@
         "behat/gherkin": "4.7.1",
         "behat/mink": "1.7.1",
         "behat/mink-extension": "^2.3",
-        "behat/mink-selenium2-driver": "^1.4",
+        "behat/mink-selenium2-driver": "^1.5",
         "ciaranmcnulty/behat-stepthroughextension" : "dev-master",
         "rdx/behat-variables": "^1.2",
         "sensiolabs/behat-page-object-extension": "^2.3",
         "symfony/translation": "^4.4",
         "sabre/xml": "^2.2",
-        "guzzlehttp/guzzle": "^7.2",
-        "phpunit/phpunit": "^9.4",
-        "laminas/laminas-ldap": "^2.10",
-        "ankitpokhrel/tus-php": "^2.1"
+        "guzzlehttp/guzzle": "^7.5",
+        "phpunit/phpunit": "^9.5",
+        "laminas/laminas-ldap": "^2.15",
+        "ankitpokhrel/tus-php": "^2.3"
     }
 }

--- a/vendor-bin/phan/composer.json
+++ b/vendor-bin/phan/composer.json
@@ -1,5 +1,5 @@
 {
     "require": {
-        "phan/phan": "^5.2"
+        "phan/phan": "^5.4"
     }
 }

--- a/vendor-bin/php_codesniffer/composer.json
+++ b/vendor-bin/php_codesniffer/composer.json
@@ -1,8 +1,5 @@
 {
     "require": {
-        "squizlabs/php_codesniffer": "^3.5"
-    },
-    "conflict": {
-        "squizlabs/php_codesniffer": "3.5.1"
+        "squizlabs/php_codesniffer": "^3.7"
     }
 }


### PR DESCRIPTION
## Description
- `php_codesniffer` is really using 3.7 these days. There is no longer any need for the `conflict` entry for 3.5.1
- adjust other dependencies for Behat acceptance tests and phan so they reflect the minor versions that actually get used in real life. That will make it a bit easier for anyone who looks at test tool issues in future.

## How Has This Been Tested?
CI

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Database schema changes (next release will require increase of minor version instead of patch)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [x] Tests only (no source changes)

## Checklist:
- [ ] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 
- [ ] Changelog item, see [TEMPLATE](https://github.com/owncloud/core/blob/master/changelog/TEMPLATE)
