### PR TITLE
[tests-only]Removed skip tag @skipOnAllVersionsGreaterThanOcV10.8.0 from acceptance tests

### DIFF
--- a/tests/acceptance/features/apiShareCreateSpecialToShares2/createShareReceivedInMultipleWays.feature
+++ b/tests/acceptance/features/apiShareCreateSpecialToShares2/createShareReceivedInMultipleWays.feature
@@ -71,12 +71,6 @@ Feature: share resources where the sharee receives the share in multiple ways
       | 1               | 100             | /CHILD                 |
       | 2               | 200             | /CHILD                 |
 
-    @skipOnAllVersionsGreaterThanOcV10.8.0 @skipOnOcis
-    Examples:
-      | ocs_api_version | ocs_status_code | pending_sub_share_path |
-      | 1               | 100             | /PARENT/CHILD          |
-      | 2               | 200             | /PARENT/CHILD          |
-
   @issue-ocis-2021
   Scenario Outline: sharing subfolder when parent already shared
     Given using OCS API version "<ocs_api_version>"
@@ -94,12 +88,6 @@ Feature: share resources where the sharee receives the share in multiple ways
       | ocs_api_version | ocs_status_code | pending_share_path |
       | 1               | 100             | /sub               |
       | 2               | 200             | /sub               |
-
-    @skipOnAllVersionsGreaterThanOcV10.8.0 @skipOnOcis
-    Examples:
-      | ocs_api_version | ocs_status_code | pending_share_path |
-      | 1               | 100             | /test/sub          |
-      | 2               | 200             | /test/sub          |
 
   @issue-ocis-2021
   Scenario Outline: sharing subfolder when parent already shared with group of sharer
@@ -119,12 +107,6 @@ Feature: share resources where the sharee receives the share in multiple ways
       | ocs_api_version | ocs_status_code | pending_share_path |
       | 1               | 100             | /sub               |
       | 2               | 200             | /sub               |
-
-    @skipOnAllVersionsGreaterThanOcV10.8.0 @skipOnOcis
-    Examples:
-      | ocs_api_version | ocs_status_code | pending_share_path |
-      | 1               | 100             | /test/sub          |
-      | 2               | 200             | /test/sub          |
 
 
   Scenario Outline: multiple users share a file with the same name but different permissions to a user
@@ -263,11 +245,6 @@ Feature: share resources where the sharee receives the share in multiple ways
       | path    |
       | /child1 |
 
-    @skipOnAllVersionsGreaterThanOcV10.8.0 @skipOnOcis
-    Examples:
-      | path           |
-      | /parent/child1 |
-
 
   Scenario Outline: Sharing parent folder to user with all permissions and its child folder to group with read permission then check rename operation
     Given group "grp1" has been created
@@ -303,11 +280,6 @@ Feature: share resources where the sharee receives the share in multiple ways
       | path    |
       | /child1 |
 
-    @skipOnAllVersionsGreaterThanOcV10.8.0 @skipOnOcis
-    Examples:
-      | path           |
-      | /parent/child1 |
-
 
   Scenario Outline: Sharing parent folder to user with all permissions and its child folder to group with read permission then check delete operation
     Given group "grp1" has been created
@@ -342,11 +314,6 @@ Feature: share resources where the sharee receives the share in multiple ways
     Examples:
       | path    |
       | /child1 |
-
-    @skipOnAllVersionsGreaterThanOcV10.8.0 @skipOnOcis
-    Examples:
-      | path           |
-      | /parent/child1 |
 
 
   Scenario Outline: Sharing parent folder to user with all permissions and its child folder to group with read permission then check reshare operation
@@ -388,11 +355,6 @@ Feature: share resources where the sharee receives the share in multiple ways
       | path    |
       | /child1 |
 
-    @skipOnAllVersionsGreaterThanOcV10.8.0 @skipOnOcis
-    Examples:
-      | path           |
-      | /parent/child1 |
-
 
   Scenario Outline: Sharing parent folder to group with read permission and its child folder to user with all permissions then check create operation
     Given group "grp1" has been created
@@ -429,11 +391,6 @@ Feature: share resources where the sharee receives the share in multiple ways
       | path    |
       | /child1 |
 
-    @skipOnAllVersionsGreaterThanOcV10.8.0 @skipOnOcis
-    Examples:
-      | path           |
-      | /parent/child1 |
-
 
   Scenario Outline: Sharing parent folder to group with read permission and its child folder to user with all permissions then check rename operation
     Given group "grp1" has been created
@@ -468,11 +425,6 @@ Feature: share resources where the sharee receives the share in multiple ways
     Examples:
       | path    |
       | /child1 |
