### PR TITLE
[tests-only] fix order of DELETE request in spaces test

### DIFF
--- a/tests/acceptance/features/apiAuthWebDav/webDavSpecialURLs.feature
+++ b/tests/acceptance/features/apiAuthWebDav/webDavSpecialURLs.feature
@@ -25,9 +25,9 @@ Feature: make webdav request with special urls
     When user "Alice" requests these endpoints with "DELETE" using password "%regular%" about user "Alice"
       | endpoint                                             |
       | //remote.php/dav/spaces/%spaceid%/textfile0.txt      |
+      | //remote.php//dav/spaces/%spaceid%/PARENT/parent.txt |
       | /remote.php//dav/spaces/%spaceid%/PARENT             |
       | //remote.php/dav//spaces/%spaceid%//FOLDER           |
-      | //remote.php//dav/spaces/%spaceid%/PARENT/parent.txt |
     Then the HTTP status code of responses on all endpoints should be "204"
 
 


### PR DESCRIPTION
## Description
deleting first the folder and then the file does not make sense, this test is doomed to fail, so change the order around as done also in the other tests

## Motivation and Context
make test passable

## How Has This Been Tested?
:robot: 
 
## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Database schema changes (next release will require increase of minor version instead of patch)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [x] Tests only (no source changes)

## Checklist:
<!-- Tick the checkboxes when done. -->
<!-- Raise documentation ticket in https://github.com/owncloud/documentation -->
- [ ] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 
- [ ] Changelog item, see [TEMPLATE](https://github.com/owncloud/core/blob/master/changelog/TEMPLATE)
