### PR TITLE
[full-ci] [tests-only] Refactored inter scenarios space

### DIFF
--- a/tests/acceptance/features/apiAuth/tokenAuth.feature
+++ b/tests/acceptance/features/apiAuth/tokenAuth.feature
@@ -6,11 +6,13 @@ Feature: tokenAuth
     And user "Alice" has been created with default attributes and without skeleton files
     And token auth has been enforced
 
+
   Scenario: creating a user with basic auth should be blocked when token auth is enforced
     Given user "brand-new-user" has been deleted
     When the administrator sends a user creation request for user "brand-new-user" password "%alt1%" using the provisioning API
     Then the OCS status code should be "997"
     And the HTTP status code should be "401"
+
 
   Scenario: moving a file should be blocked when token auth is enforced
     Given using new DAV path
@@ -24,12 +26,14 @@ Feature: tokenAuth
     When the user requests "/index.php/apps/files" with "GET" using the generated app password
     Then the HTTP status code should be "200"
 
+
   Scenario: cannot access files app with an app password that is deleted when token auth is enforced
     Given a new browser session for "Alice" has been started
     And the user has generated a new app password named "my-client"
     And the user has deleted the app password named "my-client"
     When the user requests "/index.php/apps/files" with "GET" using the generated app password
     Then the HTTP status code should be "401"
+
 
   Scenario: Access files app with when there are multiple tokens generated
     Given a new browser session for "Alice" has been started
@@ -44,6 +48,7 @@ Feature: tokenAuth
   Scenario: cannot access files app with basic auth when token auth is enforced
     When user "Alice" requests "/index.php/apps/files" with "GET" using basic auth
     Then the HTTP status code should be "401"
+
 
   Scenario: using WebDAV with basic auth should be blocked when token auth is enforced
     When user "Alice" requests "/remote.php/webdav" with "PROPFIND" using basic auth

--- a/tests/acceptance/features/apiAuth/webDavAuth.feature
+++ b/tests/acceptance/features/apiAuth/webDavAuth.feature
@@ -33,11 +33,6 @@ Feature: auth
     When user "Alice" requests "/remote.php/webdav" with "PROPFIND" using basic token auth
     Then the HTTP status code should be "207"
 
-	# DAV token auth is not possible yet
-	#Scenario: using WebDAV with a client token
-	#	When requesting "/remote.php/webdav" with "PROPFIND" using a client token
-	#	Then the HTTP status code should be "207"
-
   @smokeTest  @notToImplementOnOCIS
   Scenario: using WebDAV with browser session
     Given a new browser session for "Alice" has been started

--- a/tests/acceptance/features/apiAuthOcs/ocsDELETEAuth.feature
+++ b/tests/acceptance/features/apiAuthOcs/ocsDELETEAuth.feature
@@ -4,9 +4,7 @@ Feature: auth
   Background:
     Given user "another-admin" has been created with default attributes and without skeleton files
 
-  @smokeTest @issue-ocis-reva-30 @issue-ocis-reva-65
-  @skipOnBruteForceProtection @issue-brute_force_protection-112
-  @skipOnOcV10 @issue-32068
+  @smokeTest @issue-ocis-reva-30 @issue-ocis-reva-65 @skipOnBruteForceProtection @issue-brute_force_protection-112 @skipOnOcV10 @issue-32068
   Scenario: send DELETE requests to OCS endpoints as admin with wrong password
     Given user "another-admin" has been added to group "admin"
     When user "another-admin" requests these endpoints with "DELETE" using password "invalid" about user "Alice"

--- a/tests/acceptance/features/apiAuthOcs/ocsDELETEAuthOc10Issue32068.feature
+++ b/tests/acceptance/features/apiAuthOcs/ocsDELETEAuthOc10Issue32068.feature
@@ -1,8 +1,7 @@
 @api @files_sharing-app-required @notToImplementOnOCIS
 Feature: current oC10 behavior for issue-32068
 
-  @smokeTest @issue-32068 @issue-ocis-reva-30 @issue-ocis-reva-65
-  @skipOnBruteForceProtection @issue-brute_force_protection-112
+  @smokeTest @issue-32068 @issue-ocis-reva-30 @issue-ocis-reva-65 @skipOnBruteForceProtection @issue-brute_force_protection-112
   Scenario: send DELETE requests to OCS endpoints as admin with wrong password
     Given user "another-admin" has been created with default attributes and without skeleton files
     And user "another-admin" has been added to group "admin"

--- a/tests/acceptance/features/apiAuthOcs/ocsGETAuth.feature
+++ b/tests/acceptance/features/apiAuthOcs/ocsGETAuth.feature
@@ -4,9 +4,7 @@ Feature: auth
   Background:
     Given user "Alice" has been created with default attributes and without skeleton files
 
-  @issue-32068 @skipOnOcV10
-  @issue-ocis-reva-30
-  @smokeTest
+  @issue-32068 @skipOnOcV10 @issue-ocis-reva-30 @smokeTest
   Scenario: using OCS anonymously
     When a user requests these endpoints with "GET" and no authentication
       | endpoint                                                    |
@@ -40,14 +38,7 @@ Feature: auth
     Then the HTTP status code of responses on all endpoints should be "200"
     And the OCS status code of responses on all endpoints should be "200"
 
-  @issue-32068 @skipOnOcV10
-  @issue-ocis-reva-11
-  @issue-ocis-reva-30
-  @issue-ocis-reva-31
-  @issue-ocis-reva-32
-  @issue-ocis-reva-33
-  @issue-ocis-reva-34
-  @issue-ocis-reva-35
+  @issue-32068 @skipOnOcV10 @issue-ocis-reva-11 @issue-ocis-reva-30 @issue-ocis-reva-31 @issue-ocis-reva-32 @issue-ocis-reva-33 @issue-ocis-reva-34 @issue-ocis-reva-35
   Scenario: using OCS with non-admin basic auth
     When the user "Alice" requests these endpoints with "GET" with basic auth
       | endpoint                                                    |
@@ -78,9 +69,7 @@ Feature: auth
     Then the HTTP status code of responses on all endpoints should be "401"
     And the OCS status code of responses on all endpoints should be "401"
 
-  @issue-32068 @skipOnOcV10 @issue-ocis-reva-29 @issue-ocis-reva-30
-  @smokeTest
-  @skipOnBruteForceProtection @issue-brute_force_protection-112
+  @issue-32068 @skipOnOcV10 @issue-ocis-reva-29 @issue-ocis-reva-30 @smokeTest @skipOnBruteForceProtection @issue-brute_force_protection-112
   Scenario: using OCS as normal user with wrong password
     When user "Alice" requests these endpoints with "GET" using password "invalid"
       | endpoint                                                    |
@@ -128,8 +117,7 @@ Feature: auth
     Then the HTTP status code of responses on all endpoints should be "200"
     And the OCS status code of responses on all endpoints should be "200"
 
-  @issue-ocis-reva-30 @issue-ocis-reva-65
-  @skipOnBruteForceProtection @issue-brute_force_protection-112
+  @issue-ocis-reva-30 @issue-ocis-reva-65 @skipOnBruteForceProtection @issue-brute_force_protection-112
   Scenario: using OCS as admin user with wrong password
     Given user "another-admin" has been created with default attributes and without skeleton files
     And user "another-admin" has been added to group "admin"
@@ -161,7 +149,6 @@ Feature: auth
       | /ocs/v2.php/config |
     Then the HTTP status code of responses on all endpoints should be "200"
     And the OCS status code of responses on all endpoints should be "200"
-
 
   @notToImplementOnOCIS @issue-ocis-reva-30 @issue-ocis-reva-28
   Scenario: using OCS with token auth of a normal user

--- a/tests/acceptance/features/apiAuthOcs/ocsGETAuthFilesExternal.feature
+++ b/tests/acceptance/features/apiAuthOcs/ocsGETAuthFilesExternal.feature
@@ -4,8 +4,7 @@ Feature: auth
   Background:
     Given user "Alice" has been created with default attributes and without skeleton files
 
-  @issue-32068 @skipOnOcV10
-  @smokeTest
+  @issue-32068 @skipOnOcV10 @smokeTest
   Scenario: using OCS anonymously
     When a user requests these endpoints with "GET" and no authentication
       | endpoint                                                    |
@@ -27,9 +26,7 @@ Feature: auth
     Then the HTTP status code of responses on all endpoints should be "200"
     And the OCS status code of responses on all endpoints should be "200"
 
-  @issue-32068 @skipOnOcV10
-  @smokeTest
-  @skipOnBruteForceProtection @issue-brute_force_protection-112
+  @issue-32068 @skipOnOcV10 @smokeTest @skipOnBruteForceProtection @issue-brute_force_protection-112
   Scenario: using OCS as normal user with wrong password
     When user "Alice" requests these endpoints with "GET" using password "invalid"
       | endpoint                                                    |

--- a/tests/acceptance/features/apiAuthOcs/ocsGETAuthFilesExternalOc10Issue32068.feature
+++ b/tests/acceptance/features/apiAuthOcs/ocsGETAuthFilesExternalOc10Issue32068.feature
@@ -27,8 +27,7 @@ Feature: current oC10 behavior for issue-32068
     Then the HTTP status code of responses on all endpoints should be "200"
     And the OCS status code of responses on all endpoints should be "200"
 