-
-    @skipOnAllVersionsGreaterThanOcV10.8.0 @skipOnOcis
-    Examples:
-      | path           |
-      | /parent/child1 |
 
 
   Scenario Outline: Sharing parent folder to group with read permission and its child folder to user with all permissions then check delete operation
@@ -509,11 +461,6 @@ Feature: share resources where the sharee receives the share in multiple ways
       | path    |
       | /child1 |
 
-    @skipOnAllVersionsGreaterThanOcV10.8.0 @skipOnOcis
-    Examples:
-      | path           |
-      | /parent/child1 |
-
 
   Scenario Outline: Sharing parent folder to group with read permission and its child folder to user with all permissions then check reshare operation
     Given group "grp1" has been created
@@ -549,11 +496,6 @@ Feature: share resources where the sharee receives the share in multiple ways
     Examples:
       | path    |
       | /child1 |
-
-    @skipOnAllVersionsGreaterThanOcV10.8.0 @skipOnOcis
-    Examples:
-      | path           |
-      | /parent/child1 |
 
 
   Scenario Outline: Sharing parent folder to one group with all permissions and its child folder to another group with read permission
@@ -600,11 +542,6 @@ Feature: share resources where the sharee receives the share in multiple ways
     Examples:
       | path    |
       | /child1 |
-
-    @skipOnAllVersionsGreaterThanOcV10.8.0 @skipOnOcis
-    Examples:
-      | path           |
-      | /parent/child1 |
 
   @skipOnOcV10 @issue-39347
   Scenario Outline: Share receiver renames the received group share and shares same folder through user share again

--- a/tests/acceptance/features/apiShareManagementBasicToShares/createShareFromLocalStorageToSharesFolder.feature
+++ b/tests/acceptance/features/apiShareManagementBasicToShares/createShareFromLocalStorageToSharesFolder.feature
@@ -38,12 +38,6 @@ Feature: local-storage
       | 1               | 100             | /filetoshare.txt    |
       | 2               | 200             | /filetoshare.txt    |
 
-    @skipOnAllVersionsGreaterThanOcV10.8.0 @skipOnOcis @skipOnOcV10.6 @skipOnOcV10.7 @skipOnOcV10.8.0
-    Examples:
-      | ocs_api_version | ocs_status_code | pending_share_path             |
-      | 1               | 100             | /local_storage/filetoshare.txt |
-      | 2               | 200             | /local_storage/filetoshare.txt |
-
 
   Scenario Outline: Share a folder inside a local external storage
     Given using OCS API version "<ocs_api_version>"

--- a/tests/acceptance/features/apiShareManagementBasicToShares/createShareToSharesFolder.feature
+++ b/tests/acceptance/features/apiShareManagementBasicToShares/createShareToSharesFolder.feature
@@ -585,11 +585,6 @@ Feature: sharing
       | pending_share_path |
       | /userOneFolder     |
 
-    @skipOnAllVersionsGreaterThanOcV10.8.0 @skipOnOcis @skipOnOcV10.6 @skipOnOcV10.7 @skipOnOcV10.8.0
-    Examples:
-      | pending_share_path            |
-      | /userZeroFolder/userOneFolder |
-
   @issue-enterprise-3896 @issue-ocis-2201
   Scenario Outline: sharing back to original sharer is allowed
     Given these users have been created with default attributes and without skeleton files:
@@ -611,11 +606,6 @@ Feature: sharing
     Examples:
       | pending_share_path |
       | /userOneFolder     |
-
-    @skipOnAllVersionsGreaterThanOcV10.8.0 @skipOnOcis @skipOnOcV10.6 @skipOnOcV10.7 @skipOnOcV10.8.0
-    Examples:
-      | pending_share_path            |
-      | /userZeroFolder/userOneFolder |
 
   @issue-enterprise-3896 @issue-ocis-2201
   Scenario Outline: sharing a subfolder to a user that already received parent folder share
@@ -641,11 +631,6 @@ Feature: sharing
     Examples:
       | pending_share_path |
       | /userOneFolder     |
-
-    @skipOnAllVersionsGreaterThanOcV10.8.0 @skipOnOcis @skipOnOcV10.6 @skipOnOcV10.7 @skipOnOcV10.8.0
-    Examples:
-      | pending_share_path            |
-      | /userZeroFolder/userOneFolder |
 
   @smokeTest @skipOnOcV10.6 @skipOnOcV10.7 @skipOnOcV10.8.0
   Scenario Outline: Creating a share of a renamed file

