### PR TITLE
[full-ci] Adjust symfony deprecated

### DIFF
--- a/changelog/unreleased/PHPdependencies20220920onwardSymfony
+++ b/changelog/unreleased/PHPdependencies20220920onwardSymfony
@@ -22,3 +22,7 @@ https://symfony.com/blog/symfony-4-4-48-released
 https://github.com/owncloud/core/pull/40448
 https://symfony.com/blog/symfony-4-4-49-released
 https://github.com/owncloud/core/pull/40517
+
+Code that has been deprecated in Symfony 4 has been refactored to be ready for Symfony 5.
+
+https://github.com/owncloud/core/pull/40521

--- a/lib/private/L10N/L10N.php
+++ b/lib/private/L10N/L10N.php
@@ -25,9 +25,11 @@ namespace OC\L10N;
 use OCP\IL10N;
 use OCP\L10N\IFactory;
 use Punic\Calendar;
-use Symfony\Component\Translation\PluralizationRules;
+use Symfony\Contracts\Translation\TranslatorTrait;
 
 class L10N implements IL10N {
+	use TranslatorTrait;
+
 	/** @var IFactory */
 	protected $factory;
 
@@ -200,6 +202,6 @@ class L10N implements IL10N {
 	 * @return int
 	 */
 	public function computePlural($number) {
-		return PluralizationRules::get($number, $this->lang);
+		return $this->getPluralizationRule($number, $this->lang);
 	}
 }

--- a/lib/public/App/ManagerEvent.php
+++ b/lib/public/App/ManagerEvent.php
@@ -21,7 +21,7 @@
 
 namespace OCP\App;
 
-use Symfony\Component\EventDispatcher\Event;
+use Symfony\Contracts\EventDispatcher\Event;
 
 /**
  * Class ManagerEvent

--- a/lib/public/Comments/CommentsEntityEvent.php
+++ b/lib/public/Comments/CommentsEntityEvent.php
@@ -21,7 +21,7 @@
 
 namespace OCP\Comments;
 
-use Symfony\Component\EventDispatcher\Event;
+use Symfony\Contracts\EventDispatcher\Event;
 
 /**
  * Class CommentsEntityEvent

--- a/lib/public/Comments/CommentsEvent.php
+++ b/lib/public/Comments/CommentsEvent.php
@@ -21,7 +21,7 @@
 
 namespace OCP\Comments;
 
-use Symfony\Component\EventDispatcher\Event;
+use Symfony\Contracts\EventDispatcher\Event;
 
 /**
  * Class CommentsEvent

--- a/lib/public/Console/ConsoleEvent.php
+++ b/lib/public/Console/ConsoleEvent.php
@@ -21,7 +21,7 @@
 
 namespace OCP\Console;
 
-use Symfony\Component\EventDispatcher\Event;
+use Symfony\Contracts\EventDispatcher\Event;
 
 /**
  * Class ConsoleEvent

--- a/lib/public/Notification/Events/RegisterConsumerEvent.php
+++ b/lib/public/Notification/Events/RegisterConsumerEvent.php
@@ -21,7 +21,7 @@
 
 namespace OCP\Notification\Events;
 
-use Symfony\Component\EventDispatcher\Event;
+use Symfony\Contracts\EventDispatcher\Event;
 use OCP\Notification\IApp;
 
 /**

--- a/lib/public/Notification/Events/RegisterConsumerEvent.php
+++ b/lib/public/Notification/Events/RegisterConsumerEvent.php
@@ -51,7 +51,7 @@ abstract class RegisterConsumerEvent extends Event {
 	 *
 	 * @since 10.0.8
 	 */
-	public function stopPropagation() {
+	public function stopPropagation(): void {
 	}
 
 	/**

--- a/lib/public/Notification/Events/RegisterNotifierEvent.php
+++ b/lib/public/Notification/Events/RegisterNotifierEvent.php
@@ -21,7 +21,7 @@
 
 namespace OCP\Notification\Events;
 
-use Symfony\Component\EventDispatcher\Event;
+use Symfony\Contracts\EventDispatcher\Event;
 use OCP\Notification\INotifier;
 
 /**

--- a/lib/public/Notification/Events/RegisterNotifierEvent.php
+++ b/lib/public/Notification/Events/RegisterNotifierEvent.php
@@ -55,7 +55,7 @@ abstract class RegisterNotifierEvent extends Event {
 	 *
 	 * @since 10.0.8
 	 */
-	public function stopPropagation() {
+	public function stopPropagation(): void {
 	}
 
 	/**

--- a/lib/public/Roles/AddRolesEvent.php
+++ b/lib/public/Roles/AddRolesEvent.php
@@ -21,7 +21,7 @@
 
 namespace OCP\Roles;
 
-use Symfony\Component\EventDispatcher\Event;
+use Symfony\Contracts\EventDispatcher\Event;
 
 /**
  * Class AddRolesEvent

--- a/lib/public/SabrePluginEvent.php
+++ b/lib/public/SabrePluginEvent.php
@@ -24,7 +24,7 @@ namespace OCP;
 
 use OCP\AppFramework\Http;
 use Sabre\DAV\Server;
-use Symfony\Component\EventDispatcher\Event;
+use Symfony\Contracts\EventDispatcher\Event;
 
 /**
  * @since 8.2.0

--- a/lib/public/Share/Events/ShareEvent.php
+++ b/lib/public/Share/Events/ShareEvent.php
@@ -21,7 +21,7 @@
 
 namespace OCP\Share\Events;
 
-use Symfony\Component\EventDispatcher\Event;
+use Symfony\Contracts\EventDispatcher\Event;
 
 /**
  * Class ShareEvent

--- a/lib/public/SystemTag/ManagerEvent.php
+++ b/lib/public/SystemTag/ManagerEvent.php
@@ -21,7 +21,7 @@
 
 namespace OCP\SystemTag;
 
-use Symfony\Component\EventDispatcher\Event;
+use Symfony\Contracts\EventDispatcher\Event;
 
 /**
  * Class ManagerEvent

--- a/lib/public/SystemTag/MapperEvent.php
+++ b/lib/public/SystemTag/MapperEvent.php
@@ -21,7 +21,7 @@
 
 namespace OCP\SystemTag;
 
-use Symfony\Component\EventDispatcher\Event;
+use Symfony\Contracts\EventDispatcher\Event;
 
 /**
  * Class MapperEvent

--- a/lib/public/User/UserExtendedAttributesEvent.php
+++ b/lib/public/User/UserExtendedAttributesEvent.php
@@ -24,7 +24,7 @@
 namespace OCP\User;
 
 use OCP\IUser;
-use Symfony\Component\EventDispatcher\Event;
+use Symfony\Contracts\EventDispatcher\Event;
 
 /**
  * Class UserExtendedAttributesEvent


### PR DESCRIPTION
## Description
Some things have been deprecated in Symfony 4 and removed in Symfony 5. The new way of doing each thing is implemented in Symfony 4.4, so we can move to that, and then there will be no code to change again when moving up to Symfony 5. This is what I have found so far:

1) `Symfony\Component\EventDispatcher\Event` is now `Symfony\Contracts\EventDispatcher\Event`

2) `stopPropagation()` returns `void`. Classes that extend that need to have the return type declared.

3) `Symfony\Component\Translation\PluralizationRules` is gone in Symfony 5. `Symfony\Contracts\Translation\TranslatorTrait` has the pluralization rules in function `getPluralizationRule`

Implement these changes now.


## Related Issue
#39630 

## How Has This Been Tested?
CI

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Database schema changes (next release will require increase of minor version instead of patch)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [ ] Tests only (no source changes)

## Checklist:
- [x] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 
- [ ] Changelog item, see [TEMPLATE](https://github.com/owncloud/core/blob/master/changelog/TEMPLATE)