-  @smokeTest
-  @skipOnBruteForceProtection @issue-brute_force_protection-112
+  @smokeTest @skipOnBruteForceProtection @issue-brute_force_protection-112
   Scenario: using OCS as normal user with wrong password
     When user "Alice" requests these endpoints with "GET" using password "invalid"
       | endpoint                                                    |

--- a/tests/acceptance/features/apiAuthOcs/ocsGETAuthOc10Issue32068.feature
+++ b/tests/acceptance/features/apiAuthOcs/ocsGETAuthOc10Issue32068.feature
@@ -4,9 +4,7 @@ Feature: current oC10 behavior for issue-32068
   Background:
     Given user "Alice" has been created with default attributes and without skeleton files
 
-  @issue-32068
-  @issue-ocis-reva-30
-  @smokeTest
+  @issue-32068 @issue-ocis-reva-30 @smokeTest
   Scenario: using OCS anonymously
     When a user requests these endpoints with "GET" and no authentication
       | endpoint                                                    |
@@ -28,14 +26,7 @@ Feature: current oC10 behavior for issue-32068
     And the OCS status code of responses on all endpoints should be "997"
     #And the OCS status code of responses on all endpoints should be "401"
 
-  @issue-32068
-  @issue-ocis-reva-11
-  @issue-ocis-reva-30
-  @issue-ocis-reva-31
-  @issue-ocis-reva-32
-  @issue-ocis-reva-33
-  @issue-ocis-reva-34
-  @issue-ocis-reva-35
+  @issue-32068 @issue-ocis-reva-11 @issue-ocis-reva-30 @issue-ocis-reva-31 @issue-ocis-reva-32 @issue-ocis-reva-33 @issue-ocis-reva-34 @issue-ocis-reva-35
   Scenario: using OCS with non-admin basic auth
     When the user "Alice" requests these endpoints with "GET" with basic auth
       | endpoint                                                    |
@@ -67,9 +58,7 @@ Feature: current oC10 behavior for issue-32068
     And the OCS status code of responses on all endpoints should be "997"
     #And the OCS status code of responses on all endpoints should be "401"
 
-  @issue-32068 @issue-ocis-reva-29 @issue-ocis-reva-30
-  @smokeTest
-  @skipOnBruteForceProtection @issue-brute_force_protection-112
+  @issue-32068 @issue-ocis-reva-29 @issue-ocis-reva-30 @smokeTest @skipOnBruteForceProtection @issue-brute_force_protection-112
   Scenario: using OCS as normal user with wrong password
     When user "Alice" requests these endpoints with "GET" using password "invalid"
       | endpoint                                                    |

--- a/tests/acceptance/features/apiAuthOcs/ocsPOSTAuth.feature
+++ b/tests/acceptance/features/apiAuthOcs/ocsPOSTAuth.feature
@@ -4,9 +4,7 @@ Feature: auth
   Background:
     Given user "Alice" has been created with default attributes and without skeleton files
 
-  @issue-ocis-reva-30
-  @smokeTest
-  @skipOnBruteForceProtection @issue-brute_force_protection-112
+  @issue-ocis-reva-30 @smokeTest @skipOnBruteForceProtection @issue-brute_force_protection-112
   Scenario: send POST requests to OCS endpoints as normal user with wrong password
     When user "Alice" requests these endpoints with "POST" including body "doesnotmatter" using password "invalid" about user "Alice"
       | endpoint                                                        |

--- a/tests/acceptance/features/apiAuthOcs/ocsPUTAuth.feature
+++ b/tests/acceptance/features/apiAuthOcs/ocsPUTAuth.feature
@@ -4,9 +4,7 @@ Feature: auth
   Background:
     Given user "another-admin" has been created with default attributes and without skeleton files
 
-  @issue-ocis-reva-30
-  @smokeTest
-  @skipOnBruteForceProtection @issue-brute_force_protection-112
+  @issue-ocis-reva-30 @smokeTest @skipOnBruteForceProtection @issue-brute_force_protection-112
   Scenario: send PUT request to OCS endpoints as admin with wrong password
     Given user "another-admin" has been added to group "admin"
     When user "another-admin" requests these endpoints with "PUT" including body "doesnotmatter" using password "invalid" about user "Alice"

--- a/tests/acceptance/features/apiAuthWebDav/webDavDELETEAuth.feature
+++ b/tests/acceptance/features/apiAuthWebDav/webDavDELETEAuth.feature
@@ -12,8 +12,7 @@ Feature: delete file/folder
     And user "Alice" has created folder "/FOLDER"
     And user "Alice" has uploaded file with content "some data" to "/PARENT/parent.txt"
 
-  @smokeTest
-  @skipOnBruteForceProtection @issue-brute_force_protection-112
+  @smokeTest @skipOnBruteForceProtection @issue-brute_force_protection-112
   Scenario: send DELETE requests to webDav endpoints as normal user with wrong password
     When user "Alice" requests these endpoints with "DELETE" using password "invalid" about user "Alice"
       | endpoint                                           |
@@ -92,6 +91,7 @@ Feature: delete file/folder
       | /remote.php/dav/spaces/%spaceid%/PARENT/parent.txt |
     Then the HTTP status code of responses on all endpoints should be "401"
 
+
   Scenario: send DELETE requests to webDav endpoints using valid password and username of different user
     When user "Brian" requests these endpoints with "DELETE" using the password of user "Alice"
       | endpoint                                           |
@@ -111,8 +111,7 @@ Feature: delete file/folder
       | /remote.php/dav/spaces/%spaceid%/PARENT/parent.txt |
     Then the HTTP status code of responses on all endpoints should be "401"
 
-  @smokeTest
-  @skipOnBruteForceProtection @issue-brute_force_protection-112
+  @smokeTest @skipOnBruteForceProtection @issue-brute_force_protection-112
   Scenario: send DELETE requests to webDav endpoints without any authentication
     When a user requests these endpoints with "DELETE" with no authentication about user "Alice"
       | endpoint                                           |

--- a/tests/acceptance/features/apiAuthWebDav/webDavLOCKAuth.feature
+++ b/tests/acceptance/features/apiAuthWebDav/webDavLOCKAuth.feature
@@ -12,8 +12,7 @@ Feature: LOCK file/folder
     And user "Alice" has created folder "/FOLDER"
     And user "Alice" has uploaded file with content "some data" to "/PARENT/parent.txt"
 
-  @smokeTest
-  @skipOnBruteForceProtection @issue-brute_force_protection-112
+  @smokeTest @skipOnBruteForceProtection @issue-brute_force_protection-112
   Scenario: send LOCK requests to webDav endpoints as normal user with wrong password
     When user "Alice" requests these endpoints with "LOCK" including body "doesnotmatter" using password "invalid" about user "Alice"
       | endpoint                                           |
@@ -33,8 +32,7 @@ Feature: LOCK file/folder
       | /remote.php/dav/spaces/%spaceid%/PARENT/parent.txt |
     Then the HTTP status code of responses on all endpoints should be "401"
 
-  @smokeTest
-  @skipOnBruteForceProtection @issue-brute_force_protection-112
+  @smokeTest @skipOnBruteForceProtection @issue-brute_force_protection-112
   Scenario: send LOCK requests to webDav endpoints as normal user with no password
     When user "Alice" requests these endpoints with "LOCK" including body "doesnotmatter" using password "" about user "Alice"
       | endpoint                                           |
@@ -78,6 +76,7 @@ Feature: LOCK file/folder
       | /remote.php/dav/spaces/%spaceid%/PARENT/parent.txt |
     Then the HTTP status code of responses on all endpoints should be "409"
 
+
   Scenario: send LOCK requests to webDav endpoints using invalid username but correct password
     When user "usero" requests these endpoints with "LOCK" including body "doesnotmatter" using the password of user "Alice"
       | endpoint                                           |
@@ -96,6 +95,7 @@ Feature: LOCK file/folder
       | /remote.php/dav/spaces/%spaceid%/PARENT            |
       | /remote.php/dav/spaces/%spaceid%/PARENT/parent.txt |
     Then the HTTP status code of responses on all endpoints should be "401"
+
 
   Scenario: send LOCK requests to webDav endpoints using valid password and username of different user
     When user "Brian" requests these endpoints with "LOCK" including body "doesnotmatter" using the password of user "Alice"
@@ -116,8 +116,7 @@ Feature: LOCK file/folder
       | /remote.php/dav/spaces/%spaceid%/PARENT/parent.txt |
     Then the HTTP status code of responses on all endpoints should be "401"
 
-  @smokeTest
-  @skipOnBruteForceProtection @issue-brute_force_protection-112
+  @smokeTest @skipOnBruteForceProtection @issue-brute_force_protection-112
   Scenario: send LOCK requests to webDav endpoints without any authentication
     When a user requests these endpoints with "LOCK" with body "doesnotmatter" and no authentication about user "Alice"
       | endpoint                                           |

--- a/tests/acceptance/features/apiAuthWebDav/webDavMKCOLAuth.feature
+++ b/tests/acceptance/features/apiAuthWebDav/webDavMKCOLAuth.feature
@@ -8,8 +8,7 @@ Feature: create folder using MKCOL
     And user "Alice" has created folder "/FOLDER"
     And user "Alice" has uploaded file with content "some data" to "/PARENT/parent.txt"
 
-  @smokeTest
-  @skipOnBruteForceProtection @issue-brute_force_protection-112
+  @smokeTest @skipOnBruteForceProtection @issue-brute_force_protection-112
   Scenario: send MKCOL requests to webDav endpoints as normal user with wrong password
     When user "Alice" requests these endpoints with "MKCOL" including body "doesnotmatter" using password "invalid" about user "Alice"
       | endpoint                                           |