--- a/tests/acceptance/features/apiShareManagementBasicToShares/deleteShareFromShares.feature
+++ b/tests/acceptance/features/apiShareManagementBasicToShares/deleteShareFromShares.feature
@@ -60,11 +60,6 @@ Feature: sharing
       | pending_share_path |
       | /sub               |
 
-    @skipOnAllVersionsGreaterThanOcV10.8.0 @skipOnOcis
-    Examples:
-      | pending_share_path |
-      | /common/sub        |
-
   @smokeTest @files_trashbin-app-required
   Scenario: deleting a file out of a share as recipient creates a backup for the owner
     Given using OCS API version "1"
@@ -120,11 +115,6 @@ Feature: sharing
     Examples:
       | pending_share_path |
       | /parent.txt        |
-
-    @skipOnAllVersionsGreaterThanOcV10.8.0 @skipOnOcis
-    Examples:
-      | pending_share_path |
-      | /PARENT/parent.txt |
 
 
   Scenario: sharee of a read-only share folder tries to delete the shared folder
@@ -192,14 +182,6 @@ Feature: sharing
       | /shared                 | 1               | 200              | /Shares/shared          | /Shares/shared          |
       | /shared                 | 2               | 404              | /Shares/shared          | /Shares/shared          |
 
-    @skipOnAllVersionsGreaterThanOcV10.8.0 @skipOnOcis
-    Examples:
-      | entry_to_share          | ocs_api_version | http_status_code | received_entry          | pending_entry           |
-      | /shared/shared_file.txt | 1               | 200              | /Shares/shared_file.txt | /shared/shared_file.txt |
-      | /shared/shared_file.txt | 2               | 404              | /Shares/shared_file.txt | /shared/shared_file.txt |
-      | /shared                 | 1               | 200              | /Shares/shared          | /shared                 |
-      | /shared                 | 2               | 404              | /Shares/shared          | /shared                 |
-
 
   Scenario Outline: An individual share recipient tries to delete the share
     Given using OCS API version "<ocs_api_version>"
@@ -219,14 +201,6 @@ Feature: sharing
       | /shared/shared_file.txt | 2               | 404              | /Shares/shared_file.txt | /Shares/shared_file.txt |
       | /shared                 | 1               | 200              | /Shares/shared          | /Shares/shared          |
       | /shared                 | 2               | 404              | /Shares/shared          | /Shares/shared          |
-
-    @skipOnAllVersionsGreaterThanOcV10.8.0 @skipOnOcis
-    Examples:
-      | entry_to_share          | ocs_api_version | http_status_code | received_entry          | pending_entry           |
-      | /shared/shared_file.txt | 1               | 200              | /Shares/shared_file.txt | /shared/shared_file.txt |
-      | /shared/shared_file.txt | 2               | 404              | /Shares/shared_file.txt | /shared/shared_file.txt |
-      | /shared                 | 1               | 200              | /Shares/shared          | /shared                 |
-      | /shared                 | 2               | 404              | /Shares/shared          | /shared                 |
 
   @issue-ocis-720
   Scenario Outline: request PROPFIND after sharer deletes the collaborator

--- a/tests/acceptance/features/apiShareManagementToRoot/acceptShares.feature
+++ b/tests/acceptance/features/apiShareManagementToRoot/acceptShares.feature
@@ -158,11 +158,6 @@ Feature: accept/decline shares coming from internal users
       | declined_share_path_1 | declined_share_path_2 |
       | /PARENT (2)/          | /textfile0 (2).txt    |
 
-    @skipOnAllVersionsGreaterThanOcV10.8.0 @skipOnOcis
-    Examples:
-      | declined_share_path_1 | declined_share_path_2 |
-      | /PARENT/              | /textfile0.txt        |
-
 
   Scenario Outline: accept a share that has been declined before
     Given parameter "shareapi_auto_accept_share" of app "core" has been set to "yes"
@@ -187,11 +182,6 @@ Feature: accept/decline shares coming from internal users
       | pending_share_path_1 | pending_share_path_2 |
       | /PARENT (2)          | /textfile0 (2).txt   |
 
-    @skipOnAllVersionsGreaterThanOcV10.8.0 @skipOnOcis
-    Examples:
-      | pending_share_path_1 | pending_share_path_2 |
-      | /PARENT              | /textfile0.txt       |
-
 
   Scenario Outline: unshare a share that has been auto-accepted
     Given parameter "shareapi_auto_accept_share" of app "core" has been set to "yes"
@@ -212,11 +202,6 @@ Feature: accept/decline shares coming from internal users
     Examples:
       | declined_share_path_1 | declined_share_path_2 |
       | /PARENT (2)/          | /textfile0 (2).txt    |
