### PR TITLE
add shib auth support for redirect url

### DIFF
--- a/changelog/unreleased/40470
+++ b/changelog/unreleased/40470
@@ -1,0 +1,7 @@
+Bugfix: Add shib auth support for redirect url
+
+Without this change, server-side Apache Auth (e.g. Shibboleth) resulted in redirect to default owncloud page, instead of last visited page. We now correctly handle redirect_url.
+
+https://github.com/owncloud/core/pull/40470
+https://github.com/owncloud/core/pull/40161
+https://github.com/owncloud/enterprise/issues/5450

--- a/core/Controller/LoginController.php
+++ b/core/Controller/LoginController.php
@@ -135,7 +135,9 @@ class LoginController extends Controller {
 			return new TemplateResponse(
 				'core',
 				'apacheauthredirect',
-				[],
+				[
+					'redirect_url' => $this->getDefaultUrl()
+				],
 				'guest'
 			);
 		}

--- a/core/js/apacheauthredirect.js
+++ b/core/js/apacheauthredirect.js
@@ -16,8 +16,9 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>
  */
 
- (function() {
+ $(document).ready(function() {
 
-	window.location = OC.generateUrl('/');
+	var redirect_url = document.getElementById('redirect_url').value;
+	window.location = redirect_url;
 
-})();
+});

--- a/core/templates/apacheauthredirect.php
+++ b/core/templates/apacheauthredirect.php
@@ -4,7 +4,7 @@ script('core', [
 	'apacheauthredirect'
 ]);
 ?>
-
+<?php print_unescaped('<input type="hidden" id="redirect_url" name="redirect_url" value="' . \OCP\Util::sanitizeHTML($_['redirect_url']) . '">'); ?>
 <span class="msg">
 	<?php p($l->t('The application was authorized successfully. You can now close this window.'));?>
 </span>

--- a/core/templates/apacheauthredirect.php
+++ b/core/templates/apacheauthredirect.php
@@ -8,5 +8,5 @@ script('core', [
 <?php print_unescaped('<input type="hidden" id="redirect_url" name="redirect_url" value="' . \OCP\Util::sanitizeHTML($_['redirect_url']) . '">'); ?>
 
 <p class="info">
-	<?php p($l->t('The application was authorized successfully. You should now get redirected to the requested page, otherwise you can close this window.'));?>
+	<?php p($l->t('The application was authorized successfully. You will now get redirected to the requested page, otherwise you can close this window.'));?>
 </p>

--- a/core/templates/apacheauthredirect.php
+++ b/core/templates/apacheauthredirect.php
@@ -4,7 +4,9 @@ script('core', [
 	'apacheauthredirect'
 ]);
 ?>
+
 <?php print_unescaped('<input type="hidden" id="redirect_url" name="redirect_url" value="' . \OCP\Util::sanitizeHTML($_['redirect_url']) . '">'); ?>
-<span class="msg">
-	<?php p($l->t('The application was authorized successfully. You can now close this window.'));?>
-</span>
+
+<p class="info">
+	<?php p($l->t('The application was authorized successfully. You should now get redirected to the requested page, otherwise you can close this window.'));?>
+</p>

--- a/tests/Core/Controller/LoginControllerTest.php
+++ b/tests/Core/Controller/LoginControllerTest.php
@@ -478,7 +478,7 @@ class LoginControllerTest extends TestCase {
 		$expectedResponse = new TemplateResponse(
 			'core',
 			'apacheauthredirect',
-			[],
+			['redirect_url' => 'http://localhost/index.php/apps/files/'],
 			'guest'
 		);
 		$this->assertEquals($expectedResponse, $this->loginController->showLoginForm('0', '', ''));

--- a/tests/Core/Controller/LoginControllerTest.php
+++ b/tests/Core/Controller/LoginControllerTest.php
@@ -458,7 +458,7 @@ class LoginControllerTest extends TestCase {
 			->expects($this->never())
 			->method('isLoggedIn');
 		$this->loginController = $this->getMockBuilder(LoginController::class)
-			->setMethods(['handleApacheAuth'])
+			->setMethods(['handleApacheAuth', 'getDefaultUrl'])
 			->setConstructorArgs([
 				'core',
 				$this->request,
@@ -474,11 +474,14 @@ class LoginControllerTest extends TestCase {
 		$this->loginController->expects($this->once())
 			->method('handleApacheAuth')
 			->willReturn(true);
+		$this->loginController->expects($this->once())
+			->method('getDefaultUrl')
+			->willReturn('redirect_url/test');
 
 		$expectedResponse = new TemplateResponse(
 			'core',
 			'apacheauthredirect',
-			['redirect_url' => 'http://localhost/index.php/apps/files/'],
+			['redirect_url' => 'redirect_url/test'],
 			'guest'
 		);
 		$this->assertEquals($expectedResponse, $this->loginController->showLoginForm('0', '', ''));


### PR DESCRIPTION
## Description
Without this change, server-side Apache Auth (e.g. Shibboleth) resulted in redirect to default owncloud page, instead of last visited page. We now correctly handle redirect_url. 

## Related Issue
- Fixes https://github.com/owncloud/enterprise/issues/5450
- Related https://github.com/owncloud/core/pull/40161

## How Has This Been Tested?
- manually in internal oc2.lab test instance

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist:
- [x] Base code changes
- [x] Make sure to handle corner cases in login
- [x] Unit tests added
- [x] Acceptance tests added
- [x] Changelog item, see [TEMPLATE](https://github.com/owncloud/core/blob/master/changelog/TEMPLATE)
