### PR TITLE
[full-ci][tests-only] define OWNCLOUD_TRUSTED_DOMAINS in CI

### DIFF
--- a/.drone.star
+++ b/.drone.star
@@ -2836,6 +2836,7 @@ def owncloudDockerService(ocDockerService):
                 "OWNCLOUD_DB_USERNAME": getDbUsername(db),
                 "OWNCLOUD_DB_PASSWORD": getDbPassword(db),
                 "OWNCLOUD_DB_HOST": getDbName(db),
+                "OWNCLOUD_TRUSTED_DOMAINS": "oc-server",
             },
         },
     ] + databaseService(db)

--- a/.drone.star
+++ b/.drone.star
@@ -2818,14 +2818,15 @@ def owncloudDockerService(ocDockerService):
         return []
 
     db = "postgres"
+    domainForOcDocker = "oc-server"
 
     return [
         {
-            "name": "oc-server",
+            "name": domainForOcDocker,
             "image": OC_SERVER,
             "environment": {
                 "OWNCLOUD_VERSION": "latest",
-                "OWNCLOUD_DOMAIN": "oc-server",
+                "OWNCLOUD_DOMAIN": domainForOcDocker,
                 "OWNCLOUD_ADMIN_USERNAME": "admin",
                 "OWNCLOUD_ADMIN_PASSWORD": "admin",
                 "HTTP_PORT": "8080",
@@ -2836,7 +2837,7 @@ def owncloudDockerService(ocDockerService):
                 "OWNCLOUD_DB_USERNAME": getDbUsername(db),
                 "OWNCLOUD_DB_PASSWORD": getDbPassword(db),
                 "OWNCLOUD_DB_HOST": getDbName(db),
-                "OWNCLOUD_TRUSTED_DOMAINS": "oc-server",
+                "OWNCLOUD_TRUSTED_DOMAINS": domainForOcDocker,
             },
         },
     ] + databaseService(db)


### PR DESCRIPTION
## Description
`owncloud/server` docker image now requires that OWNCLOUD_TRUSTED_DOMAINS be set to the domain name(s) that the server is using. That happened yesterday - see https://central.owncloud.org/t/important-changes-to-owncloud-server-container-deployments/39642

We use the docker image in a CI pipeline that uses ownCloud as external storage. This PR adds a definition of OWNCLOUD_TRUSTED_DOMAINS so that the docker image works properly again.

## Related Issue
- Fixes #40436 

## How Has This Been Tested?
CI

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Database schema changes (next release will require increase of minor version instead of patch)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [x] Tests only (no source changes)

## Checklist:
- [ ] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 
- [ ] Changelog item, see [TEMPLATE](https://github.com/owncloud/core/blob/master/changelog/TEMPLATE)
