### PR TITLE
[tests-only][full-ci] Filter out cors tests for oCIS

### DIFF
--- a/tests/acceptance/features/apiAuth/cors.feature
+++ b/tests/acceptance/features/apiAuth/cors.feature
@@ -1,4 +1,4 @@
-@api @issue-ocis-reva-26 @issue-ocis-reva-27
+@api @issue-ocis-reva-26 @issue-ocis-reva-27 @skipOnOcis
 Feature: CORS headers
 
   Background:
@@ -21,12 +21,6 @@ Feature: CORS headers
       | Access-Control-Allow-Methods  | GET,OPTIONS,POST,PUT,DELETE,MKCOL,PROPFIND,PATCH,PROPPATCH,REPORT                                                                                                                                                                                                                                                                                                                                                                                                                                                                                     |
     Examples:
       | ocs_api_version | endpoint                                         | ocs-code | http-code |
-      | 1               | /config                                          | 100      | 200       |
-      | 2               | /config                                          | 200      | 200       |
-
-    @notToImplementOnOCIS
-    Examples:
-      | ocs_api_version | endpoint                                         | ocs-code | http-code |
       | 1               | /privatedata/getattribute                        | 100      | 200       |
       | 2               | /privatedata/getattribute                        | 200      | 200       |
       | 1               | /cloud/apps                                      | 997      | 401       |
@@ -35,6 +29,8 @@ Feature: CORS headers
       | 2               | /cloud/groups                                    | 997      | 401       |
       | 1               | /cloud/users                                     | 997      | 401       |
       | 2               | /cloud/users                                     | 997      | 401       |
+      | 1               | /config                                          | 100      | 200       |
+      | 2               | /config                                          | 200      | 200       |
 
     @files_external-app-required @notToImplementOnOCIS
     Examples:
@@ -42,21 +38,17 @@ Feature: CORS headers
       | 1               | /apps/files_external/api/v1/mounts               | 100      | 200       |
       | 2               | /apps/files_external/api/v1/mounts               | 200      | 200       |
 
-    @files_sharing-app-required @notToImplementOnOCIS
+    @files_sharing-app-required
     Examples:
       | ocs_api_version | endpoint                                         | ocs-code | http-code |
       | 1               | /apps/files_sharing/api/v1/remote_shares         | 100      | 200       |
       | 2               | /apps/files_sharing/api/v1/remote_shares         | 200      | 200       |
       | 1               | /apps/files_sharing/api/v1/remote_shares/pending | 100      | 200       |
       | 2               | /apps/files_sharing/api/v1/remote_shares/pending | 200      | 200       |
-
-    @files_sharing-app-required
-    Examples:
-      | ocs_api_version | endpoint                                         | ocs-code | http-code |
       | 1               | /apps/files_sharing/api/v1/shares                | 100      | 200       |
       | 2               | /apps/files_sharing/api/v1/shares                | 200      | 200       |
 
-  @skipOnOcV10.8 @skipOnOcV10.9.0 @skipOnOcV10.9.1 @notToImplementOnOCIS
+  @skipOnOcV10.8 @skipOnOcV10.9.0 @skipOnOcV10.9.1
   Scenario Outline: CORS headers should be returned when setting CORS domain sending Origin header (admin only endpoints)
     Given using OCS API version "<ocs_api_version>"
     And the administrator has added "https://aphno.badal" to the list of personal CORS domains
@@ -83,10 +75,10 @@ Feature: CORS headers
 
   Scenario Outline: no CORS headers should be returned when CORS domain does not match Origin header
     Given using OCS API version "<ocs_api_version>"
-    And user "Alice" has added "https://aphno.badal" to the list of personal CORS domains
+    And user "Alice" has added "https://mero.badal" to the list of personal CORS domains
     When user "Alice" sends HTTP method "GET" to OCS API endpoint "<endpoint>" with headers
       | header | value               |
-      | Origin | https://mero.badal  |
+      | Origin | https://aphno.badal |
     Then the OCS status code should be "<ocs-code>"
     And the HTTP status code should be "<http-code>"
     And the following headers should not be set
@@ -99,10 +91,6 @@ Feature: CORS headers
       | ocs_api_version | endpoint                                         | ocs-code | http-code |
       | 1               | /config                                          | 100      | 200       |
       | 2               | /config                                          | 200      | 200       |
-
-    @notToImplementOnOCIS
-    Examples:
-      | ocs_api_version | endpoint                                         | ocs-code | http-code |
       | 1               | /privatedata/getattribute                        | 100      | 200       |
       | 2               | /privatedata/getattribute                        | 200      | 200       |
       | 1               | /cloud/apps                                      | 997      | 401       |
