### PR TITLE
fix: on rejected shares no activities are reported to this user any more

### DIFF
--- a/changelog/unreleased/40421
+++ b/changelog/unreleased/40421
@@ -1,0 +1,6 @@
+Change: No activities on rejected shares
+
+As soon as a user has rejected a share no activities within this
+share are reported via the activity app.
+
+https://github.com/owncloud/core/pull/40421

--- a/lib/private/Share/Share.php
+++ b/lib/private/Share/Share.php
@@ -183,11 +183,12 @@ class Share extends Constants {
 		}
 
 		$paths = [];
+		$rejected = [];
 		while ($source !== -1) {
 			// Fetch all shares with another user
 			if (!$returnUserPaths) {
 				$query = \OC_DB::prepare(
-					'SELECT `share_with`, `file_source`, `file_target`
+					'SELECT `parent`, `share_with`, `file_source`, `file_target`, `accepted`
 					FROM
 					`*PREFIX*share`
 					WHERE
@@ -196,7 +197,7 @@ class Share extends Constants {
 				$result = $query->execute([$source, self::SHARE_TYPE_USER]);
 			} else {
 				$query = \OC_DB::prepare(
-					'SELECT `share_with`, `file_source`, `file_target`
+					'SELECT `parent`, `share_with`, `file_source`, `file_target`, `accepted`
 				FROM
 				`*PREFIX*share`
 				WHERE
@@ -209,6 +210,10 @@ class Share extends Constants {
 				\OCP\Util::writeLog('OCP\Share', \OC_DB::getErrorMessage(), \OCP\Util::ERROR);
 			} else {
 				while ($row = $result->fetchRow()) {
+					if ((int)($row['accepted']) === Constants::STATE_REJECTED) {
+						$rejected[]= $row['parent'];
+						continue;
+					}
 					$shares[] = $row['share_with'];
 					if ($returnUserPaths) {
 						$fileTargets[(int) $row['file_source']][$row['share_with']] = $row;
@@ -217,30 +222,28 @@ class Share extends Constants {
 			}
 
 			// We also need to take group shares into account
-			$query = \OC_DB::prepare(
-				'SELECT `share_with`, `file_source`, `file_target`
+			$sql = 'SELECT `share_with`, `file_source`, `file_target`
 				FROM
 				`*PREFIX*share`
 				WHERE
-				`item_source` = ? AND `share_type` = ? AND `item_type` IN (\'file\', \'folder\')'
+				`item_source` = ? AND `share_type` = ? AND `item_type` IN (\'file\', \'folder\') AND `id` NOT IN (?)';
+
+			$result = \OC::$server->getDatabaseConnection()->executeQuery(
+				$sql,
+				[$source, self::SHARE_TYPE_GROUP, $rejected],
+				[null, null, IQueryBuilder::PARAM_INT_ARRAY]
 			);
 
-			$result = $query->execute([$source, self::SHARE_TYPE_GROUP]);
-
-			if (\OCP\DB::isError($result)) {
-				\OCP\Util::writeLog('OCP\Share', \OC_DB::getErrorMessage(), \OCP\Util::ERROR);
-			} else {
-				while ($row = $result->fetchRow()) {
-					$usersInGroup = self::usersInGroup($row['share_with']);
-					$shares = \array_merge($shares, $usersInGroup);
-					if ($returnUserPaths) {
-						foreach ($usersInGroup as $user) {
-							if (!isset($fileTargets[(int) $row['file_source']][$user])) {
-								// When the user already has an entry for this file source
-								// the file is either shared directly with him as well, or
-								// he has an exception entry (because of naming conflict).
-								$fileTargets[(int) $row['file_source']][$user] = $row;
-							}
+			while ($row = $result->fetch()) {
+				$usersInGroup = self::usersInGroup($row['share_with']);
+				$shares = \array_merge($shares, $usersInGroup);
+				if ($returnUserPaths) {
+					foreach ($usersInGroup as $user) {
+						if (!isset($fileTargets[(int) $row['file_source']][$user])) {
+							// When the user already has an entry for this file source
+							// the file is either shared directly with him as well, or
+							// he has an exception entry (because of naming conflict).
+							$fileTargets[(int) $row['file_source']][$user] = $row;
 						}
 					}
 				}


### PR DESCRIPTION
## Description
No activities are created for files within a rejected share

## Related Issue
- Fixes https://github.com/owncloud/enterprise/issues/5417

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?
### user share
- share folder with user1
- user1 rejects share
- upload files to shared folder
- activity shown on sharer
- no activity shown on user1

### group share
- group G holds user1
- share folder with G
- user1 rejects share
- upload files to shared folder
- activity shown on sharer
- no activity shown on user1



## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Database schema changes (next release will require increase of minor version instead of patch)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [ ] Tests only (no source changes)

## Checklist:
<!-- Tick the checkboxes when done. -->
<!-- Raise documentation ticket in https://github.com/owncloud/documentation -->
- [x] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 
- [ ] Changelog item, see [TEMPLATE](https://github.com/owncloud/core/blob/master/changelog/TEMPLATE)
