### PR TITLE
[tests-only] add 'Z' for the expected webdav permission when testing with oCIS

### DIFF
--- a/tests/acceptance/features/apiShareManagementToShares/mergeShare.feature
+++ b/tests/acceptance/features/apiShareManagementToShares/mergeShare.feature
@@ -90,7 +90,7 @@ Feature: sharing
     And as "Brian" folder "/Shares/merge-test-inside-twogroups" should not exist
     And as "Brian" folder "/Shares/merge-test-inside-twogroups (2)" should not exist
 
-  Scenario: Merging shares for recipient when shared from inside with group with less permissions
+  Scenario Outline: Merging shares for recipient when shared from inside with group with less permissions
     Given group "grp2" has been created
     And user "Brian" has been added to group "grp2"
     And user "Brian" has created folder "/merge-test-inside-twogroups-perms"
@@ -98,9 +98,17 @@ Feature: sharing
     And user "Brian" shares folder "/merge-test-inside-twogroups-perms" with group "grp2" using the sharing API
     Then the OCS status code of responses on all endpoints should be "100"
     And the HTTP status code of responses on all endpoints should be "200"
-    And as user "Brian" folder "/merge-test-inside-twogroups-perms" should contain a property "oc:permissions" with value "RDNVCK" or with value "RMDNVCK"
+    And as user "Brian" folder "/merge-test-inside-twogroups-perms" should contain a property "oc:permissions" with value "<expected_permission_1>" or with value "<expected_permission_2>"
     And as "Brian" folder "/Shares/merge-test-inside-twogroups-perms" should not exist
     And as "Brian" folder "/Shares/merge-test-inside-twogroups-perms (2)" should not exist
+    @skipOnOcV10
+    Examples:
+      | expected_permission_1 | expected_permission_2 |
+      | RDNVCKZ               | RMDNVCKZ              |
+    @skipOnOcis
+    Examples:
+      | expected_permission_1 | expected_permission_2 |
+      | RDNVCK                | RMDNVCK               |
 
   Scenario: Merging shares for recipient when shared from outside with group then user and recipient renames in between
     Given user "Alice" has created folder "/merge-test-outside-groups-renamebeforesecondshare"


### PR DESCRIPTION
<!--
Thanks for submitting a change to ownCloud!

This is the bug tracker for the Server component. Find other components at https://github.com/owncloud/core/blob/master/.github/CONTRIBUTING.md#guidelines

For fixing potential security issues please see https://owncloud.com/security/

To make it possible for us to get your change reviewed and merged please carefully fill out the requested information below.

Please note that any kind of change needs first be submitted to the master branch which holds the next version of ownCloud.

Please set the following labels:

- Set label "3 - To review" for review or "2 - Development" if the PR still has open tasks
- Assignment: assign to self
- Milestone: set the same as the ticket this PR fixes, or "development" by default
- Reviewers: pick at least one
-->

## Description
Update the expected permissions on the merge share scenario `Merging shares for recipient when shared from inside with group with less permissions`.

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
- Part of https://github.com/owncloud/ocis/issues/4929

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
- :robot:

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Database schema changes (next release will require increase of minor version instead of patch)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [ ] Tests only (no source changes)

## Checklist:
<!-- Tick the checkboxes when done. -->
<!-- Raise documentation ticket in https://github.com/owncloud/documentation -->
- [ ] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 
- [ ] Changelog item, see [TEMPLATE](https://github.com/owncloud/core/blob/master/changelog/TEMPLATE)

---
Signed-off-by: Kiran Parajuli <kiranparajuli589@gmail.com>

