### PR TITLE
[tests-only][full-ci]Refactor acceptance test scenarios with public WebDAV API checks

### DIFF
--- a/tests/acceptance/features/apiSharePublicLink1/changingPublicLinkShare.feature
+++ b/tests/acceptance/features/apiSharePublicLink1/changingPublicLinkShare.feature
@@ -18,10 +18,16 @@ Feature: changing a public link share
     Then the HTTP status code should be "<http-status-code>"
     And as "Alice" file "PARENT/parent.txt" <should-or-not> exist
 
-   @issue-ocis-2079  @issue-ocis-reva-292
+    @notToImplementOnOCIS @issue-ocis-2079
     Examples:
       | permissions               | http-status-code | should-or-not | public-webdav-api-version |
       | read,update,create        | 403              | should        | old                       |
+      | read,update,create,delete | 204              | should not    | old                       |
+
+    @issue-ocis-reva-292
+    Examples:
+      | permissions               | http-status-code | should-or-not | public-webdav-api-version |
+      | read,update,create        | 403              | should        | new                       |
       | read,update,create,delete | 204              | should not    | new                       |
 
 
@@ -34,10 +40,14 @@ Feature: changing a public link share
     And as "Alice" file "/PARENT/parent.txt" should exist
     And as "Alice" file "/PARENT/newparent.txt" should not exist
 
-    @issue-ocis-reva-292 @issue-ocis-2079
+    @notToImplementOnOCIS @issue-ocis-2079
     Examples:
       | public-webdav-api-version |
       | old                       |
+
+    @issue-ocis-reva-292
+    Examples:
+      | public-webdav-api-version |
       | new                       |
 
   @skipOnRansomwareProtection @issue-ransomware-208
@@ -50,10 +60,14 @@ Feature: changing a public link share
     And as "Alice" file "/PARENT/parent.txt" should not exist
     And as "Alice" file "/PARENT/newparent.txt" should exist
 
-    @issue-ocis-2079
+    @notToImplementOnOCIS @issue-ocis-2079
     Examples:
       | public-webdav-api-version |
       | old                       |
+
+
+    Examples:
+      | public-webdav-api-version |
       | new                       |
 
 
@@ -65,10 +79,14 @@ Feature: changing a public link share
     Then the HTTP status code should be "403"
     And as "Alice" file "/PARENT/lorem.txt" should not exist
 
-    @issue-ocis-reva-292 @issue-ocis-2079
+    @notToImplementOnOCIS @issue-ocis-2079
     Examples:
       | public-webdav-api-version |
       | old                       |
+
+    @issue-ocis-reva-292
+    Examples:
+      | public-webdav-api-version |
       | new                       |
 
 
@@ -84,6 +102,10 @@ Feature: changing a public link share
     Examples:
       | public-webdav-api-version |
       | old                       |
+
+
+    Examples:
+      | public-webdav-api-version |
       | new                       |
 
 
@@ -96,11 +118,15 @@ Feature: changing a public link share
     Then the HTTP status code should be "401"
     And as "Alice" file "PARENT/parent.txt" should exist
 
-    @issue-ocis-2079
+    @notToImplementOnOCIS @issue-ocis-2079
     Examples:
       | public-webdav-api-version |
       | old                       |
-      | new                      |
+
+
+    Examples:
+      | public-webdav-api-version |
+      | new                       |
 
 
   Scenario Outline: Public can delete file through publicly shared link with password using the valid password with the public WebDAV API
@@ -112,10 +138,14 @@ Feature: changing a public link share
     Then the HTTP status code should be "204"
     And as "Alice" file "PARENT/parent.txt" should not exist
 
-    @issue-ocis-2079  @issue-ocis-reva-292
+    @notToImplementOnOCIS @issue-ocis-2079
     Examples:
       | public-webdav-api-version |
       | old                       |
+
+    @issue-ocis-reva-292
+    Examples:
+      | public-webdav-api-version |
       | new                       |
 
 
@@ -129,10 +159,14 @@ Feature: changing a public link share
     And as "Alice" file "/PARENT/newparent.txt" should not exist
     And as "Alice" file "/PARENT/parent.txt" should exist
 
-    @issue-ocis-2079
+    @notToImplementOnOCIS @issue-ocis-2079
     Examples:
       | public-webdav-api-version |
       | old                       |
+
+
+    Examples:
+      | public-webdav-api-version |
       | new                       |
 
   @skipOnRansomwareProtection @issue-ransomware-208
@@ -146,11 +180,16 @@ Feature: changing a public link share
     And as "Alice" file "/PARENT/newparent.txt" should exist
     And as "Alice" file "/PARENT/parent.txt" should not exist
 
-    @issue-ocis-2079
+    @notToImplementOnOCIS @issue-ocis-2079
     Examples:
       | public-webdav-api-version |
       | old                       |
+
+
+    Examples:
+      | public-webdav-api-version |
       | new                       |
+
 
   Scenario Outline: Public tries to upload to a password protected public share using an invalid password with the public WebDAV API
     Given user "Alice" has created a public link share with settings
@@ -161,10 +200,14 @@ Feature: changing a public link share
     Then the HTTP status code should be "401"
     And as "Alice" file "/PARENT/lorem.txt" should not exist
 
-    @issue-ocis-2079
+    @notToImplementOnOCIS @issue-ocis-2079
     Examples:
       | public-webdav-api-version |
       | old                       |
+
+
+    Examples:
+      | public-webdav-api-version |
       | new                       |
 
 
@@ -177,10 +220,14 @@ Feature: changing a public link share
     Then the HTTP status code should be "201"
     And as "Alice" file "/PARENT/lorem.txt" should exist
 
-    @issue-ocis-2079
+    @notToImplementOnOCIS @issue-ocis-2079
     Examples:
       | public-webdav-api-version |
       | old                       |
+
+
+    Examples:
+      | public-webdav-api-version |
       | new                       |
 
 
@@ -193,10 +240,14 @@ Feature: changing a public link share
     And as "Alice" file "/PARENT/parent.txt" should exist
     And as "Alice" file "/PARENT/newparent.txt" should not exist
 
-    @issue-ocis-2079 @issue-ocis-reva-292
+    @notToImplementOnOCIS @issue-ocis-2079
     Examples:
       | public-webdav-api-version |
       | old                       |
+
+    @issue-ocis-reva-292
+    Examples:
+      | public-webdav-api-version |
       | new                       |
 
 
@@ -208,8 +259,12 @@ Feature: changing a public link share
     Then the HTTP status code should be "403"
     And as "Alice" file "PARENT/parent.txt" should exist
 
-    @issue-ocis-2079 @issue-ocis-reva-292
+    @notToImplementOnOCIS @issue-ocis-2079
     Examples:
       | public-webdav-api-version |
       | old                       |
+
+    @issue-ocis-reva-292
+    Examples:
+      | public-webdav-api-version |
       | new                       |

--- a/tests/acceptance/features/apiSharePublicLink1/changingPublicLinkShare.feature
+++ b/tests/acceptance/features/apiSharePublicLink1/changingPublicLinkShare.feature
@@ -18,16 +18,10 @@ Feature: changing a public link share
     Then the HTTP status code should be "<http-status-code>"
     And as "Alice" file "PARENT/parent.txt" <should-or-not> exist
 
-    @notToImplementOnOCIS @issue-ocis-2079
+   @issue-ocis-2079  @issue-ocis-reva-292
     Examples:
       | permissions               | http-status-code | should-or-not | public-webdav-api-version |
       | read,update,create        | 403              | should        | old                       |
-      | read,update,create,delete | 204              | should not    | old                       |
-
-    @issue-ocis-reva-292
-    Examples:
-      | permissions               | http-status-code | should-or-not | public-webdav-api-version |
-      | read,update,create        | 403              | should        | new                       |
       | read,update,create,delete | 204              | should not    | new                       |
 
 
@@ -40,14 +34,10 @@ Feature: changing a public link share
     And as "Alice" file "/PARENT/parent.txt" should exist
     And as "Alice" file "/PARENT/newparent.txt" should not exist
 
-    @notToImplementOnOCIS @issue-ocis-2079
+    @issue-ocis-reva-292 @issue-ocis-2079
     Examples:
       | public-webdav-api-version |
       | old                       |
-
-    @issue-ocis-reva-292
-    Examples:
-      | public-webdav-api-version |
       | new                       |
 
   @skipOnRansomwareProtection @issue-ransomware-208
@@ -60,14 +50,10 @@ Feature: changing a public link share
     And as "Alice" file "/PARENT/parent.txt" should not exist
     And as "Alice" file "/PARENT/newparent.txt" should exist
 
