### PR TITLE
[tests-only] Refactored step implementation for adding public link to server

### DIFF
--- a/tests/acceptance/features/bootstrap/WebUISharingContext.php
+++ b/tests/acceptance/features/bootstrap/WebUISharingContext.php
@@ -1283,18 +1283,17 @@ class WebUISharingContext extends RawMinkContext implements Context {
 		if (!$this->publicLinkFilesPage->isOpen()) {
 			throw new Exception('Not on public link page!');
 		}
-		if ($server === '%remote_server%') {
+		$servers = ['%local_server%', '%remote_server%'];
+		if (\in_array($server, $servers)) {
 			$server = $this->featureContext->substituteInLineCodes($server);
 			$this->publicLinkFilesPage->addToServer($server);
-		} elseif ($server === '%local_server%') {
-			$this->publicLinkFilesPage->saveToSameServer();
 		} else {
 			throw new Exception(
 				"Invalid server provided '" . $server . "'. " .
 				"Either should be '%remote_server%' or '%local_server%'"
 			);
 		}
-		// addToServer and saveToSameServer takes us from the public link page to the login page
+		// addToServer takes us from the public link page to the login page
 		// of the remote and local server respectively, waiting for us to login.
 		$actualUsername = $this->featureContext->getActualUsername($username);
 		$password = $this->featureContext->getUserPassword($actualUsername);

--- a/tests/acceptance/features/lib/PublicLinkFilesPage.php
+++ b/tests/acceptance/features/lib/PublicLinkFilesPage.php
@@ -576,22 +576,4 @@ class PublicLinkFilesPage extends FilesPageBasic {
 		}
 		return $uploadedElements;
 	}
-
-	/**
-	 * adding public link share to same server instance
-	 *
-	 * @return void
-	 * @throws ElementNotFoundException
-	 */
-	public function saveToSameServer(): void {
-		$saveToElement = $this->findById($this->saveToOcButtonId);
-
-		$this->assertElementNotNull(
-			$saveToElement,
-			__METHOD__ .
-			" id $this->saveToOcButtonId could not find 'Add To' button"
-		);
-
-		$saveToElement->click();
-	}
 }


### PR DESCRIPTION
<!--
Thanks for submitting a change to ownCloud!

This is the bug tracker for the Server component. Find other components at https://github.com/owncloud/core/blob/master/.github/CONTRIBUTING.md#guidelines

For fixing potential security issues please see https://owncloud.com/security/

To make it possible for us to get your change reviewed and merged please carefully fill out the requested information below.

Please note that any kind of change needs first be submitted to the master branch which holds the next version of ownCloud.

Please set the following labels:

- Set label "3 - To review" for review or "2 - Development" if the PR still has open tasks
- Assignment: assign to self
- Milestone: set the same as the ticket this PR fixes, or "development" by default
- Reviewers: pick at least one
-->

## Description
Refactored the step implementation for `When the public adds the public link to :server as user :username using the webUI`. The function now works with the same approach either the local or remote server when adding a public link to the server.
```
$server = $this->featureContext->substituteInLineCodes($server);
$this->publicLinkFilesPage->addToServer($server);
```

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
- Part of https://github.com/owncloud/activity/issues/800
- Needed for activity PR https://github.com/owncloud/activity/pull/1145

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
- :robot: 
- 
## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Database schema changes (next release will require increase of minor version instead of patch)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [x] Tests only (no source changes)

## Checklist:
<!-- Tick the checkboxes when done. -->
<!-- Raise documentation ticket in https://github.com/owncloud/documentation -->
- [ ] Code changes
- [ ] Unit tests added
- [x] Acceptance tests added
- [ ] Documentation ticket raised: <link> 
- [ ] Changelog item, see [TEMPLATE](https://github.com/owncloud/core/blob/master/changelog/TEMPLATE)
