### PR TITLE
Skip public links when updating permissions of share's children

### DIFF
--- a/changelog/unreleased/40416
+++ b/changelog/unreleased/40416
@@ -1,0 +1,7 @@
+Bugfix: Skip public links when updating permissions of share's children
+
+Currently, updates to permissions of a share are wrongly propagated to public links children.
+This has now been fixed and public links are being skipped.
+
+https://github.com/owncloud/enterprise/issues/5423
+https://github.com/owncloud/core/pull/40416

--- a/lib/private/Share20/DefaultShareProvider.php
+++ b/lib/private/Share20/DefaultShareProvider.php
@@ -248,8 +248,14 @@ class DefaultShareProvider implements IShareProvider {
 			/*
 			 * Update all user defined group shares
 			 */
-			$qb = $this->dbConn->getQueryBuilder();
-			$qb->update('share')
+
+			$children[] = $this->getChildren($share->getId());
+			foreach ($children as $child) {
+				if ($child->getShareType() === \OCP\Share::SHARE_TYPE_LINK) {
+					return;
+				}
+				$qb = $this->dbConn->getQueryBuilder();
+				$qb->update('share')
 				->where($qb->expr()->eq('parent', $qb->createNamedParameter($share->getId())))
 				->set('uid_owner', $qb->createNamedParameter($share->getShareOwner()))
 				->set('uid_initiator', $qb->createNamedParameter($share->getSharedBy()))
@@ -257,16 +263,17 @@ class DefaultShareProvider implements IShareProvider {
 				->set('file_source', $qb->createNamedParameter($share->getNode()->getId()))
 				->execute();
 
-			/*
-			 * Now update the permissions for all children
-			 */
-			$qb = $this->dbConn->getQueryBuilder();
-			$qb->update('share')
+				/*
+				 * Now update the permissions for all children
+				 */
+				$qb = $this->dbConn->getQueryBuilder();
+				$qb->update('share')
 				->where($qb->expr()->eq('parent', $qb->createNamedParameter($share->getId())))
 				->set('permissions', $qb->createNamedParameter($share->getPermissions()))
 				->set('expiration', $qb->createNamedParameter($share->getExpirationDate(), IQueryBuilder::PARAM_DATE))
 				->set('attributes', $qb->createNamedParameter($shareAttributes))
 				->execute();
+			}
 		} elseif ($share->getShareType() === \OCP\Share::SHARE_TYPE_LINK) {
 			$qb = $this->dbConn->getQueryBuilder();
 			$qb->update('share')


### PR DESCRIPTION
## Description

Skip public links when updating permissions of share's children

## Related Issue

- https://github.com/owncloud/enterprise/issues/5423

## Motivation and Context

Currently, updates to permissions of a share are wrongly propagated to public links children.

## How Has This Been Tested?

Manually:

- `user1` creates a custom group `mygroup` with him/her, `user2` and `user3` (note: this is also reproducible with normal groups so not limited to customer groups only)

- `user1` creates a folder `test` and a file inside `test.txt` and shares this folder with group `mygroup`

- `user2` now creates a public link for `test.txt`

- `user1` changes permissions of the share `test`. For instance, from `["READ","UPDATE","CREATE","DELETE","SHARE"]` to `["READ","UPDATE","CREATE","DELETE"]`

- Without this PR: the public link for `test.txt` now points to the root folder (`test` in this case) with the consequence that all files in the root folder can be accessed

- With this PR: the public link for `test.txt` stays unchanged.

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Database schema changes (next release will require increase of minor version instead of patch)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [ ] Tests only (no source changes)

## Checklist:
- [x] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised
- [x] Changelog item