-    @notToImplementOnOCIS @issue-ocis-2079
+    @issue-ocis-2079
     Examples:
       | public-webdav-api-version |
       | old                       |
-
-
-    Examples:
-      | public-webdav-api-version |
       | new                       |
 
 
@@ -79,14 +65,10 @@ Feature: changing a public link share
     Then the HTTP status code should be "403"
     And as "Alice" file "/PARENT/lorem.txt" should not exist
 
-    @notToImplementOnOCIS @issue-ocis-2079
+    @issue-ocis-reva-292 @issue-ocis-2079
     Examples:
       | public-webdav-api-version |
       | old                       |
-
-    @issue-ocis-reva-292
-    Examples:
-      | public-webdav-api-version |
       | new                       |
 
 
@@ -102,10 +84,6 @@ Feature: changing a public link share
     Examples:
       | public-webdav-api-version |
       | old                       |
-
-
-    Examples:
-      | public-webdav-api-version |
       | new                       |
 
 
@@ -118,15 +96,11 @@ Feature: changing a public link share
     Then the HTTP status code should be "401"
     And as "Alice" file "PARENT/parent.txt" should exist
 
-    @notToImplementOnOCIS @issue-ocis-2079
+    @issue-ocis-2079
     Examples:
       | public-webdav-api-version |
       | old                       |
-
-
-    Examples:
-      | public-webdav-api-version |
-      | new                       |
+      | new                      |
 
 
   Scenario Outline: Public can delete file through publicly shared link with password using the valid password with the public WebDAV API
@@ -138,14 +112,10 @@ Feature: changing a public link share
     Then the HTTP status code should be "204"
     And as "Alice" file "PARENT/parent.txt" should not exist
 
-    @notToImplementOnOCIS @issue-ocis-2079
+    @issue-ocis-2079  @issue-ocis-reva-292
     Examples:
       | public-webdav-api-version |
       | old                       |
-
-    @issue-ocis-reva-292
-    Examples:
-      | public-webdav-api-version |
       | new                       |
 
 
@@ -159,14 +129,10 @@ Feature: changing a public link share
     And as "Alice" file "/PARENT/newparent.txt" should not exist
     And as "Alice" file "/PARENT/parent.txt" should exist
 
-    @notToImplementOnOCIS @issue-ocis-2079
+    @issue-ocis-2079
     Examples:
       | public-webdav-api-version |
       | old                       |
-
-
-    Examples:
-      | public-webdav-api-version |
       | new                       |
 
   @skipOnRansomwareProtection @issue-ransomware-208
@@ -180,16 +146,11 @@ Feature: changing a public link share
     And as "Alice" file "/PARENT/newparent.txt" should exist
     And as "Alice" file "/PARENT/parent.txt" should not exist
 
-    @notToImplementOnOCIS @issue-ocis-2079
+    @issue-ocis-2079
     Examples:
       | public-webdav-api-version |
       | old                       |
-
-
-    Examples:
-      | public-webdav-api-version |
       | new                       |
-
 
   Scenario Outline: Public tries to upload to a password protected public share using an invalid password with the public WebDAV API
     Given user "Alice" has created a public link share with settings
@@ -200,14 +161,10 @@ Feature: changing a public link share
     Then the HTTP status code should be "401"
     And as "Alice" file "/PARENT/lorem.txt" should not exist
 
-    @notToImplementOnOCIS @issue-ocis-2079
+    @issue-ocis-2079
     Examples:
       | public-webdav-api-version |
       | old                       |
-
-
-    Examples:
-      | public-webdav-api-version |
       | new                       |
 
 
@@ -220,14 +177,10 @@ Feature: changing a public link share
     Then the HTTP status code should be "201"
     And as "Alice" file "/PARENT/lorem.txt" should exist
 
-    @notToImplementOnOCIS @issue-ocis-2079
+    @issue-ocis-2079
     Examples:
       | public-webdav-api-version |
       | old                       |
-
-
-    Examples:
-      | public-webdav-api-version |
       | new                       |
 
 
@@ -240,14 +193,10 @@ Feature: changing a public link share
     And as "Alice" file "/PARENT/parent.txt" should exist
     And as "Alice" file "/PARENT/newparent.txt" should not exist
 
-    @notToImplementOnOCIS @issue-ocis-2079
+    @issue-ocis-2079 @issue-ocis-reva-292
     Examples:
       | public-webdav-api-version |
       | old                       |
-
-    @issue-ocis-reva-292
-    Examples:
-      | public-webdav-api-version |
       | new                       |
 
 
@@ -259,12 +208,8 @@ Feature: changing a public link share
     Then the HTTP status code should be "403"
     And as "Alice" file "PARENT/parent.txt" should exist
 
-    @notToImplementOnOCIS @issue-ocis-2079
+    @issue-ocis-2079 @issue-ocis-reva-292
     Examples:
       | public-webdav-api-version |
       | old                       |
-
-    @issue-ocis-reva-292
-    Examples:
-      | public-webdav-api-version |
       | new                       |

--- a/tests/acceptance/features/apiSharePublicLink1/createPublicLinkShare.feature
+++ b/tests/acceptance/features/apiSharePublicLink1/createPublicLinkShare.feature
@@ -25,21 +25,16 @@ Feature: create a public link share
       | uid_file_owner         | %username%      |
       | uid_owner              | %username%      |
       | name                   |                 |
-    When the public downloads the last public link shared file using the <public-webdav-api-version> public WebDAV API
-    Then the downloaded content should be "Random data"
-    And the public upload to the last publicly shared file using the <public-webdav-api-version> public WebDAV API should fail with HTTP status code "403"
+    And the public should be able to download the last publicly shared file using the old public WebDAV API without a password and the content should be "Random data"
+    And the public should be able to download the last publicly shared file using the new public WebDAV API without a password and the content should be "Random data"
+    And the public upload to the last publicly shared file using the old public WebDAV API should fail with HTTP status code "403"
+    And the public upload to the last publicly shared file using the new public WebDAV API should fail with HTTP status code "403"
 
-    @notToImplementOnOCIS @issue-ocis-2079
+    @issue-ocis-reva-12 @issue-ocis-2079
     Examples:
-      | ocs_api_version | ocs_status_code | public-webdav-api-version |
-      | 1               | 100             | old                       |
-      | 2               | 200             | old                       |
-
-    @issue-ocis-reva-12
-    Examples:
-      | ocs_api_version | ocs_status_code | public-webdav-api-version |
-      | 1               | 100             | new                       |
-      | 2               | 200             | new                       |
+      | ocs_api_version | ocs_status_code |
+      | 1               | 100             |
+      | 2               | 200             |
 
   @smokeTest @notToImplementOnOCIS @issue-ocis-2079
   Scenario Outline: Creating a new public link share of a file with password using the old public WebDAV API
@@ -126,20 +121,16 @@ Feature: create a public link share
       | uid_file_owner         | %username%      |
       | uid_owner              | %username%      |
       | name                   |                 |
-    And the public should be able to download the last publicly shared file using the <public-webdav-api-version> public WebDAV API without a password and the content should be "Random data"
-    And uploading content to a public link shared file should work using the <public-webdav-api-version> public WebDAV API
+    And the public should be able to download the last publicly shared file using the old public WebDAV API without a password and the content should be "Random data"
+    And the public should be able to download the last publicly shared file using the new public WebDAV API without a password and the content should be "Random data"
+    And uploading content to a public link shared file should work using the old public WebDAV API
+    And uploading content to a public link shared file should work using the new public WebDAV API
 
-    @notToImplementOnOCIS @issue-ocis-2079
+    @issue-ocis-2079 @issue-ocis-reva-292
     Examples:
-      | ocs_api_version | ocs_status_code | public-webdav-api-version |
-      | 1               | 100             | old                       |
-      | 2               | 200             | old                       |
-
-    @issue-ocis-reva-292
-    Examples:
-      | ocs_api_version | ocs_status_code | public-webdav-api-version |
-      | 1               | 100             | new                       |
-      | 2               | 200             | new                       |
+      | ocs_api_version | ocs_status_code |
+      | 1               | 100             |
+      | 2               | 200             |
 
 
   Scenario Outline: Creating a new public link share of a folder using the default permissions only grants read access and can be accessed with no password or any password using the public WebDAV API
@@ -162,21 +153,16 @@ Feature: create a public link share
       | uid_file_owner         | %username%           |
       | uid_owner              | %username%           |
       | name                   |                      |