@@ -29,8 +28,7 @@ Feature: create folder using MKCOL
       | /remote.php/dav/spaces/%spaceid%/PARENT/parent.txt |
     Then the HTTP status code of responses on all endpoints should be "401"
 
-  @smokeTest
-  @skipOnBruteForceProtection @issue-brute_force_protection-112
+  @smokeTest @skipOnBruteForceProtection @issue-brute_force_protection-112
   Scenario: send MKCOL requests to webDav endpoints as normal user with no password
     When user "Alice" requests these endpoints with "MKCOL" including body "doesnotmatter" using password "" about user "Alice"
       | endpoint                                           |
@@ -78,6 +76,7 @@ Feature: create folder using MKCOL
       | /remote.php/dav/spaces/%spaceid%/PARENT/parent.txt |
     Then the HTTP status code of responses on all endpoints should be "409"
 
+
   Scenario: send MKCOL requests to webDav endpoints using invalid username but correct password
     When user "usero" requests these endpoints with "MKCOL" including body "doesnotmatter" using the password of user "Alice"
       | endpoint                                           |
@@ -96,6 +95,7 @@ Feature: create folder using MKCOL
       | /remote.php/dav/spaces/%spaceid%/PARENT            |
       | /remote.php/dav/spaces/%spaceid%/PARENT/parent.txt |
     Then the HTTP status code of responses on all endpoints should be "401"
+
 
   Scenario: send MKCOL requests to webDav endpoints using valid password and username of different user
     Given user "Brian" has been created with default attributes and without skeleton files
@@ -118,8 +118,7 @@ Feature: create folder using MKCOL
       | /remote.php/dav/spaces/%spaceid%/PARENT/parent.txt |
     Then the HTTP status code of responses on all endpoints should be "401"
 
-  @smokeTest
-  @skipOnBruteForceProtection @issue-brute_force_protection-112
+  @smokeTest @skipOnBruteForceProtection @issue-brute_force_protection-112
   Scenario: send MKCOL requests to webDav endpoints without any authentication
     When a user requests these endpoints with "MKCOL" with body "doesnotmatter" and no authentication about user "Alice"
       | endpoint                                           |

--- a/tests/acceptance/features/apiAuthWebDav/webDavMOVEAuth.feature
+++ b/tests/acceptance/features/apiAuthWebDav/webDavMOVEAuth.feature
@@ -11,8 +11,7 @@ Feature: MOVE file/folder
     And user "Alice" has created folder "/FOLDER"
     And user "Alice" has uploaded file with content "some data" to "/PARENT/parent.txt"
 
-  @smokeTest
-  @skipOnBruteForceProtection @issue-brute_force_protection-112
+  @smokeTest @skipOnBruteForceProtection @issue-brute_force_protection-112
   Scenario: send MOVE requests to webDav endpoints as normal user with wrong password
     When user "Alice" requests these endpoints with "MOVE" using password "invalid" about user "Alice"
       | endpoint                                           |
@@ -32,8 +31,7 @@ Feature: MOVE file/folder
       | /remote.php/dav/spaces/%spaceid%/PARENT/parent.txt |
     Then the HTTP status code of responses on all endpoints should be "401"
 
-  @smokeTest
-  @skipOnBruteForceProtection @issue-brute_force_protection-112
+  @smokeTest @skipOnBruteForceProtection @issue-brute_force_protection-112
   Scenario: send MOVE requests to webDav endpoints as normal user with no password
     When user "Alice" requests these endpoints with "MOVE" using password "" about user "Alice"
       | endpoint                                           |
@@ -71,6 +69,7 @@ Feature: MOVE file/folder
       | /remote.php/dav/spaces/%spaceid%/PARENT/parent.txt |
     Then the HTTP status code of responses on all endpoints should be "403"
 
+
   Scenario: send MOVE requests to webDav endpoints using invalid username but correct password
     When user "usero" requests these endpoints with "MOVE" using the password of user "Alice"
       | endpoint                                           |
@@ -89,6 +88,7 @@ Feature: MOVE file/folder
       | /remote.php/dav/spaces/%spaceid%/PARENT            |
       | /remote.php/dav/spaces/%spaceid%/PARENT/parent.txt |
     Then the HTTP status code of responses on all endpoints should be "401"
+
 
   Scenario: send MOVE requests to webDav endpoints using valid password and username of different user
     When user "Brian" requests these endpoints with "MOVE" using the password of user "Alice"
@@ -109,8 +109,7 @@ Feature: MOVE file/folder
       | /remote.php/dav/spaces/%spaceid%/PARENT/parent.txt |
     Then the HTTP status code of responses on all endpoints should be "401"
 
-  @smokeTest
-  @skipOnBruteForceProtection @issue-brute_force_protection-112
+  @smokeTest @skipOnBruteForceProtection @issue-brute_force_protection-112
   Scenario: send MOVE requests to webDav endpoints without any authentication
     When a user requests these endpoints with "MOVE" with no authentication about user "Alice"
       | endpoint                                           |

--- a/tests/acceptance/features/apiAuthWebDav/webDavPOSTAuth.feature
+++ b/tests/acceptance/features/apiAuthWebDav/webDavPOSTAuth.feature
@@ -12,8 +12,7 @@ Feature: get file info using POST
     And user "Alice" has created folder "/FOLDER"
     And user "Alice" has uploaded file with content "some data" to "/PARENT/parent.txt"
 
-  @smokeTest
-  @skipOnBruteForceProtection @issue-brute_force_protection-112
+  @smokeTest @skipOnBruteForceProtection @issue-brute_force_protection-112
   Scenario: send POST requests to webDav endpoints as normal user with wrong password
     When user "Alice" requests these endpoints with "POST" including body "doesnotmatter" using password "invalid" about user "Alice"
       | endpoint                                           |
@@ -33,8 +32,7 @@ Feature: get file info using POST
       | /remote.php/dav/spaces/%spaceid%/PARENT/parent.txt |
     Then the HTTP status code of responses on all endpoints should be "401"
 
-  @smokeTest
-  @skipOnBruteForceProtection @issue-brute_force_protection-112
+  @smokeTest @skipOnBruteForceProtection @issue-brute_force_protection-112
   Scenario: send POST requests to webDav endpoints as normal user with no password
     When user "Alice" requests these endpoints with "POST" including body "doesnotmatter" using password "" about user "Alice"
       | endpoint                                           |
@@ -72,6 +70,7 @@ Feature: get file info using POST
       | /remote.php/dav/spaces/%spaceid%/PARENT/parent.txt |
     Then the HTTP status code of responses on all endpoints should be "404"
 
+
   Scenario: send POST requests to webDav endpoints using invalid username but correct password
     When user "usero" requests these endpoints with "POST" including body "doesnotmatter" using the password of user "Alice"
       | endpoint                                           |
@@ -90,6 +89,7 @@ Feature: get file info using POST
       | /remote.php/dav/spaces/%spaceid%/PARENT            |
       | /remote.php/dav/spaces/%spaceid%/PARENT/parent.txt |
     Then the HTTP status code of responses on all endpoints should be "401"
+
 
   Scenario: send POST requests to webDav endpoints using valid password and username of different user
     When user "Brian" requests these endpoints with "POST" including body "doesnotmatter" using the password of user "Alice"
@@ -110,8 +110,7 @@ Feature: get file info using POST
       | /remote.php/dav/spaces/%spaceid%/PARENT/parent.txt |
     Then the HTTP status code of responses on all endpoints should be "401"
 
-  @smokeTest
-  @skipOnBruteForceProtection @issue-brute_force_protection-112
+  @smokeTest @skipOnBruteForceProtection @issue-brute_force_protection-112
   Scenario: send POST requests to webDav endpoints without any authentication
     When a user requests these endpoints with "POST" with body "doesnotmatter" and no authentication about user "Alice"
       | endpoint                                           |

--- a/tests/acceptance/features/apiAuthWebDav/webDavPROPFINDAuth.feature
+++ b/tests/acceptance/features/apiAuthWebDav/webDavPROPFINDAuth.feature
@@ -11,8 +11,7 @@ Feature: get file info using PROPFIND
     And user "Alice" has created folder "/FOLDER"
     And user "Alice" has uploaded file with content "some data" to "/PARENT/parent.txt"
 
-  @smokeTest
-  @skipOnBruteForceProtection @issue-brute_force_protection-112
+  @smokeTest @skipOnBruteForceProtection @issue-brute_force_protection-112
   Scenario: send PROPFIND requests to webDav endpoints as normal user with wrong password
     When user "Alice" requests these endpoints with "PROPFIND" including body "doesnotmatter" using password "invalid" about user "Alice"
       | endpoint                                           |
@@ -32,8 +31,7 @@ Feature: get file info using PROPFIND
       | /remote.php/dav/spaces/%spaceid%/PARENT/parent.txt |
     Then the HTTP status code of responses on all endpoints should be "401"
 
-  @smokeTest
-  @skipOnBruteForceProtection @issue-brute_force_protection-112
+  @smokeTest @skipOnBruteForceProtection @issue-brute_force_protection-112
   Scenario: send PROPFIND requests to webDav endpoints as normal user with no password
     When user "Alice" requests these endpoints with "PROPFIND" including body "doesnotmatter" using password "" about user "Alice"
       | endpoint                                           |
