### PR TITLE
[full-ci] Test indirect resource existence leaks

### DIFF
--- a/changelog/unreleased/40406
+++ b/changelog/unreleased/40406
@@ -1,0 +1,5 @@
+Change: Test indirect resource existence
+
+We now expect a not found error instead of permission denied error for some trash interactions.
+
+https://github.com/owncloud/core/pull/40406

--- a/tests/acceptance/features/apiTrashbin/trashbinDelete.feature
+++ b/tests/acceptance/features/apiTrashbin/trashbinDelete.feature
@@ -93,19 +93,20 @@ Feature: files and folders can be deleted from the trashbin
     And user "Alice" has deleted file "/PARENT/parent.txt"
     And user "Alice" has deleted file "/PARENT/CHILD/child.txt"
     When user "Brian" tries to delete the file with original path "textfile1.txt" from the trashbin of user "Alice" using the trashbin API
-    Then the HTTP status code should be "404"
+    Then the HTTP status code should be "<status-code>"
     And as "Alice" the file with original path "/textfile1.txt" should exist in the trashbin
     And as "Alice" the file with original path "/textfile0.txt" should exist in the trashbin
     And as "Alice" the file with original path "/PARENT/parent.txt" should exist in the trashbin
     And as "Alice" the file with original path "/PARENT/CHILD/child.txt" should exist in the trashbin
+    @skipOnOcis
     Examples:
-      | dav-path |
-      | new      |
-
+      | dav-path | status-code |
+      | new      | 401         |
     @skipOnOcV10 @personalSpace
     Examples:
-      | dav-path |
-      | spaces   |
+      | dav-path | status-code |
+      | new      | 404         |
+      | spaces   | 404         |
 
   Scenario Outline: User tries to delete trashbin file using invalid password
     Given using <dav-path> DAV path

--- a/tests/acceptance/features/apiTrashbin/trashbinDelete.feature
+++ b/tests/acceptance/features/apiTrashbin/trashbinDelete.feature
@@ -93,7 +93,7 @@ Feature: files and folders can be deleted from the trashbin
     And user "Alice" has deleted file "/PARENT/parent.txt"
     And user "Alice" has deleted file "/PARENT/CHILD/child.txt"
     When user "Brian" tries to delete the file with original path "textfile1.txt" from the trashbin of user "Alice" using the trashbin API
-    Then the HTTP status code should be "401"
+    Then the HTTP status code should be "404"
     And as "Alice" the file with original path "/textfile1.txt" should exist in the trashbin
     And as "Alice" the file with original path "/textfile0.txt" should exist in the trashbin
     And as "Alice" the file with original path "/PARENT/parent.txt" should exist in the trashbin

--- a/tests/acceptance/features/apiTrashbin/trashbinFilesFolders.feature
+++ b/tests/acceptance/features/apiTrashbin/trashbinFilesFolders.feature
@@ -198,7 +198,31 @@ Feature: files and folders exist in the trashbin after being deleted
       | dav-path |
       | spaces   |
 
-  @issue-ocis-3561 @smokeTest @skipOnLDAP @skip_on_objectstore @skipOnOcV10.3
+  @issue-ocis-3561 @smokeTest @skipOnLDAP @skip_on_objectstore @skipOnOcis
+  Scenario Outline: Listing other user's trashbin is prohibited with multiple files on trashbin
+    Given using <dav-path> DAV path
+    And user "testtrashbin101" has been created with default attributes and without skeleton files
+    And user "testtrashbin101" has uploaded file "filesForUpload/textfile.txt" to "/textfile0.txt"
+    And user "testtrashbin101" has uploaded file "filesForUpload/textfile.txt" to "/textfile2.txt"
+    And user "Brian" has been created with default attributes and without skeleton files
+    And user "testtrashbin101" has deleted file "/textfile0.txt"
+    And user "testtrashbin101" has deleted file "/textfile2.txt"
+    When user "Brian" tries to list the trashbin content for user "testtrashbin101"
+    Then the HTTP status code should be "401"
+    And the last webdav response should not contain the following elements
+      | path          | user            |
+      | textfile0.txt | testtrashbin101 |
+      | textfile2.txt | testtrashbin101 |
+    Examples:
+      | dav-path |
+      | new      |
+
+    @skipOnOcV10 @personalSpace
+    Examples:
+      | dav-path |
+      | spaces   |
+  
+  @issue-ocis-3561 @smokeTest @skipOnLDAP @skip_on_objectstore @skipOnOcV10
   Scenario Outline: Listing other user's trashbin is prohibited with multiple files on trashbin
     Given using <dav-path> DAV path
     And user "testtrashbin101" has been created with default attributes and without skeleton files