-    When the public downloads file "/randomfile.txt" from inside the last public link shared folder using the <public-webdav-api-version> public WebDAV API
-    Then the downloaded content should be "Random data"
-    And the public upload to the last publicly shared folder using the <public-webdav-api-version> public WebDAV API should fail with HTTP status code "403"
+    And the public should be able to download the last publicly shared file using the old public WebDAV API without a password and the content should be "Random data"
+    And the public should be able to download the last publicly shared file using the new public WebDAV API without a password and the content should be "Random data"
+    And the public upload to the last publicly shared file using the old public WebDAV API should fail with HTTP status code "403"
+    And the public upload to the last publicly shared file using the new public WebDAV API should fail with HTTP status code "403"
 
-    @notToImplementOnOCIS @issue-ocis-2079
+    @issue-ocis-reva-12 @issue-ocis-2079
     Examples:
-      | ocs_api_version | ocs_status_code | public-webdav-api-version |
-      | 1               | 100             | old                       |
-      | 2               | 200             | old                       |
-
-    @issue-ocis-reva-12
-    Examples:
-      | ocs_api_version | ocs_status_code | public-webdav-api-version |
-      | 1               | 100             | new                       |
-      | 2               | 200             | new                       |
+      | ocs_api_version | ocs_status_code |
+      | 1               | 100             |
+      | 2               | 200             |
 
 
   Scenario Outline: Creating a new public link share of a folder, with a password and accessing using the public WebDAV API
@@ -201,22 +187,17 @@ Feature: create a public link share
       | uid_file_owner         | %username%           |
       | uid_owner              | %username%           |
       | name                   |                      |
-    And the public should be able to download file "/randomfile.txt" from inside the last public link shared folder using the <public-webdav-api-version> public WebDAV API with password "%public%"
-    And the downloaded content should be "Random data"
-    But the public should not be able to download file "/randomfile.txt" from inside the last public link shared folder using the <public-webdav-api-version> public WebDAV API without a password
-    And the public should not be able to download file "/randomfile.txt" from inside the last public link shared folder using the <public-webdav-api-version> public WebDAV API with password "%regular%"
-
-    @notToImplementOnOCIS @issue-ocis-2079
+    And the public should be able to download the last publicly shared file using the old public WebDAV API with password "%public%" and the content should be "Random data"
+    And the public should be able to download the last publicly shared file using the new public WebDAV API with password "%public%" and the content should be "Random data"
+    But the public should not be able to download file "/randomfile.txt" from inside the last public link shared folder using the old public WebDAV API without a password
+    And the public should not be able to download file "/randomfile.txt" from inside the last public link shared folder using the old public WebDAV API with password "%regular%"
+    And the public should not be able to download file "/randomfile.txt" from inside the last public link shared folder using the new public WebDAV API without a password
+    And the public should not be able to download file "/randomfile.txt" from inside the last public link shared folder using the new public WebDAV API with password "%regular%"
+    @issue-ocis-2079  @issue-ocis-reva-292
     Examples:
-      | ocs_api_version | ocs_status_code | public-webdav-api-version |
-      | 1               | 100             | old                       |
-      | 2               | 200             | old                       |
-
-    @issue-ocis-reva-292
-    Examples:
-      | ocs_api_version | ocs_status_code | public-webdav-api-version |
-      | 1               | 100             | new                       |
-      | 2               | 200             | new                       |
+      | ocs_api_version | ocs_status_code |
+      | 1               | 100             |
+      | 2               | 200             |
 
   @smokeTest @issue-ocis-reva-294
   Scenario Outline: Getting the share information of public link share from the OCS API does not expose sensitive information
@@ -277,19 +258,14 @@ Feature: create a public link share
       | id          | A_STRING    |
       | share_type  | public_link |
       | permissions | read        |
-    And the public upload to the last publicly shared folder using the <public-webdav-api-version> public WebDAV API should fail with HTTP status code "403"
+    And the public upload to the last publicly shared folder using the old public WebDAV API should fail with HTTP status code "403"
+    And the public upload to the last publicly shared folder using the new public WebDAV API should fail with HTTP status code "403"
 
-    @notToImplementOnOCIS @issue-ocis-2079
+    @issue-ocis-reva-41 @issue-ocis-2079
     Examples:
-      | ocs_api_version | ocs_status_code | public-webdav-api-version |
-      | 1               | 100             | old                       |
-      | 2               | 200             | old                       |
-
-    @issue-ocis-reva-41
-    Examples:
-      | ocs_api_version | ocs_status_code | public-webdav-api-version |
-      | 1               | 100             | new                       |
-      | 2               | 200             | new                       |
+      | ocs_api_version | ocs_status_code |
+      | 1               | 100             |
+      | 2               | 200             |
 
 
   Scenario Outline: Creating a public link share with read+create permissions is forbidden when public upload is disabled globally
@@ -386,19 +362,14 @@ Feature: create a public link share
       | id          | A_STRING                  |
       | share_type  | public_link               |
       | permissions | read,update,create,delete |
-    And uploading a file should work using the <public-webdav-api-version> public WebDAV API
+    And uploading a file should work using the old public WebDAV API
+    And uploading a file should work using the new public WebDAV API
 
-    @notToImplementOnOCIS @issue-ocis-2079
+    @issue-ocis-2079
     Examples:
-      | ocs_api_version | ocs_status_code | public-webdav-api-version |
-      | 1               | 100             | old                       |
-      | 2               | 200             | old                       |
-
-
-    Examples:
-      | ocs_api_version | ocs_status_code | public-webdav-api-version |
-      | 1               | 100             | new                       |
-      | 2               | 200             | new                       |
+      | ocs_api_version | ocs_status_code |
+      | 1               | 100             |
+      | 2               | 200             |
 
 
   Scenario Outline: Creating a link share with upload permissions keeps it using the public WebDAV API
@@ -413,19 +384,15 @@ Feature: create a public link share
       | id          | A_STRING    |
       | share_type  | public_link |
       | permissions | read,create |
-    And uploading a file should work using the <public-webdav-api-version> public WebDAV API
+    And uploading a file should work using the old public WebDAV API
+    And uploading a file should work using the new public WebDAV API
 
-    @notToImplementOnOCIS @issue-ocis-2079
+   @issue-ocis-2079
     Examples:
-      | ocs_api_version | ocs_status_code | public-webdav-api-version |
-      | 1               | 100             | old                       |
-      | 2               | 200             | old                       |
+      | ocs_api_version | ocs_status_code |
+      | 1               | 100             |
+      | 2               | 200             |
 
-
-    Examples:
-      | ocs_api_version | ocs_status_code | public-webdav-api-version |
-      | 1               | 100             | new                       |
-      | 2               | 200             | new                       |
 
   @issue-ocis-reva-283 @notToImplementOnOCIS
   Scenario Outline: Do not allow public sharing of the root on ownCloud10
@@ -459,22 +426,16 @@ Feature: create a public link share
       | uid_file_owner         | %username%           |
       | uid_owner              | %username%           |
       | name                   |                      |
-    And the public should be able to download file "/randomfile.txt" from inside the last public link shared folder using the <public-webdav-api-version> public WebDAV API
-    And the downloaded content should be "Random data"
-    And the public upload to the last publicly shared folder using the <public-webdav-api-version> public WebDAV API should fail with HTTP status code "403"
+    And the public should be able to download the last publicly shared file using the old public WebDAV API without a password and the content should be "Random data"
+    And the public should be able to download the last publicly shared file using the new public WebDAV API without a password and the content should be "Random data"
+    And the public upload to the last publicly shared folder using the old public WebDAV API should fail with HTTP status code "403"
+    And the public upload to the last publicly shared folder using the new public WebDAV API should fail with HTTP status code "403"
 
     @notToImplementOnOCIS @issue-ocis-2079
     Examples:
-      | ocs_api_version | ocs_status_code | public-webdav-api-version |
-      | 1               | 100             | old                       |
-      | 2               | 200             | old                       |
-
-
-    Examples:
-      | ocs_api_version | ocs_status_code | public-webdav-api-version |
-      | 1               | 100             | new                       |
-      | 2               | 200             | new                       |
-
+      | ocs_api_version | ocs_status_code |
+      | 1               | 100             |
+      | 2               | 200             |
 
   Scenario Outline: user creates a public link share of a file with file name longer than 64 chars using the public WebDAV API
     Given using OCS API version "<ocs_api_version>"
@@ -483,19 +444,15 @@ Feature: create a public link share
       | path | /aquickbrownfoxjumpsoveraverylazydogaquickbrownfoxjumpsoveralazydog.txt |
     Then the OCS status code should be "<ocs_status_code>"
     And the HTTP status code should be "200"
-    And the public should be able to download the last publicly shared file using the <public-webdav-api-version> public WebDAV API without a password and the content should be "long file"
+    And the public should be able to download the last publicly shared file using the old public WebDAV API without a password and the content should be "long file"
+    And the public should be able to download the last publicly shared file using the new public WebDAV API without a password and the content should be "long file"
 
