### PR TITLE
Set checksum if not seeked

### DIFF
--- a/changelog/unreleased/40513
+++ b/changelog/unreleased/40513
@@ -1,0 +1,15 @@
+Bugfix: Store checksums only if the whole stream has been read
+
+Previously, range downloads (or downloads requesting a specific
+byte range) would store a checksum, if needed, based only on the
+requested range. This causes problems because the checksum is
+expected to be for the whole file.
+
+Now, those range downloads won't store a checksum because only a
+part of the file has been read, so the checksum would be incomplete.
+
+Some additional cases have been taken into account, mostly based
+on actions that could happen on the data stream, but they shouldn't
+happen normally.
+
+https://github.com/owncloud/core/pull/40513

--- a/tests/lib/Files/Stream/ChecksumTest.php
+++ b/tests/lib/Files/Stream/ChecksumTest.php
@@ -1,0 +1,200 @@
+<?php
+/**
+ * @copyright Copyright (c) 2022, ownCloud GmbH
+ * @license AGPL-3.0
+ *
+ * This code is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License, version 3,
+ * as published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License, version 3,
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>
+ *
+ */
+
+namespace Test\Files\Stream;
+
+use OC\Files\Stream\Checksum;
+use Test\TestCase;
+use org\bovigo\vfs\vfsStream;
+
+class ChecksumTest extends \Test\TestCase {
+	private $root;
+	private $fileList = [];
+
+	protected function setUp(): void {
+		parent::setUp();
+
+		Checksum::resetChecksums();
+		$this->root = vfsStream::setup();
+	}
+
+	protected function tearDown(): void {
+		foreach ($this->fileList as $file) {
+			\unlink($file->url());
+		}
+		parent::tearDown();
+	}
+
+	private function getVfsFile($filename) {
+		$vfsFile = vfsStream::newFile($filename)->at($this->root);
+		$this->fileList[] = $vfsFile;
+		return $vfsFile;
+	}
+
+	public function testRead() {
+		$content = 'random text to fill bytes';
+		$filename = 'test001.txt';
+
+		$file = $this->getVfsFile($filename);
+		$file->setContent($content);
+		$fp = Checksum::wrap(\fopen($file->url(), 'rb'), $filename);
+
+		$contentRead = stream_get_contents($fp);
+		\fclose($fp);
+		$this->assertSame('random text to fill bytes', $contentRead);
+
+		$expectedChecksums = [
+			'sha1' => \sha1($contentRead),
+			'md5' => \md5($contentRead),
+			'adler32' => \hash('adler32', $contentRead),
+		];
+		$checksums = Checksum::getChecksums($filename);
+		$this->assertEquals($expectedChecksums, $checksums);
+	}
+
+	public function testSkipRead() {
+		$content = 'random text to fill bytes';
+		$filename = 'test001.txt';
+
+		$file = $this->getVfsFile($filename);
+		$file->setContent($content);
+		$fp = Checksum::wrap(\fopen($file->url(), 'rb'), $filename);
+
+		\fseek($fp, 10, SEEK_SET);
+		$contentRead = stream_get_contents($fp);
+		\fclose($fp);
+		$this->assertSame('t to fill bytes', $contentRead);  // skipped content
+
+		$expectedChecksums = [];
+		$checksums = Checksum::getChecksums($filename);
+		$this->assertEquals($expectedChecksums, $checksums);
+		$this->assertSame(0, \count($checksums));
+	}
+
+	public function testUnfinishedRead() {
+		// NOTE: `fread` will request chunks of 8KB to the underlying stream even if
+		// the function will only return the number of bytes asked by the caller.
+		// Since the 8KB isn't enough to read the whole content in this test, the
+		// checksums won't be available.
+		$content = 'random text to fill bytes' . \str_repeat('abc', 10000);
+		$filename = 'test001.txt';
+
+		$file = $this->getVfsFile($filename);
+		$file->setContent($content);
+		$fp = Checksum::wrap(\fopen($file->url(), 'rb'), $filename);
+
+		$contentRead = \fread($fp, 10);
+		\fclose($fp);
+		$this->assertSame('random tex', $contentRead);  // skipped content
+
+		$expectedChecksums = [];
+		$checksums = Checksum::getChecksums($filename);
+		$this->assertEquals($expectedChecksums, $checksums);
+		$this->assertSame(0, \count($checksums));
+	}
+
+	public function testUnfinishedReadButFullChunk() {
+		// NOTE: `fread` will request chunks of 8KB to the underlying stream even if
+		// the function will only return the number of bytes asked by the caller.
+		// This means that `fread` will read the whole content but return only 10B
+		// in this test case.
+		// Since the checksum stream has read the whole file (content is < 8KB),
+		// checksums are available
+		$content = 'random text to fill bytes';
+		$filename = 'test001.txt';
+
+		$file = $this->getVfsFile($filename);
+		$file->setContent($content);
+		$fp = Checksum::wrap(\fopen($file->url(), 'rb'), $filename);
+
+		$contentRead = \fread($fp, 10);
+		\fclose($fp);
+		$this->assertSame('random tex', $contentRead);  // skipped content
+
+		$expectedChecksums = [
+			'sha1' => \sha1($content),
+			'md5' => \md5($content),
+			'adler32' => \hash('adler32', $content),
+		];
+		$checksums = Checksum::getChecksums($filename);
+		$this->assertEquals($expectedChecksums, $checksums);
+	}
+
+	public function testJumpRead() {
+		// NOTE: Second `fread` might still bring the whole file for checksum if
+		// the content is less than 8KB
+		$content = 'random text to fill bytes' . \str_repeat('abc', 10000);
+		$filename = 'test001.txt';
+
+		$file = $this->getVfsFile($filename);
+		$file->setContent($content);
+		$fp = Checksum::wrap(\fopen($file->url(), 'rb'), $filename);
+
+		$contentRead = \fread($fp, 10);
+		\fseek($fp, 3, SEEK_CUR);
+		$contentRead .= \fread($fp, 100);
+		\fclose($fp);
+		$expectedContent = \substr($content, 0, 10) . \substr($content, 13, 100);
+		$this->assertSame($expectedContent, $contentRead);  // skipped content
+
+		$expectedChecksums = [];
+		$checksums = Checksum::getChecksums($filename);
+		$this->assertEquals($expectedChecksums, $checksums);
+		$this->assertSame(0, \count($checksums));
+	}
+
+	public function testWrite() {
+		$content = 'random text to fill bytes';
+		$filename = 'test001.txt';
+
+		$file = $this->getVfsFile($filename);
+		$fp = Checksum::wrap(\fopen($file->url(), 'wb'), $filename);
+
+		$contentWritten = \fwrite($fp, $content);
+		\fclose($fp);
+		$this->assertSame(\strlen($content), $contentWritten);
+
+		$expectedChecksums = [
+			'sha1' => \sha1($content),
+			'md5' => \md5($content),
+			'adler32' => \hash('adler32', $content),
+		];
+		$checksums = Checksum::getChecksums($filename);
+		$this->assertEquals($expectedChecksums, $checksums);
+	}
+
+	public function testAppend() {
+		// Append won't return checksums because there could be content
+		// the wouldn't be evaluated
+		$content = 'random text to fill bytes';
+		$filename = 'test001.txt';
+
+		$file = $this->getVfsFile($filename);
+		$file->setContent($content);
+		$fp = Checksum::wrap(\fopen($file->url(), 'ab'), $filename);
+
+		$contentWritten = \fwrite($fp, "{$content}zzz");
+		\fclose($fp);
+		$this->assertSame(\strlen($content) + 3, $contentWritten);
+
+		$expectedChecksums = [];
+		$checksums = Checksum::getChecksums($filename);
+		$this->assertEquals($expectedChecksums, $checksums);
+	}
+}