--- a/tests/acceptance/features/apiTrashbin/trashbinFilesFolders.feature
+++ b/tests/acceptance/features/apiTrashbin/trashbinFilesFolders.feature
@@ -185,7 +185,7 @@ Feature: files and folders exist in the trashbin after being deleted
     And user "Brian" has been created with default attributes and without skeleton files
     And user "testtrashbin100" has deleted file "/textfile1.txt"
     When user "Brian" tries to list the trashbin content for user "testtrashbin100"
-    Then the HTTP status code should be "401"
+    Then the HTTP status code should be "404"
     And the last webdav response should not contain the following elements
       | path          | user            |
       | textfile1.txt | testtrashbin100 |
@@ -208,7 +208,7 @@ Feature: files and folders exist in the trashbin after being deleted
     And user "testtrashbin101" has deleted file "/textfile0.txt"
     And user "testtrashbin101" has deleted file "/textfile2.txt"
     When user "Brian" tries to list the trashbin content for user "testtrashbin101"
-    Then the HTTP status code should be "401"
+    Then the HTTP status code should be "404"
     And the last webdav response should not contain the following elements
       | path          | user            |
       | textfile0.txt | testtrashbin101 |
@@ -259,7 +259,7 @@ Feature: files and folders exist in the trashbin after being deleted
     And user "testtrashbinempty" has been created with default attributes and without skeleton files
     And user "testtrashbinempty" has uploaded file "filesForUpload/textfile.txt" to "/textfile1.txt"
     When user "Alice" tries to list the trashbin content for user "testtrashbinempty"
-    Then the HTTP status code should be "401"
+    Then the HTTP status code should be "404"
     Examples:
       | dav-path |
       | new      |

--- a/tests/acceptance/features/apiTrashbin/trashbinFilesFolders.feature
+++ b/tests/acceptance/features/apiTrashbin/trashbinFilesFolders.feature
@@ -185,18 +185,19 @@ Feature: files and folders exist in the trashbin after being deleted
     And user "Brian" has been created with default attributes and without skeleton files
     And user "testtrashbin100" has deleted file "/textfile1.txt"
     When user "Brian" tries to list the trashbin content for user "testtrashbin100"
-    Then the HTTP status code should be "404"
+    Then the HTTP status code should be "<status-code>"
     And the last webdav response should not contain the following elements
       | path          | user            |
       | textfile1.txt | testtrashbin100 |
+    @skipOnOcis
     Examples:
-      | dav-path |
-      | new      |
-
+      | dav-path | status-code |
+      | new      | 401         |
     @skipOnOcV10 @personalSpace
     Examples:
-      | dav-path |
-      | spaces   |
+      | dav-path | status-code |
+      | new      | 404         |
+      | spaces   | 404         |
 
   @issue-ocis-3561 @smokeTest @skipOnLDAP @skip_on_objectstore @skipOnOcV10.3
   Scenario Outline: Listing other user's trashbin is prohibited with multiple files on trashbin
@@ -220,6 +221,7 @@ Feature: files and folders exist in the trashbin after being deleted
     @skipOnOcV10 @personalSpace
     Examples:
       | dav-path | status_code |
+      | new      | 404         |
       | spaces   | 404         |
 
   @issue-ocis-3561 @skipOnLDAP @skip_on_objectstore @skipOnOcV10.3
@@ -238,20 +240,20 @@ Feature: files and folders exist in the trashbin after being deleted
     And user "testtrashbin102" has uploaded file "filesForUpload/textfile.txt" to "/textfile3.txt"
     And user "testtrashbin102" has deleted file "/textfile3.txt"
     When user "Brian" tries to list the trashbin content for user "testtrashbin102"
-    Then the HTTP status code should be "401"
+    Then the HTTP status code should be "<status-code>"
     And the last webdav response should not contain the following elements
       | path          | user            |
       | textfile0.txt | testtrashbin102 |
       | textfile2.txt | testtrashbin102 |
       | textfile3.txt | testtrashbin102 |
     Examples:
-      | dav-path |
-      | new      |
-
+      | dav-path | status-code |
+      | new      | 401         |
     @skipOnOcV10 @personalSpace
     Examples:
