### PR TITLE
[tests-only] Do not use owncloudci/php latest in CI

### DIFF
--- a/.drone.star
+++ b/.drone.star
@@ -2184,7 +2184,7 @@ def webdavService(needed):
 
     return [{
         "name": "webdav",
-        "image": OC_CI_PHP % "latest",
+        "image": OC_CI_PHP % DEFAULT_PHP_VERSION,
         "environment": {
             "APACHE_CONFIG_TEMPLATE": "webdav",
         },


### PR DESCRIPTION
## Description
https://github.com/owncloud-ci/php/pull/159 removed the `latest` `owncloudci/php` docker image. That image had a non-obvious PHP version. It is better that we always specify the PHP version to use in every pipeline step.

The PHP unit tests with a webdav server were using PHP `latest` for the webdav server. That is now causing CI to fail.

This PR changes that to use the DEFAULT_PHP_VERSION (currently 7.4)

## How Has This Been Tested?
CI

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Database schema changes (next release will require increase of minor version instead of patch)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [x] Tests only (no source changes)

## Checklist:
- [ ] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 
- [ ] Changelog item, see [TEMPLATE](https://github.com/owncloud/core/blob/master/changelog/TEMPLATE)