@@ -118,28 +106,23 @@ Feature: CORS headers
       | 1               | /apps/files_external/api/v1/mounts               | 100      | 200       |
       | 2               | /apps/files_external/api/v1/mounts               | 200      | 200       |
 
-    @files_sharing-app-required @notToImplementOnOCIS
+    @files_sharing-app-required
     Examples:
       | ocs_api_version | endpoint                                         | ocs-code | http-code |
       | 1               | /apps/files_sharing/api/v1/remote_shares         | 100      | 200       |
       | 2               | /apps/files_sharing/api/v1/remote_shares         | 200      | 200       |
       | 1               | /apps/files_sharing/api/v1/remote_shares/pending | 100      | 200       |
       | 2               | /apps/files_sharing/api/v1/remote_shares/pending | 200      | 200       |
-
-    @files_sharing-app-required
-    Examples:
-      | ocs_api_version | endpoint                                         | ocs-code | http-code |
       | 1               | /apps/files_sharing/api/v1/shares                | 100      | 200       |
       | 2               | /apps/files_sharing/api/v1/shares                | 200      | 200       |
 
 
-  @notToImplementOnOCIS
   Scenario Outline: no CORS headers should be returned when CORS domain does not match Origin header (admin only endpoints)
     Given using OCS API version "<ocs_api_version>"
-    And the administrator has added "https://aphno.badal" to the list of personal CORS domains
+    And the administrator has added "https://mero.badal" to the list of personal CORS domains
     When the administrator sends HTTP method "GET" to OCS API endpoint "<endpoint>" with headers
       | header | value               |
-      | Origin | https://mero.badal  |
+      | Origin | https://aphno.badal |
     Then the OCS status code should be "<ocs-code>"
     And the HTTP status code should be "<http-code>"
     And the following headers should not be set
@@ -172,7 +155,6 @@ Feature: CORS headers
       | Access-Control-Expose-Headers | Content-Location,DAV,ETag,Link,Lock-Token,OC-ETag,OC-Checksum,OC-FileId,OC-JobStatus-Location,OC-RequestAppPassword,Vary,Webdav-Location,X-Sabre-Status                                                                                                                                                                                                                                                                                                                                                                                                                     |
       | Access-Control-Allow-Origin   | https://aphno.badal                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                   |
       | Access-Control-Allow-Methods  | GET,OPTIONS,POST,PUT,DELETE,MKCOL,PROPFIND,PATCH,PROPPATCH,REPORT                                                                                                                                                                                                                                                                                                                                                                                                                                                                                     |
-    @notToImplementOnOCIS
     Examples:
       | ocs_api_version | endpoint                                         | ocs-code | http-code |
       | 1               | /privatedata/getattribute                        | 997      | 401       |
@@ -190,21 +172,17 @@ Feature: CORS headers
       | 1               | /apps/files_external/api/v1/mounts               | 997      | 401       |
       | 2               | /apps/files_external/api/v1/mounts               | 997      | 401       |
 
-    @files_sharing-app-required @notToImplementOnOCIS
+    @files_sharing-app-required
     Examples:
       | ocs_api_version | endpoint                                         | ocs-code | http-code |
       | 1               | /apps/files_sharing/api/v1/remote_shares         | 997      | 401       |
       | 2               | /apps/files_sharing/api/v1/remote_shares         | 997      | 401       |
       | 1               | /apps/files_sharing/api/v1/remote_shares/pending | 997      | 401       |
       | 2               | /apps/files_sharing/api/v1/remote_shares/pending | 997      | 401       |
-
-    @files_sharing-app-required
-    Examples:
-      | ocs_api_version | endpoint                                         | ocs-code | http-code |
       | 1               | /apps/files_sharing/api/v1/shares                | 997      | 401       |
       | 2               | /apps/files_sharing/api/v1/shares                | 997      | 401       |
 
-  @issue-34679 @skipOnOcV10 @notToImplementOnOCIS
+  @issue-34679 @skipOnOcV10
   Scenario Outline: CORS headers should be returned when invalid password is used (admin only endpoints)
     Given using OCS API version "<ocs_api_version>"
     And the administrator has added "https://aphno.badal" to the list of personal CORS domains

