### PR TITLE
[full-ci] Files and folder won't be deleted from the "shared with others" section

### DIFF
--- a/apps/files_sharing/js/app.js
+++ b/apps/files_sharing/js/app.js
@@ -57,7 +57,7 @@ OCA.Sharing.App = {
 		}
 
 		var fileActions = this._createFileActions();
-		this._adjustOutShareActions(fileActions);
+		this._adjustOutAndLinkShareActions(fileActions);
 
 		this._outFileList = new OCA.Sharing.FileList(
 			$el,
@@ -82,13 +82,17 @@ OCA.Sharing.App = {
 		if (this._linkFileList) {
 			return this._linkFileList;
 		}
+
+		var fileActions = this._createFileActions();
+		this._adjustOutAndLinkShareActions(fileActions);
+
 		this._linkFileList = new OCA.Sharing.FileList(
 			$el,
 			{
 				id: 'shares.link',
 				scrollContainer: $('#app-content'),
 				linksOnly: true,
-				fileActions: this._createFileActions(),
+				fileActions: fileActions,
 				config: OCA.Files.App.getFilesConfig()
 			}
 		);
@@ -328,11 +332,11 @@ OCA.Sharing.App = {
 		});
 	},
 
-	_adjustOutShareActions: function(fileActions) {
+	_adjustOutAndLinkShareActions: function(fileActions) {
 		fileActions.addAdvancedFilter(function(actions, context) {
 			// delete action is removed to prevent confusion. Users might accidentally
 			// delete a file or a folder instead of unsharing it.
-			// If the user clicks in the a folder, he'll be moved to the "all files" section,
+			// If the user clicks in the folder, he'll be moved to the "all files" section,
 			// so there is no need check for additional context and we'll remove the delete
 			// action from all the files and folders in the list.
 			delete(actions.Delete);

--- a/apps/files_sharing/js/app.js
+++ b/apps/files_sharing/js/app.js
@@ -55,13 +55,17 @@ OCA.Sharing.App = {
 		if (this._outFileList) {
 			return this._outFileList;
 		}
+
+		var fileActions = this._createFileActions();
+		this._adjustOutShareActions(fileActions);
+
 		this._outFileList = new OCA.Sharing.FileList(
 			$el,
 			{
 				id: 'shares.others',
 				scrollContainer: $('#app-content'),
 				sharedWithUser: false,
-				fileActions: this._createFileActions(),
+				fileActions: fileActions,
 				config: OCA.Files.App.getFilesConfig()
 			}
 		);
@@ -321,6 +325,18 @@ OCA.Sharing.App = {
 			}
 
 			return newActions;
+		});
+	},
+
+	_adjustOutShareActions: function(fileActions) {
+		fileActions.addAdvancedFilter(function(actions, context) {
+			// delete action is removed to prevent confusion. Users might accidentally
+			// delete a file or a folder instead of unsharing it.
+			// If the user clicks in the a folder, he'll be moved to the "all files" section,
+			// so there is no need check for additional context and we'll remove the delete
+			// action from all the files and folders in the list.
+			delete(actions.Delete);
+			return actions;
 		});
 	}
 };

--- a/changelog/unreleased/40497
+++ b/changelog/unreleased/40497
@@ -1,0 +1,12 @@
+Change: Delete action is removed from sharing sections
+
+In the files apps, the "shared with others" and "shared by link" sections
+allowed people to use a delete action on a file or folder present in that
+list. This was causing problems because people accidentally removed the
+folder when, in fact, they wanted to unshare it.
+
+This delete action isn't present any longer. You can unshare from those
+views by accessing the file or folder's details. If you want to delete
+the file or folder, you can do it from the regular "all files" section.
+
+https://github.com/owncloud/core/pull/40497

--- a/tests/acceptance/features/webUICreateDelete/deleteFilesFolders.feature
+++ b/tests/acceptance/features/webUICreateDelete/deleteFilesFolders.feature
@@ -151,7 +151,7 @@ Feature: deleting files and folders
     And file "zzzz-must-be-last-file-in-folder.txt" should not be listed on the webUI
 
   @files_sharing-app-required
-  Scenario: delete files from shared with others page
+  Scenario: resources cannot be deleted from the shared with others page
     Given user "Alice" has created folder "simple-folder"
     And user "Alice" has uploaded file "filesForUpload/lorem.txt" to "lorem.txt"
     And user "Brian" has been created with default attributes and without skeleton files
@@ -159,28 +159,19 @@ Feature: deleting files and folders
     And user "Alice" has shared folder "simple-folder" with user "Brian"
     And user "Alice" has logged in using the webUI
     And the user has browsed to the shared-with-others page
-    When the user deletes file "lorem.txt" using the webUI
-    And the user deletes folder "simple-folder" using the webUI
-    Then as "Alice" file "lorem.txt" should not exist
-    And as "Alice" folder "simple-folder" should not exist
-    And file "lorem.txt" should not be listed on the webUI
-    And folder "simple-folder" should not be listed on the webUI
-    When the user browses to the files page
-    Then file "lorem.txt" should not be listed on the webUI
-    And folder "simple-folder" should not be listed on the webUI
+    Then file "lorem.txt" should be listed on the webUI
+    And folder "simple-folder" should be listed on the webUI
+    But it should not be possible to delete file "lorem.txt" using the webUI
+    And it should not be possible to delete folder "simple-folder" using the webUI
 
   @public_link_share-feature-required @files_sharing-app-required
-  Scenario: delete files from shared by link page
+  Scenario: resources cannot be deleted from the shared by link page
     Given user "Alice" has uploaded file "filesForUpload/lorem.txt" to "lorem.txt"
     And user "Alice" has logged in using the webUI
     And the user has created a public link share of file "lorem.txt"
     And the user has browsed to the shared-by-link page
     Then file "lorem.txt" should be listed on the webUI
-    When the user deletes file "lorem.txt" using the webUI
-    Then as "Alice" file "lorem.txt" should not exist
-    And file "lorem.txt" should not be listed on the webUI
-    When the user browses to the files page
-    Then file "lorem.txt" should not be listed on the webUI
+    But it should not be possible to delete file "lorem.txt" using the webUI
 
   @systemtags-app-required
   Scenario: delete files from tags page


### PR DESCRIPTION
<!--
Thanks for submitting a change to ownCloud!

This is the bug tracker for the Server component. Find other components at https://github.com/owncloud/core/blob/master/.github/CONTRIBUTING.md#guidelines

For fixing potential security issues please see https://owncloud.com/security/

To make it possible for us to get your change reviewed and merged please carefully fill out the requested information below.

Please note that any kind of change needs first be submitted to the master branch which holds the next version of ownCloud.

Please set the following labels:

- Set label "3 - To review" for review or "2 - Development" if the PR still has open tasks
- Assignment: assign to self
- Milestone: set the same as the ticket this PR fixes, or "development" by default
- Reviewers: pick at least one
-->

## Description
The "delete" action from the "shared with others" section might be confusing because it will delete the file or folder instead of unsharing it.
Unsharing might also be problematic as action because the file or folder might be shared with multiple people, or it could also be shared by link. Unsharing might mean that all of those connections will be removed, which might include or not the links. This also seems confusing.

The plan is to remove the delete action from that section.
If the user wants to unshare, he can access to the details view of the file and folder, so he can have all the controls he needs there.
Deleting seems clearer in the "all files" section

## Related Issue
https://github.com/owncloud/enterprise/issues/5399

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?
1. userA shares a folder with some content to userB
2. userA goes to the "shared with others" section
3. there isn't any "delete" action to delete the shared folder inside the "shared with others" section.

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Database schema changes (next release will require increase of minor version instead of patch)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [ ] Tests only (no source changes)

## Checklist:
<!-- Tick the checkboxes when done. -->
<!-- Raise documentation ticket in https://github.com/owncloud/documentation -->
- [x] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 
- [ ] Changelog item, see [TEMPLATE](https://github.com/owncloud/core/blob/master/changelog/TEMPLATE)
