### PR TITLE
Allow to temporarily ignore invalid federated shares in tightly federated setup

### DIFF
--- a/apps/files_sharing/lib/External/ScanExternalSharesJob.php
+++ b/apps/files_sharing/lib/External/ScanExternalSharesJob.php
@@ -236,7 +236,7 @@ class ScanExternalSharesJob extends TimedJob {
 			);
 		} catch (\Exception $e) {
 			$this->logger->debug(
-				"Skipping external share {$share['mountpoint']} for uid {$share['user']} from remote {$share['remote']}  due to internal server error"
+				"Skipping external share {$share['mountpoint']} for uid {$share['user']} from remote {$share['remote']} due to internal server error"
 			);
 			$this->logger->logException($e, ['app' => 'federatedfilesharing']);
 		}

--- a/apps/files_sharing/lib/External/Storage.php
+++ b/apps/files_sharing/lib/External/Storage.php
@@ -226,10 +226,10 @@ class Storage extends DAV implements ISharedStorage {
 	 */
 	public function checkStorageAvailability() {
 		// WARNING: Disabling this setting is recommended only in tightly integrated federated setups as temporarly setting,
-		//  should NOT be used in decentralized federation setup. It could cause bad user experience when dealing
-		//  with deleted external shares
+		// should NOT be used in decentralized federation setup. It could cause bad user experience when dealing
+		// with deleted external shares
 		// NOTE: This allows administrator to disable cleanup of invalid shares so only manual removal by user or admin is possible,
-		//  this is particularly useful when dealing with complex migrations that could cause unexpected server responses and instabilities.
+		// this is particularly useful when dealing with complex migrations that could cause unexpected server responses and instabilities.
 		$cleanupInvalidEnabled = $this->config->getAppValue('files_sharing', 'enable_cleanup_invalid_external_shares', 'yes');
 
 		// see if we can find out why the share is unavailable
@@ -242,7 +242,7 @@ class Storage extends DAV implements ISharedStorage {
 
 			if ($cleanupInvalidEnabled === 'yes') {
 				// FIXME: for now delete, but maybe provide a dialog in the future to the user
-				//  to inform that share no longer valid and should contact owner? Likely big refactor
+				// to inform that share no longer valid and should contact owner? Likely big refactor
 				$this->manager->removeShare($this->mountPoint);
 				$this->manager->getMountManager()->removeMount($this->mountPoint);
 				$this->logger->error(
@@ -277,14 +277,14 @@ class Storage extends DAV implements ISharedStorage {
 			// can either mean that the share no longer exists or there is no ownCloud on
 			// the remote (proxy could return 404 for that path), check remote if accessible
 			if ($this->testRemote()) {
-				// valid ownCloud instance means that the external share no longer exists
+				// valid ownCloud instance means that the external share no longer exists,
 				// since this is permanent (re-sharing the file will create a new token)
-
+				// we remove the invalid storage
 				if ($cleanupInvalidEnabled === 'yes') {
 					// FIXME: for now delete, but maybe provide a dialog in the future to the user
-					//  to inform that share no longer valid and should contact owner? Likely big refactor
-					// WARNING: we remove here to improve user experience for 99,9% of cases, but it can happen that
-					//  server is misbehaving/unstable (returning wrong responses) and valid share gets removed
+					// to inform that share no longer valid and should contact owner? Likely big refactor
+					// NOTE: we remove share here to improve user experience for 99,9% of cases, however it can happen that
+					// server is misbehaving/unstable (returning wrong responses) and valid share gets removed
 					$this->manager->removeShare($this->mountPoint);
 					$this->manager->getMountManager()->removeMount($this->mountPoint);
 					$this->logger->error(
@@ -292,6 +292,7 @@ class Storage extends DAV implements ISharedStorage {
 						['shareId' => $this->getId()]
 					);
 				} else {
+					// Ignore removal due to app config
 					$this->logger->error(
 						'Storage for external share {shareId} returns not found error. Ignoring due to app config files_sharing.enable_cleanup_invalid_external_shares={cleanupInvalidEnabled}.',
 						['shareId' => $this->getId(), 'cleanupInvalidEnabled' => $cleanupInvalidEnabled]

--- a/apps/files_sharing/lib/External/Storage.php
+++ b/apps/files_sharing/lib/External/Storage.php
@@ -32,6 +32,7 @@ use GuzzleHttp\Exception\ConnectException;
 use OC\Files\Storage\DAV;
 use OCA\FederatedFileSharing\DiscoveryManager;
 use OCA\Files_Sharing\ISharedStorage;
+use OCP\IConfig;
 use OCP\Files\StorageInvalidException;
 use OCP\Files\StorageNotAvailableException;
 use Sabre\DAV\Client;
@@ -51,6 +52,8 @@ class Storage extends DAV implements ISharedStorage {
 	private $httpClient;
 	/** @var \OCP\ILogger */
 	private $logger;
+	/** @var IConfig */
+	private $config;
 	/** @var \OCP\ICertificateManager */
 	private $certificateManager;
 	/** @var bool */
@@ -65,6 +68,7 @@ class Storage extends DAV implements ISharedStorage {
 		$this->memcacheFactory = \OC::$server->getMemCacheFactory();
 		$this->httpClient = \OC::$server->getHTTPClientService();
 		$this->logger = \OC::$server->getLogger();
+		$this->config = \OC::$server->getConfig();
 		$this->manager = $options['manager'];
 		$this->certificateManager = $options['certificateManager'];
 		$this->remote = $options['remote'];
@@ -221,19 +225,44 @@ class Storage extends DAV implements ISharedStorage {
 	 * @throws \OCP\Files\StorageInvalidException
 	 */
 	public function checkStorageAvailability() {
+		// WARNING: Disabling this setting is recommended only in tightly integrated federated setups as temporarly setting,
+		//  should NOT be used in decentralized federation setup. It could cause bad user experience when dealing
+		//  with deleted external shares
+		// NOTE: This allows administrator to disable cleanup of invalid shares so only manual removal by user or admin is possible,
+		//  this is particularly useful when dealing with complex migrations that could cause unexpected server responses and instabilities.
+		$cleanupInvalidEnabled = $this->config->getAppValue('files_sharing', 'enable_cleanup_invalid_external_shares', 'yes');
+
 		// see if we can find out why the share is unavailable
 		try {
 			// do propfind with strictNotFoundCheck=true
 			$checkShareStorage = $this->propfind('', true);
 		} catch (StorageInvalidException $e) {
-			// DAV Propfind returns StorageInvalidException on e.g. auth error (401 Unauthorized)
-			// FIXME: provide a dialog in the future and/or remove after timeout?
+			// DAV Propfind returns StorageInvalidException on e.g. auth error (401 Unauthorized),
+			// share likely has been removed on remote with failure on removal hook to receiving federated server
+
+			if ($cleanupInvalidEnabled === 'yes') {
+				// FIXME: for now delete, but maybe provide a dialog in the future to the user
+				//  to inform that share no longer valid and should contact owner? Likely big refactor
+				$this->manager->removeShare($this->mountPoint);
+				$this->manager->getMountManager()->removeMount($this->mountPoint);
+				$this->logger->error(
+					'Propfind check for storage availability on external share {shareId} returns share invalid. Removing invalid share.',
+					['shareId' => $this->getId()]
+				);
+			} else {
+				$this->logger->error(
+					'Propfind check for storage availability on external share {shareId} returns share invalid. Ignoring due to app config files_sharing.enable_cleanup_invalid_external_shares={cleanupInvalidEnabled}.',
+					['shareId' => $this->getId(), 'cleanupInvalidEnabled' => $cleanupInvalidEnabled]
+				);
+			}
+
+			// rethrow exception
+			throw $e;
+		} catch (StorageNotAvailableException $e) {
 			$this->logger->error(
-				'Propfind check for storage availability on external share {shareId} returns share invalid, share likely has been removed on remote with failure on removal hook to federated sharer. Removing invalid share.',
+				'Propfind check for storage availability on external share {shareId} returns storage not available error.',
 				['shareId' => $this->getId()]
 			);
-			$this->manager->removeShare($this->mountPoint);
-			$this->manager->getMountManager()->removeMount($this->mountPoint);
 			throw $e;
 		} catch (\Exception $e) {
 			$this->logger->error(
@@ -250,16 +279,32 @@ class Storage extends DAV implements ISharedStorage {
 			if ($this->testRemote()) {
 				// valid ownCloud instance means that the external share no longer exists
 				// since this is permanent (re-sharing the file will create a new token)
-				// we remove the invalid storage
-				$this->logger->error(
-					'Storage for external share {shareId} returns not found error. Removing share as testing of remote succeeded.',
-					['shareId' => $this->getId()]
-				);
-				$this->manager->removeShare($this->mountPoint);
-				$this->manager->getMountManager()->removeMount($this->mountPoint);
+
+				if ($cleanupInvalidEnabled === 'yes') {
+					// FIXME: for now delete, but maybe provide a dialog in the future to the user
+					//  to inform that share no longer valid and should contact owner? Likely big refactor
+					// WARNING: we remove here to improve user experience for 99,9% of cases, but it can happen that
+					//  server is misbehaving/unstable (returning wrong responses) and valid share gets removed
+					$this->manager->removeShare($this->mountPoint);
+					$this->manager->getMountManager()->removeMount($this->mountPoint);
+					$this->logger->error(
+						'Storage for external share {shareId} returns not found error. Removing share as testing of remote succeeded.',
+						['shareId' => $this->getId()]
+					);
+				} else {
+					$this->logger->error(
+						'Storage for external share {shareId} returns not found error. Ignoring due to app config files_sharing.enable_cleanup_invalid_external_shares={cleanupInvalidEnabled}.',
+						['shareId' => $this->getId(), 'cleanupInvalidEnabled' => $cleanupInvalidEnabled]
+					);
+				}
+
 				throw new StorageInvalidException();
 			} else {
 				// ownCloud instance is gone, likely to be a temporary server configuration error
+				$this->logger->error(
+					'Storage for external share {shareId} returns not found error. Throwing error as testing of remote failed.',
+					['shareId' => $this->getId()]
+				);
 				throw new StorageNotAvailableException();
 			}
 		}

--- a/changelog/unreleased/40503
+++ b/changelog/unreleased/40503
@@ -1,0 +1,15 @@
+Change: Allow to temporarily ignore invalid federated shares
+
+This change is targeted mostly at tightly federated setups
+
+Currently, if federated share is invalid or api endpoint returns not found, 
+availability check would validate whether this is a problem with a server and 
+if checks complete that given share is removed. 
+However, in some cases these checks might not be enough (e.g. complex 
+migrations in tightly federated setups), and in that case invalidation 
+behaviour can be disabled using below app setting:
+
+files_sharing.enable_cleanup_invalid_external_shares='no'
+
+https://github.com/owncloud/core/pull/40503
+https://github.com/owncloud/enterprise/issues/5427


### PR DESCRIPTION
fixes https://github.com/owncloud/enterprise/issues/5427

Currently, if federated share is invalid or api endpoint returns not found, availability check would validate whether this is a problem with a server and if checks complete that given share is removed. However, in some cases these checks might not be enough (e.g. complex migrations in tightly federated setups), and in that case invalidation behaviour can be disabled using below app setting:

```
occ config:app:set files_sharing enable_cleanup_invalid_external_shares --value no
```

Then instead of removal below warning is displayed

![Screenshot 2022-12-16 at 11 49 16](https://user-images.githubusercontent.com/13368647/208091401-77deeed2-07a7-4926-a811-7ca5f96318d8.png)

This PR also improves handling and logging to better debug the situation