### PR TITLE
[tests-only] Determine group existence using group name

### DIFF
--- a/tests/acceptance/features/bootstrap/Provisioning.php
+++ b/tests/acceptance/features/bootstrap/Provisioning.php
@@ -4570,7 +4570,6 @@ trait Provisioning {
 		}
 		if (OcisHelper::isTestingWithGraphApi()) {
 			$base = '/graph/v1.0';
-			$group = $this->getAttributeOfCreatedGroup($group, "id");
 		} else {
 			$base = '/ocs/v2.php/cloud';
 		}


### PR DESCRIPTION
## Description
Check the group existence using the group name, not the group id. This is required for the test cases where we want to check the existence of a non-existing group, which we cannot do using the id.

Similar is done for the user: https://github.com/owncloud/core/blob/e89077717de7e7ce98dd1163af902ef2a4f664a7/tests/acceptance/features/bootstrap/Provisioning.php#L3466-L3477

## Related Issue


## Motivation and Context

## How Has This Been Tested?
- test environment:

## Screenshots (if appropriate):

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Database schema changes (next release will require increase of minor version instead of patch)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [x] Tests only (no source changes)

## Checklist:
- [ ] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 
- [ ] Changelog item, see [TEMPLATE](https://github.com/owncloud/core/blob/master/changelog/TEMPLATE)