-
-    @skipOnAllVersionsGreaterThanOcV10.8.0 @skipOnOcis
-    Examples:
-      | declined_share_path_1 | declined_share_path_2 |
-      | /PARENT/              | /textfile0.txt        |
 
 
   Scenario Outline: unshare a share that was shared with a group and auto-accepted
@@ -247,11 +232,6 @@ Feature: accept/decline shares coming from internal users
       | declined_share_path_1 | declined_share_path_2 |
       | /PARENT (2)/          | /textfile0 (2).txt    |
 
-    @skipOnAllVersionsGreaterThanOcV10.8.0 @skipOnOcis
-    Examples:
-      | declined_share_path_1 | declined_share_path_2 |
-      | /PARENT/              | /textfile0.txt        |
-
 
   Scenario Outline: rename accepted share, decline it
     Given parameter "shareapi_auto_accept_share" of app "core" has been set to "yes"
@@ -272,11 +252,6 @@ Feature: accept/decline shares coming from internal users
       | declined_share_path |
       | /PARENT-renamed/    |
 
-    @skipOnAllVersionsGreaterThanOcV10.8.0 @skipOnOcis
-    Examples:
-      | declined_share_path |
-      | /PARENT/            |
-
 
   Scenario Outline: rename accepted share, decline it then accept again, name stays
     Given parameter "shareapi_auto_accept_share" of app "core" has been set to "yes"
@@ -296,11 +271,6 @@ Feature: accept/decline shares coming from internal users
     Examples:
       | declined_share_path |
       | /PARENT-renamed     |
-
-    @skipOnAllVersionsGreaterThanOcV10.8.0 @skipOnOcis
-    Examples:
-      | declined_share_path |
-      | /PARENT             |
 
 
   Scenario Outline: move accepted share, decline it, accept again
@@ -323,11 +293,6 @@ Feature: accept/decline shares coming from internal users
     Examples:
       | declined_share_path |
       | /PARENT/shared      |
-
-    @skipOnAllVersionsGreaterThanOcV10.8.0 @skipOnOcis
-    Examples:
-      | declined_share_path |
-      | /shared             |
 
 
   Scenario Outline: move accepted share, decline it, delete parent folder, accept again
@@ -352,11 +317,6 @@ Feature: accept/decline shares coming from internal users
     Examples:
       | declined_share_path |
       | /PARENT/shared      |
-
-    @skipOnAllVersionsGreaterThanOcV10.8.0 @skipOnOcis
-    Examples:
-      | declined_share_path |
-      | /shared             |
 
 
   Scenario: receive two shares with identical names from different users
@@ -580,11 +540,6 @@ Feature: accept/decline shares coming from internal users
       | declined_share_path_1 | declined_share_path_2 |
       | /PARENT (2)/          | /textfile0 (2).txt    |
 
-    @skipOnAllVersionsGreaterThanOcV10.8.0 @skipOnOcis
-    Examples:
-      | declined_share_path_1 | declined_share_path_2 |
-      | /PARENT/              | /textfile0.txt        |
-
 
   Scenario: deleting shares in pending state
     Given parameter "shareapi_auto_accept_share" of app "core" has been set to "no"
@@ -679,11 +634,6 @@ Feature: accept/decline shares coming from internal users
       | accepted_share_path |
       | /testfile (2).txt   |
 
-    @skipOnAllVersionsGreaterThanOcV10.8.0 @skipOnOcis
-    Examples:
-      | accepted_share_path |
-      | /testfile.txt       |
-
 
   Scenario Outline: user accepts shares received from multiple users with the same name when auto-accept share is disabled
     Given parameter "shareapi_auto_accept_share" of app "core" has been set to "no"
@@ -712,11 +662,6 @@ Feature: accept/decline shares coming from internal users
     Examples:
       | accepted_share_path_1 | accepted_share_path_2 |
       | /PARENT (2)           | /PARENT (2) (2)       |
-
-    @skipOnAllVersionsGreaterThanOcV10.8.0 @skipOnOcis
-    Examples:
-      | accepted_share_path_1 | accepted_share_path_2 |
-      | /PARENT               | /PARENT               |
 
 
   Scenario: user shares folder with matching folder-name for both user involved in sharing

--- a/tests/acceptance/features/apiShareManagementToShares/acceptShares.feature
+++ b/tests/acceptance/features/apiShareManagementToShares/acceptShares.feature
@@ -64,11 +64,6 @@ Feature: accept/decline shares coming from internal users
       | pending_share_path_1 | pending_share_path_2  |
       | /Shares/PARENT/      | /Shares/textfile0.txt |
 
