### PR TITLE
[tests-only] Tweak time we give for indexing new files in the search service

### DIFF
--- a/tests/acceptance/features/bootstrap/SearchContext.php
+++ b/tests/acceptance/features/bootstrap/SearchContext.php
@@ -59,9 +59,9 @@ class SearchContext implements Context {
 		?string	  $limit = null,
 		TableNode $properties = null
 	):void {
-		// Because indexing of newly uploaded files or directories with ocis is decoupled and occurs asynchronously, a 1 second wait is necessary while searching files or folders.
+		// Because indexing of newly uploaded files or directories with ocis is decoupled and occurs asynchronously, a short wait is necessary before searching files or folders.
 		if (OcisHelper::isTestingOnOcis()) {
-			sleep(1);
+			sleep(4);
 		}
 		$user = $this->featureContext->getActualUsername($user);
 		$baseUrl = $this->featureContext->getBaseUrl();


### PR DESCRIPTION
The indexing approach in the ocis search service is about to change and requires a slightly longer sleep to give it enough time to index new files.