### PR TITLE
Fix config.sample example rendering

### DIFF
--- a/config/config.sample.php
+++ b/config/config.sample.php
@@ -272,11 +272,21 @@ $CONFIG = [
 
 /**
  * Define additional login buttons on the logon screen
- * Provides the ability to create additional login buttons on the logon screen, for e.g., SSO integration
+ * Provides the ability to create additional login buttons on the logon screen, for e.g., SSO integration,
+ * see the following example structure:
+ *
+ * -----
  *  'login.alternatives' => [
- *    ['href' => 'https://www.testshib.org/Shibboleth.sso/ProtectNetwork?target=https%3A%2F%2Fmy.owncloud.tld%2Flogin%2Fsso-saml%2F', 'name' => 'ProtectNetwork', 'img' => '/img/PN_sign-in.gif'],
- *    ['href' => 'https://www.testshib.org/Shibboleth.sso/OpenIdP.org?target=https%3A%2F%2Fmy.owncloud.tld%2Flogin%2Fsso-saml%2F', 'name' => 'OpenIdP.org', 'img' => '/img/openidp.png'],
- *  ]
+ *    ['href' => 'https://www.testshib.org/Shibboleth.sso/ProtectNetwork?target=https%3A%2F%2Fmy.owncloud.tld%2Flogin%2Fsso-saml%2F',
+ *     'name' => 'ProtectNetwork',
+ *     'img'  => '/img/PN_sign-in.gif'
+ *    ],
+ *    ['href' => 'https://www.testshib.org/Shibboleth.sso/OpenIdP.org?target=https%3A%2F%2Fmy.owncloud.tld%2Flogin%2Fsso-saml%2F',
+ *     'name' => 'OpenIdP.org',
+ *     'img'  => '/img/openidp.png'
+ *    ],
+ *  ],
+ * -----
  */
 'login.alternatives' => [],
 


### PR DESCRIPTION
## Description
Found by chance that the SSO example rendered badly.
Adding a `-----` block solved the rendering problem.

## Related Issue
none

## Motivation and Context
Make the example render correctly

## How Has This Been Tested?
Local via docs build

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Database schema changes (next release will require increase of minor version instead of patch)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [ ] Tests only (no source changes)

## Checklist:
<!-- Tick the checkboxes when done. -->
<!-- Raise documentation ticket in https://github.com/owncloud/documentation -->
- [ ] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [x] Documentation PR raised: https://github.com/owncloud/docs-server/pull/758
- [ ] Changelog item, see [TEMPLATE](https://github.com/owncloud/core/blob/master/changelog/TEMPLATE)

@phil-davis when running `make test-php-style`, I get locally many errors which are unrelated to that change??