-    @skipOnAllVersionsGreaterThanOcV10.8.0 @skipOnOcis
-    Examples:
-      | pending_share_path_1 | pending_share_path_2 |
-      | /PARENT/             | /textfile0.txt       |
-
 
   Scenario Outline: share a file & folder with another internal user when auto accept is disabled
     When user "Alice" shares folder "/PARENT" with user "Brian" using the sharing API
@@ -91,11 +86,6 @@ Feature: accept/decline shares coming from internal users
     Examples:
       | pending_share_path_1 | pending_share_path_2  |
       | /Shares/PARENT/      | /Shares/textfile0.txt |
-
-    @skipOnAllVersionsGreaterThanOcV10.8.0 @skipOnOcis
-    Examples:
-      | pending_share_path_1 | pending_share_path_2 |
-      | /PARENT/             | /textfile0.txt       |
 
   @smokeTest @issue-ocis-2131 @skipOnOcV10.6 @skipOnOcV10.7 @skipOnOcV10.8.0
   Scenario: accept a pending share
@@ -223,11 +213,6 @@ Feature: accept/decline shares coming from internal users
       | declined_share_path_1 | declined_share_path_2 |
       | /Shares/PARENT/       | /Shares/textfile0.txt |
 
-    @skipOnAllVersionsGreaterThanOcV10.8.0 @skipOnOcis @skipOnOcV10.6 @skipOnOcV10.7 @skipOnOcV10.8.0
-    Examples:
-      | declined_share_path_1 | declined_share_path_2 |
-      | /PARENT/              | /textfile0.txt        |
-
   @smokeTest @issue-ocis-2128
   Scenario Outline: decline an accepted share
     Given user "Alice" has shared folder "/PARENT" with user "Brian"
@@ -250,11 +235,6 @@ Feature: accept/decline shares coming from internal users
     Examples:
       | declined_share_path_1 | declined_share_path_2 |
       | /Shares/PARENT/       | /Shares/textfile0.txt |
-
-    @skipOnAllVersionsGreaterThanOcV10.8.0 @skipOnOcis @skipOnOcV10.6 @skipOnOcV10.7 @skipOnOcV10.8.0
-    Examples:
-      | declined_share_path_1 | declined_share_path_2 |
-      | /PARENT/              | /textfile0.txt        |
 
 
   Scenario: deleting shares in pending state
@@ -294,11 +274,6 @@ Feature: accept/decline shares coming from internal users
       | pending_share_path_1 | pending_share_path_2  |
       | /Shares/PARENT/      | /Shares/textfile0.txt |
 
-    @skipOnAllVersionsGreaterThanOcV10.8.0 @skipOnOcis @skipOnOcV10.6 @skipOnOcV10.7 @skipOnOcV10.8.0
-    Examples:
-      | pending_share_path_1 | pending_share_path_2 |
-      | /PARENT/             | /textfile0.txt       |
-
   @issue-ocis-2131 @skipOnOcV10.6 @skipOnOcV10.7 @skipOnOcV10.8.0
   Scenario: receive two shares with identical names from different users, accept one by one
     Given user "Alice" has created folder "/shared"
@@ -333,11 +308,6 @@ Feature: accept/decline shares coming from internal users
       | pending_share_path |
       | /Shares/PARENT/    |
 
-    @skipOnAllVersionsGreaterThanOcV10.8.0 @skipOnOcis
-    Examples:
-      | pending_share_path |
-      | /PARENT/           |
-
 
   Scenario Outline: user accepts file that was initially accepted from another user and then declined
     Given user "Alice" has uploaded file with content "First file" to "/testfile.txt"
@@ -363,11 +333,6 @@ Feature: accept/decline shares coming from internal users
     Examples:
       | accepted_share_path |
       | /testfile (2).txt   |
-
-    @skipOnAllVersionsGreaterThanOcV10.8.0 @skipOnOcis @skipOnOcV10.6 @skipOnOcV10.7 @skipOnOcV10.8.0
-    Examples:
-      | accepted_share_path |
-      | /testfile.txt       |
 
 
   Scenario Outline: user accepts shares received from multiple users with the same name when auto-accept share is disabled
@@ -399,11 +364,6 @@ Feature: accept/decline shares coming from internal users
     Examples:
       | accepted_share_path_1 | accepted_share_path_2 |
       | /PARENT (2)           | /PARENT (2) (2)       |
