### PR TITLE
[tests-only[full-ci] Skip admin operation related tests in reva

### DIFF
--- a/tests/acceptance/features/apiShareManagementBasicToShares/createShareToSharesFolder.feature
+++ b/tests/acceptance/features/apiShareManagementBasicToShares/createShareToSharesFolder.feature
@@ -235,14 +235,14 @@ Feature: sharing
       | 1               | 100             |
       | 2               | 200             |
 
-  @smokeTest
+  @smokeTest @skipOnReva # reva doesn't have a pre-created admin user
   Scenario Outline: User included in multiple groups receives a share from the admin
     Given using OCS API version "<ocs_api_version>"
     And group "grp1" has been created
     And group "grp2" has been created
     And user "Alice" has been added to group "grp1"
     And user "Alice" has been added to group "grp2"
-    And admin "admin" has created folder "/PARENT"
+    And admin has created folder "/PARENT"
     When user "admin" shares folder "/PARENT" with group "grp1" using the sharing API
     And user "Alice" accepts share "/PARENT" offered by user "admin" using the sharing API
     Then the OCS status code of responses on all endpoints should be "<ocs_status_code>"

--- a/tests/acceptance/features/bootstrap/WebDav.php
+++ b/tests/acceptance/features/bootstrap/WebDav.php
@@ -3720,7 +3720,6 @@ trait WebDav {
 	/**
 	 * @Given admin has created folder :destination
 	 *
-	 * @param string $admin
 	 * @param string $destination
 	 *
 	 * @return void

--- a/tests/acceptance/features/bootstrap/WebDav.php
+++ b/tests/acceptance/features/bootstrap/WebDav.php
@@ -3718,7 +3718,7 @@ trait WebDav {
 	}
 
 	/**
-	 * @Given admin :admin has created folder :destination
+	 * @Given admin has created folder :destination
 	 *
 	 * @param string $admin
 	 * @param string $destination
@@ -3727,8 +3727,8 @@ trait WebDav {
 	 * @throws JsonException
 	 * @throws GuzzleException
 	 */
-	public function adminHasCreatedFolder(string $admin, string $destination):void {
-		$admin = $this->getActualUsername($admin);
+	public function adminHasCreatedFolder(string $destination):void {
+		$admin = $this->getAdminUsername();
 		Assert::assertEquals(
 			"admin",
 			$admin,


### PR DESCRIPTION
<!--
Thanks for submitting a change to ownCloud!

This is the bug tracker for the Server component. Find other components at https://github.com/owncloud/core/blob/master/.github/CONTRIBUTING.md#guidelines

For fixing potential security issues please see https://owncloud.com/security/

To make it possible for us to get your change reviewed and merged please carefully fill out the requested information below.

Please note that any kind of change needs first be submitted to the master branch which holds the next version of ownCloud.

Please set the following labels:

- Set label "3 - To review" for review or "2 - Development" if the PR still has open tasks
- Assignment: assign to self
- Milestone: set the same as the ticket this PR fixes, or "development" by default
- Reviewers: pick at least one
-->

## Description
This PR skips a test in reva which creates folder as admin user and since reva uses ldap there's no `pre-defined` admin user there. Furthermore this test was added specifically for a issue in ocis https://github.com/owncloud/ocis/issues/4671

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
- 

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
- test environment:
- CI

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Database schema changes (next release will require increase of minor version instead of patch)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [ ] Tests only (no source changes)

## Checklist:
<!-- Tick the checkboxes when done. -->
<!-- Raise documentation ticket in https://github.com/owncloud/documentation -->
- [ ] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 
- [ ] Changelog item, see [TEMPLATE](https://github.com/owncloud/core/blob/master/changelog/TEMPLATE)