--- a/tests/acceptance/features/apiAuth/cors.feature
+++ b/tests/acceptance/features/apiAuth/cors.feature
@@ -21,6 +21,12 @@ Feature: CORS headers
       | Access-Control-Allow-Methods  | GET,OPTIONS,POST,PUT,DELETE,MKCOL,PROPFIND,PATCH,PROPPATCH,REPORT                                                                                                                                                                                                                                                                                                                                                                                                                                                                                     |
     Examples:
       | ocs_api_version | endpoint                                         | ocs-code | http-code |
+      | 1               | /config                                          | 100      | 200       |
+      | 2               | /config                                          | 200      | 200       |
+
+    @notToImplementOnOCIS
+    Examples:
+      | ocs_api_version | endpoint                                         | ocs-code | http-code |
       | 1               | /privatedata/getattribute                        | 100      | 200       |
       | 2               | /privatedata/getattribute                        | 200      | 200       |
       | 1               | /cloud/apps                                      | 997      | 401       |
@@ -29,8 +35,6 @@ Feature: CORS headers
       | 2               | /cloud/groups                                    | 997      | 401       |
       | 1               | /cloud/users                                     | 997      | 401       |
       | 2               | /cloud/users                                     | 997      | 401       |
-      | 1               | /config                                          | 100      | 200       |
-      | 2               | /config                                          | 200      | 200       |
 
     @files_external-app-required @notToImplementOnOCIS
     Examples:
@@ -38,17 +42,21 @@ Feature: CORS headers
       | 1               | /apps/files_external/api/v1/mounts               | 100      | 200       |
       | 2               | /apps/files_external/api/v1/mounts               | 200      | 200       |
 
-    @files_sharing-app-required
+    @files_sharing-app-required @notToImplementOnOCIS
     Examples:
       | ocs_api_version | endpoint                                         | ocs-code | http-code |
       | 1               | /apps/files_sharing/api/v1/remote_shares         | 100      | 200       |
       | 2               | /apps/files_sharing/api/v1/remote_shares         | 200      | 200       |
       | 1               | /apps/files_sharing/api/v1/remote_shares/pending | 100      | 200       |
       | 2               | /apps/files_sharing/api/v1/remote_shares/pending | 200      | 200       |
+
+    @files_sharing-app-required
+    Examples:
+      | ocs_api_version | endpoint                                         | ocs-code | http-code |
       | 1               | /apps/files_sharing/api/v1/shares                | 100      | 200       |
       | 2               | /apps/files_sharing/api/v1/shares                | 200      | 200       |
 
-  @skipOnOcV10.8 @skipOnOcV10.9.0 @skipOnOcV10.9.1
+  @skipOnOcV10.8 @skipOnOcV10.9.0 @skipOnOcV10.9.1 @notToImplementOnOCIS
   Scenario Outline: CORS headers should be returned when setting CORS domain sending Origin header (admin only endpoints)
     Given using OCS API version "<ocs_api_version>"
     And the administrator has added "https://aphno.badal" to the list of personal CORS domains
@@ -75,10 +83,10 @@ Feature: CORS headers
 
   Scenario Outline: no CORS headers should be returned when CORS domain does not match Origin header
     Given using OCS API version "<ocs_api_version>"
-    And user "Alice" has added "https://mero.badal" to the list of personal CORS domains
+    And user "Alice" has added "https://aphno.badal" to the list of personal CORS domains
     When user "Alice" sends HTTP method "GET" to OCS API endpoint "<endpoint>" with headers
       | header | value               |
-      | Origin | https://aphno.badal |
+      | Origin | https://mero.badal  |
     Then the OCS status code should be "<ocs-code>"
     And the HTTP status code should be "<http-code>"
     And the following headers should not be set
@@ -91,6 +99,10 @@ Feature: CORS headers
       | ocs_api_version | endpoint                                         | ocs-code | http-code |
       | 1               | /config                                          | 100      | 200       |
       | 2               | /config                                          | 200      | 200       |
+
+    @notToImplementOnOCIS
+    Examples:
+      | ocs_api_version | endpoint                                         | ocs-code | http-code |
       | 1               | /privatedata/getattribute                        | 100      | 200       |
       | 2               | /privatedata/getattribute                        | 200      | 200       |
       | 1               | /cloud/apps                                      | 997      | 401       |
@@ -106,23 +118,28 @@ Feature: CORS headers
       | 1               | /apps/files_external/api/v1/mounts               | 100      | 200       |
       | 2               | /apps/files_external/api/v1/mounts               | 200      | 200       |
 
