### PR TITLE
[full-ci] Add Webdav Token endpoint by App Passwords

### DIFF
--- a/settings/templates/panels/personal/tokens.php
+++ b/settings/templates/panels/personal/tokens.php
@@ -51,4 +51,9 @@ script('settings', 'panels/authtoken_view');
 			<button id="app-password-hide" class="button"><?php p($l->t('Done')); ?></button>
 		</div>
 	</div>
+	<div>
+		<br/>
+		<p><?php p($l->t('To access your files through WebDAV, please use the following URL:'));?></p>
+		<p><code><?php p(\OCP\Util::linkToRemote('webdav')); ?></code></p>
+	</div>
 </div>


### PR DESCRIPTION
## Description
Add a link to the webdav endpoint by the App Passwords.

## Motivation and Context
Show all necessary information of this page, how to use your webdav app passwords.

## How Has This Been Tested?
- Applied to own ownCloud instances

## Screenshots (if appropriate):
![Screenshot 2022-11-23 at 10 20 43](https://user-images.githubusercontent.com/2477797/203510411-37b0a4ad-d435-4bee-991e-1ca144224a48.png)

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Database schema changes (next release will require increase of minor version instead of patch)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [ ] Tests only (no source changes)

## Checklist:
- [X] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 
- [ ] Changelog item, see [TEMPLATE](https://github.com/owncloud/core/blob/master/changelog/TEMPLATE)

## Todo:
 - Add to translation
 - Fix nasty newline
