### PR TITLE
[full-ci] [tests-only] Skipped etag test are unskipped for ocis

### DIFF
--- a/tests/acceptance/features/apiWebdavEtagPropagation1/deleteFileFolder.feature
+++ b/tests/acceptance/features/apiWebdavEtagPropagation1/deleteFileFolder.feature
@@ -32,7 +32,7 @@ Feature: propagation of etags when deleting a file or folder
       | dav_version |
       | spaces      |
 
-  @skipOnOcis-OC-Storage @issue-product-280
+  @issue-product-280
   Scenario Outline: deleting a folder changes the etags of all parents
     Given using <dav_version> DAV path
     And user "Alice" has created folder "/upload/sub"
@@ -145,7 +145,7 @@ Feature: propagation of etags when deleting a file or folder
       | old         |
       | new         |
 
-  @skipOnOcis-OC-Storage @issue-product-280 @skipOnOcV10.6 @skipOnOcV10.7 @skipOnOcV10.8.0
+  @issue-product-280 @skipOnOcV10.6 @skipOnOcV10.7 @skipOnOcV10.8.0
   Scenario Outline: as share receiver deleting a folder changes the etags of all parents for all collaborators
     Given user "Brian" has been created with default attributes and without skeleton files
     And the administrator has set the default folder for received shares to "Shares"
@@ -178,7 +178,7 @@ Feature: propagation of etags when deleting a file or folder
       | old         |
       | new         |
 
-  @skipOnOcis-OC-Storage @issue-product-280 @skipOnOcV10.6 @skipOnOcV10.7 @skipOnOcV10.8.0
+  @issue-product-280 @skipOnOcV10.6 @skipOnOcV10.7 @skipOnOcV10.8.0
   Scenario Outline: as sharer deleting a folder changes the etags of all parents for all collaborators
     Given user "Brian" has been created with default attributes and without skeleton files
     And the administrator has set the default folder for received shares to "Shares"
@@ -211,7 +211,7 @@ Feature: propagation of etags when deleting a file or folder
       | old         |
       | new         |
 
-  @skipOnOcis-OC-Storage @issue-product-280
+  @issue-product-280
   Scenario Outline: deleting a file in a publicly shared folder changes its etag for the sharer
     Given using <dav_version> DAV path
     And user "Alice" has uploaded file with content "uploaded content" to "/upload/file.txt"
@@ -236,7 +236,7 @@ Feature: propagation of etags when deleting a file or folder
       | dav_version |
       | spaces      |
 
-  @skipOnOcis-OC-Storage @issue-product-280
+  @issue-product-280
   Scenario Outline: deleting a folder in a publicly shared folder changes its etag for the sharer
     Given using <dav_version> DAV path
     And user "Alice" has created folder "/upload/sub"

--- a/tests/acceptance/features/apiWebdavEtagPropagation1/moveFileFolder.feature
+++ b/tests/acceptance/features/apiWebdavEtagPropagation1/moveFileFolder.feature
@@ -27,7 +27,7 @@ Feature: propagation of etags when moving files or folders
       | dav_version |
       | spaces      |
 
-  @skipOnOcis-OC-Storage @issue-product-280
+  @issue-product-280
   Scenario Outline: moving a file from one folder to an other changes the etags of both folders
     Given using <dav_version> DAV path
     And user "Alice" has created folder "/src"
@@ -53,7 +53,7 @@ Feature: propagation of etags when moving files or folders
       | dav_version |
       | spaces      |
 
-  @skipOnOcis-OC-Storage @issue-product-280
+  @issue-product-280
   Scenario Outline: moving a file into a subfolder changes the etags of all parents
     Given using <dav_version> DAV path
     And user "Alice" has created folder "/upload"
@@ -102,7 +102,7 @@ Feature: propagation of etags when moving files or folders
       | dav_version |
       | spaces      |
 
-  @skipOnOcis-OC-Storage @issue-product-280
+  @issue-product-280
   Scenario Outline: moving a folder from one folder to an other changes the etags of both folders
     Given using <dav_version> DAV path
     And user "Alice" has created folder "/src"
@@ -128,7 +128,7 @@ Feature: propagation of etags when moving files or folders
       | dav_version |
       | spaces      |
 
-  @skipOnOcis-OC-Storage @issue-product-280
+  @issue-product-280
   Scenario Outline: moving a folder into a subfolder changes the etags of all parents
     Given using <dav_version> DAV path
     And user "Alice" has created folder "/upload"
@@ -212,7 +212,7 @@ Feature: propagation of etags when moving files or folders
       | old         |
       | new         |
 
-  @skipOnOcis-OC-Storage @issue-product-280 @skipOnOcV10.6 @skipOnOcV10.7 @skipOnOcV10.8.0
+  @issue-product-280 @skipOnOcV10.6 @skipOnOcV10.7 @skipOnOcV10.8.0
   Scenario Outline: as sharer moving a file from one folder to an other changes the etags of both folders for all collaborators
     Given user "Brian" has been created with default attributes and without skeleton files
     And the administrator has set the default folder for received shares to "Shares"