-    @files_sharing-app-required
+    @files_sharing-app-required @notToImplementOnOCIS
     Examples:
       | ocs_api_version | endpoint                                         | ocs-code | http-code |
       | 1               | /apps/files_sharing/api/v1/remote_shares         | 100      | 200       |
       | 2               | /apps/files_sharing/api/v1/remote_shares         | 200      | 200       |
       | 1               | /apps/files_sharing/api/v1/remote_shares/pending | 100      | 200       |
       | 2               | /apps/files_sharing/api/v1/remote_shares/pending | 200      | 200       |
+
+    @files_sharing-app-required
+    Examples:
+      | ocs_api_version | endpoint                                         | ocs-code | http-code |
       | 1               | /apps/files_sharing/api/v1/shares                | 100      | 200       |
       | 2               | /apps/files_sharing/api/v1/shares                | 200      | 200       |
 
 
+  @notToImplementOnOCIS
   Scenario Outline: no CORS headers should be returned when CORS domain does not match Origin header (admin only endpoints)
     Given using OCS API version "<ocs_api_version>"
-    And the administrator has added "https://mero.badal" to the list of personal CORS domains
+    And the administrator has added "https://aphno.badal" to the list of personal CORS domains
     When the administrator sends HTTP method "GET" to OCS API endpoint "<endpoint>" with headers
       | header | value               |
-      | Origin | https://aphno.badal |
+      | Origin | https://mero.badal  |
     Then the OCS status code should be "<ocs-code>"
     And the HTTP status code should be "<http-code>"
     And the following headers should not be set
@@ -155,6 +172,7 @@ Feature: CORS headers
       | Access-Control-Expose-Headers | Content-Location,DAV,ETag,Link,Lock-Token,OC-ETag,OC-Checksum,OC-FileId,OC-JobStatus-Location,OC-RequestAppPassword,Vary,Webdav-Location,X-Sabre-Status                                                                                                                                                                                                                                                                                                                                                                                                                     |
       | Access-Control-Allow-Origin   | https://aphno.badal                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                   |
       | Access-Control-Allow-Methods  | GET,OPTIONS,POST,PUT,DELETE,MKCOL,PROPFIND,PATCH,PROPPATCH,REPORT                                                                                                                                                                                                                                                                                                                                                                                                                                                                                     |
+    @notToImplementOnOCIS
     Examples:
       | ocs_api_version | endpoint                                         | ocs-code | http-code |
       | 1               | /privatedata/getattribute                        | 997      | 401       |
@@ -172,17 +190,21 @@ Feature: CORS headers
       | 1               | /apps/files_external/api/v1/mounts               | 997      | 401       |
       | 2               | /apps/files_external/api/v1/mounts               | 997      | 401       |
 
-    @files_sharing-app-required
+    @files_sharing-app-required @notToImplementOnOCIS
     Examples:
       | ocs_api_version | endpoint                                         | ocs-code | http-code |
       | 1               | /apps/files_sharing/api/v1/remote_shares         | 997      | 401       |
       | 2               | /apps/files_sharing/api/v1/remote_shares         | 997      | 401       |
       | 1               | /apps/files_sharing/api/v1/remote_shares/pending | 997      | 401       |
       | 2               | /apps/files_sharing/api/v1/remote_shares/pending | 997      | 401       |
+
+    @files_sharing-app-required
+    Examples:
+      | ocs_api_version | endpoint                                         | ocs-code | http-code |
       | 1               | /apps/files_sharing/api/v1/shares                | 997      | 401       |
       | 2               | /apps/files_sharing/api/v1/shares                | 997      | 401       |
 
-  @issue-34679 @skipOnOcV10
+  @issue-34679 @skipOnOcV10 @notToImplementOnOCIS
   Scenario Outline: CORS headers should be returned when invalid password is used (admin only endpoints)
     Given using OCS API version "<ocs_api_version>"
     And the administrator has added "https://aphno.badal" to the list of personal CORS domains


### PR DESCRIPTION
## Description
Skipping cors tests for oCIS because cors tests require oCIS to run with special cors-allow env. Since in oCIS, core API tests run in parts it will be difficult to determine which part has the cors tests so that the oCIS can be run with cors env.
cors tests are added locally in oCIS in PR https://github.com/owncloud/ocis/pull/5187

## Related Issue
- Fixes https://github.com/owncloud/core/issues/40104

## Motivation and Context

## How Has This Been Tested?
- test environment:

## Screenshots (if appropriate):

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Database schema changes (next release will require increase of minor version instead of patch)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [x] Tests only (no source changes)

## Checklist:
- [ ] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 
- [ ] Changelog item, see [TEMPLATE](https://github.com/owncloud/core/blob/master/changelog/TEMPLATE)
