### PR TITLE
[tests-only] Remove the similar step for exporting mount storage

### DIFF
--- a/tests/acceptance/features/bootstrap/OccContext.php
+++ b/tests/acceptance/features/bootstrap/OccContext.php
@@ -2492,7 +2492,7 @@ class OccContext implements Context {
 	}
 
 	/**
-	 * @Given the administrator has exported the local storage mounts using the occ command
+	 * @Given /^the administrator has exported the (local|external) storage mounts using the occ command$/
 	 *
 	 * @return void
 	 * @throws Exception

--- a/tests/acceptance/features/bootstrap/WebDav.php
+++ b/tests/acceptance/features/bootstrap/WebDav.php
@@ -3279,42 +3279,6 @@ trait WebDav {
 	}
 
 	/**
-	 * @Given the administrator has created a json file with exported config of local storage mount :mount to :destination in temporary storage
-	 *
-	 * @param string $mount
-	 * @param string $destination
-	 *
-	 * @return void
-	 * @throws Exception
-	 * @throws GuzzleException
-	 */
-	public function theAdminHasCreatedAJsonFileWithExportedMountConfig(
-		string $mount,
-		string $destination
-	): void {
-		$actualConfig = null;
-		$commandOutput = \json_decode(
-			SetupHelper::runOcc(
-				['files_external:export'],
-				$this->getStepLineRef()
-			)['stdOut']
-		);
-
-		//identifying the correct config and also removing the "mount id" property
-		foreach ($commandOutput as $i) {
-			if ($mount === \ltrim($i->mount_point, '/')) {
-				unset($i->mount_id);
-				$actualConfig = $i;
-				break;
-			}
-		}
-
-		$actualConfig = json_encode($actualConfig);
-		$this->copyContentToFileInTemporaryStorageOnSystemUnderTest($destination, $actualConfig);
-		$this->theFileWithContentShouldExistInTheServerRoot(TEMPORARY_STORAGE_DIR_ON_REMOTE_SERVER . "/$destination", $actualConfig);
-	}
-
-	/**
 	 * @Given /^user "([^"]*)" has uploaded the following files with content "([^"]*)"$/
 	 *
 	 * @param string $user

--- a/tests/acceptance/features/cliExternalStorage/filesExternalWebdavOwncloud.feature
+++ b/tests/acceptance/features/cliExternalStorage/filesExternalWebdavOwncloud.feature
@@ -201,7 +201,9 @@ Feature: using files external service with storage as webdav_owncloud
       | storage_backend        | owncloud           |
       | mount_point            | TestMountPoint     |
       | authentication_backend | password::password |
-    And the administrator has created a json file with exported config of local storage mount "TestMountPoint" to "mountConfig.json" in temporary storage
+    And the administrator has exported the external storage mounts using the occ command
+    And the administrator has created a file "mountConfig.json" in temporary storage with the last exported content using the testing API
+    And the administrator has deleted local storage "local_storage" using the occ command
     And the administrator has deleted external storage with mount point "TestMountPoint"
     When the administrator imports the local storage mount from file "mountConfig.json" using the occ command
     Then the command should have been successful


### PR DESCRIPTION
<!--
Thanks for submitting a change to ownCloud!

This is the bug tracker for the Server component. Find other components at https://github.com/owncloud/core/blob/master/.github/CONTRIBUTING.md#guidelines

For fixing potential security issues please see https://owncloud.com/security/

To make it possible for us to get your change reviewed and merged please carefully fill out the requested information below.

Please note that any kind of change needs first be submitted to the master branch which holds the next version of ownCloud.

Please set the following labels:

- Set label "3 - To review" for review or "2 - Development" if the PR still has open tasks
- Assignment: assign to self
- Milestone: set the same as the ticket this PR fixes, or "development" by default
- Reviewers: pick at least one
-->

## Description
This PR removes the step `Given the administrator has created a json file with exported config of local storage mount "TestMountPoint" to "mountConfig.json" in temporary storage` as this step can be achieved using two steps `Given the administrator has exported the local storage mounts using the occ command` and `And the administrator has created a file "exportedMounts.json" in temporary storage with the last exported content using the testing API`, also the latter two steps are more useful than the first single step.

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
- Fixes https://github.com/owncloud/core/issues/39627

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
- Locally
- :robot: 

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Database schema changes (next release will require increase of minor version instead of patch)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [x] Tests only (no source changes)

## Checklist:
<!-- Tick the checkboxes when done. -->
<!-- Raise documentation ticket in https://github.com/owncloud/documentation -->
- [ ] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 
- [ ] Changelog item, see [TEMPLATE](https://github.com/owncloud/core/blob/master/changelog/TEMPLATE)
