### PR TITLE
[tests-only] [full-ci] Remove fsweb.test.owncloud.com SMB PHP unit test pipeline

### DIFF
--- a/.drone.star
+++ b/.drone.star
@@ -91,7 +91,7 @@ config = {
                 "oracle",
             ],
         },
-        "external-samba-windows": {
+        "external-samba": {
             "phpVersions": [
                 DEFAULT_PHP_VERSION,
             ],
@@ -100,7 +100,6 @@ config = {
             ],
             "externalTypes": [
                 "samba",
-                "windows",
             ],
             "coverage": True,
             "extraCommandsBeforeTestRun": [


### PR DESCRIPTION
## Description
`fsweb.test.owncloud.com` is a "legacy" Windows SMB server that is now only used for this PHP unit test pipeline. It is old and difficult to support.

The SMB settings for using it in the test pipeline are stored in https://github.com/owncloud/core/blob/master/tests/drone/configs/config.files_external.smb-windows.php

https://github.com/owncloud/core/blob/master/tests/drone/test-phpunit.sh#L30 has the code that sets up the pipeline for running the test.

https://github.com/owncloud/core/blob/master/apps/files_external/tests/Storage/SmbTest.php is run.

Note: those tests are also run in a pipeline against a Samba server that runs in docker, so they are run against an SMB server (which is not a "real" Windows server) The questions is, do we want to run against a real Windows SMB server, and if so, what version of Windows server(s), and how will we provide them to CI.

This PR removes the test pipeline that runs against `fsweb.test.owncloud.com`

## How Has This Been Tested?
CI

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Database schema changes (next release will require increase of minor version instead of patch)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [x] Tests only (no source changes)

## Checklist:
- [ ] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 
- [ ] Changelog item, see [TEMPLATE](https://github.com/owncloud/core/blob/master/changelog/TEMPLATE)
