### PR TITLE
Refactor login to converge in the same function

### DIFF
--- a/tests/lib/User/SessionTest.php
+++ b/tests/lib/User/SessionTest.php
@@ -631,16 +631,12 @@ class SessionTest extends TestCase {
 
 	public function testRememberLoginValidToken() {
 		$session = $this->createMock(Memory::class);
-		$session->expects($this->exactly(1))
+		$session->expects($this->exactly(2))
 			->method('set')
-			->with($this->callback(function ($key) {
-				switch ($key) {
-					case 'user_id':
-						return true;
-					default:
-						return false;
-				}
-			}));
+			->withConsecutive(
+				['user_id', 'foo'],
+				['loginname', 'foo'],
+			);
 		$session->expects($this->once())
 			->method('regenerateId');
 
@@ -1083,14 +1079,21 @@ class SessionTest extends TestCase {
 			->method('getHeader')
 			->with('Authorization')
 			->will($this->returnValue('token xxxxx'));
-		$this->tokenProvider->expects($this->once())
+		$this->tokenProvider->expects($this->exactly(2))  // one for validation and other for login
 			->method('getToken')
 			->with('xxxxx')
 			->will($this->returnValue($token));
-		$manager->expects($this->once())
+		$this->tokenProvider->expects($this->exactly(2))  // one for validation and other for login
+			->method('getPassword')
+			->will($this->returnValue('myPassword'));
+		$manager->expects($this->exactly(2))  // one for validation and other for login
 			->method('get')
 			->with('fritz0')
 			->will($this->returnValue($user));
+		$manager->expects($this->once())
+			->method('checkPassword')
+			->with('fritz', 'myPassword')
+			->willReturn($user);
 		$user->expects($this->once())
 			->method('isEnabled')
 			->will($this->returnValue(false));
@@ -1165,9 +1168,6 @@ class SessionTest extends TestCase {
 
 		/** @var IUser | \PHPUnit\Framework\MockObject\MockObject $user */
 		$user = $this->createMock(IUser::class);
-		$user->expects($this->once())
-			->method('isEnabled')
-			->willReturn(true);
 		$token = new DefaultToken();
 		$token->setLastCheck(20);
 
@@ -1575,12 +1575,9 @@ class SessionTest extends TestCase {
 
 		$failedEvent = new GenericEvent(null, ['user' => 'foo']);
 		$beforeLoginEvent = new GenericEvent(null, ['login' => 'foo', 'uid' => 'foo', 'password' => '', 'loginType' => 'apache']);
-		$eventDispatcher->expects($this->exactly(2))
+		$eventDispatcher->expects($this->once())
 			->method('dispatch')
-			->withConsecutive(
-				[$this->equalTo($beforeLoginEvent), $this->equalTo('user.beforelogin')],
-				[$this->equalTo($failedEvent), $this->equalTo('user.loginfailed')]
-			);
+			->with($this->equalTo($failedEvent), $this->equalTo('user.loginfailed'));
 
 		$userSession->loginWithApache($apacheBackend);
 	}
@@ -1617,7 +1614,7 @@ class SessionTest extends TestCase {
 		$iUser->expects($this->exactly(2))
 			->method('isEnabled')
 			->willReturn(true);
-		$iUser->expects($this->exactly(4))
+		$iUser->expects($this->exactly(5))
 			->method('getUID')
 			->willReturn('foo');
 
@@ -1625,8 +1622,8 @@ class SessionTest extends TestCase {
 			->method('get')
 			->willReturn($iUser);
 
-		$beforeLoginEvent = new GenericEvent(null, ['login' => 'foo', 'uid' => 'foo', 'password' => '', 'loginType' => 'apache']);
-		$afterLoginEvent = new GenericEvent(null, ['user' => $iUser, 'login' => 'foo', 'uid' => 'foo', 'password' => '', 'loginType' => 'apache']);
+		$beforeLoginEvent = new GenericEvent(null, ['login' => 'foo', 'uid' => 'foo', 'password' => '', 'loginType' => 'apache', '_uid' => 'deprecated: please use \'login\', the real uid is not yet known',]);
+		$afterLoginEvent = new GenericEvent(null, ['user' => $iUser, 'uid' => 'foo', 'password' => '', 'loginType' => 'apache']);
 		$eventDispatcher->expects($this->exactly(2))
 			->method('dispatch')
 			->withConsecutive(
@@ -1661,19 +1658,10 @@ class SessionTest extends TestCase {
 			$eventDispatcher
 		);
 
-		$beforeEvent = new GenericEvent(
-			null,
-			['loginType' => 'password', 'login' => 'foo', 'uid' => 'foo',
-				'_uid' => 'deprecated: please use \'login\', the real uid is not yet known',
-				'password' => 'foo']
-		);
 		$failedLogin = new GenericEvent(null, ['user' => 'foo']);
-		$eventDispatcher->expects($this->exactly(2))
+		$eventDispatcher->expects($this->once())
 			->method('dispatch')
-			->withConsecutive(
-				[$this->equalTo($beforeEvent), $this->equalTo('user.beforelogin')],
-				[$this->equalTo($failedLogin), $this->equalTo('user.loginfailed')]
-			);
+			->with($this->equalTo($failedLogin), $this->equalTo('user.loginfailed'));
 
 		$this->invokePrivate($userSession, 'loginWithPassword', ['foo', 'foo']);
 	}
@@ -1768,14 +1756,10 @@ class SessionTest extends TestCase {
 			->method('get')
 			->willReturn(null);
 
-		$event = new GenericEvent(null, ['login' => 'foo', 'uid' => 'foo', 'password' => 'foobar', 'loginType' => 'token']);
 		$failedEvent = new GenericEvent(null, ['user' => 'foo']);
-		$eventDispatcher->expects($this->exactly(2))
+		$eventDispatcher->expects($this->once())
 			->method('dispatch')
-			->withConsecutive(
-				[$this->equalTo($event), $this->equalTo('user.beforelogin')],
-				[$this->equalTo($failedEvent), $this->equalTo('user.loginfailed')]
-			);
+			->with($this->equalTo($failedEvent), $this->equalTo('user.loginfailed'));
 
 		$this->invokePrivate($userSession, 'loginWithToken', ['token']);
 	}
@@ -1828,13 +1812,13 @@ class SessionTest extends TestCase {
 		$beforeEvent = new GenericEvent(
 			null,
 			[
-				'login' => 'foo', 'uid' => 'foo', 'password' => 'foobar', 'loginType' => 'token'
+				'login' => 'foo', 'uid' => 'foo', 'password' => 'foobar', 'loginType' => 'token', '_uid' => 'deprecated: please use \'login\', the real uid is not yet known',
 			]
 		);
 		$afterEvent = new GenericEvent(
 			null,
 			[
-				'user' => $iUser, 'login' => 'foo', 'uid' => 'foo', 'password' => 'foobar', 'loginType' => 'token'
+				'user' => $iUser, 'uid' => 'foo', 'password' => 'foobar', 'loginType' => 'token'
 			]
 		);
 
@@ -2052,13 +2036,6 @@ class SessionTest extends TestCase {
 			$eventDispatcher
 		);
 
-		$failedEvent = new GenericEvent(null, ['user' => 'foo']);
-		$eventDispatcher->expects($this->once())
-			->method('dispatch')
-			->withConsecutive(
-				[$this->equalTo($failedEvent), $this->equalTo('user.loginfailed')]
-			);
-
 		$iUser = $this->createMock(IUser::class);
 		$iUser->expects($this->once())
 			->method('isEnabled')
@@ -2068,13 +2045,16 @@ class SessionTest extends TestCase {
 		$iUser->expects($this->never())
 			->method('updateLastLoginTimestamp');
 
-		$failedEvent = new GenericEvent(null, ['user' => 'foo']);
+		$beforeEvent = new GenericEvent(
+			null,
+			['loginType' => null, 'login' => 'foo', 'uid' => 'foo',  // loginType == null because no authModule specified
+				'_uid' => 'deprecated: please use \'login\', the real uid is not yet known',
+				'password' => 'bar']
+		);
 		$eventDispatcher->expects($this->once())
 			->method('dispatch')
-			->withConsecutive(
-				[$this->equalTo($failedEvent), $this->equalTo('user.loginfailed')]
-			);
+			->with($this->equalTo($beforeEvent), $this->equalTo('user.beforelogin'));
 
-		$this->invokePrivate($userSession, 'loginUser', [$iUser, 'foo']);
+		$this->invokePrivate($userSession, 'loginUser', [$iUser, 'bar']);
 	}
 }


### PR DESCRIPTION
<!--
Thanks for submitting a change to ownCloud!

This is the bug tracker for the Server component. Find other components at https://github.com/owncloud/core/blob/master/.github/CONTRIBUTING.md#guidelines

For fixing potential security issues please see https://owncloud.com/security/

To make it possible for us to get your change reviewed and merged please carefully fill out the requested information below.

Please note that any kind of change needs first be submitted to the master branch which holds the next version of ownCloud.

Please set the following labels:

- Set label "3 - To review" for review or "2 - Development" if the PR still has open tasks
- Assignment: assign to self
- Milestone: set the same as the ticket this PR fixes, or "development" by default
- Reviewers: pick at least one
-->

## Description
Refactor login process so it ends going through the new `loginInOwnCloud` method.

The new method will be perform the following:
* It will trigger the login events (pre and post login)
* Perform common checks to all auth mechanisms, such as checking if the logging user is disabled
* Set the user, and prepare it
* Update login timestamp

Specific checks based on the auth mechanism (checking if the password is correct, or checking the expiration of the token) will be performed outside.

Additional changes brought in the PR:
* As said, the login will be performed by the new `loginInOwnCloud` method. This has caused some changes for some authentication methods about when the login events are triggered. This means that for some auth methods, the events will be triggered later and after some operations / checks have been performed. This might cause issues and will require verification.
* For the `loginWithToken`, the token will be validated before trying to login with it. Previously, we logged in and then validated the token, so this might cause changes in the behavior
* The `createSessionToken` will be called after a successful login. There were cases were this was called before login and others after login, so it's unclear when the session token should be created. This might need to be adjusted.
* `preRememberedLogin` and `postRememberedLogin` events have been removed. These were additional events triggered by the "remember me" login which was broken until recently, so it's very unlikely they were used. Currently, the "remember me" login won't trigger any login event, but it might need to trigger the regular ones (prelogin and postlogin). They're currently being skipped.

Known issues:
* openidconnect's `LoginFlowController` will call the `loginUser` method without a module class. This will report the login type as empty instead of the expected openidconnect class name. There is nothing we can do without changing the app. This is harmless for this PR, but it will affect further functionality.
* Since user_shibboleth depends on an apache module and ownCloud will get the info from apache, the "apache" login type will be reported for the user_shibboleth app.

## Related Issue
Preparations for https://github.com/owncloud/enterprise/issues/5295

## Motivation and Context
This is a preparation to bring new functionality. We need a centralized point where all login paths can converge.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
- test environment:
- test case 1:
- test case 2:
- ...

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Database schema changes (next release will require increase of minor version instead of patch)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [ ] Tests only (no source changes)

## Checklist:
<!-- Tick the checkboxes when done. -->
<!-- Raise documentation ticket in https://github.com/owncloud/documentation -->
- [ ] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 
- [ ] Changelog item, see [TEMPLATE](https://github.com/owncloud/core/blob/master/changelog/TEMPLATE)
