### PR TITLE
Add per-user storage view

### DIFF
--- a/changelog/unreleased/40506
+++ b/changelog/unreleased/40506
@@ -1,0 +1,6 @@
+Enhancement: Add per-user storage view
+
+Adding option for displaying used storage on per-user basis
+
+https://github.com/owncloud/enterprise/issues/5468
+https://github.com/owncloud/core/pull/40506

--- a/settings/Controller/UsersController.php
+++ b/settings/Controller/UsersController.php
@@ -226,6 +226,17 @@ class UsersController extends Controller {
 			];
 		}
 
+		// we are going to setup a different FS and not reverting it back. There shouldn't anyway be any code needed to access the FS after this
+		try {
+			\OC_Util::tearDownFS();
+			\OC_Util::setupFS($user->getUID());
+			$storage = \OC_Helper::getStorageInfo('/');
+			$storageUsed = \sprintf("%.1f MB", $storage['used'] / 1024 / 1024);
+		} catch (\Exception $e) {
+			$this->log->error("Can't compute used storage for user " . $user->getUID() . ": " . $e->getMessage(), ['app' => 'settings']);
+			$storageUsed = "0 MB";
+		}
+
 		return [
 			'name' => $user->getUID(),
 			'displayname' => $user->getDisplayName(),
@@ -234,6 +245,7 @@ class UsersController extends Controller {
 			'isEnabled' => $user->isEnabled(),
 			'quota' => $user->getQuota(),
 			'storageLocation' => $user->getHome(),
+						'storageUsed' => $storageUsed,
 			'lastLogin' => $user->getLastLogin() * 1000,
 			'backend' => $user->getBackendClassName(),
 			'email' => $displayName,

--- a/settings/Controller/UsersController.php
+++ b/settings/Controller/UsersController.php
@@ -245,7 +245,7 @@ class UsersController extends Controller {
 			'isEnabled' => $user->isEnabled(),
 			'quota' => $user->getQuota(),
 			'storageLocation' => $user->getHome(),
-						'storageUsed' => $storageUsed,
+			'storageUsed' => $storageUsed,
 			'lastLogin' => $user->getLastLogin() * 1000,
 			'backend' => $user->getBackendClassName(),
 			'email' => $displayName,

--- a/settings/css/settings.css
+++ b/settings/css/settings.css
@@ -267,6 +267,7 @@ span.usersLastLoginTooltip { white-space: nowrap; }
 #userlist .mailAddress,
 #userlist .enabled,
 #userlist .storageLocation,
+serlist .storageUsed,
 #userlist .userBackend,
 #userlist .lastLogin {
 	display : none;

--- a/settings/css/settings.css
+++ b/settings/css/settings.css
@@ -267,7 +267,7 @@ span.usersLastLoginTooltip { white-space: nowrap; }
 #userlist .mailAddress,
 #userlist .enabled,
 #userlist .storageLocation,
-serlist .storageUsed,
+#userlist .storageUsed,
 #userlist .userBackend,
 #userlist .lastLogin {
 	display : none;

--- a/settings/js/users/users.js
+++ b/settings/js/users/users.js
@@ -165,6 +165,11 @@ var UserList = {
 		 */
 		$tr.find('td.storageLocation').text(user.storageLocation);
 
+                /**
+                * storage used
+                */
+                $tr.find('td.storageUsed').text(user.storageUsed);
+
 		/**
 		 * user backend
 		 */
@@ -1076,6 +1081,20 @@ $(document).ready(function () {
 			OC.AppConfig.setValue('core', 'umgmt_show_storage_location', 'false');
 		}
 	});
+
+        if ($('#CheckboxStorageUsed').is(':checked')) {
+                 $("#userlist .storageUsed").show();
+        }
+        // Option to display/hide the "Storage used" column
+        $('#CheckboxStorageUsed').click(function() {
+                 if ($('#CheckboxStorageUsed').is(':checked')) {
+                         $("#userlist .storageUsed").show();
+                         OC.AppConfig.setValue('core', 'umgmt_show_storage_used', 'true');
+                 } else {
+                         $("#userlist .storageUsed").hide();
+                         OC.AppConfig.setValue('core', 'umgmt_show_storage_used', 'false');
+                 }
+         });
 
 	if ($('#CheckboxLastLogin').is(':checked')) {
 		$("#userlist .lastLogin").show();

--- a/settings/templates/users/main.php
+++ b/settings/templates/users/main.php
@@ -62,6 +62,15 @@ translation('settings');
 						<?php p($l->t('Show storage location')) ?>
 					</label>
 				</p>
+                                <p>
+                                        <input type="checkbox" name="StorageUsed" value="StorageUsed" id="CheckboxStorageUsed"
+                                                class="checkbox" <?php if ($_['show_storage_used'] === 'true') {
+                                                	print_unescaped('checked="checked"');
+                                                } ?> />
+                                        <label for="CheckboxStorageUsed">
+                                                <?php p($l->t('Show storage used')) ?>
+                                        </label>
+                                </p>
 				<p>
 					<input type="checkbox" name="LastLogin" value="LastLogin" id="CheckboxLastLogin"
 						class="checkbox" <?php if ($_['show_last_login'] === 'true') {

--- a/settings/templates/users/part.userlist.php
+++ b/settings/templates/users/part.userlist.php
@@ -15,6 +15,7 @@
 			<th class="enabled" scope="col"><?php p($l->t('Enabled')); ?></th>
 			<th class="quota" id="headerQuota" scope="col"><?php p($l->t('Quota')); ?></th>
 			<th class="storageLocation" scope="col"><?php p($l->t('Storage Location')); ?></th>
+                        <th class="storageUsed" scope="col"><?php p($l->t('Storage Used')); ?></th>
 			<th class="userBackend" scope="col"><?php p($l->t('User Backend')); ?></th>
 			<th class="lastLogin" scope="col"><?php p($l->t('Last Login')); ?></th>
 			<th id="headerResendInvitationEmail">&nbsp;</th>
@@ -70,6 +71,7 @@
 				</select>
 			</td>
 			<td class="storageLocation"></td>
+                        <td class="storageUsed"></td>
 			<td class="userBackend"></td>
 			<td class="lastLogin"></td>
 			<td class="resendInvitationEmail"></td>

--- a/settings/users.php
+++ b/settings/users.php
@@ -121,6 +121,7 @@ $tmpl->assign('enableAvatars', \OC::$server->getConfig()->getSystemValue('enable
 
 $tmpl->assign('show_is_enabled', $config->getAppValue('core', 'umgmt_show_is_enabled', 'false'));
 $tmpl->assign('show_storage_location', $config->getAppValue('core', 'umgmt_show_storage_location', 'false'));
+$tmpl->assign('show_storage_used', $config->getAppValue('core', 'umgmt_show_storage_used', 'false'));
 $tmpl->assign('show_last_login', $config->getAppValue('core', 'umgmt_show_last_login', 'false'));
 $tmpl->assign('show_email', $config->getAppValue('core', 'umgmt_show_email', 'false'));
 $tmpl->assign('show_backend', $config->getAppValue('core', 'umgmt_show_backend', 'false'));


### PR DESCRIPTION
## Description
Add per-user storage view

## Related Issue
- https://github.com/owncloud/enterprise/issues/5468

## Motivation and Context
Make possible to visualise used storage on per-user basis

## How Has This Been Tested?
- Access ~/settings/users URL. A new column `Storage Used` will display the amount of used storage for every user. This option can be also opted in/out under `Settings` in order to align with all other available users' options.

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Database schema changes (next release will require increase of minor version instead of patch)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [ ] Tests only (no source changes)

## Checklist:
- [X] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised
- [X] Changelog item
