### PR TITLE
[tests-only][do-not-merge]Add debug when search match not found

### DIFF
--- a/tests/acceptance/features/bootstrap/WebDav.php
+++ b/tests/acceptance/features/bootstrap/WebDav.php
@@ -5375,6 +5375,10 @@ trait WebDav {
 		if ($entryNameToSearch === null) {
 			return $results;
 		}
+
+		//print all response of search request if match not found
+		print_r($multistatusResults);
+
 		return false;
 	}
 


### PR DESCRIPTION
## Description
 
This PR is not for fixing. It's just for debugging purposes for the future, it adds code to print the search request responses when a match is not found.

### Related issue 
- https://github.com/owncloud/search_elastic/issues/302