### PR TITLE
Encryption copy keys first3

### DIFF
--- a/changelog/unreleased/40433
+++ b/changelog/unreleased/40433
@@ -1,0 +1,17 @@
+Change: Copy the encryption keys first and then rename the files
+
+Having encryption enabled, when a file was renamed, first the actual
+file was renamed, and then the encryption keys were moved to the new
+location. If something went wrong, it was possible that the keys weren't
+moved. This caused the file to become inaccessible because we couldn't
+decrypt the file due to the missing keys (which weren't in the right place)
+
+Now, when a file is renamed, the encryption keys will be copied first, and
+then the file will be renamed. If the encryption keys fail to be copied, the
+rename will fail. After the encryption keys are copied, the file could
+failed to be renamed. In this case, the copied keys will be removed, but
+the file will still be accessible because we still keep the old keys.
+The original keys (not the copy) will be removed if the file is renamed
+successfully.
+
+https://github.com/owncloud/core/pull/40433

--- a/lib/private/Encryption/Keys/Storage.php
+++ b/lib/private/Encryption/Keys/Storage.php
@@ -300,12 +300,10 @@ class Storage implements IStorage {
 
 		if ($this->view->file_exists($sourcePath)) {
 			$this->keySetPreparation(\dirname($targetPath));
-			$this->view->rename($sourcePath, $targetPath);
-
-			return true;
+			return $this->view->rename($sourcePath, $targetPath);
 		}
 
-		return false;
+		return true;
 	}
 
 	/**
@@ -321,11 +319,10 @@ class Storage implements IStorage {
 
 		if ($this->view->file_exists($sourcePath)) {
 			$this->keySetPreparation(\dirname($targetPath));
-			$this->view->copy($sourcePath, $targetPath);
-			return true;
+			return $this->view->copy($sourcePath, $targetPath);
 		}
 
-		return false;
+		return true;
 	}
 
 	/**

--- a/lib/private/Files/Storage/Wrapper/Encryption.php
+++ b/lib/private/Files/Storage/Wrapper/Encryption.php
@@ -270,7 +270,8 @@ class Encryption extends Wrapper {
 	public function rename($path1, $path2) {
 		$renameOk = false;
 		$copyKeysOk = true;  // assume keys are copied, in case we deal with versions
-		if ($this->isVersion($path2) === false && $this->encryptionManager->isEnabled()) {
+		$isVersion = !($this->isVersion($path2) === false && $this->encryptionManager->isEnabled());
+		if (!$isVersion) {
 			// versions always use the keys from the original file, so we can skip
 			// this step for versions
 			$source = $this->getFullPath($path1);
@@ -292,6 +293,10 @@ class Encryption extends Wrapper {
 
 		if ($copyKeysOk) {
 			$renameOk = $this->storage->rename($path1, $path2);
+			if ($isVersion) {
+				return $renameOk;
+			}
+
 			if ($renameOk) {
 				$sourceKeyDeleteOk = $this->keyStorage->deleteAllFileKeys($source);
 				if (!$sourceKeyDeleteOk) {

--- a/lib/private/Files/Storage/Wrapper/Encryption.php
+++ b/lib/private/Files/Storage/Wrapper/Encryption.php
@@ -271,7 +271,11 @@ class Encryption extends Wrapper {
 		$renameOk = false;
 		$copyKeysOk = true;  // assume keys are copied, in case we deal with versions
 
-		$isVersion = !($this->isVersion($path2) === false && $this->encryptionManager->isEnabled());
+		$isVersion = $this->isVersion($path2) || $this->isVersion($path1);
+		// if encryption is disabled, consider it's a version in order to skip
+		// moving the keys
+		$isVersion = $isVersion || !$this->encryptionManager->isEnabled();
+
 		$source = $this->getFullPath($path1);
 		$target = $this->getFullPath($path2);
 		$keysExcluded = $this->util->isExcluded($source);

--- a/tests/lib/Files/Storage/Wrapper/EncryptionTest.php
+++ b/tests/lib/Files/Storage/Wrapper/EncryptionTest.php
@@ -413,11 +413,11 @@ class EncryptionTest extends Storage {
 		if ($encryptionEnabled) {
 			$this->keyStore
 				->expects($this->once())
-				->method('renameKeys')
+				->method('copyKeys')
 				->willReturn($renameKeysReturn);
 		} else {
 			$this->keyStore
-				->expects($this->never())->method('renameKeys');
+				->expects($this->never())->method('copyKeys');
 		}
 		$this->util->expects($this->any())
 			->method('isFile')->willReturn(true);


### PR DESCRIPTION
<!--
Thanks for submitting a change to ownCloud!

This is the bug tracker for the Server component. Find other components at https://github.com/owncloud/core/blob/master/.github/CONTRIBUTING.md#guidelines

For fixing potential security issues please see https://owncloud.com/security/

To make it possible for us to get your change reviewed and merged please carefully fill out the requested information below.

Please note that any kind of change needs first be submitted to the master branch which holds the next version of ownCloud.

Please set the following labels:

- Set label "3 - To review" for review or "2 - Development" if the PR still has open tasks
- Assignment: assign to self
- Milestone: set the same as the ticket this PR fixes, or "development" by default
- Reviewers: pick at least one
-->

## Description
Follow up on https://github.com/owncloud/core/pull/40433 to solve https://github.com/owncloud/enterprise/issues/5344

The PR will copy the encryption keys instead of renaming them, so in case of error we can revert the action and we keep the encryption keys in the right location so the target file can be decrypted.

It seems the old PR was causing problems due to the failures caused by empty directories, which don't have encryption keys associated. The copyKeys method was reporting a failure because the expected directory with the keys doesn't exist. This has been adjusted: both copyKeys and renameKeys methods will return true if the directory doesn't exists.

## Related Issue
https://github.com/owncloud/enterprise/issues/5344

## Motivation and Context
Tests from other apps were failing due to the changes made in the old PR (which was reverted). This PR should cover the old failing scenarios.

## How Has This Been Tested?
Checked some of the previously failing scenarios.
1. With encryption active (after re-login to create the keys), create an empty directory
2. Delete the directory

With the old PR, a log about the encryption keys not being copied was showing. There was a forbidden exception happening. This is not happening with this PR.

1. With encryption active, create a directory and upload a file there
2. Run `occ encryption:recreate-master-key` command
3. From the desktop client, logout, login and upload a file

With the old PR, there were errors happening and uploading wasn't possible. This is also fixed with this PR.

1. With encryption active, create a directory
2. Share the directory with user2
3. With user2, upload a file and create a directory inside the shared directory.
4. With user2, delete the file and the folder

There were errors happening in the acceptance tests (these steps are based on the failing test). It works fine with the PR.

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Database schema changes (next release will require increase of minor version instead of patch)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [ ] Tests only (no source changes)

## Checklist:
<!-- Tick the checkboxes when done. -->
<!-- Raise documentation ticket in https://github.com/owncloud/documentation -->
- [x] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 
- [ ] Changelog item, see [TEMPLATE](https://github.com/owncloud/core/blob/master/changelog/TEMPLATE)