-
-    @skipOnAllVersionsGreaterThanOcV10.8.0 @skipOnOcis @skipOnOcV10.6 @skipOnOcV10.7 @skipOnOcV10.8.0
-    Examples:
-      | accepted_share_path_1 | accepted_share_path_2 |
-      | /PARENT               | /PARENT               |
 
   @skipOnOcV10.6 @skipOnOcV10.7 @skipOnOcV10.8.0
   Scenario: user shares folder with matching folder-name for both user involved in sharing
@@ -569,11 +529,6 @@ Feature: accept/decline shares coming from internal users
     Examples:
       | declined_share_path |
       | /Shares/PARENT      |
-
-    @skipOnAllVersionsGreaterThanOcV10.8.0 @skipOnOcis @skipOnOcV10.6 @skipOnOcV10.7 @skipOnOcV10.8.0
-    Examples:
-      | declined_share_path |
-      | /PARENT             |
 
   @issue-ocis-765 @issue-ocis-2131 @skipOnOcV10.6 @skipOnOcV10.7 @skipOnOcV10.8.0
   Scenario: shares exist after restoring already shared file to a previous version

--- a/tests/acceptance/features/apiShareManagementToShares/moveReceivedShareFromLocalStorage.feature
+++ b/tests/acceptance/features/apiShareManagementToShares/moveReceivedShareFromLocalStorage.feature
@@ -27,12 +27,6 @@ Feature: local-storage
       | 1               | /filetoshare.txt   |
       | 2               | /filetoshare.txt   |
 
-    @skipOnAllVersionsGreaterThanOcV10.8.0 @skipOnOcis @skipOnOcV10.6 @skipOnOcV10.7 @skipOnOcV10.8.0
-    Examples:
-      | ocs_api_version | pending_share_path             |
-      | 1               | /local_storage/filetoshare.txt |
-      | 2               | /local_storage/filetoshare.txt |
-
 
   Scenario Outline: receiver renames a received folder share from local storage
     Given using OCS API version "<ocs_api_version>"
@@ -50,12 +44,6 @@ Feature: local-storage
       | ocs_api_version | pending_share_path |
       | 1               | /foo               |
       | 2               | /foo               |
-
-    @skipOnAllVersionsGreaterThanOcV10.8.0 @skipOnOcis @skipOnOcV10.6 @skipOnOcV10.7 @skipOnOcV10.8.0
-    Examples:
-      | ocs_api_version | pending_share_path |
-      | 1               | /local_storage/foo |
-      | 2               | /local_storage/foo |
 
   @skipOnEncryptionType:user-keys @encryption-issue-181
   Scenario Outline: sub-folders,file inside a renamed received folder shared from local storage are accessible
@@ -83,12 +71,6 @@ Feature: local-storage
       | 1               | /foo               |
       | 2               | /foo               |
 
-    @skipOnAllVersionsGreaterThanOcV10.8.0 @skipOnOcis @skipOnOcV10.6 @skipOnOcV10.7 @skipOnOcV10.8.0
-    Examples:
-      | ocs_api_version | pending_share_path |
-      | 1               | /local_storage/foo |
-      | 2               | /local_storage/foo |
-
   @skipOnEncryptionType:user-keys @encryption-issue-181
   Scenario Outline: receiver renames a received file share from local storage in group sharing
     Given using OCS API version "<ocs_api_version>"
@@ -108,10 +90,5 @@ Feature: local-storage
     Examples:
       | ocs_api_version | pending_share_path |
       | 1               | /filetoshare.txt   |
-      | 2               | /filetoshare.txt   |
-
-   @skipOnAllVersionsGreaterThanOcV10.8.0 @skipOnOcis @skipOnOcV10.6 @skipOnOcV10.7 @skipOnOcV10.8.0
-    Examples:
-      | ocs_api_version | pending_share_path             |
-      | 1               | /local_storage/filetoshare.txt |
-      | 2               | /local_storage/filetoshare.txt |
+      | 2               | /filetoshare.txt   |      
+ 

--- a/tests/acceptance/features/apiShareOperationsToShares1/gettingShares.feature
+++ b/tests/acceptance/features/apiShareOperationsToShares1/gettingShares.feature
@@ -221,9 +221,3 @@ Feature: sharing
       | ocs_api_version | ocs_status_code | pending_share_path |
       | 1               | 100             | /parent.txt        |
       | 2               | 200             | /parent.txt        |
-
-    @skipOnAllVersionsGreaterThanOcV10.8.0 @skipOnOcis
-    Examples:
-      | ocs_api_version | ocs_status_code | pending_share_path |
-      | 1               | 100             | /PARENT/parent.txt |
-      | 2               | 200             | /PARENT/parent.txt |

