### PR TITLE
Upgrading guzzlehttp/psr7 (2.4.1 => 2.4.3)

### DIFF
--- a/changelog/unreleased/PHPdependencies20220920onward
+++ b/changelog/unreleased/PHPdependencies20220920onward
@@ -4,7 +4,7 @@ The following have been updated:
 - doctrine/event-manager (1.1.2 to 1.2.0)
 - guzzlehttp/guzzle (7.4.5 to 7.5.0)
 - guzzlehttp/promises (1.5.1 to 1.5.2)
-- guzzlehttp/psr7 (2.4.0 to 2.4.1)
+- guzzlehttp/psr7 (2.4.0 to 2.4.3)
 - phpseclib/phpseclib (3.0.14 to 3.0.17)
 - laminas/laminas-filter (2.12.0 to 2.22.0)
 - laminas/laminas-inputfilter (2.12.1 to 2.21.0)
@@ -19,10 +19,11 @@ The following have been updated:
 The following have been updated in apps/files_external/3rdparty:
 - google/auth (v1.21.1 to v1.23.0)
 - google/apiclient-services (v0.259.0 to v0.272.0)
-- guzzlehttp/psr7 (2.4.0 to 2.4.1)
+- guzzlehttp/psr7 (2.4.0 to 2.4.3)
 
 https://github.com/owncloud/core/pull/40337
 https://github.com/owncloud/core/pull/40394
 https://github.com/owncloud/core/pull/40410
 https://github.com/owncloud/core/pull/40424
 https://github.com/owncloud/core/pull/40449
+https://github.com/owncloud/core/pull/40494

--- a/composer.lock
+++ b/composer.lock
@@ -977,16 +977,16 @@
         },
         {
             "name": "guzzlehttp/psr7",
-            "version": "2.4.1",
+            "version": "2.4.3",
             "source": {
                 "type": "git",
                 "url": "https://github.com/guzzle/psr7.git",
-                "reference": "69568e4293f4fa993f3b0e51c9723e1e17c41379"
+                "reference": "67c26b443f348a51926030c83481b85718457d3d"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/guzzle/psr7/zipball/69568e4293f4fa993f3b0e51c9723e1e17c41379",
-                "reference": "69568e4293f4fa993f3b0e51c9723e1e17c41379",
+                "url": "https://api.github.com/repos/guzzle/psr7/zipball/67c26b443f348a51926030c83481b85718457d3d",
+                "reference": "67c26b443f348a51926030c83481b85718457d3d",
                 "shasum": ""
             },
             "require": {
@@ -1076,7 +1076,7 @@
             ],
             "support": {
                 "issues": "https://github.com/guzzle/psr7/issues",
-                "source": "https://github.com/guzzle/psr7/tree/2.4.1"
+                "source": "https://github.com/guzzle/psr7/tree/2.4.3"
             },
             "funding": [
                 {
@@ -1092,7 +1092,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2022-08-28T14:45:39+00:00"
+            "time": "2022-10-26T14:07:24+00:00"
         },
         {
             "name": "icewind/streams",


### PR DESCRIPTION
## Description
```
Loading composer repositories with package information
Updating dependencies
Lock file operations: 0 installs, 1 update, 0 removals
  - Upgrading guzzlehttp/psr7 (2.4.1 => 2.4.3)
Writing lock file
```

## How Has This Been Tested?
CI

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Database schema changes (next release will require increase of minor version instead of patch)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [ ] Tests only (no source changes)

## Checklist:
- [ ] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 
- [x] Changelog item, see [TEMPLATE](https://github.com/owncloud/core/blob/master/changelog/TEMPLATE)