@@ -284,7 +284,7 @@ Feature: propagation of etags when moving files or folders
       | old         |
       | new         |
 
-  @skipOnOcis-OC-Storage @issue-product-280 @skipOnOcV10.6 @skipOnOcV10.7 @skipOnOcV10.8.0
+  @issue-product-280 @skipOnOcV10.6 @skipOnOcV10.7 @skipOnOcV10.8.0
   Scenario Outline: as sharer moving a folder from one folder to an other changes the etags of both folders for all collaborators
     Given user "Brian" has been created with default attributes and without skeleton files
     And the administrator has set the default folder for received shares to "Shares"

--- a/tests/acceptance/features/apiWebdavEtagPropagation2/copyFileFolder.feature
+++ b/tests/acceptance/features/apiWebdavEtagPropagation2/copyFileFolder.feature
@@ -4,7 +4,7 @@ Feature: propagation of etags when copying files or folders
   Background:
     Given user "Alice" has been created with default attributes and without skeleton files
 
-  @skipOnOcis-OC-Storage @issue-product-280
+  @issue-product-280
   Scenario Outline: copying a file does not change its etag
     Given using <dav_version> DAV path
     And user "Alice" has uploaded file with content "uploaded content" to "file.txt"
@@ -30,7 +30,7 @@ Feature: propagation of etags when copying files or folders
       | dav_version |
       | spaces      |
 
-  @skipOnOcis-OC-Storage @issue-product-280
+  @issue-product-280
   Scenario Outline: copying a file inside a folder changes its etag
     Given using <dav_version> DAV path
     And user "Alice" has created folder "/folder"
@@ -57,7 +57,7 @@ Feature: propagation of etags when copying files or folders
       | dav_version |
       | spaces      |
 
-  @skipOnOcis-OC-Storage @issue-product-280
+  @issue-product-280
   Scenario Outline: copying a file from one folder to an other changes the etags of destination
     Given using <dav_version> DAV path
     And user "Alice" has created folder "/src"
@@ -85,7 +85,7 @@ Feature: propagation of etags when copying files or folders
       | dav_version |
       | spaces      |
 
-  @skipOnOcis-OC-Storage @issue-product-280
+  @issue-product-280
   Scenario Outline: copying a file into a subfolder changes the etags of all parents
     Given using <dav_version> DAV path
     And user "Alice" has created folder "/upload"
@@ -107,7 +107,7 @@ Feature: propagation of etags when copying files or folders
     And these etags should not have changed:
       | user  | path             |
       | Alice | /upload/file.txt |
-    @skipOnOcis @issue-ocis-4091
+    @issue-ocis-4091
     Examples:
       | dav_version |
       | old         |
@@ -118,7 +118,7 @@ Feature: propagation of etags when copying files or folders
       | dav_version |
       | spaces      |
 
-  @skipOnOcis-OC-Storage @issue-product-280
+  @issue-product-280
   Scenario Outline: copying a file inside a publicly shared folder by public changes etag for the sharer
     Given using <dav_version> DAV path
     And user "Alice" has created folder "/upload"
@@ -140,7 +140,7 @@ Feature: propagation of etags when copying files or folders
     And these etags should not have changed:
       | user  | path             |
       | Alice | /upload/file.txt |
-    @skipOnOcis @issue-ocis-4091
+    @issue-ocis-4091
     Examples:
       | dav_version |
       | old         |
@@ -190,7 +190,7 @@ Feature: propagation of etags when copying files or folders
       | old         |
       | new         |
 
-  @skipOnOcis-OC-Storage @issue-product-280 @skipOnOcV10.6 @skipOnOcV10.7 @skipOnOcV10.8.0
+  @issue-product-280 @skipOnOcV10.6 @skipOnOcV10.7 @skipOnOcV10.8.0
   Scenario Outline: as sharer copying a file inside a folder changes its etag for all collaborators
     Given user "Brian" has been created with default attributes and without skeleton files
     And the administrator has set the default folder for received shares to "Shares"

--- a/tests/acceptance/features/apiWebdavEtagPropagation2/createFolder.feature
+++ b/tests/acceptance/features/apiWebdavEtagPropagation2/createFolder.feature
@@ -6,7 +6,7 @@ Feature: propagation of etags when creating folders
     And the administrator has set the default folder for received shares to "Shares"
     And parameter "shareapi_auto_accept_share" of app "core" has been set to "no"
 
-  @skipOnOcis-OC-Storage @issue-product-280
+  @issue-product-280
   Scenario Outline: creating a folder inside a folder changes its etag
     Given using <dav_version> DAV path
     And user "Alice" has created folder "/folder"
@@ -53,7 +53,7 @@ Feature: propagation of etags when creating folders
       | dav_version |
       | spaces      |
 