-      | dav-path |
-      | spaces   |
+      | dav-path | status_code |
+      | new      | 404         |
+      | spaces   | 404         |
 
   @issue-ocis-3561 @skipOnLDAP @skip_on_objectstore
   Scenario Outline: Listing other user's empty unused trashbin is prohibited
@@ -259,15 +261,16 @@ Feature: files and folders exist in the trashbin after being deleted
     And user "testtrashbinempty" has been created with default attributes and without skeleton files
     And user "testtrashbinempty" has uploaded file "filesForUpload/textfile.txt" to "/textfile1.txt"
     When user "Alice" tries to list the trashbin content for user "testtrashbinempty"
-    Then the HTTP status code should be "404"
+    Then the HTTP status code should be "<status-code>"
+    @skipOnOcis
     Examples:
-      | dav-path |
-      | new      |
-
+      | dav-path | status-code |
+      | new      | 401         |
     @skipOnOcV10 @personalSpace
     Examples:
-      | dav-path |
-      | spaces   |
+      | dav-path | status-code |
+      | new      | 404         |
+      | spaces   | 404         |
 
   @issue-ocis-3561 @skipOnLDAP @skip_on_objectstore
   Scenario Outline: Listing non-existent user's trashbin is prohibited

--- a/tests/acceptance/features/apiTrashbin/trashbinFilesFolders.feature
+++ b/tests/acceptance/features/apiTrashbin/trashbinFilesFolders.feature
@@ -220,7 +220,7 @@ Feature: files and folders exist in the trashbin after being deleted
       | new      | 401         |
     @skipOnOcV10 @personalSpace
     Examples:
-      | dav-path | status_code |
+      | dav-path | status-code |
       | new      | 404         |
       | spaces   | 404         |
 
@@ -246,12 +246,13 @@ Feature: files and folders exist in the trashbin after being deleted
       | textfile0.txt | testtrashbin102 |
       | textfile2.txt | testtrashbin102 |
       | textfile3.txt | testtrashbin102 |
+    @skipOnOcis
     Examples:
       | dav-path | status-code |
       | new      | 401         |
     @skipOnOcV10 @personalSpace
     Examples:
-      | dav-path | status_code |
+      | dav-path | status-code |
       | new      | 404         |
       | spaces   | 404         |
 

--- a/tests/acceptance/features/apiTrashbin/trashbinFilesFolders.feature
+++ b/tests/acceptance/features/apiTrashbin/trashbinFilesFolders.feature
@@ -198,7 +198,7 @@ Feature: files and folders exist in the trashbin after being deleted
       | dav-path |
       | spaces   |
 
-  @issue-ocis-3561 @smokeTest @skipOnLDAP @skip_on_objectstore @skipOnOcis
+  @issue-ocis-3561 @smokeTest @skipOnLDAP @skip_on_objectstore @skipOnOcV10.3
   Scenario Outline: Listing other user's trashbin is prohibited with multiple files on trashbin
     Given using <dav-path> DAV path
     And user "testtrashbin101" has been created with default attributes and without skeleton files

--- a/tests/acceptance/features/apiTrashbin/trashbinFilesFolders.feature
+++ b/tests/acceptance/features/apiTrashbin/trashbinFilesFolders.feature
@@ -208,43 +208,19 @@ Feature: files and folders exist in the trashbin after being deleted
     And user "testtrashbin101" has deleted file "/textfile0.txt"
     And user "testtrashbin101" has deleted file "/textfile2.txt"
     When user "Brian" tries to list the trashbin content for user "testtrashbin101"
-    Then the HTTP status code should be "401"
+    Then the HTTP status code should be <status_code>
     And the last webdav response should not contain the following elements
       | path          | user            |
       | textfile0.txt | testtrashbin101 |
       | textfile2.txt | testtrashbin101 |
+    @skipOnOcis
     Examples:
-      | dav-path |
-      | new      |
-
+      | dav-path | status_code |
+      | new      | 401         |
     @skipOnOcV10 @personalSpace
     Examples:
