### PR TITLE
fix: hidden (dotted) text files shall be detected as text/plain

### DIFF
--- a/changelog/unreleased/40427
+++ b/changelog/unreleased/40427
@@ -1,0 +1,5 @@
+Change: Detect mime types of hidden files
+
+Mime type of hidden files are now properly detected.
+
+https://github.com/owncloud/core/pull/40427

--- a/lib/private/Files/Type/Detection.php
+++ b/lib/private/Files/Type/Detection.php
@@ -192,21 +192,18 @@ class Detection implements IMimeTypeDetector {
 		$this->loadMappings();
 
 		$fileName = \basename($path);
-		// note: leading dot doesn't qualify as extension
-		if (\strpos($fileName, '.') > 0) {
-			//try to guess the type by the file extension
-			if ($this->detectSharedObjFileName($fileName)) {
-				$extension = 'so';
-			} else {
-				$extension = \strtolower(\strrchr($fileName, '.'));
-				$extension = \substr($extension, 1); //remove leading .
-			}
-			return (isset($this->mimetypes[$extension], $this->mimetypes[$extension][0]))
-				? $this->mimetypes[$extension][0]
-				: 'application/octet-stream';
+		# let's eat the first char if it is a .
+		$fileName = ltrim($fileName, ".");
+		//try to guess the type by the file extension
+		if ($this->detectSharedObjFileName($fileName)) {
+			$extension = 'so';
 		} else {
-			return 'application/octet-stream';
+			$extension = \strtolower(\strrchr($fileName, '.'));
+			$extension = \substr($extension, 1); //remove leading .
 		}
+		return (isset($this->mimetypes[$extension], $this->mimetypes[$extension][0]))
+			? $this->mimetypes[$extension][0]
+			: 'application/octet-stream';
 	}
 
 	/**

--- a/tests/lib/Files/Type/DetectionTest.php
+++ b/tests/lib/Files/Type/DetectionTest.php
@@ -37,7 +37,7 @@ class DetectionTest extends \Test\TestCase {
 		);
 	}
 
-	public function testDetect() {
+	public function testDetect(): void {
 		$dir = \OC::$SERVERROOT.'/tests/data';
 
 		$result = $this->detection->detect($dir."/");
@@ -61,7 +61,7 @@ class DetectionTest extends \Test\TestCase {
 		$this->assertEquals($expected, $result);
 	}
 
-	public function testGetSecureMimeType() {
+	public function testGetSecureMimeType(): void {
 		$result = $this->detection->getSecureMimeType('image/svg+xml');
 		$expected = 'text/plain';
 		$this->assertEquals($expected, $result);
@@ -71,7 +71,8 @@ class DetectionTest extends \Test\TestCase {
 		$this->assertEquals($expected, $result);
 	}
 
-	public function testDetectPath() {
+	public function testDetectPath(): void {
+		$this->assertEquals('text/plain', $this->detection->detectPath('.foo.txt'));
 		$this->assertEquals('text/plain', $this->detection->detectPath('foo.txt'));
 		$this->assertEquals('image/png', $this->detection->detectPath('foo.png'));
 		$this->assertEquals('image/png', $this->detection->detectPath('foo.bar.png'));
@@ -89,13 +90,13 @@ class DetectionTest extends \Test\TestCase {
 		$this->assertEquals('application/octet-stream', $this->detection->detectPath(''));
 	}
 
-	public function testDetectString() {
+	public function testDetectString(): void {
 		$result = $this->detection->detectString("/data/data.tar.gz");
 		$expected = 'text/plain; charset=us-ascii';
 		$this->assertEquals($expected, $result);
 	}
 
-	public function testMimeTypeIcon() {
+	public function testMimeTypeIcon(): void {
 		$confDir = vfsStream::setup();
 		$mimetypealiases_dist = vfsStream::newFile('mimetypealiases.dist.json')->at($confDir);
 
@@ -189,14 +190,12 @@ class DetectionTest extends \Test\TestCase {
 				[$this->equalTo('core'), $this->equalTo('filetypes/my-type.svg')],
 				[$this->equalTo('core'), $this->equalTo('filetypes/my.svg')]
 			)
-			->will($this->returnCallback(
-				function ($appName, $file) {
-					if ($file === 'filetypes/my.svg') {
-						return 'my.svg';
-					}
-					throw new \RuntimeException();
+			->willReturnCallback(function ($appName, $file) {
+				if ($file === 'filetypes/my.svg') {
+					return 'my.svg';
 				}
-			));
+				throw new \RuntimeException();
+			});
 
 		$detection = new Detection($urlGenerator, $confDir->url(), $confDir->url());
 		$mimeType = $detection->mimeTypeIcon('my-type');
@@ -219,14 +218,12 @@ class DetectionTest extends \Test\TestCase {
 				[$this->equalTo('core'), $this->equalTo('filetypes/foo.svg')],
 				[$this->equalTo('core'), $this->equalTo('filetypes/file.svg')]
 			)
-			->will($this->returnCallback(
-				function ($appName, $file) {
-					if ($file === 'filetypes/file.svg') {
-						return 'file.svg';
-					}
-					throw new \RuntimeException();
+			->willReturnCallback(function ($appName, $file) {
+				if ($file === 'filetypes/file.svg') {
+					return 'file.svg';
 				}
-			));
+				throw new \RuntimeException();
+			});
 
 		$detection = new Detection($urlGenerator, $confDir->url(), $confDir->url());
 		$mimeType = $detection->mimeTypeIcon('foo-bar');


### PR DESCRIPTION
## Description
hidden text files ```.test.txt``` is not detected as text/plan.

## How Has This Been Tested?
- :robot: 

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Database schema changes (next release will require increase of minor version instead of patch)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [ ] Tests only (no source changes)

## Checklist:
<!-- Tick the checkboxes when done. -->
<!-- Raise documentation ticket in https://github.com/owncloud/documentation -->
- [x] Code changes
- [x] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 
- [ ] Changelog item, see [TEMPLATE](https://github.com/owncloud/core/blob/master/changelog/TEMPLATE)
