### PR TITLE
[full-ci] Show Username on personal profile settings page

### DIFF
--- a/changelog/unreleased/40510
+++ b/changelog/unreleased/40510
@@ -1,0 +1,6 @@
+Enhancement: Show username on personal profile page
+
+The username as well as the full name of a user is now shown on their personal
+general settings page.
+
+https://github.com/owncloud/core/pull/40510

--- a/settings/Panels/Personal/Profile.php
+++ b/settings/Panels/Personal/Profile.php
@@ -104,6 +104,7 @@ class Profile implements ISettings {
 		$tmpl->assign('passwordChangeSupported', $this->userSession->getUser()->canChangePassword());
 		$groups = $this->groupManager->getUserGroups($this->userSession->getUser());
 		$tmpl->assign('groups', $groups);
+		$tmpl->assign('username', $this->userSession->getUser()->getUID());
 		$tmpl->assign('languageSelector', $selector->fetchPage());
 		return $tmpl;
 	}

--- a/settings/css/settings.css
+++ b/settings/css/settings.css
@@ -51,6 +51,7 @@ input#webdav {
 #groups,
 #language,
 #emailform,
+#username,
 #passwordform {
 	display: inline-block;
 	margin-bottom: 0;

--- a/settings/templates/panels/personal/profile.php
+++ b/settings/templates/panels/personal/profile.php
@@ -110,6 +110,11 @@ if ($_['mailAddressChangeSupported']) {
 
 </div>
 
+<div id="username" class="section">
+       <h2 class="username"><?php p($l->t('Username')); ?></h2>
+       <p><?php p($_['username']); ?></p>
+</div>
+
 <?php
 if ($_['passwordChangeSupported']) {
 	script('jquery-showpassword'); ?>

--- a/tests/Settings/Panels/Personal/ProfileTest.php
+++ b/tests/Settings/Panels/Personal/ProfileTest.php
@@ -67,7 +67,7 @@ class ProfileTest extends \Test\TestCase {
 		$group2->method('getDisplayName')->willReturn('group2');
 		$user = $this->createMock(IUser::class);
 		$user->expects($this->once())->method('getEMailAddress')->will($this->returnValue('test@example.com'));
-		$this->userSession->expects($this->exactly(8))->method('getUser')->will($this->returnValue($user));
+		$this->userSession->expects($this->exactly(9))->method('getUser')->will($this->returnValue($user));
 		$this->groupManager->expects($this->once())->method('getUserGroups')->willReturn([$group1, $group2]);
 		$this->lfactory->expects($this->once())->method('findLanguage')->will($this->returnValue('en'));
 		$this->config->expects($this->once())->method('getUserValue')->will($this->returnValue(''));

--- a/tests/acceptance/features/bootstrap/WebUIPersonalGeneralSettingsContext.php
+++ b/tests/acceptance/features/bootstrap/WebUIPersonalGeneralSettingsContext.php
@@ -287,6 +287,22 @@ class WebUIPersonalGeneralSettingsContext extends RawMinkContext implements Cont
 	}
 
 	/**
+	 * @Then username :userName should be displayed on the personal general settings page on the webUI
+	 *
+	 * @param string $userName
+	 *
+	 * @return void
+	 */
+	public function usernameShouldBeDisplayedOnThePersonalGeneralSettingsPageOnTheWebui(string $userName):void {
+		Assert::assertEquals(
+			$userName,
+			$this->personalGeneralSettingsPage->getUsername(),
+			__METHOD__
+			. " Username '$userName' is not displayed on the personal general settings page on the webUI."
+		);
+	}
+
+	/**
 	 * @When the user follows the email change confirmation link received by :emailAddress using the webUI
 	 * @Given the user has followed the email change confirmation link received by :emailAddress using the webUI
 	 *

--- a/tests/acceptance/features/lib/PersonalGeneralSettingsPage.php
+++ b/tests/acceptance/features/lib/PersonalGeneralSettingsPage.php
@@ -50,6 +50,7 @@ class PersonalGeneralSettingsPage extends OwncloudPage {
 
 	protected $versionSectionXpath = "//div[@id='OC\\Settings\\Panels\\Personal\\Version']";
 	protected $federatedCloudIDXpath = "//*[@id='fileSharingSettings']/p/strong";
+	protected $usernameXpath = "//div[@id='OC\\Settings\\Panels\\Personal\\Profile']/div[@id='username']";
 	protected $groupListXpath = "//div[@id='OC\\Settings\\Panels\\Personal\\Profile']/div[@id='groups']";
 
 	protected $setProfilePicFromFilesBtnXpath = "//*[@id='selectavatar']";
@@ -198,6 +199,18 @@ class PersonalGeneralSettingsPage extends OwncloudPage {
 	public function getFederatedCloudID(): string {
 		$this->waitTillElementIsNotNull($this->federatedCloudIDXpath);
 		return $this->find("xpath", $this->federatedCloudIDXpath)->getText();
+	}
+
+	/**
+	 * get username displayed in the UI
+	 *
+	 * @return string
+	 */
+	public function getUsername(): string {
+		$this->waitTillElementIsNotNull($this->usernameXpath);
+		// The text is like "Username Alice"
+		$text = $this->find("xpath", $this->usernameXpath)->getText();
+		return \substr($text, \strlen("Username "));
 	}
 
 	/**

--- a/tests/acceptance/features/webUIPersonalSettings/personalGeneralSettings.feature
+++ b/tests/acceptance/features/webUIPersonalSettings/personalGeneralSettings.feature
@@ -35,6 +35,13 @@ Feature: personal general settings
     And group "new-group" should be displayed on the personal general settings page on the webUI
     And group "another-group" should be displayed on the personal general settings page on the webUI
 
+  @skipOnOcV10.11 @skipOnOcV10.10
+  Scenario: user sees their username displayed on the personal general settings page
+    Given the administrator has changed the display name of user "Alice" to "New display name"
+    And the user has reloaded the current page of the webUI
+    Then "New display name" should be shown as the name of the current user on the webUI
+    And username "Alice" should be displayed on the personal general settings page on the webUI
+
 
   Scenario: User sets profile picture from their existing cloud file
     Given user "Alice" has uploaded file "filesForUpload/testavatar.jpg" to "/testimage.jpg"


### PR DESCRIPTION
## Description
When you make use of an external identity provider, for example Shibboleth or OIDC.
Your username within the environment may be different from the one you use to log in to the IdP.
When autocomplete is disabled for sharing and your full username have to be entered, then it's handy to know what's your username

## How Has This Been Tested?
 - Applied within own environment

## Screenshots (if appropriate):
![Screenshot 2022-11-23 at 10 36 27](https://user-images.githubusercontent.com/2477797/203514215-c6e252d0-cd00-4371-b24c-0efd471c1101.png)

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Database schema changes (next release will require increase of minor version instead of patch)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [ ] Tests only (no source changes)

## Checklist:
- [X] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 
- [ ] Changelog item, see [TEMPLATE](https://github.com/owncloud/core/blob/master/changelog/TEMPLATE)

## Todo:
 - Translation option should be added.