@@ -71,6 +69,7 @@ Feature: get file info using PROPFIND
       | /remote.php/dav/spaces/%spaceid%/PARENT/parent.txt |
     Then the HTTP status code of responses on all endpoints should be "404"
 
+
   Scenario: send PROPFIND requests to webDav endpoints using invalid username but correct password
     When user "usero" requests these endpoints with "PROPFIND" including body "doesnotmatter" using the password of user "Alice"
       | endpoint                                           |
@@ -89,6 +88,7 @@ Feature: get file info using PROPFIND
       | /remote.php/dav/spaces/%spaceid%/PARENT            |
       | /remote.php/dav/spaces/%spaceid%/PARENT/parent.txt |
     Then the HTTP status code of responses on all endpoints should be "401"
+
 
   Scenario: send PROPFIND requests to webDav endpoints using valid password and username of different user
     When user "Brian" requests these endpoints with "PROPFIND" including body "doesnotmatter" using the password of user "Alice"
@@ -109,8 +109,7 @@ Feature: get file info using PROPFIND
       | /remote.php/dav/spaces/%spaceid%/PARENT/parent.txt |
     Then the HTTP status code of responses on all endpoints should be "401"
 
-  @smokeTest
-  @skipOnBruteForceProtection @issue-brute_force_protection-112
+  @smokeTest @skipOnBruteForceProtection @issue-brute_force_protection-112
   Scenario: send PROPFIND requests to webDav endpoints without any authentication
     When a user requests these endpoints with "PROPFIND" with body "doesnotmatter" and no authentication about user "Alice"
       | endpoint                                           |

--- a/tests/acceptance/features/apiAuthWebDav/webDavPROPPATCHAuth.feature
+++ b/tests/acceptance/features/apiAuthWebDav/webDavPROPPATCHAuth.feature
@@ -12,8 +12,7 @@ Feature: PROPPATCH file/folder
     And user "Alice" has created folder "/FOLDER"
     And user "Alice" has uploaded file with content "some data" to "/PARENT/parent.txt"
 
-  @smokeTest
-  @skipOnBruteForceProtection @issue-brute_force_protection-112
+  @smokeTest @skipOnBruteForceProtection @issue-brute_force_protection-112
   Scenario: send PROPPATCH requests to webDav endpoints as normal user with wrong password
     When user "Alice" requests these endpoints with "PROPPATCH" including body "doesnotmatter" using password "invalid" about user "Alice"
       | endpoint                                           |
@@ -33,8 +32,7 @@ Feature: PROPPATCH file/folder
       | /remote.php/dav/spaces/%spaceid%/PARENT/parent.txt |
     Then the HTTP status code of responses on all endpoints should be "401"
 
-  @smokeTest
-  @skipOnBruteForceProtection @issue-brute_force_protection-112
+  @smokeTest @skipOnBruteForceProtection @issue-brute_force_protection-112
   Scenario: send PROPPATCH requests to webDav endpoints as normal user with no password
     When user "Alice" requests these endpoints with "PROPPATCH" including body "doesnotmatter" using password "" about user "Alice"
       | endpoint                                           |
@@ -72,6 +70,7 @@ Feature: PROPPATCH file/folder
       | /remote.php/dav/spaces/%spaceid%/PARENT/parent.txt |
     Then the HTTP status code of responses on all endpoints should be "404"
 
+
   Scenario: send PROPPATCH requests to webDav endpoints using invalid username but correct password
     When user "usero" requests these endpoints with "PROPPATCH" including body "doesnotmatter" using the password of user "Alice"
       | endpoint                                           |
@@ -90,6 +89,7 @@ Feature: PROPPATCH file/folder
       | /remote.php/dav/spaces/%spaceid%/PARENT            |
       | /remote.php/dav/spaces/%spaceid%/PARENT/parent.txt |
     Then the HTTP status code of responses on all endpoints should be "401"
+
 
   Scenario: send PROPPATCH requests to webDav endpoints using valid password and username of different user
     When user "Brian" requests these endpoints with "PROPPATCH" including body "doesnotmatter" using the password of user "Alice"
@@ -110,8 +110,7 @@ Feature: PROPPATCH file/folder
       | /remote.php/dav/spaces/%spaceid%/PARENT/parent.txt |
     Then the HTTP status code of responses on all endpoints should be "401"
 
-  @smokeTest
-  @skipOnBruteForceProtection @issue-brute_force_protection-112
+  @smokeTest @skipOnBruteForceProtection @issue-brute_force_protection-112
   Scenario: send PROPPATCH requests to webDav endpoints without any authentication
     When a user requests these endpoints with "PROPPATCH" with body "doesnotmatter" and no authentication about user "Alice"
       | endpoint                                           |

--- a/tests/acceptance/features/apiAuthWebDav/webDavPUTAuth.feature
+++ b/tests/acceptance/features/apiAuthWebDav/webDavPUTAuth.feature
@@ -12,8 +12,7 @@ Feature: get file info using PUT
     And user "Alice" has created folder "/FOLDER"
     And user "Alice" has uploaded file with content "some data" to "/PARENT/parent.txt"
 
-  @smokeTest
-  @skipOnBruteForceProtection @issue-brute_force_protection-112
+  @smokeTest @skipOnBruteForceProtection @issue-brute_force_protection-112
   Scenario: send PUT requests to webDav endpoints as normal user with wrong password
     When user "Alice" requests these endpoints with "PUT" including body "doesnotmatter" using password "invalid" about user "Alice"
       | endpoint                                           |
@@ -33,8 +32,7 @@ Feature: get file info using PUT
       | /remote.php/dav/spaces/%spaceid%/PARENT/parent.txt |
     Then the HTTP status code of responses on all endpoints should be "401"
 
-  @smokeTest
-  @skipOnBruteForceProtection @issue-brute_force_protection-112
+  @smokeTest @skipOnBruteForceProtection @issue-brute_force_protection-112
   Scenario: send PUT requests to webDav endpoints as normal user with no password
     When user "Alice" requests these endpoints with "PUT" including body "doesnotmatter" using password "" about user "Alice"
       | endpoint                                           |
@@ -118,8 +116,7 @@ Feature: get file info using PUT
       | /remote.php/dav/spaces/%spaceid%/PARENT/parent.txt |
     Then the HTTP status code of responses on all endpoints should be "401"
 
-  @smokeTest
-  @skipOnBruteForceProtection @issue-brute_force_protection-112
+  @smokeTest @skipOnBruteForceProtection @issue-brute_force_protection-112
   Scenario: send PUT requests to webDav endpoints without any authentication
     When a user requests these endpoints with "PUT" with body "doesnotmatter" and no authentication about user "Alice"
       | endpoint                                           |

--- a/tests/acceptance/features/apiCapabilities/capabilities.feature
+++ b/tests/acceptance/features/apiCapabilities/capabilities.feature
@@ -948,8 +948,7 @@ Feature: capabilities
       | capability | path_to_element         | value    |
       | files      | blacklisted_files_regex | \.(part\|filepart)$ |
 
-  @smokeTest
-  @skipOnOcV10.7 @skipOnOcV10.8 @skipOnOcV10.9.0 @skipOnOcV10.9.1
+  @smokeTest @skipOnOcV10.7 @skipOnOcV10.8 @skipOnOcV10.9.0 @skipOnOcV10.9.1
   # This is a new capability after 10.9.1
   Scenario: getting default capabilities with admin user
     When the administrator retrieves the capabilities using the capabilities API

--- a/tests/acceptance/features/apiComments/comments.feature
+++ b/tests/acceptance/features/apiComments/comments.feature
@@ -22,6 +22,7 @@ Feature: Comments
     And the single response should contain a property "oc:comments-unread" with value "0"
     And the single response should contain a property "oc:comments-href" with value "%a_comment_url%"
 
+
   Scenario: Getting info on comments for a folder using the endpoint
     Given user "Alice" has created folder "/PARENT"
     And user "Alice" has commented with content "My first comment" on folder "/PARENT"
@@ -38,6 +39,7 @@ Feature: Comments
     And the single response should contain a property "oc:comments-unread" with value "0"
     And the single response should contain a property "oc:comments-href" with value "%a_comment_url%"
 
+
   Scenario: Getting more info about comments using REPORT method
     Given user "Alice" has uploaded file "filesForUpload/textfile.txt" to "/myFileToComment.txt"
     And user "Alice" has commented with content "My first comment" on file "/myFileToComment.txt"
@@ -52,6 +54,7 @@ Feature: Comments
       | isUnread         | false            |
       | actorDisplayName | %displayname%    |
       | message          | My first comment |
+
 
   Scenario: Getting more info about comments using PROPFIND method
     Given user "Alice" has uploaded file "filesForUpload/textfile.txt" to "/myFileToComment.txt"

--- a/tests/acceptance/features/apiComments/createComments.feature
+++ b/tests/acceptance/features/apiComments/createComments.feature
@@ -22,6 +22,7 @@ Feature: Comments
       | 😀    🤖         |
       | नेपालि           |
 
+
   Scenario: Creating a comment on a shared file belonging to another user
     Given user "Alice" has uploaded file "filesForUpload/textfile.txt" to "/myFileToComment.txt"
     And user "Alice" has shared file "/myFileToComment.txt" with user "Brian"
@@ -33,6 +34,7 @@ Feature: Comments
       | Brian | A comment from sharee |
       | Alice | A comment from sharer |
 
