### PR TITLE
Remove empty directories from the files_versions

### DIFF
--- a/apps/files_trashbin/lib/Trashbin.php
+++ b/apps/files_trashbin/lib/Trashbin.php
@@ -608,6 +608,21 @@ class Trashbin {
 		return false;
 	}
 
+	private static function recursiveMkdir($view, $targetDir) {
+		$checkingDir = $targetDir;
+		$toBeCreated = [];
+		while (!$view->file_exists($checkingDir) && $checkingDir !== '/' && $checkingDir !== '.' && $checkingDir !== '') {
+			$toBeCreated[] = $checkingDir;
+			$checkingDir = \dirname($checkingDir);
+		}
+
+		// need to reverse the array
+		$toBeCreated = \array_reverse($toBeCreated);
+		foreach ($toBeCreated as $creatingDir) {
+			$view->mkdir($creatingDir);
+		}
+	}
+
 	/**
 	 * restore all versions for the filename from trashbin in the target location
 	 *
@@ -642,6 +657,7 @@ class Trashbin {
 			}
 
 			if ($view->is_dir('/files_trashbin/versions/' . $filename)) {
+				self::recursiveMkdir($rootView, "{$owner}/files_versions/" . \dirname($ownerPath));
 				$rootView->rename(Filesystem::normalizePath($user . '/files_trashbin/versions/' . $filename), Filesystem::normalizePath($owner . '/files_versions/' . $ownerPath));
 			} else {
 				$dir = \dirname($filename);
@@ -669,6 +685,7 @@ class Trashbin {
 					if ($timestamp) {
 						$src = '/files_trashbin/versions/' . $dirAndFilename . '.v' . $v . '.d' . $timestamp;
 						$dst = '/files_versions/' . $ownerPath . '.v' . $v;
+						self::recursiveMkdir($rootView, $owner . \dirname($dst));
 						$rootView->rename("$user$src", "$owner$dst");
 						if ($metaEnabled) {
 							$metaStorage->renameOrCopy('rename', $src . MetaStorage::VERSION_FILE_EXT, $user, $dst . MetaStorage::VERSION_FILE_EXT, $owner);
@@ -676,6 +693,7 @@ class Trashbin {
 					} else {
 						$src = '/files_trashbin/versions/' . $dirAndFilename . '.v' . $v;
 						$dst = '/files_versions/' . $ownerPath . '.v' . $v;
+						self::recursiveMkdir($rootView, $owner . \dirname($dst));
 						$rootView->rename("$user$src", "$owner$dst");
 						if ($metaEnabled) {
 							$metaStorage->renameOrCopy('rename', $src . MetaStorage::VERSION_FILE_EXT, $user, $dst . MetaStorage::VERSION_FILE_EXT, $owner);

--- a/changelog/unreleased/40499
+++ b/changelog/unreleased/40499
@@ -1,0 +1,10 @@
+Bugfix: Remove empty directories from the files_versions
+
+Empty directories were left when the contained versions were deleted
+or moved. Large installations might end up with too many of these
+empty directories.
+
+Now, when a version is deleted, the containing directory will also
+be deleted if there aren't any more versions inside.
+
+https://github.com/owncloud/core/pull/40499


### PR DESCRIPTION
<!--
Thanks for submitting a change to ownCloud!

This is the bug tracker for the Server component. Find other components at https://github.com/owncloud/core/blob/master/.github/CONTRIBUTING.md#guidelines

For fixing potential security issues please see https://owncloud.com/security/

To make it possible for us to get your change reviewed and merged please carefully fill out the requested information below.

Please note that any kind of change needs first be submitted to the master branch which holds the next version of ownCloud.

Please set the following labels:

- Set label "3 - To review" for review or "2 - Development" if the PR still has open tasks
- Assignment: assign to self
- Milestone: set the same as the ticket this PR fixes, or "development" by default
- Reviewers: pick at least one
-->

## Description
Empty directories were left inside the files_versions directory. For large installations this is a waste of space because there could be a lot of empty directories that aren't useful in any way.

## Related Issue
https://github.com/owncloud/enterprise/issues/5471

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?
Mostly tested by deleting files from the web UI
1. Create "/f1/f2/f3" folder and upload a file with some versions
2. Check that the there are versions in `<userdir>/files_versions/f1/f2/f3/`
3. Remove the uploaded file

There should be only the `<userdir>/files_versions` folder without any directory in it. This is because the "f1/f2/f3" folders were empty.

Additional checks done:
* With multiple files, removing only one will keep the folder in the files_versions because there are more versions inside
* Removing the directory containing the files (removing "/f1/f2/f3" folder so "/f1/f2" is empty). Only `<userdir>/files_versions` exists because the rest of the folders were empty.
* Moving the files / directory around. As long as the source parent folder doesn't have versions, the folders will also be removed.
* `occ versions:cleanup` and `occ versions:expire` works with the same conditions.

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Database schema changes (next release will require increase of minor version instead of patch)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [ ] Tests only (no source changes)

## Checklist:
<!-- Tick the checkboxes when done. -->
<!-- Raise documentation ticket in https://github.com/owncloud/documentation -->
- [x] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 
- [ ] Changelog item, see [TEMPLATE](https://github.com/owncloud/core/blob/master/changelog/TEMPLATE)


Note:
Existing empty version folder won't be removed unless a version ends up inside any of them. In this case, there won't be any difference and the folder will be removed once the last version is removed from the folder.