-    @notToImplementOnOCIS @issue-ocis-2079
+    @issue-ocis-2079
     Examples:
-      | ocs_api_version | ocs_status_code | public-webdav-api-version |
-      | 1               | 100             | old                       |
-      | 2               | 200             | old                       |
+      | ocs_api_version | ocs_status_code |
+      | 1               | 100             |
+      | 2               | 200             |
 
-
-    Examples:
-      | ocs_api_version | ocs_status_code | public-webdav-api-version |
-      | 1               | 100             | new                       |
-      | 2               | 200             | new                       |
 
 
   Scenario Outline: user creates a public link share of a folder with folder name longer than 64 chars and access using the public WebDAV API
@@ -506,20 +463,14 @@ Feature: create a public link share
       | path | /aquickbrownfoxjumpsoveraverylazydogaquickbrownfoxjumpsoveralazydog |
     Then the OCS status code should be "<ocs_status_code>"
     And the HTTP status code should be "200"
-    And the public should be able to download file "/randomfile.txt" from inside the last public link shared folder using the <public-webdav-api-version> public WebDAV API
-    And the downloaded content should be "Random data"
+    And the public should be able to download the last publicly shared file using the old public WebDAV API without a password and the content should be "Random Data"
+    And the public should be able to download the last publicly shared file using the new public WebDAV API without a password and the content should be "Random Data"
 
-    @notToImplementOnOCIS @issue-ocis-2079
+    @issue-ocis-2079
     Examples:
-      | ocs_api_version | ocs_status_code | public-webdav-api-version |
-      | 1               | 100             | old                       |
-      | 2               | 200             | old                       |
-
-
-    Examples:
-      | ocs_api_version | ocs_status_code | public-webdav-api-version |
-      | 1               | 100             | new                       |
-      | 2               | 200             | new                       |
+      | ocs_api_version | ocs_status_code |
+      | 1               | 100             |
+      | 2               | 200             |
 
   @issue-ocis-reva-41
   Scenario Outline: Create a public link with default expiration date set and max expiration date enforced and access using the public WebDAV API

--- a/tests/acceptance/features/apiSharePublicLink1/createPublicLinkShare.feature
+++ b/tests/acceptance/features/apiSharePublicLink1/createPublicLinkShare.feature
@@ -153,10 +153,10 @@ Feature: create a public link share
       | uid_file_owner         | %username%           |
       | uid_owner              | %username%           |
       | name                   |                      |
-    And the public should be able to download the last publicly shared file using the old public WebDAV API without a password and the content should be "Random data"
-    And the public should be able to download the last publicly shared file using the new public WebDAV API without a password and the content should be "Random data"
-    And the public upload to the last publicly shared file using the old public WebDAV API should fail with HTTP status code "403"
-    And the public upload to the last publicly shared file using the new public WebDAV API should fail with HTTP status code "403"
+    And the public should be able to download file "/randomfile.txt" from inside the last public link shared folder using the old public WebDAV API without password and the content should be "Random data"
+    And the public should be able to download file "/randomfile.txt" from inside the last public link shared folder using the new public WebDAV API without password and the content should be "Random data"
+    And the public upload to the last publicly shared folder using the old public WebDAV API should fail with HTTP status code "403"
+    And the public upload to the last publicly shared folder using the new public WebDAV API should fail with HTTP status code "403"
 
     @issue-ocis-reva-12 @issue-ocis-2079
     Examples:
@@ -187,8 +187,8 @@ Feature: create a public link share
       | uid_file_owner         | %username%           |
       | uid_owner              | %username%           |
       | name                   |                      |
-    And the public should be able to download the last publicly shared file using the old public WebDAV API with password "%public%" and the content should be "Random data"
-    And the public should be able to download the last publicly shared file using the new public WebDAV API with password "%public%" and the content should be "Random data"
+    And the public should be able to download file "/randomfile.txt" from inside the last public link shared folder using the old public WebDAV API with password "%public%" and the content should be "Random data"
+    And the public should be able to download file "/randomfile.txt" from inside the last public link shared folder using the new public WebDAV API with password "%public%" and the content should be "Random data"
     But the public should not be able to download file "/randomfile.txt" from inside the last public link shared folder using the old public WebDAV API without a password
     And the public should not be able to download file "/randomfile.txt" from inside the last public link shared folder using the old public WebDAV API with password "%regular%"
     And the public should not be able to download file "/randomfile.txt" from inside the last public link shared folder using the new public WebDAV API without a password
@@ -463,8 +463,8 @@ Feature: create a public link share
       | path | /aquickbrownfoxjumpsoveraverylazydogaquickbrownfoxjumpsoveralazydog |
     Then the OCS status code should be "<ocs_status_code>"
     And the HTTP status code should be "200"
-    And the public should be able to download the last publicly shared file using the old public WebDAV API without a password and the content should be "Random Data"
-    And the public should be able to download the last publicly shared file using the new public WebDAV API without a password and the content should be "Random Data"
+    And the public should be able to download file "/randomfile.txt" from inside the last public link shared folder using the old public WebDAV API without password and the content should be "Random data"
+    And the public should be able to download file "/randomfile.txt" from inside the last public link shared folder using the new public WebDAV API without password and the content should be "Random data"
 
     @issue-ocis-2079
     Examples:
@@ -501,15 +501,14 @@ Feature: create a public link share
       | permissions | read            |
       | uid_owner   | %username%      |
       | expiration  | +7 days         |
-    And the public should be able to download the last publicly shared file using the <public-webdav-api-version> public WebDAV API without a password and the content should be "Random data"
+    And the public should be able to download the last publicly shared file using the old public WebDAV API without a password and the content should be "Random data"
+    And the public should be able to download the last publicly shared file using the new public WebDAV API without a password and the content should be "Random data"
 
     @notToImplementOnOCIS @issue-ocis-2079
     Examples:
-      | ocs_api_version | ocs_status_code | http_status_code | public-webdav-api-version |
-      | 1               | 100             | 200              | old                       |
-      | 2               | 200             | 200              | old                       |
-      | 1               | 100             | 200              | new                       |
-      | 2               | 200             | 200              | new                       |
+      | ocs_api_version | ocs_status_code | http_status_code |
+      | 1               | 100             | 200              |
+      | 2               | 200             | 200              |
 
   @issue-ocis-reva-199
   Scenario Outline: Delete a folder that has been publicly shared and try to access using the public WebDAV API

--- a/tests/acceptance/features/apiSharePublicLink2/reShareAsPublicLinkToRoot.feature
+++ b/tests/acceptance/features/apiSharePublicLink2/reShareAsPublicLinkToRoot.feature
@@ -36,8 +36,8 @@ Feature: reshare as public link
       | publicUpload | false |
     Then the OCS status code should be "<ocs_status_code>"
     And the HTTP status code should be "200"
-    And the public should be able to download the last publicly shared file using the old public WebDAV API without a password and the content should be "some content"
-    And the public should be able to download the last publicly shared file using the new public WebDAV API without a password and the content should be "some content"
+    And the public should be able to download file "file.txt" from inside the last public link shared folder using the old public WebDAV API without password and the content should be "some content"
+    And the public should be able to download file "file.txt" from inside the last public link shared folder using the new public WebDAV API without password and the content should be "some content"
     But uploading a file should not work using the old public WebDAV API
     But uploading a file should not work using the new public WebDAV API
 
@@ -87,8 +87,8 @@ Feature: reshare as public link
       | publicUpload | false |
     Then the OCS status code should be "<ocs_status_code>"
     And the HTTP status code should be "200"
-    And the public should be able to download the last publicly shared file using the old public WebDAV API without a password and the content should be "some content"
-    And the public should be able to download the last publicly shared file using the new public WebDAV API without a password and the content should be "some content"
+    And the public should be able to download file "file.txt" from inside the last public link shared folder using the old public WebDAV API without password and the content should be "some content"
+    And the public should be able to download file "file.txt" from inside the last public link shared folder using the new public WebDAV API without password and the content should be "some content"
     But uploading a file should not work using the old public WebDAV API
     But uploading a file should not work using the new public WebDAV API
 
@@ -108,8 +108,8 @@ Feature: reshare as public link
       | publicUpload | true                      |
     Then the OCS status code should be "<ocs_status_code>"
     And the HTTP status code should be "200"
