### PR TITLE
[tests-only] Add conditional checking for users and groups between graph and provisioning APIs

### DIFF
--- a/tests/acceptance/features/bootstrap/Provisioning.php
+++ b/tests/acceptance/features/bootstrap/Provisioning.php
@@ -4941,11 +4941,15 @@ trait Provisioning {
 			},
 			$this->simplifyArray($users)
 		);
-		$respondedArray = $this->getArrayOfUsersResponded($this->response);
-		Assert::assertEqualsCanonicalizing(
-			$usersSimplified,
-			$respondedArray
-		);
+		if (OcisHelper::isTestingWithGraphApi()) {
+			$this->graphContext->theseUsersShouldBeInTheResponse($usersSimplified);
+		} else {
+			$respondedArray = $this->getArrayOfUsersResponded($this->response);
+			Assert::assertEqualsCanonicalizing(
+				$usersSimplified,
+				$respondedArray
+			);
+		}
 	}
 
 	/**
@@ -5008,14 +5012,18 @@ trait Provisioning {
 		$this->verifyTableNodeColumnsCount($groupsList, 1);
 		$groups = $groupsList->getRows();
 		$groupsSimplified = $this->simplifyArray($groups);
-		$expectedGroups = \array_merge($this->startingGroups, $groupsSimplified);
-		$respondedArray = $this->getArrayOfGroupsResponded($this->response);
-		\asort($expectedGroups);
-		\asort($respondedArray);
-		Assert::assertEqualsCanonicalizing(
-			$expectedGroups,
-			$respondedArray
-		);
+		if (OcisHelper::isTestingWithGraphApi()) {
+			$this->graphContext->theseExtraGroupsShouldBeInTheResponse($groupsSimplified);
+		} else {
+			$expectedGroups = \array_merge($this->startingGroups, $groupsSimplified);
+			$respondedArray = $this->getArrayOfGroupsResponded($this->response);
+			\asort($expectedGroups);
+			\asort($respondedArray);
+			Assert::assertEqualsCanonicalizing(
+				$expectedGroups,
+				$respondedArray
+			);
+		}
 	}
 
 	/**

--- a/tests/acceptance/features/bootstrap/Provisioning.php
+++ b/tests/acceptance/features/bootstrap/Provisioning.php
@@ -4947,7 +4947,9 @@ trait Provisioning {
 			$respondedArray = $this->getArrayOfUsersResponded($this->response);
 			Assert::assertEqualsCanonicalizing(
 				$usersSimplified,
-				$respondedArray
+				$respondedArray,
+				__METHOD__
+				. " Provided users do not match the users returned in the response."
 			);
 		}
 	}
@@ -4994,10 +4996,16 @@ trait Provisioning {
 		$groups = $groupsList->getRows();
 		$groupsSimplified = $this->simplifyArray($groups);
 		$respondedArray = $this->getArrayOfGroupsResponded($this->response);
-		Assert::assertEqualsCanonicalizing(
-			$groupsSimplified,
-			$respondedArray
-		);
+		if (OcisHelper::isTestingWithGraphApi()) {
+			$this->graphContext->theseGroupsShouldBeInTheResponse($groupsSimplified);
+		} else {
+			Assert::assertEqualsCanonicalizing(
+				$groupsSimplified,
+				$respondedArray,
+				__METHOD__
+				. " Provided groups do not match the groups returned in the response."
+			);
+		}
 	}
 
 	/**
@@ -5013,15 +5021,15 @@ trait Provisioning {
 		$groups = $groupsList->getRows();
 		$groupsSimplified = $this->simplifyArray($groups);
 		if (OcisHelper::isTestingWithGraphApi()) {
-			$this->graphContext->theseExtraGroupsShouldBeInTheResponse($groupsSimplified);
+			$this->graphContext->theseGroupsShouldBeInTheResponse($groupsSimplified);
 		} else {
 			$expectedGroups = \array_merge($this->startingGroups, $groupsSimplified);
 			$respondedArray = $this->getArrayOfGroupsResponded($this->response);
-			\asort($expectedGroups);
-			\asort($respondedArray);
 			Assert::assertEqualsCanonicalizing(
 				$expectedGroups,
-				$respondedArray
+				$respondedArray,
+				__METHOD__
+				. " Provided groups do not match the groups returned in the response."
 			);
 		}
 	}


### PR DESCRIPTION
## Description
Use helper functions from GraphContext while checking user and group existence in the response.

## Related Issue

## Motivation and Context

## How Has This Been Tested?
- test environment:

## Screenshots (if appropriate):

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Database schema changes (next release will require increase of minor version instead of patch)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [x] Tests only (no source changes)

## Checklist:
- [ ] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 
- [ ] Changelog item, see [TEMPLATE](https://github.com/owncloud/core/blob/master/changelog/TEMPLATE)