-  @skipOnOcis-OC-Storage @issue-product-280 @skipOnOcV10.6 @skipOnOcV10.7 @skipOnOcV10.8.0
+  @issue-product-280 @skipOnOcV10.6 @skipOnOcV10.7 @skipOnOcV10.8.0
   Scenario Outline: as share receiver creating a folder inside a folder received as a share changes its etag for all collaborators
     Given user "Brian" has been created with default attributes and without skeleton files
     And using <dav_version> DAV path
@@ -79,7 +79,7 @@ Feature: propagation of etags when creating folders
       | old         |
       | new         |
 
-  @skipOnOcis-OC-Storage @issue-product-280 @skipOnOcV10.6 @skipOnOcV10.7 @skipOnOcV10.8.0
+  @issue-product-280 @skipOnOcV10.6 @skipOnOcV10.7 @skipOnOcV10.8.0
   Scenario Outline: as a sharer creating a folder inside a shared folder changes etag for all collaborators
     Given user "Brian" has been created with default attributes and without skeleton files
     And using <dav_version> DAV path
@@ -105,7 +105,7 @@ Feature: propagation of etags when creating folders
       | old         |
       | new         |
 
-  @skipOnOcis-OC-Storage @issue-product-280
+  @issue-product-280
   Scenario Outline: creating a folder in a publicly shared folder changes its etag for the sharer
     Given using <dav_version> DAV path
     And user "Alice" has created folder "/folder"

--- a/tests/acceptance/features/apiWebdavEtagPropagation2/restoreFromTrash.feature
+++ b/tests/acceptance/features/apiWebdavEtagPropagation2/restoreFromTrash.feature
@@ -49,7 +49,7 @@ Feature: propagation of etags when restoring a file or folder from trash
       | old         |
       | new         |
 
-  @skipOnOcis-OC-Storage
+
   Scenario Outline: restoring a folder to its original location changes the etags of all parents
     Given using <dav_version> DAV path
     And user "Alice" has created folder "/upload/sub"

--- a/tests/acceptance/features/apiWebdavEtagPropagation2/restoreVersion.feature
+++ b/tests/acceptance/features/apiWebdavEtagPropagation2/restoreVersion.feature
@@ -1,4 +1,4 @@
-@api @skipOnOcis-OC-Storage @issue-product-280
+@api @issue-product-280
 Feature: propagation of etags when restoring a version of a file
 
   Background:

--- a/tests/acceptance/features/apiWebdavEtagPropagation2/upload.feature
+++ b/tests/acceptance/features/apiWebdavEtagPropagation2/upload.feature
@@ -7,7 +7,7 @@ Feature: propagation of etags when uploading data
     And parameter "shareapi_auto_accept_share" of app "core" has been set to "no"
     And user "Alice" has created folder "/upload"
 
-  @skipOnOcis-OC-Storage @issue-product-280
+  @issue-product-280
   Scenario Outline: uploading a file inside a folder changes its etag
     Given using <dav_version> DAV path
     And user "Alice" has stored etag of element "/"
@@ -52,7 +52,7 @@ Feature: propagation of etags when uploading data
       | dav_version |
       | spaces      |
 
-  @skipOnOcis-OC-Storage @issue-product-280 @skipOnOcV10.6 @skipOnOcV10.7 @skipOnOcV10.8.0
+  @issue-product-280 @skipOnOcV10.6 @skipOnOcV10.7 @skipOnOcV10.8.0
   Scenario Outline: as share receiver uploading a file inside a received shared folder should update etags for all collaborators
     Given user "Brian" has been created with default attributes and without skeleton files
     And using <dav_version> DAV path
@@ -77,7 +77,7 @@ Feature: propagation of etags when uploading data
       | old         |
       | new         |
 
-  @skipOnOcis-OC-Storage @issue-product-280 @skipOnOcV10.6 @skipOnOcV10.7 @skipOnOcV10.8.0
+  @issue-product-280 @skipOnOcV10.6 @skipOnOcV10.7 @skipOnOcV10.8.0
   Scenario Outline: as sharer uploading a file inside a shared folder should update etags for all collaborators
     Given user "Brian" has been created with default attributes and without skeleton files
     And using <dav_version> DAV path
@@ -154,7 +154,7 @@ Feature: propagation of etags when uploading data
       | old         |
       | new         |
 
-  @skipOnOcis-OC-Storage @issue-product-280
+  @issue-product-280
   Scenario Outline: uploading a file into a publicly shared folder changes its etag for the sharer
     Given using <dav_version> DAV path
     And user "Alice" has created a public link share with settings


### PR DESCRIPTION
The ETag-related issues (https://github.com/owncloud/ocis/issues/4091, https://github.com/owncloud/product/issues/280) have been fixed and the tests skipped for ocis previously were not reverted back. This PR removes the `skipOnOcis` and `skipOnOcis-OC-Storage` tags and tested for ocis with PR https://github.com/owncloud/ocis/pull/4722.

CC @dragonchaser @butonic @individual-it @phil-davis 