-    And the public should be able to download the last publicly shared file using the old public WebDAV API without a password and the content should be "some content"
-    And the public should be able to download the last publicly shared file using the new public WebDAV API without a password and the content should be "some content"
+    And the public should be able to download file "file.txt" from inside the last public link shared folder using the old public WebDAV API without password and the content should be "some content"
+    And the public should be able to download file "file.txt" from inside the last public link shared folder using the new public WebDAV API without password and the content should be "some content"
     And uploading a file should work using the old public WebDAV API
     And uploading a file should work using the new public WebDAV API
     Examples:

--- a/tests/acceptance/features/apiSharePublicLink2/reShareAsPublicLinkToRoot.feature
+++ b/tests/acceptance/features/apiSharePublicLink2/reShareAsPublicLinkToRoot.feature
@@ -36,22 +36,15 @@ Feature: reshare as public link
       | publicUpload | false |
     Then the OCS status code should be "<ocs_status_code>"
     And the HTTP status code should be "200"
-    And the public should be able to download file "file.txt" from inside the last public link shared folder using the <public-webdav-api-version> public WebDAV API
-    And the downloaded content should be "some content"
-    But uploading a file should not work using the <public-webdav-api-version> public WebDAV API
-
-    @notToImplementOnOCIS
-    Examples:
-      | ocs_api_version | ocs_status_code | public-webdav-api-version |
-      | 1               | 100             | old                       |
-      | 2               | 200             | old                       |
-
+    And the public should be able to download the last publicly shared file using the old public WebDAV API without a password and the content should be "some content"
+    And the public should be able to download the last publicly shared file using the new public WebDAV API without a password and the content should be "some content"
+    But uploading a file should not work using the old public WebDAV API
+    But uploading a file should not work using the new public WebDAV API
 
     Examples:
-      | ocs_api_version | ocs_status_code | public-webdav-api-version |
-      | 1               | 100             | new                       |
-      | 2               | 200             | new                       |
-
+      | ocs_api_version | ocs_status_code |
+      | 1               | 100             |
+      | 2               | 200             |
 
   Scenario Outline: creating an upload public link from a share with share+read only permissions is not allowed
     Given using OCS API version "<ocs_api_version>"
@@ -94,22 +87,15 @@ Feature: reshare as public link
       | publicUpload | false |
     Then the OCS status code should be "<ocs_status_code>"
     And the HTTP status code should be "200"
-    And the public should be able to download file "file.txt" from inside the last public link shared folder using the <public-webdav-api-version> public WebDAV API
-    And the downloaded content should be "some content"
-    But uploading a file should not work using the <public-webdav-api-version> public WebDAV API
-
-    @notToImplementOnOCIS
-    Examples:
-      | ocs_api_version | ocs_status_code | public-webdav-api-version |
-      | 1               | 100             | old                       |
-      | 2               | 200             | old                       |
-
+    And the public should be able to download the last publicly shared file using the old public WebDAV API without a password and the content should be "some content"
+    And the public should be able to download the last publicly shared file using the new public WebDAV API without a password and the content should be "some content"
+    But uploading a file should not work using the old public WebDAV API
+    But uploading a file should not work using the new public WebDAV API
 
     Examples:
-      | ocs_api_version | ocs_status_code | public-webdav-api-version |
-      | 1               | 100             | new                       |
-      | 2               | 200             | new                       |
-
+      | ocs_api_version | ocs_status_code |
+      | 1               | 100             |
+      | 2               | 200             |
 
   Scenario Outline: creating an upload public link from a share with share+read+write permissions is allowed
     Given using OCS API version "<ocs_api_version>"
@@ -122,21 +108,14 @@ Feature: reshare as public link
       | publicUpload | true                      |
     Then the OCS status code should be "<ocs_status_code>"
     And the HTTP status code should be "200"
-    And the public should be able to download file "file.txt" from inside the last public link shared folder using the <public-webdav-api-version> public WebDAV API
-    And the downloaded content should be "some content"
-    And uploading a file should work using the <public-webdav-api-version> public WebDAV API
-
-    @notToImplementOnOCIS
+    And the public should be able to download the last publicly shared file using the old public WebDAV API without a password and the content should be "some content"
+    And the public should be able to download the last publicly shared file using the new public WebDAV API without a password and the content should be "some content"
+    And uploading a file should work using the old public WebDAV API
+    And uploading a file should work using the new public WebDAV API
     Examples:
-      | ocs_api_version | ocs_status_code | public-webdav-api-version |
-      | 1               | 100             | old                       |
-      | 2               | 200             | old                       |
-
-
-    Examples:
-      | ocs_api_version | ocs_status_code | public-webdav-api-version |
-      | 1               | 100             | new                       |
-      | 2               | 200             | new                       |
+      | ocs_api_version | ocs_status_code |
+      | 1               | 100             |
+      | 2               | 200             |
 
 
   Scenario Outline: creating an upload public link from a sub-folder of a share with share+read only permissions is not allowed
@@ -169,19 +148,13 @@ Feature: reshare as public link
       | permissions | read,update,create,delete |
     Then the OCS status code should be "404"
     And the HTTP status code should be "<http_status_code>"
-    And uploading a file should not work using the <public-webdav-api-version> public WebDAV API
-
-    @notToImplementOnOCIS
-    Examples:
-      | ocs_api_version | http_status_code | public-webdav-api-version |
-      | 1               | 200              | old                       |
-      | 2               | 404              | old                       |
-
+    And uploading a file should not work using the old public WebDAV API
+    And uploading a file should not work using the new public WebDAV API
 
     Examples:
-      | ocs_api_version | http_status_code | public-webdav-api-version |
-      | 1               | 200              | new                       |
-      | 2               | 404              | new                       |
+      | ocs_api_version | http_status_code |
+      | 1               | 200              |
+      | 2               | 404              |
 
 
   Scenario Outline: increasing permissions of a public link from a sub-folder of a share with share+read only permissions is not allowed
@@ -193,21 +166,16 @@ Feature: reshare as public link
       | path         | /test/sub |
       | permissions  | read      |
       | publicUpload | false     |
-    And uploading a file should not work using the <public-webdav-api-version> public WebDAV API
+    And uploading a file should not work using the old public WebDAV API
+    And uploading a file should not work using the new public WebDAV API
     When user "Brian" updates the last public link share using the sharing API with
       | permissions | read,update,create,delete |
     Then the OCS status code should be "404"
     And the HTTP status code should be "<http_status_code>"
-    And uploading a file should not work using the <public-webdav-api-version> public WebDAV API
-
-    @notToImplementOnOCIS
-    Examples:
-      | ocs_api_version | http_status_code | public-webdav-api-version |
-      | 1               | 200              | old                       |
-      | 2               | 404              | old                       |
-
+    And uploading a file should not work using the old public WebDAV API
+    And uploading a file should not work using the new public WebDAV API
 
     Examples:
-      | ocs_api_version | http_status_code | public-webdav-api-version |
-      | 1               | 200              | new                       |
-      | 2               | 404              | new                       |
+      | ocs_api_version | http_status_code |
+      | 1               | 200              |
+      | 2               | 404              |

--- a/tests/acceptance/features/apiSharePublicLink3/updatePublicLinkShare.feature
+++ b/tests/acceptance/features/apiSharePublicLink3/updatePublicLinkShare.feature
@@ -350,20 +350,14 @@ Feature: update a public link share
       | publicUpload | true |
     Then the OCS status code should be "404"
     And the HTTP status code should be "<http_status_code>"
-    And uploading a file should not work using the <public-webdav-api-version> public WebDAV API
+    And uploading a file should not work using the old public WebDAV API
+    And uploading a file should not work using the new public WebDAV API
 
-    @notToImplementOnOCIS @issue-ocis-2079 @skipOnOcV10.6 @skipOnOcV10.7 @skipOnOcV10.8.0
+    @issue-ocis-2079 @skipOnOcV10.6 @skipOnOcV10.7 @skipOnOcV10.8.0
     Examples:
-      | ocs_api_version | http_status_code | public-webdav-api-version |
-      | 1               | 200              | old                       |
-      | 2               | 404              | old                       |
-
-    @issue-ocis-reva-11 @skipOnOcV10.6 @skipOnOcV10.7 @skipOnOcV10.8.0
-    Examples:
-      | ocs_api_version | http_status_code | public-webdav-api-version |
-      | 1               | 200              | new                       |
-      | 2               | 404              | new                       |
-
+      | ocs_api_version | http_status_code |
+      | 1               | 200              |
+      | 2               | 404              |
 
   Scenario Outline: Adding public upload to a shared folder as recipient is allowed with permissions using the public API
     Given the administrator has set the default folder for received shares to "Shares"
@@ -380,19 +374,14 @@ Feature: update a public link share
       | publicUpload | true |
     Then the OCS status code should be "<ocs_status_code>"
     And the HTTP status code should be "200"
