### PR TITLE
Bump phpstan to 1.9

### DIFF
--- a/apps/files_external/lib/Lib/Storage/Google.php
+++ b/apps/files_external/lib/Lib/Storage/Google.php
@@ -577,6 +577,7 @@ class Google extends \OCP\Files\Storage\StorageAdapter {
 				self::$tempFiles[$tmpFile] = $path;
 				return \fopen('close://'.$tmpFile, $mode);
 		}
+		return false;
 	}
 
 	public function writeBack($tmpFile) {

--- a/phpstan.neon
+++ b/phpstan.neon
@@ -2,14 +2,13 @@ parameters:
   bootstrapFiles:
     - %currentWorkingDirectory%/lib/base.php
   excludePaths:
-    - %currentWorkingDirectory%/core/ajax/update.php
-    - %currentWorkingDirectory%/apps/*/tests*
-    - %currentWorkingDirectory%/apps/*/composer/*
-    - %currentWorkingDirectory%/apps/*/3rdparty/*
-    - %currentWorkingDirectory%/apps/files_external/ajax/oauth2.php
-    - %currentWorkingDirectory%/apps/files_external/lib/Lib/Storage/Google.php
-    - %currentWorkingDirectory%/apps/files_external/lib/Lib/Storage/SMB.php
-    - %currentWorkingDirectory%/settings/templates/*
+    analyseAndScan:
+      - %currentWorkingDirectory%/core/ajax/update.php
+      - %currentWorkingDirectory%/apps/*/tests*
+      - %currentWorkingDirectory%/settings/templates/*
+    analyse:
+      - %currentWorkingDirectory%/apps/*/composer/*
+      - %currentWorkingDirectory%/apps/*/3rdparty/*
   ignoreErrors:
     - '#Undefined variable: \$OC_[a-zA-Z0-9\\_]+#'
     - '#Undefined variable: \$vendor#'

--- a/vendor-bin/phpstan/composer.json
+++ b/vendor-bin/phpstan/composer.json
@@ -1,5 +1,5 @@
 {
     "require": {
-        "phpstan/phpstan": "1.8.2"
+        "phpstan/phpstan": "^1.9"
     }
 }


### PR DESCRIPTION
## Description
- use the latest phpstan, which is 1.9.* series

without doing anything else, it starts reporting:
```
------ ------------------------------------------------------------------------------------------------------------------------------------------- 
  Line   apps/files_external/lib/Lib/Cache/SmbCacheWrapper.php                                                                                      
 ------ ------------------------------------------------------------------------------------------------------------------------------------------- 
  46     Parameter $smb of method OCA\Files_External\Lib\Cache\SmbCacheWrapper::__construct() has invalid type OCA\Files_External\Lib\Storage\SMB.  
 ------ ------------------------------------------------------------------------------------------------------------------------------------------- 

 ------ --------------------------------------------------------------------------------------------------------------------------------------------------- 
  Line   apps/files_external/lib/Lib/Storage/SMB2.php                                                                                                       
 ------ --------------------------------------------------------------------------------------------------------------------------------------------------- 
  46     Class OCA\Files_External\Lib\Storage\SMB2 extends unknown class OCA\Files_External\Lib\Storage\SMB.                                                
         💡 Learn more at https://phpstan.org/user-guide/discovering-symbols                                                                                 
  53     Instantiated class OCA\Files_External\Lib\Storage\SMB not found.                                                                                   
         💡 Learn more at https://phpstan.org/user-guide/discovering-symbols                                                                                 
  59     OCA\Files_External\Lib\Storage\SMB2::__construct() calls parent::__construct() but OCA\Files_External\Lib\Storage\SMB2 does not extend any class.  
  63     Access to an undefined property OCA\Files_External\Lib\Storage\SMB2::$root.                                                                        
  63     Access to an undefined property OCA\Files_External\Lib\Storage\SMB2::$server.                                                                      
  63     Access to an undefined property OCA\Files_External\Lib\Storage\SMB2::$share.                                                                       
  67     OCA\Files_External\Lib\Storage\SMB2::getCache() calls parent::getCache() but OCA\Files_External\Lib\Storage\SMB2 does not extend any class.        
 ------ --------------------------------------------------------------------------------------------------------------------------------------------------- 
                                                                                                                        
 [ERROR] Found 8 errors                                                                                                 
```

It cannot find the SMB class, because that is in excludePaths in `phpstan.neon` from somewhere in the past.

- remove individually excluded files from `phpstan.neon`
- separate the remaining ecludedPaths items into `analyseAndScan` (things to not analyze and not scan for problems) and `analyse` (things to scan in order to find classes, but do not scan them for problems)
- fix a missing `return false` in `apps/files_external/lib/Lib/Storage/Google.php`

This is a code-analysis update. I don't think that a changelog entry is needed. The only code change is adding a `return false` in a place at the end of a function, which should never happen.

## How Has This Been Tested?
CI

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Database schema changes (next release will require increase of minor version instead of patch)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [ ] Tests only (no source changes)

## Checklist:
- [x] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 
- [ ] Changelog item, see [TEMPLATE](https://github.com/owncloud/core/blob/master/changelog/TEMPLATE)