--- a/tests/acceptance/features/apiShareOperationsToShares2/shareAccessByID.feature
+++ b/tests/acceptance/features/apiShareOperationsToShares2/shareAccessByID.feature
@@ -124,12 +124,6 @@ Feature: share access by ID
       | 1               | 100             | /Shares/textfile0.txt |
       | 2               | 200             | /Shares/textfile0.txt |
 
-    @skipOnAllVersionsGreaterThanOcV10.8.0 @skipOnOcis @skipOnOcV10.6 @skipOnOcV10.7 @skipOnOcV10.8.0
-    Examples:
-      | ocs_api_version | ocs_status_code | declined_share_path |
-      | 1               | 100             | /textfile0.txt      |
-      | 2               | 200             | /textfile0.txt      |
-
 
   Scenario Outline: decline a share using a invalid share Id
     Given parameter "shareapi_auto_accept_share" of app "core" has been set to "yes"

--- a/tests/acceptance/features/apiShareReshareToShares2/reShareChain.feature
+++ b/tests/acceptance/features/apiShareReshareToShares2/reShareChain.feature
@@ -31,12 +31,6 @@ Feature: resharing can be done on a reshared resource
       | /textfile0_shared.txt |
       | /textfile0_shared.txt |
 
-    @skipOnAllVersionsGreaterThanOcV10.8.0 @skipOnOcis @skipOnOcV10.6 @skipOnOcV10.7 @skipOnOcV10.8.0
-    Examples:
-      | pending_share_path |
-      | /textfile0.txt     |
-      | /textfile0.txt     |
-
   @skipOnOcV10
   Scenario: Reshared files can be still accessed if a user in the middle removes it.
     Given user "Alice" has uploaded file with content "ownCloud test text file 0" to "/textfile0.txt"

--- a/tests/acceptance/features/apiShareReshareToShares2/reShareSubfolder.feature
+++ b/tests/acceptance/features/apiShareReshareToShares2/reShareSubfolder.feature
@@ -29,12 +29,6 @@ Feature: a subfolder of a received share can be reshared
       | 1               | 100             | /SUB                   |
       | 2               | 200             | /SUB                   |
 
-    @skipOnAllVersionsGreaterThanOcV10.8.0 @skipOnOcis
-    Examples:
-      | ocs_api_version | ocs_status_code | pending_sub_share_path |
-      | 1               | 100             | /TMP/SUB               |
-      | 2               | 200             | /TMP/SUB               |
-
 
   Scenario Outline: User is not allowed to reshare a sub-folder with more permissions
     Given using OCS API version "<ocs_api_version>"
@@ -116,12 +110,6 @@ Feature: a subfolder of a received share can be reshared
       | 1               | 100             | /SUB                   |
       | 2               | 200             | /SUB                   |
 
-    @skipOnAllVersionsGreaterThanOcV10.8.0 @skipOnOcis
-    Examples:
-      | ocs_api_version | ocs_status_code | pending_sub_share_path |
-      | 1               | 100             | /TMP/SUB               |
-      | 2               | 200             | /TMP/SUB               |
-
   @issue-ocis-2214
   Scenario Outline: User is allowed to update reshare of a sub-folder to the maximum allowed permissions
     Given using OCS API version "<ocs_api_version>"
@@ -146,12 +134,6 @@ Feature: a subfolder of a received share can be reshared
       | 1               | 100             | /SUB                   |
       | 2               | 200             | /SUB                   |
 
-    @skipOnAllVersionsGreaterThanOcV10.8.0 @skipOnOcis
-    Examples:
-      | ocs_api_version | ocs_status_code | pending_sub_share_path |
-      | 1               | 100             | /TMP/SUB               |
-      | 2               | 200             | /TMP/SUB               |
-
   @issue-ocis-2214
   Scenario Outline: User is not allowed to update reshare of a sub-folder with more permissions
     Given using OCS API version "<ocs_api_version>"
@@ -175,9 +157,3 @@ Feature: a subfolder of a received share can be reshared
       | ocs_api_version | http_status_code | pending_sub_share_path |
       | 1               | 200              | /SUB                   |
       | 2               | 404              | /SUB                   |
-
-    @skipOnAllVersionsGreaterThanOcV10.8.0 @skipOnOcis
-    Examples:
-      | ocs_api_version | http_status_code | pending_sub_share_path |
-      | 1               | 200              | /TMP/SUB               |
-      | 2               | 404              | /TMP/SUB               |