+
   Scenario: sharee comments on a group shared file
     Given group "grp1" has been created
     And user "Brian" has been added to group "grp1"
@@ -43,6 +45,7 @@ Feature: Comments
     And user "Alice" should have the following comments on file "/myFileToComment.txt"
       | user  | comment             |
       | Brian | Comment from sharee |
+
 
   Scenario: sharee comments on read-only shared file
     Given user "Alice" has uploaded file "filesForUpload/textfile.txt" to "/myFileToComment.txt"
@@ -57,6 +60,7 @@ Feature: Comments
       | user  | comment             |
       | Brian | Comment from sharee |
 
+
   Scenario: sharee comments on upload-only shared folder
     Given user "Alice" has created folder "/FOLDER_TO_SHARE"
     And user "Alice" has created a share with settings
@@ -68,6 +72,7 @@ Feature: Comments
     Then the HTTP status code should be "501"
     And user "Alice" should have 0 comments on file "/FOLDER_TO_SHARE"
 
+
   Scenario: Creating a comment on a folder belonging to myself
     Given user "Alice" has created folder "/FOLDER"
     When user "Alice" comments with content "My first comment" on folder "/FOLDER" using the WebDAV API
@@ -75,6 +80,7 @@ Feature: Comments
     And user "Alice" should have the following comments on folder "/FOLDER"
       | user  | comment          |
       | Alice | My first comment |
+
 
   Scenario: Creating a comment on a shared folder belonging to another user
     Given user "Alice" has created folder "/FOLDER_TO_SHARE"
@@ -86,6 +92,7 @@ Feature: Comments
       | user  | comment               |
       | Brian | A comment from sharee |
       | Alice | A comment from sharer |
+
 
   Scenario: sharee comments on a group shared folder
     Given group "grp1" has been created

--- a/tests/acceptance/features/apiComments/deleteComments.feature
+++ b/tests/acceptance/features/apiComments/deleteComments.feature
@@ -20,6 +20,7 @@ Feature: Comments
       | 😀 🤖            |
       | नेपालि           |
 
+
   Scenario: Deleting a comment on a file belonging to myself having several comments
     Given user "Alice" has uploaded file "filesForUpload/textfile.txt" to "/myFileToComment.txt"
     And user "Alice" has commented with content "My first comment" on file "/myFileToComment.txt"
@@ -45,12 +46,14 @@ Feature: Comments
     Then the HTTP status code should be "204"
     And user "Brian" should have 1 comments on file "/myFileToComment.txt"
 
+
   Scenario: Deleting my own comments on a folder belonging to myself
     Given user "Alice" has created folder "/FOLDER_TO_COMMENT_AND_DELETE"
     And user "Alice" has commented with content "My first comment" on folder "/FOLDER_TO_COMMENT_AND_DELETE"
     When user "Alice" deletes the last created comment using the WebDAV API
     Then the HTTP status code should be "204"
     And user "Alice" should have 0 comments on folder "/FOLDER_TO_COMMENT_AND_DELETE"
+
 
   Scenario: Deleting a comment on a folder belonging to myself having several comments
     Given user "Alice" has created folder "/FOLDER_TO_COMMENT"
@@ -73,6 +76,7 @@ Feature: Comments
     Then the HTTP status code should be "204"
     And user "Brian" should have 1 comments on folder "/FOLDER_TO_COMMENT"
 
+
   Scenario: deleting a folder removes existing comments on the folder
     Given user "Alice" has created folder "/FOLDER_TO_DELETE"
     When user "Alice" comments with content "This should be deleted" on folder "/FOLDER_TO_DELETE" using the WebDAV API
@@ -94,6 +98,7 @@ Feature: Comments
     And user "Alice" should have the following comments on folder "/FOLDER_TO_COMMENT"
       | user          | comment             |
       | deleted_users | Comment from sharee |
+
 
   Scenario: deleting a content owner deletes the comment
     Given user "Alice" has created folder "/FOLDER_TO_COMMENT"

--- a/tests/acceptance/features/apiComments/editComments.feature
+++ b/tests/acceptance/features/apiComments/editComments.feature
@@ -49,6 +49,7 @@ Feature: Comments
       | user  | comment        |
       | Brian | Sharee comment |
 
+
   Scenario: Edit my own comments on a folder belonging to myself
     Given user "Alice" has created folder "FOLDER"
     And user "Alice" has commented with content "Folder owner comment" on folder "/FOLDER"

--- a/tests/acceptance/features/apiFavorites/favorites.feature
+++ b/tests/acceptance/features/apiFavorites/favorites.feature
@@ -120,6 +120,7 @@ Feature: favorite
       | dav_version |
       | spaces      |
 
+
   Scenario Outline: Get favorited elements of a subfolder
     Given using <dav_version> DAV path
     And user "Alice" has created folder "/subfolder"
@@ -248,6 +249,7 @@ Feature: favorite
       | dav_version |
       | old         |
       | new         |
+
 
   Scenario Outline: favoriting a folder does not change the favorite state of elements inside the folder
     Given using <dav_version> DAV path

--- a/tests/acceptance/features/apiFederationToRoot1/etagPropagation.feature
+++ b/tests/acceptance/features/apiFederationToRoot1/etagPropagation.feature
@@ -10,6 +10,7 @@ Feature: propagation of etags between federated and local server
     And user "Brian" has been created with default attributes and without skeleton files
     And user "Brian" has created folder "PARENT"
 
+
   Scenario: Overwrite a federated shared folder as sharer propagates etag for recipient
     Given user "Brian" from server "LOCAL" has shared "/PARENT" with user "Alice" from server "REMOTE"
     And user "Alice" from server "REMOTE" has accepted the last pending share
@@ -46,6 +47,7 @@ Feature: propagation of etags between federated and local server
     And the etag of element "/" of user "Alice" on server "REMOTE" should not have changed
     #And the etag of element "/" of user "Alice" on server "REMOTE" should have changed
 
+
   Scenario: Overwrite a federated shared folder as recipient propagates etag for recipient
     Given user "Brian" from server "LOCAL" has shared "/PARENT" with user "Alice" from server "REMOTE"
     And user "Alice" from server "REMOTE" has accepted the last pending share
@@ -54,6 +56,7 @@ Feature: propagation of etags between federated and local server
     When user "Alice" uploads file "filesForUpload/file_to_overwrite.txt" to "/PARENT (2)/textfile0.txt" using the WebDAV API
     Then the HTTP status code should be "201"
     And the etag of element "/PARENT (2)" of user "Alice" on server "REMOTE" should have changed
+
 
   Scenario: Overwrite a federated shared folder as recipient propagates etag to root folder for recipient
     Given user "Brian" from server "LOCAL" has shared "/PARENT" with user "Alice" from server "REMOTE"
@@ -64,6 +67,7 @@ Feature: propagation of etags between federated and local server
     Then the HTTP status code should be "201"
     And the etag of element "/" of user "Alice" on server "REMOTE" should have changed
 
+
   Scenario: Overwrite a federated shared folder as recipient propagates etag for sharer
     Given user "Brian" from server "LOCAL" has shared "/PARENT" with user "Alice" from server "REMOTE"
     And user "Brian" has stored etag of element "/PARENT"
@@ -73,6 +77,7 @@ Feature: propagation of etags between federated and local server
     Then the HTTP status code should be "201"
     And the etag of element "/PARENT" of user "Brian" on server "LOCAL" should have changed
 
+
   Scenario: Overwrite a federated shared folder as recipient propagates etag to root folder for sharer
     Given user "Brian" from server "LOCAL" has shared "/PARENT" with user "Alice" from server "REMOTE"
     And user "Brian" has stored etag of element "/"
@@ -81,6 +86,7 @@ Feature: propagation of etags between federated and local server
     When user "Alice" uploads file "filesForUpload/file_to_overwrite.txt" to "/PARENT (2)/textfile0.txt" using the WebDAV API
     Then the HTTP status code should be "201"
     And the etag of element "/" of user "Brian" on server "LOCAL" should have changed
+
 
   Scenario: Adding a file to a federated shared folder as recipient propagates etag to root folder for sharer
     Given user "Brian" from server "LOCAL" has shared "/PARENT" with user "Alice" from server "REMOTE"

--- a/tests/acceptance/features/apiFederationToRoot1/federated.feature
+++ b/tests/acceptance/features/apiFederationToRoot1/federated.feature
@@ -63,6 +63,7 @@ Feature: federated
       | 1               | 100        |
       | 2               | 200        |
 
+
   Scenario Outline: Federated sharee can see the pending share
     Given using OCS API version "<ocs-api-version>"
     And using server "REMOTE"
@@ -86,6 +87,7 @@ Feature: federated
       | ocs-api-version | ocs-status |
       | 1               | 100        |
       | 2               | 200        |
+
 
   Scenario Outline: Federated sharee requests information of only one share
     Given using OCS API version "<ocs-api-version>"
@@ -139,6 +141,7 @@ Feature: federated
       | 1               | 100        |
       | 2               | 200        |
 
+
   Scenario Outline: sending a GET request to a pending federated share is not valid
     Given using OCS API version "<ocs-api-version>"
     When user "Brian" sends HTTP method "GET" to OCS API endpoint "/apps/files_sharing/api/v1/remote_shares/pending/12"
@@ -149,6 +152,7 @@ Feature: federated
       | 1               |
       | 2               |
 
