### PR TITLE
setting for recursive extra config.php search

### DIFF
--- a/changelog/unreleased/40413
+++ b/changelog/unreleased/40413
@@ -1,0 +1,11 @@
+Enhancement: Setting for recursive extra config.php search
+
+Before this change extra config.php files were required to be placed directly in the config folder.
+This change allows to have nested folders configuration structure, 
+enabled by config value OC_CONFIG_EXTRA_RECURSIVE_SEARCH, that can be useful in some deployments.
+
+NOTE: due to the fact that `config_extra_recursive_search` setting controls the configuration itself, 
+it is only possible to enable this via environment variable. It is not possible to enable it with *.config.php file.
+
+https://github.com/owncloud/core/pull/40413
+https://github.com/owncloud/enterprise/issues/5406


### PR DESCRIPTION
## Description

Feature: setting for recursive extra config.php search

Before this change extra config.php files were required to be placed directly in the config folder. 
This change allows to have nested folders configuration structure, enabled by config value OC_CONFIG_EXTRA_RECURSIVE_SEARCH, that can be useful in some deployments.

NOTE: due to the fact that this configuration control setting the configuration itself, it is only possible to enable this setting with environment variable, it is not possible to enable it with *.config.php file.

## Related Issue
- Fixes https://github.com/owncloud/enterprise/issues/5406

## How Has This Been Tested?
- manually in the developer instance

-> add nested config
-> Update entry in `/etc/apache2/sites-available/owncloud.conf` with `SetEnv OC_CONFIG_EXTRA_RECURSIVE_SEARCH true` 
@d7oc NOTE: probably in your case it needs to be Dockefile env, but you would need to test this. In owncloud code we do not care how env is provided, as soon as it is provided by methods allowed by deployment (docker, apache2, etc..).
-> check that config is applied

- unit/acceptance tests

## Types of changes
- [x] New feature (non-breaking change which adds functionality)

## Checklist:
- [x] Base code changes
- [x] Unit tests added
- [x] Acceptance tests added
- [x] Changelog item, see [TEMPLATE](https://github.com/owncloud/core/blob/master/changelog/TEMPLATE)


