### PR TITLE
Add a genrenic config sample description for S3 Primary

### DIFF
--- a/config/config.apps.sample.php
+++ b/config/config.apps.sample.php
@@ -449,6 +449,25 @@ $CONFIG = [
 'collabora_group' => '',
 
 /**
+ * App: S3 Primary Object Storage
+ *
+ * Possible keys: `objectstore` ARRAY
+ */
+
+/**
+ * Configure the access parameters for a particular S3 provider.
+ * The detailed configuration of that array depends on the S3 provider.
+ * This example can therefore only show the general construct.
+ * See the "S3 Compatible Object Storage as Primary Storage Location" documentation for more details.
+ */
+'objectstore' => [
+	'class' => 'Implementation\Of\OCP\Files\ObjectStore\IObjectStore',
+	'arguments' => [
+		// ...
+	],
+],
+
+/**
  * App: Windows Network Drive (WND)
  *
  * Note: This app is for Enterprise customers only.

--- a/config/config.apps.sample.php
+++ b/config/config.apps.sample.php
@@ -461,7 +461,8 @@ $CONFIG = [
  * See the "S3 Compatible Object Storage as Primary Storage Location" documentation for more details.
  */
 'objectstore' => [
-	'class' => 'Implementation\Of\OCP\Files\ObjectStore\IObjectStore',
+	'class' => 'OCA\Files_Primary_S3\S3Storage',
+
 	'arguments' => [
 		// ...
 	],


### PR DESCRIPTION
## Description
Referencing https://github.com/owncloud/docs-server/pull/704, I have seen that we do not have a minimalistic S3 config description in our config sample. This is fixed now. Note that there is no link to the documentation by purpose but a text finding the referenced document.

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
- Fixes <issue_link>

## Motivation and Context
Completeness of docs

## How Has This Been Tested?
- text only

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Database schema changes (next release will require increase of minor version instead of patch)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [ ] Tests only (no source changes)

## Checklist:
<!-- Tick the checkboxes when done. -->
<!-- Raise documentation ticket in https://github.com/owncloud/documentation -->
- [ ] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [x] Documentation ticket raised: https://github.com/owncloud/docs-server/pull/705
- [ ] Changelog item, see [TEMPLATE](https://github.com/owncloud/core/blob/master/changelog/TEMPLATE)