+
   Scenario Outline: sending a GET request to a nonexistent federated share
     Given using OCS API version "<ocs-api-version>"
     When user "Brian" sends HTTP method "GET" to OCS API endpoint "/apps/files_sharing/api/v1/remote_shares/9999999999"
@@ -158,6 +162,7 @@ Feature: federated
       | ocs-api-version | ocs-status | http-status |
       | 1               | 404        | 200         |
       | 2               | 404        | 404         |
+
 
   Scenario Outline: accept a pending federated share
     Given using OCS API version "<ocs-api-version>"
@@ -171,6 +176,7 @@ Feature: federated
       | ocs-api-version | ocs-status |
       | 1               | 100        |
       | 2               | 200        |
+
 
   Scenario Outline: Reshare a federated shared file
     Given using OCS API version "<ocs-api-version>"
@@ -207,6 +213,7 @@ Feature: federated
       | 1               | 100        |
       | 2               | 200        |
 
+
   Scenario Outline: Overwrite a federated shared file as recipient - local server shares - remote server receives
     Given using OCS API version "<ocs-api-version>"
     And user "Brian" has uploaded file "filesForUpload/textfile.txt" to "textfile0.txt"
@@ -220,6 +227,7 @@ Feature: federated
       | ocs-api-version |
       | 1               |
       | 2               |
+
 
   Scenario Outline: Overwrite a federated shared file as recipient - remote server shares - local server receives
     Given using OCS API version "<ocs-api-version>"
@@ -236,6 +244,7 @@ Feature: federated
       | 1               |
       | 2               |
 
+
   Scenario Outline: Overwrite a file in a federated shared folder as recipient - local server shares - remote server receives
     Given using OCS API version "<ocs-api-version>"
     And user "Brian" has created folder "PARENT"
@@ -249,6 +258,7 @@ Feature: federated
       | ocs-api-version |
       | 1               |
       | 2               |
+
 
   Scenario Outline: Overwrite a file in a federated shared folder as recipient - remote server shares - local server receives
     Given using OCS API version "<ocs-api-version>"
@@ -264,6 +274,7 @@ Feature: federated
       | ocs-api-version |
       | 1               |
       | 2               |
+
 
   Scenario Outline: Overwrite a federated shared file as recipient using old chunking
     Given using OCS API version "<ocs-api-version>"
@@ -285,6 +296,7 @@ Feature: federated
       | 1               |
       | 2               |
 
+
   Scenario Outline: Overwrite a file in a federated shared folder as recipient using old chunking
     Given using OCS API version "<ocs-api-version>"
     And using server "REMOTE"
@@ -304,6 +316,7 @@ Feature: federated
       | ocs-api-version |
       | 1               |
       | 2               |
+
 
   Scenario Outline: Federated sharee deletes an accepted federated share
     Given using OCS API version "<ocs-api-version>"
@@ -363,6 +376,7 @@ Feature: federated
       | 1               |
       | 2               |
 
+
   Scenario Outline: Federated sharee deletes a pending federated share
     Given using server "REMOTE"
     And user "Alice" has uploaded file "filesForUpload/textfile.txt" to "textfile0.txt"
@@ -417,6 +431,7 @@ Feature: federated
       | 1               |
       | 2               |
 
+
   Scenario Outline: Trusted server handshake does not require authenticated requests - we force 403 by sending an empty body
     Given using OCS API version "<ocs-api-version>"
     When user "UNAUTHORIZED_USER" requests shared secret using the federation API
@@ -459,6 +474,7 @@ Feature: federated
     When user "Brian" uploads file "filesForUpload/textfile.txt" to filenames based on "/PARENT/testquota.txt" with all mechanisms using the WebDAV API
     Then the HTTP status code of all upload responses should be "507"
 
+
   Scenario Outline: share of a folder to a federated user who already has a folder with the same name
     Given using server "REMOTE"
     And user "Alice" has created folder "/zzzfolder"
@@ -487,6 +503,7 @@ Feature: federated
       | ocs-api-version | ocs-status |
       | 1               | 100        |
       | 2               | 200        |
+
 
   Scenario Outline: share of a file to the federated user who already has a file with the same name
     Given using server "REMOTE"
@@ -542,6 +559,7 @@ Feature: federated
     And as "Carol" folder "zzzfolder/local" should exist
     And the content of file "/randomfile (2).txt" for user "Carol" on server "LOCAL" should be "remote content"
     And the content of file "/randomfile.txt" for user "Carol" on server "LOCAL" should be "local content"
+
 
   Scenario: receive a federated share that has the same name as a previously received local share
     Given using server "REMOTE"

--- a/tests/acceptance/features/apiFederationToRoot2/federated.feature
+++ b/tests/acceptance/features/apiFederationToRoot2/federated.feature
@@ -37,6 +37,7 @@ Feature: federated
     And as "Brian" file "textfile1.txt" should not exist
     And url "%remote_server%" should be a trusted server
 
+
   Scenario: Federated share with "Auto add server" enabled
     Given using server "REMOTE"
     And user "Alice" has uploaded file "filesForUpload/textfile.txt" to "textfile1.txt"
@@ -50,6 +51,7 @@ Feature: federated
     And the HTTP status code of responses on all endpoints should be "200"
     And as "Brian" file "textfile1.txt" should exist
     And url "%remote_server%" should be a trusted server
+
 
   Scenario: Federated share with "Auto add server" disabled
     Given using server "REMOTE"
@@ -104,6 +106,7 @@ Feature: federated
     And the HTTP status code should be "200"
     And as "Brian" file "textfile1.txt" should not exist
 
+
   Scenario Outline: federated share receiver sees the original content of a received file
     Given using server "REMOTE"
     And user "Alice" has uploaded file with content "thisContentIsVisible" to "/file-to-share"
@@ -116,6 +119,7 @@ Feature: federated
       | ocs-api-version |
       | 1               |
       | 2               |
+
 
   Scenario Outline: federated share receiver sees the original content of a received file in multiple levels of folders
     Given using server "REMOTE"
@@ -131,6 +135,7 @@ Feature: federated
       | ocs-api-version |
       | 1               |
       | 2               |
+
 
   Scenario Outline: remote federated share receiver adds files/folders in the federated share
     Given user "Brian" has created folder "/PARENT"
@@ -152,6 +157,7 @@ Feature: federated
       | ocs-api-version |
       | 1               |
       | 2               |
+
 
   Scenario Outline: local federated share receiver adds files/folders in the federated share
     Given using server "REMOTE"
@@ -175,6 +181,7 @@ Feature: federated
       | 1               |
       | 2               |
 
+
   Scenario Outline: local federated share receiver deletes files/folders of the received share
     Given using server "REMOTE"
     And user "Alice" has created folder "/PARENT"
@@ -197,6 +204,7 @@ Feature: federated
       | 1               |
       | 2               |
 
+
   Scenario Outline: remote federated share receiver deletes files/folders of the received share
     Given user "Brian" has created folder "/PARENT"
     And user "Brian" has created folder "/PARENT/RandomFolder"
@@ -217,6 +225,7 @@ Feature: federated
       | ocs-api-version |
       | 1               |
       | 2               |
+
 
   Scenario Outline: local federated share receiver renames files/folders of the received share
     Given using server "REMOTE"
@@ -242,6 +251,7 @@ Feature: federated
       | 1               |
       | 2               |
 
+
   Scenario Outline: remote federated share receiver renames files/folders of the received share
     Given user "Brian" has created folder "/PARENT"
     And user "Brian" has created folder "/PARENT/RandomFolder"
@@ -265,6 +275,7 @@ Feature: federated
       | 1               |
       | 2               |
 
+
   Scenario Outline: sharer modifies the share which was shared to the federated share receiver
     Given using server "REMOTE"
     And user "Alice" has created folder "/PARENT"
@@ -281,6 +292,7 @@ Feature: federated
       | ocs-api-version |
       | 1               |
       | 2               |
+
 
   Scenario Outline: sharer adds files/folders in the share which was shared to the federated share receiver
     Given using server "REMOTE"
@@ -303,6 +315,7 @@ Feature: federated
       | 1               |
       | 2               |
 
+
   Scenario Outline: sharer deletes files/folders of the share which was shared to the federated share receiver
     Given using server "REMOTE"
     And user "Alice" has created folder "/PARENT"
@@ -323,6 +336,7 @@ Feature: federated
       | ocs-api-version |
       | 1               |
       | 2               |
+
 
   Scenario Outline: sharer renames files/folders of the share which was shared to the federated share receiver
     Given using server "REMOTE"
@@ -347,6 +361,7 @@ Feature: federated
       | 1               |
       | 2               |
 
+
   Scenario Outline: sharer unshares the federated share and the receiver no longer sees the files/folders
     Given user "Brian" has created folder "/PARENT"
     And user "Brian" has created folder "/PARENT/RandomFolder"
@@ -364,6 +379,7 @@ Feature: federated
       | ocs-api-version | ocs-status-code |
       | 1               | 100             |
       | 2               | 200             |
+
 
   Scenario Outline: federated share receiver can move the location of the received share and changes are correctly seen at both ends
     Given user "Brian" has created folder "/PARENT"
@@ -391,6 +407,7 @@ Feature: federated
       | 1               |
       | 2               |
 
+
   Scenario Outline: federated sharer can move the location of the received share and changes are correctly seen at both ends
     Given user "Brian" has created folder "/PARENT"
     And user "Brian" has created folder "/PARENT/RandomFolder"
