### PR TITLE
fix: Better output in case dataDirectory is invalid

### DIFF
--- a/changelog/unreleased/40482
+++ b/changelog/unreleased/40482
@@ -1,0 +1,9 @@
+Bugfix: Better output if dataDirectory is invalid
+
+If the server data directory is invalid, and the problem is being reported by
+an occ CLI command, then the value of the data directory setting is reported
+in the command output.
+
+This will assist the user of the command to analyse the problem.
+
+https://github.com/owncloud/core/pull/40482

--- a/lib/private/legacy/util.php
+++ b/lib/private/legacy/util.php
@@ -1035,7 +1035,7 @@ class OC_Util {
 					' ".ocdata" in its root.')
 			];
 		}
-		if (\OC::$CLI) {
+		if (\OC::$CLI && !empty($errors)) {
 			print "Value of Data directory was: '$dataDirectory'" . PHP_EOL;
 		}
 		return $errors;

--- a/lib/private/legacy/util.php
+++ b/lib/private/legacy/util.php
@@ -1030,10 +1030,13 @@ class OC_Util {
 		}
 		if (!\file_exists($dataDirectory . '/.ocdata')) {
 			$errors[] = [
-				'error' => $l->t('Your Data directory  is invalid'),
+				'error' => $l->t('Your Data directory is invalid'),
 				'hint' => $l->t('Please check that the data directory contains a file' .
 					' ".ocdata" in its root.')
 			];
+		}
+		if (\OC::$CLI) {
+			print "Value of Data directory was: '$dataDirectory'" . PHP_EOL;
 		}
 		return $errors;
 	}

--- a/tests/lib/UtilTest.php
+++ b/tests/lib/UtilTest.php
@@ -421,13 +421,27 @@ class UtilTest extends \Test\TestCase {
 		\OCP\Files::rmdirr($dataDir);
 
 		$dataDir = \OCP\Files::tmpFolder();
+		$expectedDataDirMessage = "Value of Data directory was: '$dataDir'\n";
 		// no touch
 		$errors = \OC_Util::checkDataDirectoryValidity($dataDir);
 		$this->assertNotEmpty($errors);
+		$this->assertArrayHasKey(0, $errors);
+		$this->assertArrayHasKey("error", $errors[0]);
+		$this->assertArrayHasKey("hint", $errors[0]);
+		$this->assertSame('Your Data directory is invalid', $errors[0]["error"]);
+		$this->assertSame('Please check that the data directory contains a file ".ocdata" in its root.', $errors[0]["hint"]);
 		\OCP\Files::rmdirr($dataDir);
 
-		$errors = \OC_Util::checkDataDirectoryValidity('relative/path');
+		$relativeDataDir = 'relative/path';
+		$expectedDataDirMessage .= "Value of Data directory was: '$relativeDataDir'\n";
+		$this->expectOutputString($expectedDataDirMessage);
+		$errors = \OC_Util::checkDataDirectoryValidity($relativeDataDir);
 		$this->assertNotEmpty($errors);
+		$this->assertArrayHasKey(0, $errors);
+		$this->assertArrayHasKey("error", $errors[0]);
+		$this->assertArrayHasKey("hint", $errors[0]);
+		$this->assertSame('Your Data directory must be an absolute path', $errors[0]["error"]);
+		$this->assertSame('Check the value of "datadirectory" in your configuration', $errors[0]["hint"]);
 	}
 
 	/**


### PR DESCRIPTION
## Description
If the dataDirectory is not correct there is currently only the message `Your Data directory  is invalid` without specifying which directory is currently set. This small PR aims to add more output in this case.

## Motivation and Context
It solved the missing output in case something is wrong with the data directory.

## How Has This Been Tested?
- Local test

## Screenshots (if appropriate):

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Database schema changes (next release will require increase of minor version instead of patch)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [ ] Tests only (no source changes)

## Checklist:
- [x] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 
- [ ] Changelog item, see [TEMPLATE](https://github.com/owncloud/core/blob/master/changelog/TEMPLATE)
