### PR TITLE
[tests-only][full-ci]Refactor `MCKOL` request to non-existence user and to another users endpoint

### DIFF
--- a/tests/TestHelpers/SpaceNotFoundException.php
+++ b/tests/TestHelpers/SpaceNotFoundException.php
@@ -1,0 +1,14 @@
+<?php
+/**
+ * @author Sagar Gurung <sagar@jankatitech.com>
+ *
+ */
+namespace TestHelpers;
+use Exception;
+
+/**
+ * Class SpaceNotFoundException
+ * Exception when space id for a user is not found
+ */
+class SpaceNotFoundException extends Exception {
+}

--- a/tests/TestHelpers/WebDavHelper.php
+++ b/tests/TestHelpers/WebDavHelper.php
@@ -29,6 +29,7 @@ use PHPUnit\Framework\Assert;
 use Psr\Http\Message\ResponseInterface;
 use Psr\Http\Message\StreamInterface;
 use DateTime;
+use TestHelpers\SpaceNotFoundException;
 
 /**
  * Helper to make WebDav Requests
@@ -475,7 +476,9 @@ class WebDavHelper {
 			);
 			// we expect to get a multipart XML response with status 207
 			$status = $response->getStatusCode();
-			if ($status !== 207) {
+			if ($status === 401) {
+				throw new SpaceNotFoundException(__METHOD__ . " Personal space not found for user " . $user);
+			} elseif ($status !== 207) {
 				throw new Exception(
 					__METHOD__ . " webdav propfind for user $user failed with status $status - so the personal space id cannot be discovered"
 				);
@@ -535,8 +538,39 @@ class WebDavHelper {
 			self::$spacesIdRef[$user] = [];
 			self::$spacesIdRef[$user]["personal"] = $personalSpaceId;
 			return $personalSpaceId;
+		} else {
+			throw new SpaceNotFoundException(__METHOD__ . " Personal space not found for user " . $user);
 		}
-		throw new Exception(__METHOD__ . " Personal space not found for user " . $user);
+	}
+
+	/**
+	 * First checks if a user exist to return its space ID
+	 * In case of any exception, it returns a fake space ID
+	 *
+	 * @param string $baseUrl
+	 * @param string $user
+	 * @param string $password
+	 * @param string $xRequestId
+	 *
+	 * @return string
+	 * @throws Exception
+	 */
+	public static function getPersonalSpaceIdForUserOrFakeIfNotFound(string $baseUrl, string $user, string $password, string $xRequestId):string {
+		try {
+			$spaceId = self::getPersonalSpaceIdForUser(
+				$baseUrl,
+				$user,
+				$password,
+				$xRequestId,
+			);
+		} catch (SpaceNotFoundException $e) {
+			// if the fetch fails, and the user is not found, then a fake space id is prepared
+			// this is useful for testing when the personal space is of a non-existing user
+			$fakeSpaceId = self::generateUUIDv4();
+			self::$spacesIdRef[$user]["personal"] = $fakeSpaceId;
+			$spaceId = $fakeSpaceId;
+		}
+		return $spaceId;
 	}
 
 	/**
@@ -597,20 +631,12 @@ class WebDavHelper {
 
 		// get space id if testing with spaces dav
 		if (self::$SPACE_ID_FROM_OCIS === '' && $davPathVersionToUse === self::DAV_VERSION_SPACES) {
-			try {
-				$spaceId = self::getPersonalSpaceIdForUser(
-					$baseUrl,
-					$doDavRequestAsUser ?? $user,
-					$password,
-					$xRequestId,
-				);
-			} catch (Exception $e) {
-				// if the fetch fails, and the user is not found, then a fake space id is prepared
-				// this is useful for testing when the personal space is of a non-existing user
-				$fakeSpaceId = self::generateUUIDv4();
-				self::$spacesIdRef[$user]["personal"] = $fakeSpaceId;
-				$spaceId = $fakeSpaceId;
-			}
+			$spaceId = self::checkAndGetPersonalSpaceIdForUser(
+				$baseUrl,
+				$doDavRequestAsUser ?? $user,
+				$password,
+				$xRequestId
+			);
 		} else {
 			$spaceId = self::$SPACE_ID_FROM_OCIS;
 		}

--- a/tests/acceptance/features/apiAuthWebDav/webDavMCKOLAuthOC10Issue40485.feature
+++ b/tests/acceptance/features/apiAuthWebDav/webDavMCKOLAuthOC10Issue40485.feature
@@ -1,0 +1,24 @@
+@api @notToImplementOnOCIS
+Feature: MOVE file/folder
+
+  Background:
+    Given these users have been created with default attributes and without skeleton files:
+      | username |
+      | Alice    |
+      | Brian    |
+    And user "Alice" has uploaded file with content "some data" to "/textfile0.txt"
+    And user "Alice" has created folder "/PARENT"
+    And user "Alice" has created folder "/FOLDER"
+    And user "Alice" has uploaded file with content "some data" to "/PARENT/parent.txt"
+
+
+  Scenario: send MOVE requests to webDav endpoints with body as normal user
+    When user "Alice" requests these endpoints with "MOVE" including body "doesnotmatter" about user "Alice"
+      | endpoint                                           |
+      | /remote.php/webdav/textfile0.txt                   |
+      | /remote.php/dav/files/%username%/textfile0.txt     |
+      | /remote.php/webdav/PARENT                          |
+      | /remote.php/dav/files/%username%/PARENT            |
+      | /remote.php/webdav/PARENT/parent.txt               |
+      | /remote.php/dav/files/%username%/PARENT/parent.txt |
+    Then the HTTP status code of responses on all endpoints should be "403"

--- a/tests/acceptance/features/apiAuthWebDav/webDavMCKOLAuthOC10Issue40485.feature
+++ b/tests/acceptance/features/apiAuthWebDav/webDavMCKOLAuthOC10Issue40485.feature
@@ -1,24 +1,19 @@
-@api @notToImplementOnOCIS
-Feature: MOVE file/folder
+@api @skipOnOcis
+Feature: create folder using MKCOL
 
   Background:
-    Given these users have been created with default attributes and without skeleton files:
-      | username |
-      | Alice    |
-      | Brian    |
+    Given user "Alice" has been created with default attributes and without skeleton files
     And user "Alice" has uploaded file with content "some data" to "/textfile0.txt"
     And user "Alice" has created folder "/PARENT"
     And user "Alice" has created folder "/FOLDER"
     And user "Alice" has uploaded file with content "some data" to "/PARENT/parent.txt"
 
-
-  Scenario: send MOVE requests to webDav endpoints with body as normal user
-    When user "Alice" requests these endpoints with "MOVE" including body "doesnotmatter" about user "Alice"
-      | endpoint                                           |
-      | /remote.php/webdav/textfile0.txt                   |
-      | /remote.php/dav/files/%username%/textfile0.txt     |
-      | /remote.php/webdav/PARENT                          |
-      | /remote.php/dav/files/%username%/PARENT            |
-      | /remote.php/webdav/PARENT/parent.txt               |
+  Scenario: send MKCOL requests to another user's webDav endpoints as normal user
+    Given user "Brian" has been created with default attributes and without skeleton files
+    When user "Brian" requests these endpoints with "MKCOL" including body "" about user "Alice"
+      | endpoint                                        |
+      | /remote.php/dav/files/%username%/textfile0.txt  |
+      | /remote.php/dav/files/%username%/PARENT         |
+      | /remote.php/dav/files/%username%/does-not-exist |
       | /remote.php/dav/files/%username%/PARENT/parent.txt |
-    Then the HTTP status code of responses on all endpoints should be "403"
+    Then the HTTP status code of responses on each endpoint should be "403, 403, 403, 409" respectively

--- a/tests/acceptance/features/apiAuthWebDav/webDavMCKOLAuthOC10Issue40485.feature
+++ b/tests/acceptance/features/apiAuthWebDav/webDavMCKOLAuthOC10Issue40485.feature
@@ -17,3 +17,14 @@ Feature: create folder using MKCOL
       | /remote.php/dav/files/%username%/does-not-exist |
       | /remote.php/dav/files/%username%/PARENT/parent.txt |
     Then the HTTP status code of responses on each endpoint should be "403, 403, 403, 409" respectively
+
+
+  Scenario: send MKCOL requests to non-existent user's webDav endpoints as normal user
+    Given user "Brian" has been created with default attributes and without skeleton files
+    When user "Brian" requests these endpoints with "MKCOL" including body "" about user "non-existent-user"
+      | endpoint                                                  |
+      | /remote.php/dav/files/non-existent-user/textfile0.txt     |
+      | /remote.php/dav/files/non-existent-user/PARENT            |
+      | /remote.php/dav/files/non-existent-user/does-not-exist    |
+      | /remote.php/dav/files/non-existent-user/PARENT/parent.txt |
+    Then the HTTP status code of responses on all endpoints should be "409"

--- a/tests/acceptance/features/apiAuthWebDav/webDavMKCOLAuth.feature
+++ b/tests/acceptance/features/apiAuthWebDav/webDavMKCOLAuth.feature
@@ -52,13 +52,10 @@ Feature: create folder using MKCOL
   Scenario: send MKCOL requests to another user's webDav endpoints as normal user
     Given user "Brian" has been created with default attributes and without skeleton files
     When user "Brian" requests these endpoints with "MKCOL" including body "" about user "Alice"
-      | endpoint                                        |
-      | /remote.php/dav/files/%username%/textfile0.txt  |
-      | /remote.php/dav/files/%username%/PARENT         |
-      | /remote.php/dav/files/%username%/does-not-exist |
-    Then the HTTP status code of responses on all endpoints should be "404"
-    When user "Brian" requests these endpoints with "MKCOL" including body "" about user "Alice"
       | endpoint                                           |
+      | /remote.php/dav/files/%username%/textfile0.txt     |
+      | /remote.php/dav/files/%username%/PARENT            |
+      | /remote.php/dav/files/%username%/does-not-exist    |
       | /remote.php/dav/files/%username%/PARENT/parent.txt |
     Then the HTTP status code of responses on all endpoints should be "404"
 
@@ -70,9 +67,6 @@ Feature: create folder using MKCOL
       | /remote.php/dav/spaces/%spaceid%/textfile0.txt  |
       | /remote.php/dav/spaces/%spaceid%/PARENT         |
       | /remote.php/dav/spaces/%spaceid%/does-not-exist |
-    Then the HTTP status code of responses on all endpoints should be "404"
-    When user "Brian" requests these endpoints with "MKCOL" including body "" about user "Alice"
-      | endpoint                                           |
       | /remote.php/dav/spaces/%spaceid%/PARENT/parent.txt |
     Then the HTTP status code of responses on all endpoints should be "404"
 

--- a/tests/acceptance/features/apiAuthWebDav/webDavMKCOLAuth.feature
+++ b/tests/acceptance/features/apiAuthWebDav/webDavMKCOLAuth.feature
@@ -48,7 +48,7 @@ Feature: create folder using MKCOL
       | /remote.php/dav/spaces/%spaceid%/PARENT/parent.txt |
     Then the HTTP status code of responses on all endpoints should be "401"
 
-  @issue-ocis-reva-9 @issue-ocis-reva-197
+  @skipOnOcV10 @issue-ocis-reva-9 @issue-ocis-reva-197
   Scenario: send MKCOL requests to another user's webDav endpoints as normal user
     Given user "Brian" has been created with default attributes and without skeleton files
     When user "Brian" requests these endpoints with "MKCOL" including body "" about user "Alice"
@@ -56,11 +56,11 @@ Feature: create folder using MKCOL
       | /remote.php/dav/files/%username%/textfile0.txt  |
       | /remote.php/dav/files/%username%/PARENT         |
       | /remote.php/dav/files/%username%/does-not-exist |
-    Then the HTTP status code of responses on all endpoints should be "403"
+    Then the HTTP status code of responses on all endpoints should be "404"
     When user "Brian" requests these endpoints with "MKCOL" including body "" about user "Alice"
       | endpoint                                           |
       | /remote.php/dav/files/%username%/PARENT/parent.txt |
-    Then the HTTP status code of responses on all endpoints should be "409"
+    Then the HTTP status code of responses on all endpoints should be "404"
 
   @skipOnOcV10 @personalSpace @issue-ocis-reva-9 @issue-ocis-reva-197
   Scenario: send MKCOL requests to another user's webDav endpoints as normal user using the spaces WebDAV API
@@ -70,11 +70,11 @@ Feature: create folder using MKCOL
       | /remote.php/dav/spaces/%spaceid%/textfile0.txt  |
       | /remote.php/dav/spaces/%spaceid%/PARENT         |
       | /remote.php/dav/spaces/%spaceid%/does-not-exist |
-    Then the HTTP status code of responses on all endpoints should be "403"
+    Then the HTTP status code of responses on all endpoints should be "404"
     When user "Brian" requests these endpoints with "MKCOL" including body "" about user "Alice"
       | endpoint                                           |
       | /remote.php/dav/spaces/%spaceid%/PARENT/parent.txt |
-    Then the HTTP status code of responses on all endpoints should be "409"
+    Then the HTTP status code of responses on all endpoints should be "404"
 
 
   Scenario: send MKCOL requests to webDav endpoints using invalid username but correct password

--- a/tests/acceptance/features/apiAuthWebDav/webDavMKCOLAuth.feature
+++ b/tests/acceptance/features/apiAuthWebDav/webDavMKCOLAuth.feature
@@ -48,7 +48,7 @@ Feature: create folder using MKCOL
       | /remote.php/dav/spaces/%spaceid%/PARENT/parent.txt |
     Then the HTTP status code of responses on all endpoints should be "401"
 
-  @skipOnOcV10 @issue-ocis-reva-9 @issue-ocis-reva-197
+  @skipOnOcV10 @issue-ocis-5049 @issue-ocis-reva-9 @issue-ocis-reva-197
   Scenario: send MKCOL requests to another user's webDav endpoints as normal user
     Given user "Brian" has been created with default attributes and without skeleton files
     When user "Brian" requests these endpoints with "MKCOL" including body "" about user "Alice"
@@ -59,14 +59,36 @@ Feature: create folder using MKCOL
       | /remote.php/dav/files/%username%/PARENT/parent.txt |
     Then the HTTP status code of responses on all endpoints should be "404"
 
+  @skipOnOcV10 @issue-ocis-5049 @issue-ocis-reva-9 @issue-ocis-reva-197
+  Scenario: send MKCOL requests to non-existent user's webDav endpoints as normal user
+    Given user "Brian" has been created with default attributes and without skeleton files
+    When user "Brian" requests these endpoints with "MKCOL" including body "" about user "non-existent-user"
+      | endpoint                                                  |
+      | /remote.php/dav/files/non-existent-user/textfile0.txt     |
+      | /remote.php/dav/files/non-existent-user/PARENT            |
+      | /remote.php/dav/files/non-existent-user/does-not-exist    |
+      | /remote.php/dav/files/non-existent-user/PARENT/parent.txt |
+    Then the HTTP status code of responses on all endpoints should be "404"
+
   @skipOnOcV10 @personalSpace @issue-ocis-reva-9 @issue-ocis-reva-197
   Scenario: send MKCOL requests to another user's webDav endpoints as normal user using the spaces WebDAV API
     Given user "Brian" has been created with default attributes and without skeleton files
     When user "Brian" requests these endpoints with "MKCOL" including body "" about user "Alice"
-      | endpoint                                        |
-      | /remote.php/dav/spaces/%spaceid%/textfile0.txt  |
-      | /remote.php/dav/spaces/%spaceid%/PARENT         |
-      | /remote.php/dav/spaces/%spaceid%/does-not-exist |
+      | endpoint                                           |
+      | /remote.php/dav/spaces/%spaceid%/textfile0.txt     |
+      | /remote.php/dav/spaces/%spaceid%/PARENT            |
+      | /remote.php/dav/spaces/%spaceid%/does-not-exist    |
+      | /remote.php/dav/spaces/%spaceid%/PARENT/parent.txt |
+    Then the HTTP status code of responses on all endpoints should be "404"
+
+  @skipOnOcV10 @issue-ocis-5049 @personalSpace @issue-ocis-reva-9 @issue-ocis-reva-197
+  Scenario: send MKCOL requests to non-existent user's webDav endpoints as normal user using the spaces WebDAV API
+    Given user "Brian" has been created with default attributes and without skeleton files
+    When user "Brian" requests these endpoints with "MKCOL" including body "" about user "non-existent-user"
+      | endpoint                                           |
+      | /remote.php/dav/spaces/%spaceid%/textfile0.txt     |
+      | /remote.php/dav/spaces/%spaceid%/PARENT            |
+      | /remote.php/dav/spaces/%spaceid%/does-not-exist    |
       | /remote.php/dav/spaces/%spaceid%/PARENT/parent.txt |
     Then the HTTP status code of responses on all endpoints should be "404"
 

--- a/tests/acceptance/features/bootstrap/FeatureContext.php
+++ b/tests/acceptance/features/bootstrap/FeatureContext.php
@@ -3329,6 +3329,9 @@ class FeatureContext extends BehatVariablesContext {
 	 * @throws GuzzleException
 	 */
 	public function getPersonalSpaceIdForUser(string $user, bool $alwaysDoIt = false): ?string {
+		if ($user === 'non-existent-user') {
+			return WebDavHelper::generateUUIDv4();
+		}
 		if ($alwaysDoIt || ($this->getDavPathVersion() === WebDavHelper::DAV_VERSION_SPACES)) {
 			return WebDavHelper::getPersonalSpaceIdForUser(
 				$this->getBaseUrl(),

--- a/tests/acceptance/features/bootstrap/FeatureContext.php
+++ b/tests/acceptance/features/bootstrap/FeatureContext.php
@@ -3329,11 +3329,8 @@ class FeatureContext extends BehatVariablesContext {
 	 * @throws GuzzleException
 	 */
 	public function getPersonalSpaceIdForUser(string $user, bool $alwaysDoIt = false): ?string {
-		if ($user === 'non-existent-user') {
-			return WebDavHelper::generateUUIDv4();
-		}
 		if ($alwaysDoIt || ($this->getDavPathVersion() === WebDavHelper::DAV_VERSION_SPACES)) {
-			return WebDavHelper::getPersonalSpaceIdForUser(
+			return WebDavHelper::getPersonalSpaceIdForUserOrFakeIfNotFound(
 				$this->getBaseUrl(),
 				$user,
 				$this->getPasswordForUser($user),


### PR DESCRIPTION
## Description
- This PR adjust the response status code when a user make a `MCKOL` request to `non-existence-user` and other user's endpoint.
- Adds the bug demonstration test for the `MCKOL` request for `oc10`

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
- https://github.com/owncloud/core/issues/40485

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
- Locally
- CI

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Database schema changes (next release will require increase of minor version instead of patch)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [ ] Tests only (no source changes)

## Checklist:
<!-- Tick the checkboxes when done. -->
<!-- Raise documentation ticket in https://github.com/owncloud/documentation -->
- [ ] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 
- [ ] Changelog item, see [TEMPLATE](https://github.com/owncloud/core/blob/master/changelog/TEMPLATE)