@@ -415,6 +432,7 @@ Feature: federated
       | ocs-api-version |
       | 1               |
       | 2               |
+
 
   Scenario Outline: Both Incoming and Outgoing federation shares are allowed
     Given parameter "incoming_server2server_share_enabled" of app "files_sharing" has been set to "yes"
@@ -441,6 +459,7 @@ Feature: federated
       | 1               | 100             |
       | 2               | 200             |
 
+
   Scenario Outline: Incoming federation shares are allowed but outgoing federation shares are restricted
     Given parameter "incoming_server2server_share_enabled" of app "files_sharing" has been set to "yes"
     And parameter "outgoing_server2server_share_enabled" of app "files_sharing" has been set to "no"
@@ -464,6 +483,7 @@ Feature: federated
       | 1               | 100             | 200              |
       | 2               | 200             | 403              |
 
+
   Scenario Outline: Incoming federation shares are restricted but outgoing federation shares are allowed
     Given parameter "incoming_server2server_share_enabled" of app "files_sharing" has been set to "no"
     And parameter "outgoing_server2server_share_enabled" of app "files_sharing" has been set to "yes"
@@ -483,6 +503,7 @@ Feature: federated
       | ocs-api-version | http-status-code |
       | 1               | 201, 200         |
       | 2               | 201, 403         |
+
 
   Scenario Outline: Both Incoming and outgoing federation shares are restricted
     Given parameter "incoming_server2server_share_enabled" of app "files_sharing" has been set to "no"
@@ -506,6 +527,7 @@ Feature: federated
       | ocs-api-version | http-status-code |
       | 1               | 201, 200         |
       | 2               | 201, 403         |
+
 
   Scenario Outline: Incoming and outgoing federation shares are enabled for local server but incoming federation shares are restricted for remote server
     Given using server "REMOTE"
@@ -533,6 +555,7 @@ Feature: federated
       | ocs-api-version | ocs-status-code | http-status-code |
       | 1               | 100             | 201, 200         |
       | 2               | 200             | 201, 403         |
+
 
   Scenario Outline: Incoming and outgoing federation shares are enabled for local server but outgoing federation shares are restricted for remote server
     Given using server "REMOTE"

--- a/tests/acceptance/features/apiFederationToShares1/etagPropagation.feature
+++ b/tests/acceptance/features/apiFederationToShares1/etagPropagation.feature
@@ -49,6 +49,7 @@ Feature: propagation of etags between federated and local server
     And the etag of element "/" of user "Alice" on server "REMOTE" should not have changed
     #And the etag of element "/" of user "Alice" on server "REMOTE" should have changed
 
+
   Scenario: Overwrite a federated shared folder as recipient propagates etag for recipient
     Given user "Brian" from server "LOCAL" has shared "/PARENT" with user "Alice" from server "REMOTE"
     And user "Alice" from server "REMOTE" has accepted the last pending share
@@ -57,6 +58,7 @@ Feature: propagation of etags between federated and local server
     When user "Alice" uploads file "filesForUpload/file_to_overwrite.txt" to "/Shares/PARENT/textfile0.txt" using the WebDAV API
     Then the HTTP status code should be "201"
     And the etag of element "/Shares/PARENT" of user "Alice" on server "REMOTE" should have changed
+
 
   Scenario: Overwrite a federated shared folder as recipient propagates etag to root folder for recipient
     Given user "Brian" from server "LOCAL" has shared "/PARENT" with user "Alice" from server "REMOTE"
@@ -67,6 +69,7 @@ Feature: propagation of etags between federated and local server
     Then the HTTP status code should be "201"
     And the etag of element "/" of user "Alice" on server "REMOTE" should have changed
 
+
   Scenario: Overwrite a federated shared folder as recipient propagates etag for sharer
     Given user "Brian" from server "LOCAL" has shared "/PARENT" with user "Alice" from server "REMOTE"
     And user "Brian" has stored etag of element "/PARENT"
@@ -76,6 +79,7 @@ Feature: propagation of etags between federated and local server
     Then the HTTP status code should be "201"
     And the etag of element "/PARENT" of user "Brian" on server "LOCAL" should have changed
 
+
   Scenario: Overwrite a federated shared folder as recipient propagates etag to root folder for sharer
     Given user "Brian" from server "LOCAL" has shared "/PARENT" with user "Alice" from server "REMOTE"
     And user "Brian" has stored etag of element "/"
@@ -84,6 +88,7 @@ Feature: propagation of etags between federated and local server
     When user "Alice" uploads file "filesForUpload/file_to_overwrite.txt" to "/Shares/PARENT/textfile0.txt" using the WebDAV API
     Then the HTTP status code should be "201"
     And the etag of element "/" of user "Brian" on server "LOCAL" should have changed
+
 
   Scenario: Adding a file to a federated shared folder as recipient propagates etag to root folder for sharer
     Given user "Brian" from server "LOCAL" has shared "/PARENT" with user "Alice" from server "REMOTE"

--- a/tests/acceptance/features/apiFederationToShares2/federated.feature
+++ b/tests/acceptance/features/apiFederationToShares2/federated.feature
@@ -71,7 +71,6 @@ Feature: federated
     Then as "Brian" file "Shares/textfile1.txt" should exist
     And url "%remote_server%" should not be a trusted server
 
-
   @issue-35839 @skipOnOcV10
   Scenario: enable "Add server automatically" once a federated share was created successfully
     Given using server "REMOTE"
@@ -600,7 +599,6 @@ Feature: federated
       | 1               | 100             | 201,200          |
       | 2               | 200             | 201,403          |
 
-
   @skipOnOcV10.3 @skipOnOcV10.4 @skipOnOcV10.5.0
   Scenario Outline: Federated share a file with another server with expiration date
     Given using OCS API version "<ocs-api-version>"
@@ -633,7 +631,6 @@ Feature: federated
       | 1               | 100        |
       | 2               | 200        |
 
-
   @skipOnOcV10.3 @skipOnOcV10.4 @skipOnOcV10.5.0
   Scenario Outline: Federated sharing with default expiration date enabled but not enforced, user shares without specifying expireDate
     Given using OCS API version "<ocs_api_version>"
@@ -648,7 +645,6 @@ Feature: federated
       | ocs_api_version | ocs-status |
       | 1               | 100        |
 #      | 2               | 200        |
-
 
   @skipOnOcV10.3 @skipOnOcV10.4 @skipOnOcV10.5.0
   Scenario Outline: Federated sharing with default expiration date enabled and enforced, user shares without specifying expireDate
@@ -666,7 +662,6 @@ Feature: federated
       | 1               | 100        |
       | 2               | 200        |
 
-
   @skipOnOcV10.3 @skipOnOcV10.4 @skipOnOcV10.5.0
   Scenario Outline: Federated sharing with default expiration date disabled
     Given using OCS API version "<ocs_api_version>"
@@ -681,7 +676,6 @@ Feature: federated
       | ocs_api_version | ocs-status |
       | 1               | 100        |
       | 2               | 200        |
-
 
   @skipOnOcV10.3 @skipOnOcV10.4 @skipOnOcV10.5.0
   Scenario Outline: Expiration date is enforced for federated share, user modifies expiration date
@@ -702,7 +696,6 @@ Feature: federated
       | 1               | 100        |
       | 2               | 200        |
 
-
   @skipOnOcV10.3 @skipOnOcV10.4 @skipOnOcV10.5.0
   Scenario Outline: Federated sharing with default expiration date enabled and enforced, user updates the share with expiration date more than the default
     Given using OCS API version "<ocs_api_version>"
@@ -720,7 +713,6 @@ Feature: federated
       | ocs_api_version | http_status_code |
       | 1               | 200              |
       | 2               | 404              |
-
 
   @skipOnOcV10.6 @skipOnOcV10.7 @skipOnOcV10.8.0
   Scenario Outline: User modifies expiration date for federated reshare of a file with another server with default expiration date
@@ -744,7 +736,6 @@ Feature: federated
       | ocs_api_version | ocs-status |
       | 1               | 100        |
       | 2               | 200        |
-
 
   @skipOnOcV10.6 @skipOnOcV10.7 @skipOnOcV10.8.0
   Scenario Outline: User modifies expiration date more than the default for federated reshare of a file

--- a/tests/acceptance/features/apiMain/appManagement.feature
+++ b/tests/acceptance/features/apiMain/appManagement.feature
@@ -12,6 +12,7 @@ Feature: AppManagement
     And the administrator enables app "updatetest"
     Then the installed version of "updatetest" should be "2.0.1"
 
+
   Scenario: Update of patch version of an app in apps-external, previous version in apps folder
     Given these apps' path has been configured additionally with following attributes:
       | dir         | is_writable |
@@ -22,6 +23,7 @@ Feature: AppManagement
     When the administrator puts app "updatetest" with version "2.0.1" in dir "apps-external"
     And the administrator enables app "updatetest"
     Then the installed version of "updatetest" should be "2.0.1"
+
 
   Scenario: Update of patch version of an app in apps-external
     Given these apps' path has been configured additionally with following attributes:
@@ -34,6 +36,7 @@ Feature: AppManagement
     And the administrator enables app "updatetest"
     Then the installed version of "updatetest" should be "2.0.1"
 
+
   Scenario: Update of patch version of an app but update is put in alternative folder
     Given these apps' path has been configured additionally with following attributes:
       | dir         | is_writable |