### PR DESCRIPTION
<!--
Thanks for submitting a change to ownCloud!

This is the bug tracker for the Server component. Find other components at https://github.com/owncloud/core/blob/master/.github/CONTRIBUTING.md#guidelines

For fixing potential security issues please see https://owncloud.com/security/

To make it possible for us to get your change reviewed and merged please carefully fill out the requested information below.

Please note that any kind of change needs first be submitted to the master branch which holds the next version of ownCloud.

Please set the following labels:

- Set label "3 - To review" for review or "2 - Development" if the PR still has open tasks
- Assignment: assign to self
- Milestone: set the same as the ticket this PR fixes, or "development" by default
- Reviewers: pick at least one
-->

## Description
Range downloads might set up a wrong checksum if there isn't a checksum set. This causes problems later because a full download will send the wrong checksum and clients might flag the download even though the file was downloaded ok.

Note that range downloads might still get the checksum of the whole file, not just the downloaded piece.

In addition, appending content won't calculate a checksum.

There are some additional cases that might still need to be covered

## Related Issue
https://github.com/owncloud/enterprise/issues/5457

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
- test environment:
- test case 1:
- test case 2:
- ...

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Database schema changes (next release will require increase of minor version instead of patch)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [ ] Tests only (no source changes)

## Checklist:
<!-- Tick the checkboxes when done. -->
<!-- Raise documentation ticket in https://github.com/owncloud/documentation -->
- [x] Code changes
- [x] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 
- [ ] Changelog item, see [TEMPLATE](https://github.com/owncloud/core/blob/master/changelog/TEMPLATE)

### Notes
* On average, range download don't generate a checksum because not the whole file is read. However, it really depends on how PHP reads the stream internally. PHP usually read blocks of 8KB and keep them in a buffer even though only a few bytes are requested and returned. This means that, for small files (less than 8KB), there is a chance that the whole file is buffered, so in this case a checksum could be stored even though, technically, not the whole file is returned.
* It's expected that, regardless of the outcome, the checksum stored in the DB is always correct. This is important taking into account the behavior of the previous point.
* While the expected actions on the data stream are expected to be easy coming from the outside (either read the whole o a part of the file, or write contents) additional actions might happen, such as overwrite a part of the stream while leaving the rest intact. In this case, a conservative approach is taken, so if there are doubts on whether we've read the whole file or the checksum could be compromised (by moving the stream pointer to a previous position, for example), no checksum will be stored because it's very likely it will be wrong.
* Partial data won't be saved among requests. This could be relevant for apps that download the file by chunks. The app could request the first megabyte, then the second, then the third... In this case, even though the file ends up being downloaded, no checksum will be stored.