-      | dav-path |
-      | spaces   |
-  
-  @issue-ocis-3561 @smokeTest @skipOnLDAP @skip_on_objectstore @skipOnOcV10
-  Scenario Outline: Listing other user's trashbin is prohibited with multiple files on trashbin
-    Given using <dav-path> DAV path
-    And user "testtrashbin101" has been created with default attributes and without skeleton files
-    And user "testtrashbin101" has uploaded file "filesForUpload/textfile.txt" to "/textfile0.txt"
-    And user "testtrashbin101" has uploaded file "filesForUpload/textfile.txt" to "/textfile2.txt"
-    And user "Brian" has been created with default attributes and without skeleton files
-    And user "testtrashbin101" has deleted file "/textfile0.txt"
-    And user "testtrashbin101" has deleted file "/textfile2.txt"
-    When user "Brian" tries to list the trashbin content for user "testtrashbin101"
-    Then the HTTP status code should be "404"
-    And the last webdav response should not contain the following elements
-      | path          | user            |
-      | textfile0.txt | testtrashbin101 |
-      | textfile2.txt | testtrashbin101 |
-    Examples:
-      | dav-path |
-      | new      |
-
-    @skipOnOcV10 @personalSpace
-    Examples:
-      | dav-path |
-      | spaces   |
+      | dav-path | status_code |
+      | spaces   | 404         |
 
   @issue-ocis-3561 @skipOnLDAP @skip_on_objectstore @skipOnOcV10.3
   Scenario Outline: Listing other user's trashbin is prohibited for newly recreated user with same name

--- a/tests/acceptance/features/apiTrashbin/trashbinFilesFolders.feature
+++ b/tests/acceptance/features/apiTrashbin/trashbinFilesFolders.feature
@@ -208,14 +208,14 @@ Feature: files and folders exist in the trashbin after being deleted
     And user "testtrashbin101" has deleted file "/textfile0.txt"
     And user "testtrashbin101" has deleted file "/textfile2.txt"
     When user "Brian" tries to list the trashbin content for user "testtrashbin101"
-    Then the HTTP status code should be <status_code>
+    Then the HTTP status code should be "<status-code>"
     And the last webdav response should not contain the following elements
       | path          | user            |
       | textfile0.txt | testtrashbin101 |
       | textfile2.txt | testtrashbin101 |
     @skipOnOcis
     Examples:
-      | dav-path | status_code |
+      | dav-path | status-code |
       | new      | 401         |
     @skipOnOcV10 @personalSpace
     Examples:

--- a/tests/acceptance/features/apiTrashbinRestore/trashbinRestore.feature
+++ b/tests/acceptance/features/apiTrashbinRestore/trashbinRestore.feature
@@ -195,7 +195,7 @@ Feature: Restore deleted files/folders
     And user "Brian" has been created with default attributes and without skeleton files
     And user "Alice" has deleted file "/textfile0.txt"
     When user "Brian" tries to restore the file with original path "/textfile0.txt" from the trashbin of user "Alice" using the trashbin API
-    Then the HTTP status code should be "401"
+    Then the HTTP status code should be "404"
     And as "Alice" the folder with original path "/textfile0.txt" should exist in the trashbin
     And user "Alice" should not see the following elements
       | /textfile0.txt |

--- a/tests/acceptance/features/apiTrashbinRestore/trashbinRestore.feature
+++ b/tests/acceptance/features/apiTrashbinRestore/trashbinRestore.feature
@@ -195,13 +195,13 @@ Feature: Restore deleted files/folders
     And user "Brian" has been created with default attributes and without skeleton files
     And user "Alice" has deleted file "/textfile0.txt"
     When user "Brian" tries to restore the file with original path "/textfile0.txt" from the trashbin of user "Alice" using the trashbin API
-    Then the HTTP status code should be <status_code>
+    Then the HTTP status code should be "<status-code>"
     And as "Alice" the folder with original path "/textfile0.txt" should exist in the trashbin
     And user "Alice" should not see the following elements
       | /textfile0.txt |
     @skipOnOcis
     Examples:
-      | dav-path | status_code |
+      | dav-path | status-code |
       | old      | 401         |
       | new      | 401         |
     @skipOnOcV10

--- a/tests/acceptance/features/apiTrashbinRestore/trashbinRestore.feature
+++ b/tests/acceptance/features/apiTrashbinRestore/trashbinRestore.feature
@@ -189,35 +189,26 @@ Feature: Restore deleted files/folders
     And as "Alice" the folder with original path "/local_storage/tmp/textfile0.txt" should not exist in the trashbin
     And the content of file "/local_storage/tmp/textfile0.txt" for user "Alice" should be "AA"
 
