### PR TITLE
[tests-only] [full-ci] Public upload filename for ocis

### DIFF
--- a/tests/acceptance/features/apiSharePublicLink3/uploadToPublicLinkShare.feature
+++ b/tests/acceptance/features/apiSharePublicLink3/uploadToPublicLinkShare.feature
@@ -28,7 +28,7 @@ Feature: upload to a public link share
       | permissions | create |
     When the public uploads file "test.txt" with content "test" using the new public WebDAV API
     And the public uploads file "test.txt" with content "test2" using the new public WebDAV API
-    Then the HTTP status code of responses on all endpoints should be "201"
+    Then the HTTP status code of responses on each endpoint should be "<httpStatuses>" respectively
     And the following headers should match these regular expressions
       | ETag | /^"[a-f0-9:\.]{1,32}"$/ |
     And the content of file "/FOLDER/test.txt" for user "Alice" should be "test"
@@ -36,13 +36,13 @@ Feature: upload to a public link share
 
     @skipOnOcis
     Examples:
-      | secondFileName       |
-      | /FOLDER/test (2).txt |
+      | secondFileName       | httpStatuses |
+      | /FOLDER/test (2).txt | 201,201      |
 
     @skipOnOcV10
     Examples:
-      | secondFileName       |
-      | /FOLDER/test (1).txt |
+      | secondFileName       | httpStatuses |
+      | /FOLDER/test (1).txt | 201,204      |
 
 
   Scenario Outline: Uploading file to a public upload-only share using public API that was deleted does not work
@@ -289,16 +289,16 @@ Feature: upload to a public link share
     And the following headers should match these regular expressions
       | ETag | /^"[a-f0-9:\.]{1,32}"$/ |
     When the public uploads file "test.txt" with content "test2" using the new public WebDAV API
-    Then the HTTP status code should be "201"
+    Then the HTTP status code should be "<httpStatus>"
     And the content of file "/FOLDER/test.txt" for user "Alice" should be "test"
     And the content of file "<secondFileName>" for user "Alice" should be "test2"
 
     @skipOnOcis
     Examples:
-      | secondFileName       |
-      | /FOLDER/test (2).txt |
+      | secondFileName       | httpStatus |
+      | /FOLDER/test (2).txt | 201        |
 
     @skipOnOcV10
     Examples:
-      | secondFileName       |
-      | /FOLDER/test (1).txt |
+      | secondFileName       | httpStatus |
+      | /FOLDER/test (1).txt | 204        |

--- a/tests/acceptance/features/apiSharePublicLink3/uploadToPublicLinkShare.feature
+++ b/tests/acceptance/features/apiSharePublicLink3/uploadToPublicLinkShare.feature
@@ -20,8 +20,8 @@ Feature: upload to a public link share
     And the content of file "/FOLDER/test.txt" for user "Alice" should be "test"
     And the content of file "/FOLDER/test (2).txt" for user "Alice" should be "test2"
 
-  @smokeTest @issue-ocis-reva-286
-  Scenario: Uploading same file to a public upload-only share multiple times via new API
+  @smokeTest @issue-ocis-1267
+  Scenario Outline: Uploading same file to a public upload-only share multiple times via new API
     # The new API does the autorename automatically in upload-only folders
     Given user "Alice" has created a public link share with settings
       | path        | FOLDER |
@@ -32,7 +32,17 @@ Feature: upload to a public link share
     And the following headers should match these regular expressions
       | ETag | /^"[a-f0-9:\.]{1,32}"$/ |
     And the content of file "/FOLDER/test.txt" for user "Alice" should be "test"
-    And the content of file "/FOLDER/test (2).txt" for user "Alice" should be "test2"
+    And the content of file "<secondFileName>" for user "Alice" should be "test2"
+
+    @skipOnOcis
+    Examples:
+      | secondFileName       |
+      | /FOLDER/test (2).txt |
+
+    @skipOnOcV10
+    Examples:
+      | secondFileName       |
+      | /FOLDER/test (1).txt |
 
 
   Scenario Outline: Uploading file to a public upload-only share using public API that was deleted does not work
@@ -269,8 +279,8 @@ Feature: upload to a public link share
     Then the HTTP status code should be "403"
     And the content of file "/FOLDER/test.txt" for user "Alice" should be "test"
 
-  @smokeTest @issue-ocis-reva-286
-  Scenario: Uploading same file to a public upload-write and no edit and no overwrite share multiple times with new public API
+  @smokeTest @issue-ocis-1267
+  Scenario Outline: Uploading same file to a public upload-write and no edit and no overwrite share multiple times with new public API
     Given user "Alice" has created a public link share with settings
       | path        | FOLDER          |
       | permissions | uploadwriteonly |
@@ -281,4 +291,14 @@ Feature: upload to a public link share
     When the public uploads file "test.txt" with content "test2" using the new public WebDAV API
     Then the HTTP status code should be "201"
     And the content of file "/FOLDER/test.txt" for user "Alice" should be "test"
-    And the content of file "/FOLDER/test (2).txt" for user "Alice" should be "test2"
+    And the content of file "<secondFileName>" for user "Alice" should be "test2"
+
+    @skipOnOcis
+    Examples:
+      | secondFileName       |
+      | /FOLDER/test (2).txt |
+
+    @skipOnOcV10
+    Examples:
+      | secondFileName       |
+      | /FOLDER/test (1).txt |


### PR DESCRIPTION
## Description
Adjust the test scenarios that test public upload-only links. When the same filename is uploaded twice, the 2nd upload should be stored in a file with a different name. Currently in ocis that does not happen, and the feature needs to be implemented.

With received shares, the resolution of naming conflicts was done by appending ` (1)` to the filename. (oC10 appends ` (2)`). So this PR adjusts the public-upload-only link test scenarios so that they expect that ` (1)` is appended. That 
is probably what will be implemented some day.

I also adjusted the expected HTTP status values to have `204`. That helps the current test results to more clearly demonstrate the current behavior - the 2nd upload gets a `204` because it currently overwrites the first upload.

## Related Issue
https://github.com/owncloud/ocis/issues/5074

## How Has This Been Tested?
CI - tried with PR https://github.com/owncloud/ocis/pull/5097 from oCIS

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Database schema changes (next release will require increase of minor version instead of patch)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [x] Tests only (no source changes)

## Checklist:
- [ ] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 
- [ ] Changelog item, see [TEMPLATE](https://github.com/owncloud/core/blob/master/changelog/TEMPLATE)
