### PR TITLE
Remove note about remote shares

### DIFF
--- a/lib/private/Share/Constants.php
+++ b/lib/private/Share/Constants.php
@@ -30,7 +30,7 @@ class Constants {
 	public const SHARE_TYPE_LINK = 3;
 	public const SHARE_TYPE_GUEST = 4;
 	public const SHARE_TYPE_CONTACT = 5; // ToDo Check if it is still in use otherwise remove it
-	public const SHARE_TYPE_REMOTE = 6;  // ToDo Check if it is still in use otherwise remove it
+	public const SHARE_TYPE_REMOTE = 6;
 
 	public const CONVERT_SHARE_TYPE_TO_STRING = [
 		self::SHARE_TYPE_USER => 'user',


### PR DESCRIPTION
## Description
I checked and yes, this is still in use. It's used for federated sharing (OCM / OCS). When a user einstein at an ownCloud server oc1.com shares a file or folder with a user marie at an ownCloud server oc2.com, a type-6 entry will appear in the `oc_share` table of oc1.com, and in oc2.com, an (untyped) entry will appear in the `oc_share_external` table.

## Motivation and Context
There was a 'TODO' item about this in the code

## How Has This Been Tested?
Using https://github.com/cs3org/ocm-test-suite/tree/vanilla-owncloud to run two ownCloud instances in a testnet, and then just creating the share through the GUI of oc1.docker and looking at the db contents on maria1.docker.

## Screenshots (if appropriate)
<img width="1203" alt="Screenshot 2022-10-24 at 14 08 00" src="https://user-images.githubusercontent.com/408412/197522096-4c5e8435-b8e4-495a-be07-9a080733f4c3.png">

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Database schema changes (next release will require increase of minor version instead of patch)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [x] Tests only (no source changes)

## Checklist:
<!-- Tick the checkboxes when done. -->
<!-- Raise documentation ticket in https://github.com/owncloud/documentation -->
- [ ] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 
- [ ] Changelog item, see [TEMPLATE](https://github.com/owncloud/core/blob/master/changelog/TEMPLATE)
