### PR TITLE
[tests-only] [full-ci] Unpin behat/gherkin version and use 4.9

### DIFF
--- a/vendor-bin/behat/composer.json
+++ b/vendor-bin/behat/composer.json
@@ -1,7 +1,7 @@
 {
     "require": {
-        "behat/behat": "^3.8",
-        "behat/gherkin": "4.7.1",
+        "behat/behat": "^3.11",
+        "behat/gherkin": "^4.9",
         "behat/mink": "1.7.1",
         "behat/mink-extension": "^2.3",
         "behat/mink-selenium2-driver": "^1.5",


### PR DESCRIPTION
## Description
Issue #38338 and PR #38347 pinned `behat/gherkin` to 4.7.1 because of some issues with `behat/gherkin` releases. The upstream problem was resolved a long time ago. The activity app (and other oC10 apps) have been using `behat/gherkin` 4.9.* for some time.

This PR bumps the version of `behat/gherkin`  and `behat/behat` so that they are up-to-date in core. These are used in the acceptance tests.

## How Has This Been Tested?
CI

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Database schema changes (next release will require increase of minor version instead of patch)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [x] Tests only (no source changes)

## Checklist:
- [ ] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 
- [ ] Changelog item, see [TEMPLATE](https://github.com/owncloud/core/blob/master/changelog/TEMPLATE)