@@ -44,6 +47,7 @@ Feature: AppManagement
     When the administrator puts app "updatetest" with version "2.0.1" in dir "apps-custom"
     And the administrator enables app "updatetest"
     Then the installed version of "updatetest" should be "2.0.1"
+
 
   Scenario: Update of patch version of an app previously in apps-external but update is put in alternative folder
     Given these apps' path has been configured additionally with following attributes:

--- a/tests/acceptance/features/apiMain/caldav.feature
+++ b/tests/acceptance/features/apiMain/caldav.feature
@@ -26,8 +26,7 @@ Feature: caldav
     And the CalDAV exception should be "Sabre\DAV\Exception\NotFound"
     And the CalDAV message should be "Node with name 'MyCalendar' could not be found"
 
-  @caldav
-  @smokeTest
+  @caldav @smokeTest
   Scenario: Creating a new calendar
     Given user "Alice" has successfully created a calendar named "MyCalendar"
     When user "Alice" requests calendar "%username%/MyCalendar" of user "Alice" using the new WebDAV API

--- a/tests/acceptance/features/apiMain/carddav.feature
+++ b/tests/acceptance/features/apiMain/carddav.feature
@@ -26,8 +26,7 @@ Feature: carddav
     And the CardDAV exception should be "Sabre\DAV\Exception\NotFound"
     And the CardDAV message should be "Addressbook with name 'MyAddressbook' could not be found"
 
-  @carddav
-  @smokeTest
+  @carddav @smokeTest
   Scenario: Creating a new addressbook
     Given user "Alice" has successfully created an address book named "MyAddressbook"
     When user "Alice" requests address book "%username%/MyAddressbook" of user "Alice" using the new WebDAV API

--- a/tests/acceptance/features/apiMain/checksums.feature
+++ b/tests/acceptance/features/apiMain/checksums.feature
@@ -188,8 +188,7 @@ Feature: checksums
       | dav_version |
       | spaces      |
 
-  @files_sharing-app-required
-  @issue-ocis-reva-196 @skipOnOcV10.6 @skipOnOcV10.7 @skipOnOcV10.8.0
+  @files_sharing-app-required @issue-ocis-reva-196 @skipOnOcV10.6 @skipOnOcV10.7 @skipOnOcV10.8.0
   Scenario Outline: Sharing a file with checksum should return the checksum in the propfind using new DAV path
     Given the administrator has set the default folder for received shares to "Shares"
     And auto-accept shares has been disabled
@@ -205,8 +204,7 @@ Feature: checksums
       | dav_version |
       | new         |
 
-  @files_sharing-app-required
-  @issue-ocis-reva-196 @skipOnOcV10
+  @files_sharing-app-required @issue-ocis-reva-196 @skipOnOcV10
   Scenario Outline: Modifying a shared file should return correct checksum in the propfind using new DAV path
     Given the administrator has set the default folder for received shares to "Shares"
     And auto-accept shares has been disabled
@@ -230,7 +228,6 @@ Feature: checksums
     And user "Alice" uploads new chunk file "3" with "CCCCC" to id "chunking-42" using the WebDAV API
     And user "Alice" moves new chunk file with id "chunking-42" to "/myChunkedFile.txt" with checksum "SHA1:5d84d61b03fdacf813640f5242d309721e0629b1" using the WebDAV API
     Then the HTTP status code of responses on all endpoints should be "201"
-
 
   @issue-ocis-reva-56 @notToImplementOnOCIS @newChunking @issue-ocis-1321
   Scenario: Upload new DAV chunked file where checksum does not match
@@ -310,6 +307,7 @@ Feature: checksums
     Examples:
       | dav_version |
       | spaces      |
+
 
   Scenario Outline: Upload a file where checksum does match
     Given using <dav_version> DAV path
@@ -422,8 +420,7 @@ Feature: checksums
       | dav_version |
       | spaces      |
 
-  @skipOnStorage:ceph @skipOnStorage:scality @files_primary_s3-issue-224
-  @issue-ocis-reva-196
+  @skipOnStorage:ceph @skipOnStorage:scality @files_primary_s3-issue-224 @issue-ocis-reva-196
   Scenario Outline: Uploading a file with invalid SHA1 checksum overwriting an existing file
     Given using <dav_version> DAV path
     And user "Alice" has uploaded file with content "ownCloud test text file 0" to "/textfile0.txt"
@@ -452,8 +449,7 @@ Feature: checksums
     Then the HTTP status code of responses on each endpoint should be "201, 201, 204" respectively
     And the content of file "/textfile0.txt" for user "Alice" should be "BBBBBCCCCC"
 
-  @skipOnStorage:ceph @skipOnStorage:scality @files_primary_s3-issue-224
-  @issue-ocis-reva-56 @notToImplementOnOCIS @newChunking @issue-ocis-1321
+  @skipOnStorage:ceph @skipOnStorage:scality @files_primary_s3-issue-224 @issue-ocis-reva-56 @notToImplementOnOCIS @newChunking @issue-ocis-1321
   Scenario: Upload overwriting a file with new chunking and invalid checksum
     Given using new DAV path
     And user "Alice" has uploaded file with content "ownCloud test text file 0" to "/textfile0.txt"

--- a/tests/acceptance/features/apiMain/external-storage.feature
+++ b/tests/acceptance/features/apiMain/external-storage.feature
@@ -24,6 +24,7 @@ Feature: external-storage
       | token    | A_TOKEN              |
       | mimetype | httpd/unix-directory |
 
+
   Scenario: Move a file into storage
     Given these users have been created with default attributes and small skeleton files:
       | username |
@@ -34,6 +35,7 @@ Feature: external-storage
     Then the HTTP status code should be "201"
     And as "Brian" file "/local_storage/foo1/textfile0.txt" should exist
     And as "Alice" file "/local_storage/foo1/textfile0.txt" should exist
+
 
   Scenario: Move a file out of storage
     Given these users have been created with default attributes and small skeleton files:
@@ -71,6 +73,7 @@ Feature: external-storage
     And as "Alice" file "/fileInsideLocalStorage.txt" should exist
     And as "Alice" file "/local_storage/foo1/fileInsideLocalStorage.txt" should exist
 
+
   Scenario: Download a file that exists in filecache but not storage fails with 404
     Given user "Alice" has been created with default attributes and small skeleton files
     And user "Alice" has created folder "/local_storage/foo3"
@@ -82,12 +85,14 @@ Feature: external-storage
     # in the folder. The file cache will be cleared after the local storage is scanned.
     And as "Alice" file "local_storage/foo3/textfile0.txt" should exist
 
+
   Scenario: Upload a file to external storage while quota is set on home storage
     Given user "Alice" has been created with default attributes and small skeleton files
     And the quota of user "Alice" has been set to "1 B"
     When user "Alice" uploads file "filesForUpload/textfile.txt" to filenames based on "/local_storage/testquota.txt" with all mechanisms using the WebDAV API
     Then the HTTP status code of all upload responses should be "201"
     And as "Alice" the files uploaded to "/local_storage/testquota.txt" with all mechanisms should exist
+
 
   Scenario Outline: query OCS endpoint for information about the mount
     Given using OCS API version "<ocs_api_version>"

--- a/tests/acceptance/features/apiMain/quota.feature
+++ b/tests/acceptance/features/apiMain/quota.feature
@@ -309,6 +309,7 @@ Feature: quota
     Then the HTTP status code should be "201"
     And as "Brian" file "testquota.txt" should exist
 
+
   Scenario: User with zero quota can upload an empty file
     Given the quota of user "Alice" has been set to "0 B"
     When user "Alice" uploads file with content "" to "testquota.txt" using the WebDAV API


### PR DESCRIPTION
<!--
Thanks for submitting a change to ownCloud!

This is the bug tracker for the Server component. Find other components at https://github.com/owncloud/core/blob/master/.github/CONTRIBUTING.md#guidelines

For fixing potential security issues please see https://owncloud.com/security/

To make it possible for us to get your change reviewed and merged please carefully fill out the requested information below.

Please note that any kind of change needs first be submitted to the master branch which holds the next version of ownCloud.

Please set the following labels:

- Set label "3 - To review" for review or "2 - Development" if the PR still has open tasks
- Assignment: assign to self
- Milestone: set the same as the ticket this PR fixes, or "development" by default
- Reviewers: pick at least one
-->

## Description
Interspacing between two scenarios is made consistent as documented https://github.com/owncloud/docs-server/pull/697/files#diff-12a0f404a5bbbda65e50018a487cd725797106d670f4308b921d2081dc4b3516R1129-R1154:~:text=more%20relevant%20discussion.-,%3D%3D%3D%3D%20Inter%2Dscenario%20spacings,%2D%2D%2D%2D,-Commenting%20on%20lines

Suites covered:
- apiAuth
- apiAuthOcs
- apiAuthWebDav
- apiCapabilities
- apiComments
- apiFavorites
- apiFederationToRoot1
- apiFederationToRoot2
- apiFederationToShares1
- apiFederationToShares2
- apiMain

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
- Part of https://github.com/owncloud/QA/issues/769

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
- :robot: 

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Database schema changes (next release will require increase of minor version instead of patch)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [x] Tests only (no source changes)

## Checklist:
<!-- Tick the checkboxes when done. -->
<!-- Raise documentation ticket in https://github.com/owncloud/documentation -->
- [ ] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 
- [ ] Changelog item, see [TEMPLATE](https://github.com/owncloud/core/blob/master/changelog/TEMPLATE)