-  @smokeTest @skipOnOcV10.3 @skipOnOcis
+  @smokeTest @skipOnOcV10.3 
   Scenario Outline: A deleted file cannot be restored by a different user
     Given using <dav-path> DAV path
     And user "Brian" has been created with default attributes and without skeleton files
     And user "Alice" has deleted file "/textfile0.txt"
     When user "Brian" tries to restore the file with original path "/textfile0.txt" from the trashbin of user "Alice" using the trashbin API
-    Then the HTTP status code should be "401"
+    Then the HTTP status code should be <status_code>
     And as "Alice" the folder with original path "/textfile0.txt" should exist in the trashbin
     And user "Alice" should not see the following elements
       | /textfile0.txt |
+    @skipOnOcis
     Examples:
-      | dav-path |
-      | old      |
-      | new      |
-  
-  @smokeTest @skipOnOcV10
-  Scenario Outline: A deleted file cannot be restored by a different user
-    Given using <dav-path> DAV path
-    And user "Brian" has been created with default attributes and without skeleton files
-    And user "Alice" has deleted file "/textfile0.txt"
-    When user "Brian" tries to restore the file with original path "/textfile0.txt" from the trashbin of user "Alice" using the trashbin API
-    Then the HTTP status code should be "404"
-    And as "Alice" the folder with original path "/textfile0.txt" should exist in the trashbin
-    And user "Alice" should not see the following elements
-      | /textfile0.txt |
+      | dav-path | status_code |
+      | old      | 401         |
+      | new      | 401         |
+    @skipOnOcV10
     Examples:
-      | dav-path |
-      | old      |
-      | new      |
+      | dav-path | status_code |
+      | old      | 404         |
+      | new      | 404         |
 
   @smokeTest
   Scenario Outline: A deleted file cannot be restored with invalid password

--- a/tests/acceptance/features/apiTrashbinRestore/trashbinRestore.feature
+++ b/tests/acceptance/features/apiTrashbinRestore/trashbinRestore.feature
@@ -206,7 +206,7 @@ Feature: Restore deleted files/folders
       | new      | 401         |
     @skipOnOcV10
     Examples:
-      | dav-path | status_code |
+      | dav-path | status-code |
       | old      | 404         |
       | new      | 404         |
 

--- a/tests/acceptance/features/apiTrashbinRestore/trashbinRestore.feature
+++ b/tests/acceptance/features/apiTrashbinRestore/trashbinRestore.feature
@@ -189,7 +189,22 @@ Feature: Restore deleted files/folders
     And as "Alice" the folder with original path "/local_storage/tmp/textfile0.txt" should not exist in the trashbin
     And the content of file "/local_storage/tmp/textfile0.txt" for user "Alice" should be "AA"
 
-  @smokeTest @skipOnOcV10.3
+  @smokeTest @skipOnOcV10.3 @skipOnOcis
+  Scenario Outline: A deleted file cannot be restored by a different user
+    Given using <dav-path> DAV path
+    And user "Brian" has been created with default attributes and without skeleton files
+    And user "Alice" has deleted file "/textfile0.txt"
+    When user "Brian" tries to restore the file with original path "/textfile0.txt" from the trashbin of user "Alice" using the trashbin API
+    Then the HTTP status code should be "401"
+    And as "Alice" the folder with original path "/textfile0.txt" should exist in the trashbin
+    And user "Alice" should not see the following elements
+      | /textfile0.txt |
+    Examples:
+      | dav-path |
+      | old      |
+      | new      |
+  
+  @smokeTest @skipOnOcV10
   Scenario Outline: A deleted file cannot be restored by a different user
     Given using <dav-path> DAV path
     And user "Brian" has been created with default attributes and without skeleton files

--- a/tests/acceptance/features/apiTrashbinRestore/trashbinRestore.feature
+++ b/tests/acceptance/features/apiTrashbinRestore/trashbinRestore.feature
@@ -189,7 +189,7 @@ Feature: Restore deleted files/folders
     And as "Alice" the folder with original path "/local_storage/tmp/textfile0.txt" should not exist in the trashbin
     And the content of file "/local_storage/tmp/textfile0.txt" for user "Alice" should be "AA"
 
-  @smokeTest @skipOnOcV10.3 
+  @smokeTest @skipOnOcV10.3
   Scenario Outline: A deleted file cannot be restored by a different user
     Given using <dav-path> DAV path
     And user "Brian" has been created with default attributes and without skeleton files


### PR DESCRIPTION
We now expect a not found error instead of permission denied error for some trash interactions.

Needed for https://github.com/cs3org/reva/pull/3300

Driven by https://github.com/owncloud/ocis/issues/3561