-    And uploading a file should work using the <public-webdav-api-version> public WebDAV API
+    And uploading a file should work using the old public WebDAV API
+    And uploading a file should work using the new public WebDAV API
 
-    @notToImplementOnOCIS @issue-ocis-2079 @skipOnOcV10.6 @skipOnOcV10.7 @skipOnOcV10.8.0
+    @issue-ocis-2079 @skipOnOcV10.6 @skipOnOcV10.7 @skipOnOcV10.8.0
     Examples:
-      | ocs_api_version | ocs_status_code | public-webdav-api-version |
-      | 1               | 100             | old                       |
-      | 2               | 200             | old                       |
-
-    @issue-ocis-reva-11 @skipOnOcV10.6 @skipOnOcV10.7 @skipOnOcV10.8.0
-    Examples:
-      | ocs_api_version | ocs_status_code | public-webdav-api-version |
-      | 1               | 100             | new                       |
-      | 2               | 200             | new                       |
+      | ocs_api_version | ocs_status_code |
+      | 1               | 100             |
+      | 2               | 200             |
 
 
   Scenario Outline: Adding public link with all permissions to a read only shared folder as recipient is not allowed using the public API
@@ -410,19 +399,14 @@ Feature: update a public link share
       | permissions | read,update,create,delete |
     Then the OCS status code should be "404"
     And the HTTP status code should be "<http_status_code>"
-    And uploading a file should not work using the <public-webdav-api-version> public WebDAV API
+    And uploading a file should not work using the old public WebDAV API
+    And uploading a file should not work using the new public WebDAV API
 
-    @notToImplementOnOCIS @issue-ocis-2079 @skipOnOcV10.6 @skipOnOcV10.7 @skipOnOcV10.8.0
+    @issue-ocis-2079 @skipOnOcV10.6 @skipOnOcV10.7 @skipOnOcV10.8.0
     Examples:
-      | ocs_api_version | http_status_code | public-webdav-api-version |
-      | 1               | 200              | old                       |
-      | 2               | 404              | old                       |
-
-    @issue-ocis-reva-11 @skipOnOcV10.6 @skipOnOcV10.7 @skipOnOcV10.8.0
-    Examples:
-      | ocs_api_version | http_status_code | public-webdav-api-version |
-      | 1               | 200              | new                       |
-      | 2               | 404              | new                       |
+      | ocs_api_version | http_status_code |
+      | 1               | 200              |
+      | 2               | 404              |
 
 
   Scenario Outline: Adding public link with all permissions to a read only shared folder as recipient is allowed with permissions using the public API
@@ -440,19 +424,14 @@ Feature: update a public link share
       | permissions | read,update,create,delete |
     Then the OCS status code should be "<ocs_status_code>"
     And the HTTP status code should be "200"
-    And uploading a file should work using the <public-webdav-api-version> public WebDAV API
+    And uploading a file should work using the old public WebDAV API
+    And uploading a file should work using the new public WebDAV API
 
-    @notToImplementOnOCIS @issue-ocis-2079 @skipOnOcV10.6 @skipOnOcV10.7 @skipOnOcV10.8.0
+  @issue-ocis-2079 @skipOnOcV10.6 @skipOnOcV10.7 @skipOnOcV10.8.0
     Examples:
-      | ocs_api_version | ocs_status_code | public-webdav-api-version |
-      | 1               | 100             | old                       |
-      | 2               | 200             | old                       |
-
-    @issue-ocis-reva-11 @skipOnOcV10.6 @skipOnOcV10.7 @skipOnOcV10.8.0
-    Examples:
-      | ocs_api_version | ocs_status_code | public-webdav-api-version |
-      | 1               | 100             | new                       |
-      | 2               | 200             | new                       |
+      | ocs_api_version | ocs_status_code |
+      | 1               | 100             |
+      | 2               | 200             |
 
 
   Scenario Outline: Updating share permissions from change to read restricts public from deleting files using the public API
@@ -465,21 +444,16 @@ Feature: update a public link share
       | permissions | read,update,create,delete |
     And user "Alice" has updated the last public link share with
       | permissions | read |
-    When the public deletes file "CHILD/child.txt" from the last public link share using the <public-webdav-api-version> public WebDAV API
-    Then the HTTP status code should be "403"
+    When the public deletes file "CHILD/child.txt" from the last public link share using the old public WebDAV API
+    And the public deletes file "CHILD/child.txt" from the last public link share using the new public WebDAV API
+    And the HTTP status code of responses on all endpoints should be "403"
     And as "Alice" file "PARENT/CHILD/child.txt" should exist
 
-    @notToImplementOnOCIS @issue-ocis-2079
+   @issue-ocis-2079 @issue-ocis-reva-292
     Examples:
-      | ocs_api_version | public-webdav-api-version |
-      | 1               | old                       |
-      | 2               | old                       |
-
-    @issue-ocis-reva-292
-    Examples:
-      | ocs_api_version | public-webdav-api-version |
-      | 1               | new                       |
-      | 2               | new                       |
+      | ocs_api_version |
+      | 1               |
+      | 2               |
 
 
   Scenario Outline: Updating share permissions from read to change allows public to delete files using the public API

--- a/tests/acceptance/features/apiSharePublicLink3/updatePublicLinkShare.feature
+++ b/tests/acceptance/features/apiSharePublicLink3/updatePublicLinkShare.feature
@@ -133,19 +133,14 @@ Feature: update a public link share
       | expireDate | +3 days |
     Then the OCS status code should be "<ocs_status_code>"
     And the HTTP status code should be "200"
-    And the public should be able to download the last publicly shared file using the <public-webdav-api-version> public WebDAV API with password "%public%" and the content should be "Random data"
+    And the public should be able to download the last publicly shared file using the old public WebDAV API with password "%public%" and the content should be "Random data"
+    And the public should be able to download the last publicly shared file using the new public WebDAV API with password "%public%" and the content should be "Random data"
 
-    @notToImplementOnOCIS @issue-ocis-2079
+   @issue-ocis-2079
     Examples:
-      | ocs_api_version | ocs_status_code | public-webdav-api-version |
-      | 1               | 100             | old                       |
-      | 2               | 200             | old                       |
-
-
-    Examples:
-      | ocs_api_version | ocs_status_code | public-webdav-api-version |
-      | 1               | 100             | new                       |
-      | 2               | 200             | new                       |
+      | ocs_api_version | ocs_status_code |
+      | 1               | 100             |
+      | 2               | 200             |
 
 
   Scenario Outline: Creating a new public link share with password and removing (updating) it to make the resources accessible without password using public API
@@ -159,19 +154,14 @@ Feature: update a public link share
       | password | %remove% |
     Then the OCS status code should be "<ocs_status_code>"
     And the HTTP status code should be "200"
-    And the public should be able to download the last publicly shared file using the <public-webdav-api-version> public WebDAV API without a password and the content should be "Random data"
+    And the public should be able to download the last publicly shared file using the old public WebDAV API without a password and the content should be "Random data"
+    And the public should be able to download the last publicly shared file using the new public WebDAV API without a password and the content should be "Random data"
 
-    @notToImplementOnOCIS @issue-ocis-2079
+  @issue-ocis-2079
     Examples:
-      | ocs_api_version | ocs_status_code | public-webdav-api-version |
-      | 1               | 100             | old                       |
-      | 2               | 200             | old                       |
-
-
-    Examples:
-      | ocs_api_version | ocs_status_code | public-webdav-api-version |
-      | 1               | 100             | new                       |
-      | 2               | 200             | new                       |
+      | ocs_api_version | ocs_status_code |
+      | 1               | 100             |
+      | 2               | 200             |
 
   @issue-ocis-reva-336
   Scenario Outline: Creating a new public link share, updating its expiration date and getting its info (ocis Bug demonstration)

