### PR TITLE
[tests-only] Match step to check group in the share response

### DIFF
--- a/tests/acceptance/features/bootstrap/Sharing.php
+++ b/tests/acceptance/features/bootstrap/Sharing.php
@@ -1431,15 +1431,18 @@ trait Sharing {
 	}
 
 	/**
-	 * @Then /^user "([^"]*)" should be included in the response$/
+	 * @Then /^(user|group) "([^"]*)" should be included in the response$/
 	 *
+	 * @param string $type
 	 * @param string $user
 	 *
 	 * @return void
 	 * @throws Exception
 	 */
-	public function checkSharedUserInResponse(string $user):void {
-		$user = $this->getActualUsername($user);
+	public function checkSharedUserOrGroupInResponse(string $type, string $user):void {
+		if ($type === 'user') {
+			$user = $this->getActualUsername($user);
+		}
 		Assert::assertTrue(
 			$this->isFieldInResponse('share_with', "$user"),
 			"'share_with' value '$user' was not found in response"
@@ -1448,16 +1451,17 @@ trait Sharing {
 
 	/**
 	 * @Then /^user "([^"]*)" should not be included in the response$/
+	 * @Then /^group "([^"]*)" should not be included in the response$/
 	 *
-	 * @param string $user
+	 * @param string $userOrGroup
 	 *
 	 * @return void
 	 * @throws Exception
 	 */
-	public function checkSharedUserNotInResponse(string $user):void {
+	public function checkSharedUserOrGroupNotInResponse(string $userOrGroup):void {
 		Assert::assertFalse(
-			$this->isFieldInResponse('share_with', "$user", false),
-			"'share_with' value '$user' was unexpectedly found in response"
+			$this->isFieldInResponse('share_with', "$userOrGroup", false),
+			"'share_with' value '$userOrGroup' was unexpectedly found in response"
 		);
 	}
 


### PR DESCRIPTION
## Description
Match the these steps:
- `Then group "grp2" should be included in the response`
- `Then group "grp1" should not be included in the response`

## Related Issue
- Required for https://github.com/owncloud/ocis/pull/5076

## Motivation and Context

## How Has This Been Tested?
- test environment: local

## Screenshots (if appropriate):

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Database schema changes (next release will require increase of minor version instead of patch)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [x] Tests only (no source changes)

## Checklist:
- [ ] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 
- [ ] Changelog item, see [TEMPLATE](https://github.com/owncloud/core/blob/master/changelog/TEMPLATE)
