### PR TITLE
Files_external mount config will show group displaynames

### DIFF
--- a/apps/files_external/ajax/applicable.php
+++ b/apps/files_external/ajax/applicable.php
@@ -41,7 +41,7 @@ if (isset($_GET['offset'])) {
 
 $groups = [];
 foreach (\OC::$server->getGroupManager()->search($pattern, $limit, $offset) as $group) {
-	$groups[$group->getGID()] = $group->getGID();
+	$groups[$group->getGID()] = $group->getDisplayName();
 }
 
 $users = [];

--- a/changelog/unreleased/40412
+++ b/changelog/unreleased/40412
@@ -1,0 +1,18 @@
+Bugfix: "available for" in the mount point configuration will show displaynames
+
+The "available for" select of the mount configuration of external storages
+were using the group id. This wasn't a problem because for local groups the
+group id matches the group displayname, and for ldap groups the group id was
+the "cn" attribute.
+Due to recent changes, the ldap group will now use the objectuid attribute
+(or a similar attribute) as group id by default. This was causing the "available
+for" select to show that objectuid, so identifying the right group was problematic.
+
+Now, the "available for" select will show the group displayname, which for
+ldap is the "cn" attribute by default.
+
+Note that this happens on new installations. There is an automatic migration
+in place, so for upgrades, the "cn" attribute will be set as groupname in order
+to keep the old behavior
+
+https://github.com/owncloud/core/pull/40412


### PR DESCRIPTION
<!--
Thanks for submitting a change to ownCloud!

This is the bug tracker for the Server component. Find other components at https://github.com/owncloud/core/blob/master/.github/CONTRIBUTING.md#guidelines

For fixing potential security issues please see https://owncloud.com/security/

To make it possible for us to get your change reviewed and merged please carefully fill out the requested information below.

Please note that any kind of change needs first be submitted to the master branch which holds the next version of ownCloud.

Please set the following labels:

- Set label "3 - To review" for review or "2 - Development" if the PR still has open tasks
- Assignment: assign to self
- Milestone: set the same as the ticket this PR fixes, or "development" by default
- Reviewers: pick at least one
-->

## Description
Group ids were being shown in the "available for" selection of the files_external mount point configuration. This happens due to recent changes in the user_ldap app and OC 10.11

This PR shows the displayname instead, making eaiser for the admin to select the right group

## Related Issue
https://github.com/owncloud/core/issues/40404

## Motivation and Context
Since recently, the user_ldap app uses the objectuid (or similar attributes) as group id. Previously, the app used the "cn" attribute.
Anyway, using the displayname for visualizing the list makes more sense.

## How Has This Been Tested?
1. Setup an OC 10.11 and user_ldap 0.17.0 with default configuration. Make sure there are ldap groups available
2. Go to the settings -> admin storages, and click and the "available for" select.

The list includes groups showing their configured displayname (the "cn" attribute for ldap groups, but default)

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Database schema changes (next release will require increase of minor version instead of patch)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [ ] Tests only (no source changes)

## Checklist:
<!-- Tick the checkboxes when done. -->
<!-- Raise documentation ticket in https://github.com/owncloud/documentation -->
- [x] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 
- [ ] Changelog item, see [TEMPLATE](https://github.com/owncloud/core/blob/master/changelog/TEMPLATE)