--- a/tests/acceptance/features/apiShareUpdateToShares/updateShare.feature
+++ b/tests/acceptance/features/apiShareUpdateToShares/updateShare.feature
@@ -194,11 +194,6 @@ Feature: sharing
       | folder2_share_path |
       | /folder2           |
 
-    @skipOnAllVersionsGreaterThanOcV10.8.0 @skipOnOcis
-    Examples:
-      | folder2_share_path |
-      | /folder1/folder2   |
-
 
   Scenario Outline: Share ownership change after moving a shared file to another share
     Given these users have been created with default attributes and without skeleton files:

--- a/tests/acceptance/features/apiWebdavLocksUnlock/unlockSharingToShares.feature
+++ b/tests/acceptance/features/apiWebdavLocksUnlock/unlockSharingToShares.feature
@@ -30,14 +30,6 @@ Feature: UNLOCK locked items (sharing)
       | new      | shared     | /parent.txt        |
       | new      | exclusive  | /parent.txt        |
 
-    @skipOnAllVersionsGreaterThanOcV10.8.0 @skipOnOcis
-    Examples:
-      | dav-path | lock-scope | pending_share_path |
-      | old      | shared     | /PARENT/parent.txt |
-      | old      | exclusive  | /PARENT/parent.txt |
-      | new      | shared     | /PARENT/parent.txt |
-      | new      | exclusive  | /PARENT/parent.txt |
-
     @personalSpace @skipOnOcV10
     Examples:
       | dav-path | lock-scope | pending_share_path |
@@ -111,14 +103,6 @@ Feature: UNLOCK locked items (sharing)
       | new      | shared     | /parent.txt        |
       | new      | exclusive  | /parent.txt        |
 
-    @skipOnAllVersionsGreaterThanOcV10.8.0 @skipOnOcis
-    Examples:
-      | dav-path | lock-scope | pending_share_path |
-      | old      | shared     | /PARENT/parent.txt |
-      | old      | exclusive  | /PARENT/parent.txt |
-      | new      | shared     | /PARENT/parent.txt |
-      | new      | exclusive  | /PARENT/parent.txt |
-
     @personalSpace @skipOnOcV10
     Examples:
       | dav-path | lock-scope | pending_share_path |
@@ -143,14 +127,6 @@ Feature: UNLOCK locked items (sharing)
       | old      | exclusive  | /parent.txt        |
       | new      | shared     | /parent.txt        |
       | new      | exclusive  | /parent.txt        |
-
-    @skipOnAllVersionsGreaterThanOcV10.8.0 @skipOnOcis
-    Examples:
-      | dav-path | lock-scope | pending_share_path |
-      | old      | shared     | /PARENT/parent.txt |
-      | old      | exclusive  | /PARENT/parent.txt |
-      | new      | shared     | /PARENT/parent.txt |
-      | new      | exclusive  | /PARENT/parent.txt |
 
     @personalSpace @skipOnOcV10
     Examples:

--- a/tests/acceptance/run.sh
+++ b/tests/acceptance/run.sh
@@ -1097,11 +1097,6 @@ BEHAT_FILTER_TAGS='~@skipOnOcV'${OWNCLOUD_VERSION_ONE_DIGIT}'&&'${BEHAT_FILTER_T
 
 function version { echo "$@" | awk -F. '{ printf("%d%03d%03d\n", $1,$2,$3); }'; }
 
-# Skip tests for OC versions greater than 10.8.0
-if [ $(version $OWNCLOUD_VERSION_THREE_DIGIT) -gt $(version "10.8.0") ]; then
-	BEHAT_FILTER_TAGS='~@skipOnAllVersionsGreaterThanOcV10.8.0&&'${BEHAT_FILTER_TAGS}
-fi
-
 if [ -n "${TEST_SERVER_FED_URL}" ]
 then
 	remote_occ ${ADMIN_AUTH} ${OCC_FED_URL} "config:system:get version"


### PR DESCRIPTION
## Description
This PR removes the tag @skipOnAllVersionsGreaterThanOcV10.8.0 and related examples and scenarios which will never run anymore from the acceptance tests. This should cleanup the tagging a lot, which will reduce future confusion.

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
This is a part of
- https://github.com/owncloud/core/issues/40443

## Motivation and Context

## How Has This Been Tested?
- Locally

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Database schema changes (next release will require increase of minor version instead of patch)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [x] Tests only (no source changes)

## Checklist:
<!-- Tick the checkboxes when done. -->
<!-- Raise documentation ticket in https://github.com/owncloud/documentation -->
- [ ] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 
- [ ] Changelog item, see [TEMPLATE](https://github.com/owncloud/core/blob/master/changelog/TEMPLATE)