--- a/tests/acceptance/features/bootstrap/PublicWebDavContext.php
+++ b/tests/acceptance/features/bootstrap/PublicWebDavContext.php
@@ -959,26 +959,7 @@ class PublicWebDavContext implements Context {
 		string $publicWebDAVAPIVersion,
 		string $content
 	):void {
-		if (OcisHelper::isTestingOnOcisOrReva() && $publicWebDAVAPIVersion === "old") {
-			return;
-		} elseif ($publicWebDAVAPIVersion === "new") {
-			$techPreviewHadToBeEnabled = $this->occContext->enableDAVTechPreview();
-		} else {
-			$techPreviewHadToBeEnabled = false;
-		}
-
-		$this->publicDownloadsTheFileInsideThePublicSharedFolderWithPassword(
-			$path,
-			"",
-			$publicWebDAVAPIVersion
-		);
-
-		$this->featureContext->downloadedContentShouldBe($content);
-
-		if ($techPreviewHadToBeEnabled) {
-			$this->occContext->disableDAVTechPreview();
-		}
-		$this->featureContext->theHTTPStatusCodeShouldBeSuccess();
+		$this->shouldBeAbleToDownloadFileInsidePublicSharedFolderWithPasswordAndContentShouldBe($path, $publicWebDAVAPIVersion, "", $content);
 	}
 
 	/**

--- a/tests/acceptance/features/bootstrap/PublicWebDavContext.php
+++ b/tests/acceptance/features/bootstrap/PublicWebDavContext.php
@@ -883,7 +883,9 @@ class PublicWebDavContext implements Context {
 		string $password,
 		string $content
 	):void {
-		if ($publicWebDAVAPIVersion === "new") {
+		if (OcisHelper::isTestingOnOcisOrReva() && $publicWebDAVAPIVersion === "old") {
+			return;
+		} elseif ($publicWebDAVAPIVersion === "new") {
 			$techPreviewHadToBeEnabled = $this->occContext->enableDAVTechPreview();
 		} else {
 			$techPreviewHadToBeEnabled = false;
@@ -896,6 +898,82 @@ class PublicWebDavContext implements Context {
 		);
 
 		$this->featureContext->downloadedContentShouldBePlusEndOfLine($content);
+
+		if ($techPreviewHadToBeEnabled) {
+			$this->occContext->disableDAVTechPreview();
+		}
+		$this->featureContext->theHTTPStatusCodeShouldBeSuccess();
+	}
+
+	/**
+	 * @Then /^the public should be able to download file "([^"]*)" from inside the last public link shared folder using the (old|new) public WebDAV API with password "([^"]*)" and the content should be "([^"]*)"$/
+	 *
+	 * @param string $path
+	 * @param string $publicWebDAVAPIVersion
+	 * @param string $password
+	 * @param string $content
+	 *
+	 * @return void
+	 * @throws Exception
+	 */
+	public function shouldBeAbleToDownloadFileInsidePublicSharedFolderWithPasswordAndContentShouldBe(
+		string $path,
+		string $publicWebDAVAPIVersion,
+		string $password,
+		string $content
+	):void {
+		if (OcisHelper::isTestingOnOcisOrReva() && $publicWebDAVAPIVersion === "old") {
+			return;
+		} elseif ($publicWebDAVAPIVersion === "new") {
+			$techPreviewHadToBeEnabled = $this->occContext->enableDAVTechPreview();
+		} else {
+			$techPreviewHadToBeEnabled = false;
+		}
+
+		$this->publicDownloadsTheFileInsideThePublicSharedFolderWithPassword(
+			$path,
+			$password,
+			$publicWebDAVAPIVersion
+		);
+
+		$this->featureContext->downloadedContentShouldBe($content);
+
+		if ($techPreviewHadToBeEnabled) {
+			$this->occContext->disableDAVTechPreview();
+		}
+		$this->featureContext->theHTTPStatusCodeShouldBeSuccess();
+	}
+
+	/**
+	 * @Then /^the public should be able to download file "([^"]*)" from inside the last public link shared folder using the (old|new) public WebDAV API without password and the content should be "([^"]*)"$/
+	 *
+	 * @param string $path
+	 * @param string $publicWebDAVAPIVersion
+	 * @param string $content
+	 *
+	 * @return void
+	 * @throws Exception
+	 */
+	public function shouldBeAbleToDownloadFileInsidePublicSharedFolderWithoutPassword(
+		string $path,
+		string $publicWebDAVAPIVersion,
+		string $content
+	):void {
+		if (OcisHelper::isTestingOnOcisOrReva() && $publicWebDAVAPIVersion === "old") {
+			return;
+		} elseif ($publicWebDAVAPIVersion === "new") {
+			$techPreviewHadToBeEnabled = $this->occContext->enableDAVTechPreview();
+		} else {
+			$techPreviewHadToBeEnabled = false;
+		}
+
+		$this->publicDownloadsTheFileInsideThePublicSharedFolderWithPassword(
+			$path,
+			"",
+			$publicWebDAVAPIVersion
+		);
+
+		$this->featureContext->downloadedContentShouldBe($content);
 
 		if ($techPreviewHadToBeEnabled) {
 			$this->occContext->disableDAVTechPreview();

--- a/tests/acceptance/features/bootstrap/PublicWebDavContext.php
+++ b/tests/acceptance/features/bootstrap/PublicWebDavContext.php
@@ -131,7 +131,7 @@ class PublicWebDavContext implements Context {
 	 * @return void
 	 */
 	public function deleteFileFromPublicShare(string $fileName, string $publicWebDAVAPIVersion, string $password = ""):void {
-		if (OcisHelper::isTestingOnOcisOrReva() && $publicWebDAVAPIVersion === "old"){
+		if (OcisHelper::isTestingOnOcisOrReva() && $publicWebDAVAPIVersion === "old") {
 			return;
 		}
 		$token = $this->featureContext->getLastPublicShareToken();
@@ -185,6 +185,9 @@ class PublicWebDavContext implements Context {
 	 * @return void
 	 */
 	public function renameFileFromPublicShare(string $fileName, string $toFileName, string $publicWebDAVAPIVersion, ?string $password = ""):void {
+		if (OcisHelper::isTestingOnOcisOrReva() && $publicWebDAVAPIVersion === "old") {
+			return;
+		}
 		$token = $this->featureContext->getLastPublicShareToken();
 		$davPath = WebDavHelper::getDavPath(
 			$token,
@@ -723,10 +726,9 @@ class PublicWebDavContext implements Context {
 		string $password,
 		string $expectedContent
 	):void {
-		if (OcisHelper::isTestingOnOcisOrReva() && $publicWebDAVAPIVersion === "old"){
+		if (OcisHelper::isTestingOnOcisOrReva() && $publicWebDAVAPIVersion === "old") {
 			return;
-		}
-		else if ($publicWebDAVAPIVersion === "new") {
+		} elseif ($publicWebDAVAPIVersion === "new") {
 			$techPreviewHadToBeEnabled = $this->occContext->enableDAVTechPreview();
 		} else {
 			$techPreviewHadToBeEnabled = false;
@@ -944,10 +946,9 @@ class PublicWebDavContext implements Context {
 		string $publicWebDAVAPIVersion,
 		string $password
 	):void {
-		if (OcisHelper::isTestingOnOcisOrReva() && $publicWebDAVAPIVersion === "old"){
+		if (OcisHelper::isTestingOnOcisOrReva() && $publicWebDAVAPIVersion === "old") {
 			return;
-		}
-		else if ($publicWebDAVAPIVersion === "new") {
+		} elseif ($publicWebDAVAPIVersion === "new") {
 			$techPreviewHadToBeEnabled = $this->occContext->enableDAVTechPreview();
 		} else {
 			$techPreviewHadToBeEnabled = false;
@@ -981,7 +982,9 @@ class PublicWebDavContext implements Context {
 		string $password,
 		string $expectedHttpCode = "401"
 	):void {
-		if ($publicWebDAVAPIVersion === "new") {
+		if (OcisHelper::isTestingOnOcisOrReva() && $publicWebDAVAPIVersion === "old") {
+			return;
+		} elseif ($publicWebDAVAPIVersion === "new") {
 			$techPreviewHadToBeEnabled = $this->occContext->enableDAVTechPreview();
 		} else {
 			$techPreviewHadToBeEnabled = false;
@@ -1071,10 +1074,9 @@ class PublicWebDavContext implements Context {
 		string $expectedHttpCode
 	):void {
 		$filename = "";
-		if (OcisHelper::isTestingOnOcisOrReva() && $publicWebDAVAPIVersion === "old"){
+		if (OcisHelper::isTestingOnOcisOrReva() && $publicWebDAVAPIVersion === "old") {
 			return;
-		}
-		else if ($publicWebDAVAPIVersion === "new") {
+		} elseif ($publicWebDAVAPIVersion === "new") {
 			$filename = (string)$this->featureContext->getLastPublicShareData()->data[0]->file_target;
 			$techPreviewHadToBeEnabled = $this->occContext->enableDAVTechPreview();
 		} else {
@@ -1111,10 +1113,9 @@ class PublicWebDavContext implements Context {
 		string $publicWebDAVAPIVersion,
 		string $expectedHttpCode = null
 	):void {
-		if (OcisHelper::isTestingOnOcisOrReva() && $publicWebDAVAPIVersion === "old"){
+		if (OcisHelper::isTestingOnOcisOrReva() && $publicWebDAVAPIVersion === "old") {
 			return;
-		}
-		else if ($publicWebDAVAPIVersion === "new") {
+		} elseif ($publicWebDAVAPIVersion === "new") {
 			$techPreviewHadToBeEnabled = $this->occContext->enableDAVTechPreview();
 		} else {
 			$techPreviewHadToBeEnabled = false;
@@ -1215,10 +1216,9 @@ class PublicWebDavContext implements Context {
 		$path = "whateverfilefortesting-$publicWebDAVAPIVersion-publicWebDAVAPI.txt";
 		$content = "test $publicWebDAVAPIVersion";
 
-		if (OcisHelper::isTestingOnOcisOrReva() && $publicWebDAVAPIVersion === "old"){
+		if (OcisHelper::isTestingOnOcisOrReva() && $publicWebDAVAPIVersion === "old") {
 			return;
-		}
-		else if ($publicWebDAVAPIVersion === "new") {
+		} elseif ($publicWebDAVAPIVersion === "new") {
 			$techPreviewHadToBeEnabled = $this->occContext->enableDAVTechPreview();
 		} else {
 			$techPreviewHadToBeEnabled = false;
@@ -1264,10 +1264,9 @@ class PublicWebDavContext implements Context {
 	):void {
 		$content = "test $publicWebDAVAPIVersion";
 		$should = ($shouldOrNot !== "not");
-		if (OcisHelper::isTestingOnOcisOrReva() && $publicWebDAVAPIVersion === "old"){
+		if (OcisHelper::isTestingOnOcisOrReva() && $publicWebDAVAPIVersion === "old") {
 			return;
-		}
-		else if ($publicWebDAVAPIVersion === "new") {
+		} elseif ($publicWebDAVAPIVersion === "new") {
 			$techPreviewHadToBeEnabled = $this->occContext->enableDAVTechPreview();
 			$path = $this->featureContext->getLastPublicSharePath();
 		} else {
@@ -1519,6 +1518,9 @@ class PublicWebDavContext implements Context {
 		array $additionalHeaders = [],
 		string $publicWebDAVAPIVersion = "old"
 	):void {
+		if (OcisHelper::isTestingOnOcisOrReva() && $publicWebDAVAPIVersion === "old") {
+			return;
+		}
 		$password = $this->featureContext->getActualPassword($password);
 		$token = $this->featureContext->getLastPublicShareToken();
 		$davPath = WebDavHelper::getDavPath(

--- a/tests/acceptance/features/bootstrap/PublicWebDavContext.php
+++ b/tests/acceptance/features/bootstrap/PublicWebDavContext.php
@@ -24,6 +24,7 @@ use Behat\Behat\Context\Context;
 use Behat\Behat\Hook\Scope\BeforeScenarioScope;
 use PHPUnit\Framework\Assert;
 use TestHelpers\HttpRequestHelper;
+use TestHelpers\OcisHelper;
 use TestHelpers\WebDavHelper;
 
 require_once 'bootstrap.php';
@@ -130,6 +131,9 @@ class PublicWebDavContext implements Context {
 	 * @return void
 	 */
 	public function deleteFileFromPublicShare(string $fileName, string $publicWebDAVAPIVersion, string $password = ""):void {
+		if (OcisHelper::isTestingOnOcisOrReva() && $publicWebDAVAPIVersion === "old"){
+			return;
+		}
 		$token = $this->featureContext->getLastPublicShareToken();
 		$davPath = WebDavHelper::getDavPath(
 			$token,
@@ -719,7 +723,10 @@ class PublicWebDavContext implements Context {
 		string $password,
 		string $expectedContent
 	):void {
-		if ($publicWebDAVAPIVersion === "new") {
+		if (OcisHelper::isTestingOnOcisOrReva() && $publicWebDAVAPIVersion === "old"){
+			return;
+		}
+		else if ($publicWebDAVAPIVersion === "new") {
 			$techPreviewHadToBeEnabled = $this->occContext->enableDAVTechPreview();
 		} else {
 			$techPreviewHadToBeEnabled = false;
@@ -937,7 +944,10 @@ class PublicWebDavContext implements Context {
 		string $publicWebDAVAPIVersion,
 		string $password
 	):void {
-		if ($publicWebDAVAPIVersion === "new") {
+		if (OcisHelper::isTestingOnOcisOrReva() && $publicWebDAVAPIVersion === "old"){
+			return;
+		}
+		else if ($publicWebDAVAPIVersion === "new") {
 			$techPreviewHadToBeEnabled = $this->occContext->enableDAVTechPreview();
 		} else {
 			$techPreviewHadToBeEnabled = false;
@@ -1061,8 +1071,10 @@ class PublicWebDavContext implements Context {
 		string $expectedHttpCode
 	):void {
 		$filename = "";
-
-		if ($publicWebDAVAPIVersion === "new") {
+		if (OcisHelper::isTestingOnOcisOrReva() && $publicWebDAVAPIVersion === "old"){
+			return;
+		}
+		else if ($publicWebDAVAPIVersion === "new") {
 			$filename = (string)$this->featureContext->getLastPublicShareData()->data[0]->file_target;
 			$techPreviewHadToBeEnabled = $this->occContext->enableDAVTechPreview();
 		} else {
@@ -1099,7 +1111,10 @@ class PublicWebDavContext implements Context {
 		string $publicWebDAVAPIVersion,
 		string $expectedHttpCode = null
 	):void {
-		if ($publicWebDAVAPIVersion === "new") {
+		if (OcisHelper::isTestingOnOcisOrReva() && $publicWebDAVAPIVersion === "old"){
+			return;
+		}
+		else if ($publicWebDAVAPIVersion === "new") {
 			$techPreviewHadToBeEnabled = $this->occContext->enableDAVTechPreview();
 		} else {
 			$techPreviewHadToBeEnabled = false;
@@ -1200,7 +1215,10 @@ class PublicWebDavContext implements Context {
 		$path = "whateverfilefortesting-$publicWebDAVAPIVersion-publicWebDAVAPI.txt";
 		$content = "test $publicWebDAVAPIVersion";
 
-		if ($publicWebDAVAPIVersion === "new") {
+		if (OcisHelper::isTestingOnOcisOrReva() && $publicWebDAVAPIVersion === "old"){
+			return;
+		}
+		else if ($publicWebDAVAPIVersion === "new") {
 			$techPreviewHadToBeEnabled = $this->occContext->enableDAVTechPreview();
 		} else {
 			$techPreviewHadToBeEnabled = false;
@@ -1246,8 +1264,10 @@ class PublicWebDavContext implements Context {
 	):void {
 		$content = "test $publicWebDAVAPIVersion";
 		$should = ($shouldOrNot !== "not");
-
-		if ($publicWebDAVAPIVersion === "new") {
+		if (OcisHelper::isTestingOnOcisOrReva() && $publicWebDAVAPIVersion === "old"){
+			return;
+		}
+		else if ($publicWebDAVAPIVersion === "new") {
 			$techPreviewHadToBeEnabled = $this->occContext->enableDAVTechPreview();
 			$path = $this->featureContext->getLastPublicSharePath();
 		} else {


### PR DESCRIPTION
<!--
Thanks for submitting a change to ownCloud!

This is the bug tracker for the Server component. Find other components at https://github.com/owncloud/core/blob/master/.github/CONTRIBUTING.md#guidelines

For fixing potential security issues please see https://owncloud.com/security/

To make it possible for us to get your change reviewed and merged please carefully fill out the requested information below.

Please note that any kind of change needs first be submitted to the master branch which holds the next version of ownCloud.

Please set the following labels:

- Set label "3 - To review" for review or "2 - Development" if the PR still has open tasks
- Assignment: assign to self
- Milestone: set the same as the ticket this PR fixes, or "development" by default
- Reviewers: pick at least one
-->

## Description
The examples for "old" public-webdav-api-version are skipped on oCIS because that "old" API is not implemented on oCIS. Currently, we write a separate example for ocis and oc10 skipping `old` api tests in ocis, this resulted into running 4 scenarios in OC10 and two in OCIS. This PR makes the function return if the test is being run on ocis and same examples are run in both oc10 and ocis but it's internally managed what version should run on what server. See issue https://github.com/owncloud/core/issues/40254 for detailed explanation

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
- Fixes https://github.com/owncloud/core/issues/40254

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
- Locally
- CI
- https://github.com/owncloud/ocis/pull/5220

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Database schema changes (next release will require increase of minor version instead of patch)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [x] Tests only (no source changes)

## Checklist:
<!-- Tick the checkboxes when done. -->
<!-- Raise documentation ticket in https://github.com/owncloud/documentation -->
- [ ] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 
- [ ] Changelog item, see [TEMPLATE](https://github.com/owncloud/core/blob/master/changelog/TEMPLATE)
