### PR TITLE
[full-ci] [tests-only]Removed other old skips tags for versions before OcV10.10

### DIFF
--- a/tests/acceptance/features/apiAuth/cors.feature
+++ b/tests/acceptance/features/apiAuth/cors.feature
@@ -4,7 +4,7 @@ Feature: CORS headers
   Background:
     Given user "Alice" has been created with default attributes and without skeleton files
 
-  @skipOnOcV10.8 @skipOnOcV10.9.0 @skipOnOcV10.9.1
+
   Scenario Outline: CORS headers should be returned when setting CORS domain sending Origin header
     Given using OCS API version "<ocs_api_version>"
     And user "Alice" has added "https://aphno.badal" to the list of personal CORS domains
@@ -48,7 +48,7 @@ Feature: CORS headers
       | 1               | /apps/files_sharing/api/v1/shares                | 100      | 200       |
       | 2               | /apps/files_sharing/api/v1/shares                | 200      | 200       |
 
-  @skipOnOcV10.8 @skipOnOcV10.9.0 @skipOnOcV10.9.1
+
   Scenario Outline: CORS headers should be returned when setting CORS domain sending Origin header (admin only endpoints)
     Given using OCS API version "<ocs_api_version>"
     And the administrator has added "https://aphno.badal" to the list of personal CORS domains

--- a/tests/acceptance/features/apiAuthWebDav/webDavCaseInsensitiveAuth.feature
+++ b/tests/acceptance/features/apiAuthWebDav/webDavCaseInsensitiveAuth.feature
@@ -11,7 +11,7 @@ Feature: usernames are case-insensitive in webDAV requests with app passwords
     And user "Alice" has created folder "/FOLDER"
     And user "Alice" has uploaded file with content "some data" to "/PARENT/parent.txt"
 
-  @skipOnOcV10.8 @skipOnOcV10.9 @skipOnOcV10.10.0
+  @skipOnOcV10.10.0
   Scenario: send PUT requests to webDav endpoints using app password token as password and lowercase of username
     Given token auth has been enforced
     And a new browser session for "Alice" has been started

--- a/tests/acceptance/features/apiAuthWebDav/webDavLOCKAuth.feature
+++ b/tests/acceptance/features/apiAuthWebDav/webDavLOCKAuth.feature
@@ -52,7 +52,7 @@ Feature: LOCK file/folder
       | /remote.php/dav/spaces/%spaceid%/PARENT/parent.txt |
     Then the HTTP status code of responses on all endpoints should be "401"
 
-  @issue-ocis-reva-9 @skipOnOcV10.3 @skipOnOcV10.4 @skipOnOcV10.5
+  @issue-ocis-reva-9
   Scenario: send LOCK requests to another user's webDav endpoints as normal user
     When user "Brian" requests these endpoints with "LOCK" to get property "d:shared" about user "Alice"
       | endpoint                                       |
@@ -64,7 +64,7 @@ Feature: LOCK file/folder
       | /remote.php/dav/files/%username%/PARENT/parent.txt |
     Then the HTTP status code of responses on all endpoints should be "409"
 
-  @issue-ocis-reva-9 @skipOnOcV10.3 @skipOnOcV10.4 @skipOnOcV10.5 @skipOnOcV10 @personalSpace
+  @issue-ocis-reva-9 @skipOnOcV10 @personalSpace
   Scenario: send LOCK requests to another user's webDav endpoints as normal user using the spaces WebDAV API
     When user "Brian" requests these endpoints with "LOCK" to get property "d:shared" about user "Alice"
       | endpoint                                       |

--- a/tests/acceptance/features/apiAuthWebDav/webDavPUTAuthOC10Issue39597.feature
+++ b/tests/acceptance/features/apiAuthWebDav/webDavPUTAuthOC10Issue39597.feature
@@ -1,4 +1,4 @@
-@api @issue-39597 @skipOnOcV10.3 @skipOnOcV10.4 @skipOnOcV10.5 @skipOnOcis
+@api @issue-39597 @skipOnOcis
 Feature: get file info using PUT
 
   Background:

--- a/tests/acceptance/features/apiAuthWebDav/webDavSpecialURLs.feature
+++ b/tests/acceptance/features/apiAuthWebDav/webDavSpecialURLs.feature
@@ -1,4 +1,4 @@
-@api @skipOnOcV10.8 @skipOnOcV10.9 @skipOnOcV10.10.0
+@api @skipOnOcV10.10.0
 Feature: make webdav request with special urls
 
   Background:

--- a/tests/acceptance/features/apiCapabilities/capabilities.feature
+++ b/tests/acceptance/features/apiCapabilities/capabilities.feature
@@ -32,7 +32,7 @@ Feature: capabilities
     When the administrator sets parameter "shareapi_allow_group_sharing" of app "core" to "no"
     Then the capabilities setting of "files_sharing" path "group_sharing" should be ""
 
-  @smokeTest @skipOnOcV10.7 @skipOnOcV10.8 @skipOnOcV10.9.0 @skipOnOcV10.9.1 @skipOnOcis
+  @smokeTest @skipOnOcis
   Scenario: getting default capabilities with admin user
     When the administrator retrieves the capabilities using the capabilities API
     Then the OCS status code should be "100"
@@ -75,8 +75,7 @@ Feature: capabilities
       | files         | privateLinks                              | 1                 |
       | files         | privateLinksDetailsParam                  | 1                 |
 
-  @smokeTest @skipOnOcV10.3 @skipOnOcis
-  # These are new capabilities in 10.4
+  @smokeTest @skipOnOcis
   Scenario: getting default capabilities with admin user with new values
     When the administrator retrieves the capabilities using the capabilities API
     Then the OCS status code should be "100"
@@ -90,8 +89,7 @@ Feature: capabilities
       | files_sharing | providers_capabilities@@@ocinternal@@@link@@@element[0]  | shareExpiration   |
       | files_sharing | providers_capabilities@@@ocinternal@@@link@@@element[1]  | passwordProtected |
 
-  @smokeTest @skipOnOcV10.3 @skipOnOcV10.4 @skipOnOcV10.5.0 @skipOnOcis
-  # These are a new combination of capabilities after 10.5.0
+  @smokeTest @skipOnOcis
   Scenario: the default capabilities should include share expiration for all of user, group, link and remote (federated)
     When the administrator retrieves the capabilities using the capabilities API
     Then the OCS status code should be "100"
@@ -106,8 +104,7 @@ Feature: capabilities
       | files_sharing | providers_capabilities@@@ocinternal@@@link@@@element[0]           | shareExpiration |
       | files_sharing | providers_capabilities@@@ocFederatedSharing@@@remote@@@element[0] | shareExpiration |
 
-  @smokeTest @skipOnOcV10.3 @skipOnOcV10.4 @skipOnOcV10.5.0 @skipOnOcis
-  # These are new capabilities after 10.5.0
+  @smokeTest @skipOnOcis
   Scenario: getting new default capabilities in versions after 10.5.0 with admin user
     When the administrator retrieves the capabilities using the capabilities API
     Then the OCS status code should be "100"
@@ -118,7 +115,7 @@ Feature: capabilities
       | files      | file_locking_support            | 1     |
       | files      | file_locking_enable_file_action | EMPTY |
 
-  @smokeTest @skipOnOcV10.3 @skipOnOcV10.4 @skipOnOcV10.5.0 @skipOnOcis
+  @smokeTest @skipOnOcis
   Scenario: lock file action can be enabled
     Given parameter "enable_lock_file_action" of app "files" has been set to "yes"
     When the administrator retrieves the capabilities using the capabilities API
@@ -129,8 +126,7 @@ Feature: capabilities
       | files      | file_locking_support            | 1     |
       | files      | file_locking_enable_file_action | 1     |
 
-  @smokeTest @skipOnOcV10.6 @skipOnOcV10.7.0 @skipOnOcis
-  # These are new capabilities after 10.7.0
+  @smokeTest @skipOnOcis
   Scenario: getting default capabilities with admin user
     When the administrator retrieves the capabilities using the capabilities API
     Then the OCS status code should be "100"
@@ -196,7 +192,7 @@ Feature: capabilities
       | files      | blacklisted_files@@@element[0] | test.txt  |
       | files      | blacklisted_files@@@element[1] | .htaccess |
 
-  @skipOnOcV10.3 @skipOnOcis
+  @skipOnOcis
   Scenario: user expire date can be enabled
     Given parameter "shareapi_default_expire_date_user_share" of app "core" has been set to "yes"
     When the administrator retrieves the capabilities using the capabilities API
@@ -208,7 +204,7 @@ Feature: capabilities
       | files_sharing | user@@@expire_date@@@days     | 7     |
       | files_sharing | user@@@expire_date@@@enforced | EMPTY |
 
-  @skipOnOcV10.3 @skipOnOcis
+  @skipOnOcis
   Scenario: user expire date can be enforced
     Given parameter "shareapi_default_expire_date_user_share" of app "core" has been set to "yes"
     And parameter "shareapi_enforce_expire_date_user_share" of app "core" has been set to "yes"
@@ -221,7 +217,7 @@ Feature: capabilities
       | files_sharing | user@@@expire_date@@@days     | 7     |
       | files_sharing | user@@@expire_date@@@enforced | 1     |
 
-  @skipOnOcV10.3 @skipOnOcis
+  @skipOnOcis
   Scenario: user expire date days can be set
     Given parameter "shareapi_default_expire_date_user_share" of app "core" has been set to "yes"
     And parameter "shareapi_expire_after_n_days_user_share" of app "core" has been set to "14"
@@ -234,7 +230,7 @@ Feature: capabilities
       | files_sharing | user@@@expire_date@@@days     | 14    |
       | files_sharing | user@@@expire_date@@@enforced | EMPTY |
 
-  @skipOnOcV10.3 @skipOnOcis
+  @skipOnOcis
   Scenario: group expire date can be enabled
     Given parameter "shareapi_default_expire_date_group_share" of app "core" has been set to "yes"
     When the administrator retrieves the capabilities using the capabilities API
@@ -246,7 +242,7 @@ Feature: capabilities
       | files_sharing | group@@@expire_date@@@days     | 7     |
       | files_sharing | group@@@expire_date@@@enforced | EMPTY |
 
-  @skipOnOcV10.3 @skipOnOcis
+  @skipOnOcis
   Scenario: group expire date can be enforced
     Given parameter "shareapi_default_expire_date_group_share" of app "core" has been set to "yes"
     And parameter "shareapi_enforce_expire_date_group_share" of app "core" has been set to "yes"
@@ -259,7 +255,7 @@ Feature: capabilities
       | files_sharing | group@@@expire_date@@@days     | 7     |
       | files_sharing | group@@@expire_date@@@enforced | 1     |
 
-  @skipOnOcV10.3 @skipOnOcis
+  @skipOnOcis
   Scenario: group expire date days can be set
     Given parameter "shareapi_default_expire_date_group_share" of app "core" has been set to "yes"
     And parameter "shareapi_expire_after_n_days_group_share" of app "core" has been set to "14"
@@ -301,7 +297,7 @@ Feature: capabilities
       | capability | path_to_element | value |
       | async      |                 | EMPTY |
 
-  @skipOnOcV10.7 @skipOnOcV10.8 @skipOnOcV10.9.0 @skipOnOcV10.9.1 @skipOnOcis
+  @skipOnOcis
   Scenario: Changing public upload
     Given parameter "shareapi_allow_public_upload" of app "core" has been set to "no"
     When the administrator retrieves the capabilities using the capabilities API
@@ -327,7 +323,7 @@ Feature: capabilities
       | files_sharing | user_enumeration@@@group_members_only | EMPTY             |
       | files         | bigfilechunking                       | 1                 |
 
-  @skipOnOcV10.7 @skipOnOcV10.8 @skipOnOcV10.9.0 @skipOnOcV10.9.1 @skipOnOcis
+  @skipOnOcis
   Scenario: Disabling share api
     Given parameter "shareapi_enabled" of app "core" has been set to "no"
     When the administrator retrieves the capabilities using the capabilities API
@@ -347,7 +343,7 @@ Feature: capabilities
       | files_sharing | federation@@@incoming | 1                 |
       | files         | bigfilechunking       | 1                 |
 
-  @skipOnOcV10.7 @skipOnOcV10.8 @skipOnOcV10.9.0 @skipOnOcV10.9.1 @skipOnOcis
+  @skipOnOcis
   Scenario: Disabling public links
     Given parameter "shareapi_allow_links" of app "core" has been set to "no"
     When the administrator retrieves the capabilities using the capabilities API
@@ -371,7 +367,7 @@ Feature: capabilities
       | files_sharing | user_enumeration@@@group_members_only | EMPTY             |
       | files         | bigfilechunking                       | 1                 |
 
-  @skipOnOcV10.7 @skipOnOcV10.8 @skipOnOcV10.9.0 @skipOnOcV10.9.1 @skipOnOcis
+  @skipOnOcis
   Scenario: Changing resharing
     Given parameter "shareapi_allow_resharing" of app "core" has been set to "no"
     When the administrator retrieves the capabilities using the capabilities API
@@ -396,7 +392,7 @@ Feature: capabilities
       | files_sharing | user_enumeration@@@group_members_only | EMPTY             |
       | files         | bigfilechunking                       | 1                 |
 
-  @skipOnOcV10.7 @skipOnOcV10.8 @skipOnOcV10.9.0 @skipOnOcV10.9.1 @skipOnOcis
+  @skipOnOcis
   Scenario: Changing federation outgoing
     Given parameter "outgoing_server2server_share_enabled" of app "files_sharing" has been set to "no"
     When the administrator retrieves the capabilities using the capabilities API
@@ -421,7 +417,7 @@ Feature: capabilities
       | files_sharing | user_enumeration@@@group_members_only | EMPTY             |
       | files         | bigfilechunking                       | 1                 |
 
-  @skipOnOcV10.7 @skipOnOcV10.8 @skipOnOcV10.9.0 @skipOnOcV10.9.1 @skipOnOcis
+  @skipOnOcis
   Scenario: Changing federation incoming
     Given parameter "incoming_server2server_share_enabled" of app "files_sharing" has been set to "no"
     When the administrator retrieves the capabilities using the capabilities API
@@ -446,7 +442,7 @@ Feature: capabilities
       | files_sharing | user_enumeration@@@group_members_only | EMPTY             |
       | files         | bigfilechunking                       | 1                 |
 
-  @skipOnOcV10.7 @skipOnOcV10.8 @skipOnOcV10.9.0 @skipOnOcV10.9.1 @skipOnOcis
+  @skipOnOcis
   Scenario: Changing "password enforced for read-only public link shares"
     Given parameter "shareapi_enforce_links_password_read_only" of app "core" has been set to "yes"
     When the administrator retrieves the capabilities using the capabilities API
@@ -474,7 +470,7 @@ Feature: capabilities
       | files_sharing | user_enumeration@@@group_members_only          | EMPTY             |
       | files         | bigfilechunking                                | 1                 |
 
-  @skipOnOcV10.7 @skipOnOcV10.8 @skipOnOcV10.9.0 @skipOnOcV10.9.1 @skipOnOcis
+  @skipOnOcis
   Scenario: Changing "password enforced for read-write public link shares"
     Given parameter "shareapi_enforce_links_password_read_write" of app "core" has been set to "yes"
     When the administrator retrieves the capabilities using the capabilities API
@@ -502,7 +498,7 @@ Feature: capabilities
       | files_sharing | user_enumeration@@@group_members_only          | EMPTY             |
       | files         | bigfilechunking                                | 1                 |
 
-  @skipOnOcV10.7 @skipOnOcV10.8 @skipOnOcV10.9.0 @skipOnOcV10.9.1 @skipOnOcis
+  @skipOnOcis
   Scenario: Changing "password enforced for write-only public link shares"
     Given parameter "shareapi_enforce_links_password_write_only" of app "core" has been set to "yes"
     When the administrator retrieves the capabilities using the capabilities API
@@ -530,7 +526,7 @@ Feature: capabilities
       | files_sharing | user_enumeration@@@group_members_only          | EMPTY             |
       | files         | bigfilechunking                                | 1                 |
 
-  @skipOnOcV10.7 @skipOnOcV10.8 @skipOnOcV10.9.0 @skipOnOcV10.9.1 @skipOnOcis
+  @skipOnOcis
   Scenario: Changing public notifications
     Given parameter "shareapi_allow_public_notification" of app "core" has been set to "yes"
     When the administrator retrieves the capabilities using the capabilities API
@@ -555,7 +551,7 @@ Feature: capabilities
       | files_sharing | user_enumeration@@@group_members_only | EMPTY             |
       | files         | bigfilechunking                       | 1                 |
 
-  @skipOnOcV10.7 @skipOnOcV10.8 @skipOnOcV10.9.0 @skipOnOcV10.9.1 @skipOnOcis
+  @skipOnOcis
   Scenario: Changing public social share
     Given parameter "shareapi_allow_social_share" of app "core" has been set to "no"
     When the administrator retrieves the capabilities using the capabilities API
@@ -580,7 +576,7 @@ Feature: capabilities
       | files_sharing | user_enumeration@@@group_members_only | EMPTY             |
       | files         | bigfilechunking                       | 1                 |
 
-  @skipOnOcV10.7 @skipOnOcV10.8 @skipOnOcV10.9.0 @skipOnOcV10.9.1 @skipOnOcis
+  @skipOnOcis
   Scenario: Changing expire date
     Given parameter "shareapi_default_expire_date" of app "core" has been set to "yes"
     When the administrator retrieves the capabilities using the capabilities API
@@ -606,7 +602,7 @@ Feature: capabilities
       | files_sharing | user_enumeration@@@group_members_only | EMPTY             |
       | files         | bigfilechunking                       | 1                 |
 
-  @skipOnOcV10.7 @skipOnOcV10.8 @skipOnOcV10.9.0 @skipOnOcV10.9.1 @skipOnOcis
+  @skipOnOcis
   Scenario: Changing expire date enforcing
     Given parameter "shareapi_default_expire_date" of app "core" has been set to "yes"
     And parameter "shareapi_enforce_expire_date" of app "core" has been set to "yes"
@@ -634,7 +630,7 @@ Feature: capabilities
       | files_sharing | user_enumeration@@@group_members_only | EMPTY             |
       | files         | bigfilechunking                       | 1                 |
 
-  @skipOnOcV10.7 @skipOnOcV10.8 @skipOnOcV10.9.0 @skipOnOcV10.9.1 @skipOnOcis
+  @skipOnOcis
   Scenario: Changing group sharing allowed
     Given parameter "shareapi_allow_group_sharing" of app "core" has been set to "no"
     When the administrator retrieves the capabilities using the capabilities API
@@ -659,7 +655,7 @@ Feature: capabilities
       | files_sharing | user_enumeration@@@group_members_only | EMPTY             |
       | files         | bigfilechunking                       | 1                 |
 
-  @skipOnOcV10.7 @skipOnOcV10.8 @skipOnOcV10.9.0 @skipOnOcV10.9.1 @skipOnOcis
+  @skipOnOcis
   Scenario: Changing only share with group member
     Given parameter "shareapi_only_share_with_group_members" of app "core" has been set to "yes"
     When the administrator retrieves the capabilities using the capabilities API
@@ -684,7 +680,7 @@ Feature: capabilities
       | files_sharing | user_enumeration@@@group_members_only | EMPTY             |
       | files         | bigfilechunking                       | 1                 |
 
-  @skipOnOcV10.7 @skipOnOcV10.8 @skipOnOcV10.9.0 @skipOnOcV10.9.1 @skipOnOcis
+  @skipOnOcis
   Scenario: Changing only share with membership groups
     Given parameter "shareapi_only_share_with_membership_groups" of app "core" has been set to "yes"
     When the administrator retrieves the capabilities using the capabilities API
@@ -710,7 +706,7 @@ Feature: capabilities
       | files_sharing | user_enumeration@@@group_members_only | EMPTY             |
       | files         | bigfilechunking                       | 1                 |
 
-  @skipOnOcV10.7 @skipOnOcV10.8 @skipOnOcV10.9.0 @skipOnOcV10.9.1 @skipOnOcis
+  @skipOnOcis
   Scenario: Changing auto accept share
     Given parameter "shareapi_auto_accept_share" of app "core" has been set to "no"
     When the administrator retrieves the capabilities using the capabilities API
@@ -737,7 +733,7 @@ Feature: capabilities
       | files_sharing | user_enumeration@@@group_members_only | EMPTY             |
       | files         | bigfilechunking                       | 1                 |
 
-  @skipOnOcV10.7 @skipOnOcV10.8 @skipOnOcV10.9.0 @skipOnOcV10.9.1 @skipOnOcis
+  @skipOnOcis
   Scenario: Changing allow share dialog user enumeration
     Given parameter "shareapi_allow_share_dialog_user_enumeration" of app "core" has been set to "no"
     When the administrator retrieves the capabilities using the capabilities API
@@ -761,7 +757,7 @@ Feature: capabilities
       | files_sharing | user_enumeration@@@enabled    | EMPTY             |
       | files         | bigfilechunking               | 1                 |
 
-  @skipOnOcV10.7 @skipOnOcV10.8 @skipOnOcV10.9.0 @skipOnOcV10.9.1 @skipOnOcis
+  @skipOnOcis
   Scenario: Changing allow share dialog user enumeration for group members only
     Given parameter "shareapi_share_dialog_user_enumeration_group_members" of app "core" has been set to "yes"
     When the administrator retrieves the capabilities using the capabilities API
@@ -786,7 +782,7 @@ Feature: capabilities
       | files_sharing | user_enumeration@@@group_members_only | 1                 |
       | files         | bigfilechunking                       | 1                 |
 
-  @skipOnOcV10.7 @skipOnOcV10.8 @skipOnOcV10.9.0 @skipOnOcV10.9.1 @skipOnOcis
+  @skipOnOcis
   Scenario: Changing allow mail notification
     Given parameter "shareapi_allow_mail_notification" of app "core" has been set to "yes"
     When the administrator retrieves the capabilities using the capabilities API
@@ -812,7 +808,7 @@ Feature: capabilities
       | files_sharing | user@@@send_mail                      | 1                 |
       | files         | bigfilechunking                       | 1                 |
 
-  @skipOnOcV10.7 @skipOnOcV10.8 @skipOnOcV10.9.0 @skipOnOcV10.9.1 @skipOnOcis
+  @skipOnOcis
   Scenario: Changing exclude groups from sharing
     Given parameter "shareapi_exclude_groups" of app "core" has been set to "yes"
     And group "group1" has been created
@@ -841,7 +837,7 @@ Feature: capabilities
       | files_sharing | user_enumeration@@@group_members_only | EMPTY             |
       | files         | bigfilechunking                       | 1                 |
 
-  @skipOnOcV10.7 @skipOnOcV10.8 @skipOnOcV10.9.0 @skipOnOcV10.9.1 @skipOnOcis
+  @skipOnOcis
   Scenario: When in a group that is excluded from sharing, can_share is off
     Given parameter "shareapi_exclude_groups" of app "core" has been set to "yes"
     And user "Alice" has been created with default attributes and without skeleton files
@@ -873,7 +869,7 @@ Feature: capabilities
       | files_sharing | user_enumeration@@@group_members_only | EMPTY             |
       | files         | bigfilechunking                       | 1                 |
 
-  @skipOnOcV10.7 @skipOnOcV10.8 @skipOnOcV10.9.0 @skipOnOcV10.9.1 @skipOnOcis
+  @skipOnOcis
   Scenario: When not in any group that is excluded from sharing, can_share is on
     Given parameter "shareapi_exclude_groups" of app "core" has been set to "yes"
     And user "Alice" has been created with default attributes and without skeleton files
@@ -905,7 +901,7 @@ Feature: capabilities
       | files_sharing | user_enumeration@@@group_members_only | EMPTY             |
       | files         | bigfilechunking                       | 1                 |
 
-  @skipOnOcV10.7 @skipOnOcV10.8 @skipOnOcV10.9.0 @skipOnOcV10.9.1 @skipOnOcis
+  @skipOnOcis
   Scenario: When in a group that is excluded from sharing and in another group, can_share is off
     Given parameter "shareapi_exclude_groups" of app "core" has been set to "yes"
     And user "Alice" has been created with default attributes and without skeleton files
@@ -938,8 +934,7 @@ Feature: capabilities
       | files_sharing | user_enumeration@@@group_members_only | EMPTY             |
       | files         | bigfilechunking                       | 1                 |
 
-  @skipOnOcV10.6 @skipOnOcV10.7 @skipOnOcV10.8.0 @skipOnOcis
-  # This is a new capability in 10.9
+  @skipOnOcis
   Scenario: blacklisted_files_regex is reported in capabilities
     When the administrator retrieves the capabilities using the capabilities API
     Then the OCS status code should be "100"
@@ -948,8 +943,7 @@ Feature: capabilities
       | capability | path_to_element         | value    |
       | files      | blacklisted_files_regex | \.(part\|filepart)$ |
 
-  @smokeTest @skipOnOcV10.7 @skipOnOcV10.8 @skipOnOcV10.9.0 @skipOnOcV10.9.1
-  # This is a new capability after 10.9.1
+  @smokeTest
   Scenario: getting default capabilities with admin user
     When the administrator retrieves the capabilities using the capabilities API
     Then the capabilities should contain

--- a/tests/acceptance/features/apiCapabilities/capabilitiesWithNormalUser.feature
+++ b/tests/acceptance/features/apiCapabilities/capabilitiesWithNormalUser.feature
@@ -7,7 +7,7 @@ Feature: default capabilities for normal user
 
   # adjust this scenario after fixing tagged issues as its just created to show difference
   # in the response items in different environment (core & ocis-reva)
-  @issue-ocis-reva-175 @issue-ocis-reva-176 @skipOnOcV10.7 @skipOnOcV10.8 @skipOnOcV10.9.0 @skipOnOcV10.9.1
+  @issue-ocis-reva-175 @issue-ocis-reva-176
   Scenario: getting default capabilities with normal user
     When user "Alice" retrieves the capabilities using the capabilities API
     Then the OCS status code should be "100"

--- a/tests/acceptance/features/apiFavorites/favoritesSharingToShares.feature
+++ b/tests/acceptance/features/apiFavorites/favoritesSharingToShares.feature
@@ -1,4 +1,4 @@
-@api @files_sharing-app-required @skipOnOcV10.6 @skipOnOcV10.7 @skipOnOcV10.8.0
+@api @files_sharing-app-required
 Feature: favorite
 
   Background:

--- a/tests/acceptance/features/apiFederationToRoot1/federated.feature
+++ b/tests/acceptance/features/apiFederationToRoot1/federated.feature
@@ -116,7 +116,7 @@ Feature: federated
       | 1               | 100        |
       | 2               | 200        |
 
-  @skipOnOcV10.3 @skipOnOcV10.4.0 @skipOnOcV10.4.1
+
   Scenario Outline: Federated sharee requests information of only one share before accepting it
     Given using OCS API version "<ocs-api-version>"
     And using server "REMOTE"

--- a/tests/acceptance/features/apiFederationToRoot2/federated.feature
+++ b/tests/acceptance/features/apiFederationToRoot2/federated.feature
@@ -584,7 +584,7 @@ Feature: federated
       | 1               | 100             | 201, 200         |
       | 2               | 200             | 201, 403         |
 
-  @skipOnOcV10.3 @skipOnOcV10.4 @skipOnOcV10.5.0
+
   Scenario Outline: Federated share a file with another server with expiration date
     Given using OCS API version "<ocs-api-version>"
     And parameter "shareapi_default_expire_date_remote_share" of app "core" has been set to "yes"
@@ -616,7 +616,7 @@ Feature: federated
       | 1               | 100        |
       | 2               | 200        |
 
-  @skipOnOcV10.3 @skipOnOcV10.4 @skipOnOcV10.5.0
+
   Scenario Outline: Federated sharing with default expiration date enabled but not enforced, user shares without specifying expireDate
     Given using OCS API version "<ocs_api_version>"
     And parameter "shareapi_default_expire_date_remote_share" of app "core" has been set to "yes"
@@ -631,7 +631,7 @@ Feature: federated
       | 1               | 100        |
 #      | 2               | 200        |
 
-  @skipOnOcV10.3 @skipOnOcV10.4 @skipOnOcV10.5.0
+
   Scenario Outline: Federated sharing with default expiration date enabled and enforced, user shares without specifying expireDate
     Given using OCS API version "<ocs_api_version>"
     And parameter "shareapi_default_expire_date_remote_share" of app "core" has been set to "yes"
@@ -647,7 +647,7 @@ Feature: federated
       | 1               | 100        |
       | 2               | 200        |
 
-  @skipOnOcV10.3 @skipOnOcV10.4 @skipOnOcV10.5.0
+
   Scenario Outline: Federated sharing with default expiration date disabled
     Given using OCS API version "<ocs_api_version>"
     And parameter "shareapi_default_expire_date_remote_share" of app "core" has been set to "no"
@@ -662,7 +662,7 @@ Feature: federated
       | 1               | 100        |
       | 2               | 200        |
 
-  @skipOnOcV10.3 @skipOnOcV10.4 @skipOnOcV10.5.0
+
   Scenario Outline: Expiration date is enforced for federated share, user modifies expiration date
     Given using OCS API version "<ocs-api-version>"
     And parameter "shareapi_default_expire_date_remote_share" of app "core" has been set to "yes"
@@ -681,7 +681,7 @@ Feature: federated
       | 1               | 100        |
       | 2               | 200        |
 
-  @skipOnOcV10.3 @skipOnOcV10.4 @skipOnOcV10.5.0
+
   Scenario Outline: Federated sharing with default expiration date enabled and enforced, user shares with expiration date more than the default
     Given using OCS API version "<ocs_api_version>"
     And parameter "shareapi_default_expire_date_remote_share" of app "core" has been set to "yes"
@@ -699,7 +699,7 @@ Feature: federated
       | 1               | 200              |
       | 2               | 404              |
 
-  @skipOnOcV10.3 @skipOnOcV10.4 @skipOnOcV10.5.0
+
   Scenario Outline: User modifies expiration date for federated reshare of a file with another server with default expiration date
     Given using OCS API version "<ocs_api_version>"
     And using server "LOCAL"
@@ -722,7 +722,7 @@ Feature: federated
       | 1               | 100        |
       | 2               | 200        |
 
-  @skipOnOcV10.3 @skipOnOcV10.4 @skipOnOcV10.5.0
+
   Scenario Outline: User modifies expiration date more than the default for federated reshare of a file
     Given using OCS API version "<ocs_api_version>"
     And using server "LOCAL"
@@ -745,7 +745,7 @@ Feature: federated
       | 1               | 200              |
       | 2               | 404              |
 
-  @skipOnOcV10.6 @skipOnOcV10.7 @skipOnFedOcV10.7 @skipOnFedOcV10.6
+  @skipOnFedOcV10.7 @skipOnFedOcV10.6
   Scenario: set a federated user share to expire yesterday and verify that it is not accessible
     Given using OCS API version "2"
     And using server "REMOTE"

--- a/tests/acceptance/features/apiFederationToShares1/federated.feature
+++ b/tests/acceptance/features/apiFederationToShares1/federated.feature
@@ -119,7 +119,7 @@ Feature: federated
       | 1               | 100        |
       | 2               | 200        |
 
-  @skipOnOcV10.3 @skipOnOcV10.4.0 @skipOnOcV10.4.1
+
   Scenario Outline: Federated sharee requests information of only one share before accepting it
     Given using server "REMOTE"
     And user "Alice" has uploaded file "filesForUpload/textfile.txt" to "textfile0.txt"
@@ -532,7 +532,7 @@ Feature: federated
       | 1               | 100        |
       | 2               | 200        |
 
-  @issue-35154 @skipOnOcV10.6 @skipOnOcV10.7 @skipOnOcV10.8.0
+  @issue-35154
   Scenario: receive a local share that has the same name as a previously received federated share
     Given using server "REMOTE"
     And user "Alice" has created folder "/zzzfolder"
@@ -559,7 +559,7 @@ Feature: federated
     And the content of file "/Shares/randomfile.txt" for user "Carol" on server "LOCAL" should be "remote content"
     And the content of file "/Shares/randomfile (2).txt" for user "Carol" on server "LOCAL" should be "local content"
 
-  @skipOnOcV10.6 @skipOnOcV10.7 @skipOnOcV10.8.0
+
   Scenario: receive a federated share that has the same name as a previously received local share
     Given using server "REMOTE"
     And user "Alice" has created folder "/zzzfolder"

--- a/tests/acceptance/features/apiFederationToShares2/federated.feature
+++ b/tests/acceptance/features/apiFederationToShares2/federated.feature
@@ -599,7 +599,7 @@ Feature: federated
       | 1               | 100             | 201,200          |
       | 2               | 200             | 201,403          |
 
-  @skipOnOcV10.3 @skipOnOcV10.4 @skipOnOcV10.5.0
+
   Scenario Outline: Federated share a file with another server with expiration date
     Given using OCS API version "<ocs-api-version>"
     And parameter "shareapi_default_expire_date_remote_share" of app "core" has been set to "yes"
@@ -631,7 +631,7 @@ Feature: federated
       | 1               | 100        |
       | 2               | 200        |
 
-  @skipOnOcV10.3 @skipOnOcV10.4 @skipOnOcV10.5.0
+
   Scenario Outline: Federated sharing with default expiration date enabled but not enforced, user shares without specifying expireDate
     Given using OCS API version "<ocs_api_version>"
     And parameter "shareapi_default_expire_date_remote_share" of app "core" has been set to "yes"
@@ -646,7 +646,7 @@ Feature: federated
       | 1               | 100        |
 #      | 2               | 200        |
 
-  @skipOnOcV10.3 @skipOnOcV10.4 @skipOnOcV10.5.0
+
   Scenario Outline: Federated sharing with default expiration date enabled and enforced, user shares without specifying expireDate
     Given using OCS API version "<ocs_api_version>"
     And parameter "shareapi_default_expire_date_remote_share" of app "core" has been set to "yes"
@@ -662,7 +662,7 @@ Feature: federated
       | 1               | 100        |
       | 2               | 200        |
 
-  @skipOnOcV10.3 @skipOnOcV10.4 @skipOnOcV10.5.0
+
   Scenario Outline: Federated sharing with default expiration date disabled
     Given using OCS API version "<ocs_api_version>"
     And parameter "shareapi_default_expire_date_remote_share" of app "core" has been set to "no"
@@ -677,7 +677,7 @@ Feature: federated
       | 1               | 100        |
       | 2               | 200        |
 
-  @skipOnOcV10.3 @skipOnOcV10.4 @skipOnOcV10.5.0
+
   Scenario Outline: Expiration date is enforced for federated share, user modifies expiration date
     Given using OCS API version "<ocs-api-version>"
     And parameter "shareapi_default_expire_date_remote_share" of app "core" has been set to "yes"
@@ -696,7 +696,7 @@ Feature: federated
       | 1               | 100        |
       | 2               | 200        |
 
-  @skipOnOcV10.3 @skipOnOcV10.4 @skipOnOcV10.5.0
+
   Scenario Outline: Federated sharing with default expiration date enabled and enforced, user updates the share with expiration date more than the default
     Given using OCS API version "<ocs_api_version>"
     And parameter "shareapi_default_expire_date_remote_share" of app "core" has been set to "yes"
@@ -714,7 +714,7 @@ Feature: federated
       | 1               | 200              |
       | 2               | 404              |
 
-  @skipOnOcV10.6 @skipOnOcV10.7 @skipOnOcV10.8.0
+
   Scenario Outline: User modifies expiration date for federated reshare of a file with another server with default expiration date
     Given using OCS API version "<ocs_api_version>"
     And user "Carol" has been created with default attributes and without skeleton files
@@ -737,7 +737,7 @@ Feature: federated
       | 1               | 100        |
       | 2               | 200        |
 
-  @skipOnOcV10.6 @skipOnOcV10.7 @skipOnOcV10.8.0
+
   Scenario Outline: User modifies expiration date more than the default for federated reshare of a file
     Given using OCS API version "<ocs_api_version>"
     And user "Carol" has been created with default attributes and without skeleton files

--- a/tests/acceptance/features/apiMain/checksums-TestOc10Issue38835.feature
+++ b/tests/acceptance/features/apiMain/checksums-TestOc10Issue38835.feature
@@ -1,4 +1,4 @@
-@api @notToImplementOnOCIS @skipOnOcV10.6 @skipOnOcV10.7 @skipOnOcV10.8.0
+@api @notToImplementOnOCIS
 Feature: checksums
 
   Background:

--- a/tests/acceptance/features/apiMain/checksums.feature
+++ b/tests/acceptance/features/apiMain/checksums.feature
@@ -188,7 +188,7 @@ Feature: checksums
       | dav_version |
       | spaces      |
 
-  @files_sharing-app-required @issue-ocis-reva-196 @skipOnOcV10.6 @skipOnOcV10.7 @skipOnOcV10.8.0
+  @files_sharing-app-required @issue-ocis-reva-196
   Scenario Outline: Sharing a file with checksum should return the checksum in the propfind using new DAV path
     Given the administrator has set the default folder for received shares to "Shares"
     And auto-accept shares has been disabled

--- a/tests/acceptance/features/apiMain/quota.feature
+++ b/tests/acceptance/features/apiMain/quota.feature
@@ -220,7 +220,7 @@ Feature: quota
     Then the HTTP status code should be "201"
     And as "Alice" folder "testQuota" should exist
 
-  @skipOnOcV10.6 @skipOnOcV10.7 @skipOnOcV10.8.0 @files_sharing-app-required
+  @files_sharing-app-required
   Scenario: user cannot create file on shared folder by a user with zero quota
     Given the administrator has set the default folder for received shares to "Shares"
     And auto-accept shares has been disabled
@@ -235,7 +235,7 @@ Feature: quota
     And the DAV exception should be "Sabre\DAV\Exception\InsufficientStorage"
     And as "Brian" file "/shareFolder/newTextFile.txt" should not exist
 
-  @skipOnOcV10.6 @skipOnOcV10.7 @skipOnOcV10.8.0 @files_sharing-app-required
+  @files_sharing-app-required
   Scenario: share receiver with 0 quota should not be able to move file from shared folder to home folder
     Given the administrator has set the default folder for received shares to "Shares"
     And auto-accept shares has been disabled
@@ -249,7 +249,7 @@ Feature: quota
     Then the HTTP status code should be "507"
     And the DAV exception should be "Sabre\DAV\Exception\InsufficientStorage"
 
-  @skipOnOcV10.6 @skipOnOcV10.7 @skipOnOcV10.8.0 @files_sharing-app-required
+  @files_sharing-app-required
   Scenario: sharer should be able to upload to a folder shared with user having zero quota
     Given the administrator has set the default folder for received shares to "Shares"
     And auto-accept shares has been disabled
@@ -265,7 +265,7 @@ Feature: quota
     And the content of file "/testquota.txt" for user "Alice" should be "test"
     And as "Brian" file "/Shares/testquota" should not exist
 
-  @skipOnOcV10.6 @skipOnOcV10.7 @skipOnOcV10.8.0 @files_sharing-app-required
+  @files_sharing-app-required
   Scenario: share receiver with 0 quota should be able to upload on shared folder
     Given the administrator has set the default folder for received shares to "Shares"
     And auto-accept shares has been disabled
@@ -294,7 +294,7 @@ Feature: quota
     Then the HTTP status code should be "201"
     And the content of file "/testquota.txt" for user "Alice" should be "test"
 
-  @files_sharing-app-required @skipOnOcV10.8 @skipOnOcV10.9 @skipOnOcV10.10
+  @files_sharing-app-required @skipOnOcV10.10
   Scenario: share receiver with 0 quota can copy empty file from shared folder to home folder
     Given the administrator has set the default folder for received shares to "Shares"
     And auto-accept shares has been disabled
@@ -316,7 +316,7 @@ Feature: quota
     Then the HTTP status code should be "201"
     And as "Alice" file "testquota.txt" should exist
 
-  @files_sharing-app-required @skipOnOcV10.8 @skipOnOcV10.9 @skipOnOcV10.10
+  @files_sharing-app-required @skipOnOcV10.10
   Scenario Outline: share receiver with insufficient quota should not be able to copy received shared file to home folder
     Given the administrator has set the default folder for received shares to "Shares"
     And auto-accept shares has been disabled
@@ -335,7 +335,7 @@ Feature: quota
       | 0 B   | four            |
       | 10 B  | test-content-15 |
 
-  @files_sharing-app-required @skipOnOcV10.8 @skipOnOcV10.9 @skipOnOcV10.10
+  @files_sharing-app-required @skipOnOcV10.10
   Scenario Outline: share receiver with insufficient quota should not be able to copy file from shared folder to home folder
     Given the administrator has set the default folder for received shares to "Shares"
     And auto-accept shares has been disabled
@@ -355,7 +355,7 @@ Feature: quota
       | 0 B   | four            |
       | 10 B  | test-content-15 |
 
-  @files_sharing-app-required @skipOnOcV10.8 @skipOnOcV10.9 @skipOnOcV10.10 @skipOnEncryption @issue-encryption-357
+  @files_sharing-app-required @skipOnOcV10.10 @skipOnEncryption @issue-encryption-357
   Scenario: share receiver of a share with insufficient quota should not be able to copy from home folder to the received shared file
     Given the administrator has set the default folder for received shares to "Shares"
     And auto-accept shares has been disabled
@@ -374,7 +374,7 @@ Feature: quota
     # The copy should have failed, so Alice should still see the original content
     And the content of file "/testquota.txt" for user "Alice" should be "short"
 
-  @files_sharing-app-required @skipOnOcV10.8 @skipOnOcV10.9 @skipOnOcV10.10
+  @files_sharing-app-required @skipOnOcV10.10
   Scenario: share receiver of a share with insufficient quota should not be able to copy file from home folder to the received shared folder
     Given the administrator has set the default folder for received shares to "Shares"
     And auto-accept shares has been disabled

--- a/tests/acceptance/features/apiMain/status.feature
+++ b/tests/acceptance/features/apiMain/status.feature
@@ -1,7 +1,7 @@
 @api
 Feature: Status
 
-  @smokeTest @skipOnOcV10.7 @skipOnOcV10.8 @skipOnOcV10.9.0 @skipOnOcV10.9.1
+  @smokeTest
   Scenario: Status.php is correct
     When the administrator requests status.php
     Then the status.php response should include

--- a/tests/acceptance/features/apiProvisioning-v1/addUser.feature
+++ b/tests/acceptance/features/apiProvisioning-v1/addUser.feature
@@ -16,7 +16,7 @@ Feature: add user
     And user "brand-new-user" should exist
     And user "brand-new-user" should be able to upload file "filesForUpload/textfile.txt" to "/textfile.txt"
 
-  @skipOnOcV10.3
+
   Scenario: admin creates a user with special characters in the username
     Given the following users have been deleted
       | username |

--- a/tests/acceptance/features/apiProvisioning-v1/deleteUser.feature
+++ b/tests/acceptance/features/apiProvisioning-v1/deleteUser.feature
@@ -15,7 +15,7 @@ Feature: delete users
     And the HTTP status code should be "200"
     And user "brand-new-user" should not exist
 
-  @skipOnOcV10.3
+
   Scenario: Delete a user with special characters in the username
     Given these users have been created without skeleton files:
       | username | email               |

--- a/tests/acceptance/features/apiProvisioning-v1/disableUser.feature
+++ b/tests/acceptance/features/apiProvisioning-v1/disableUser.feature
@@ -15,7 +15,7 @@ Feature: disable user
     And the HTTP status code should be "200"
     And user "Alice" should be disabled
 
-  @skipOnOcV10.3
+
   Scenario: admin disables an user with special characters in the username
     Given these users have been created without skeleton files:
       | username | email               |
@@ -189,7 +189,7 @@ Feature: disable user
     When user "Alice" shares folder "/PARENT" with user "Brian" using the sharing API
     Then the HTTP status code should be "401"
 
-  @skipOnOcV10.6 @skipOnOcV10.7 @skipOnOcV10.8.0
+
   Scenario: getting shares shared by disabled user (to shares folder)
     Given the administrator has set the default folder for received shares to "Shares"
     And auto-accept shares has been disabled
@@ -216,7 +216,7 @@ Feature: disable user
     And as "Brian" file "/textfile0.txt" should exist
     And the content of file "/textfile0.txt" for user "Brian" should be "ownCloud test text file 0" plus end-of-line
 
-  @skipOnOcV10.6 @skipOnOcV10.7 @skipOnOcV10.8.0
+
   Scenario: getting shares shared by disabled user in a group (to shares folder)
     Given the administrator has set the default folder for received shares to "Shares"
     And auto-accept shares has been disabled

--- a/tests/acceptance/features/apiProvisioning-v1/editUser.feature
+++ b/tests/acceptance/features/apiProvisioning-v1/editUser.feature
@@ -15,7 +15,7 @@ Feature: edit users
     And the OCS status code should be "100"
     And the email address of user "brand-new-user" should be "brand-new-user@example.com"
 
-  @skipOnOcV10.3
+
   Scenario Outline: the administrator can edit a user email of an user with special characters in the username
     Given these users have been created without skeleton files:
       | username   | email   |
@@ -71,7 +71,7 @@ Feature: edit users
     And the HTTP status code should be "200"
     And the email address of user "brand-new-user" should be "brand-new-user@example.com"
 
-  @skipOnOcV10.3 @skipOnOcV10.4
+
   Scenario: the administrator can clear an existing user email
     Given user "brand-new-user" has been created with default attributes and without skeleton files
     And the administrator has changed the email of user "brand-new-user" to "brand-new-user@gmail.com"
@@ -215,7 +215,7 @@ Feature: edit users
     And the HTTP status code should be "401"
     And the email address of user "Brian" should not have changed
 
-  @skipOnOcV10.6 @skipOnOcV10.7 @skipOnOcV10.8.0
+
   Scenario: Admin gives access to users to change their email address
     Given user "Alice" has been created with default attributes and without skeleton files
     And the administrator has updated system config key "allow_user_to_change_mail_address" with value "true" and type "boolean"
@@ -226,7 +226,7 @@ Feature: edit users
       | email | alice@gmail.com |
     And the email address of user "Alice" should be "alice@gmail.com"
 
-  @notToImplementOnOCIS @skipOnOcV10.6 @skipOnOcV10.7 @skipOnOcV10.8.0
+  @notToImplementOnOCIS
   Scenario: Admin does not give access to users to change their email address
     Given user "Alice" has been created with default attributes and without skeleton files
     And the administrator has updated system config key "allow_user_to_change_mail_address" with value "false" and type "boolean"
@@ -237,7 +237,7 @@ Feature: edit users
       | email | alice@example.org |
     And the email address of user "Alice" should not have changed
 
-  @notToImplementOnOCIS @skipOnOcV10.7 @skipOnOcV10.8 @skipOnOcV10.9.0 @skipOnOcV10.9.1
+  @notToImplementOnOCIS
   Scenario: Admin does not give access to users to change their email address, admin can still change the email address
     Given user "Alice" has been created with default attributes and without skeleton files
     And the administrator has updated system config key "allow_user_to_change_mail_address" with value "false" and type "boolean"
@@ -248,7 +248,7 @@ Feature: edit users
       | email | alice@gmail.com |
     And the email address of user "Alice" should be "alice@gmail.com"
 
-  @notToImplementOnOCIS @skipOnOcV10.7 @skipOnOcV10.8 @skipOnOcV10.9.0 @skipOnOcV10.9.1
+  @notToImplementOnOCIS
   Scenario: Admin does not give access to users to change their email address, admin can still change their own email address
     Given the administrator has updated system config key "allow_user_to_change_mail_address" with value "false" and type "boolean"
     When the administrator changes the email of user "admin" to "something@example.com" using the provisioning API
@@ -258,7 +258,7 @@ Feature: edit users
       | email | something@example.com |
     And the email address of user "admin" should be "something@example.com"
 
-  @notToImplementOnOCIS @skipOnOcV10.7 @skipOnOcV10.8 @skipOnOcV10.9.0 @skipOnOcV10.9.1
+  @notToImplementOnOCIS
   Scenario: Admin does not give access to users to change their email address, subadmin can still change the email address of a user they are subadmin of
     Given these users have been created with default attributes and without skeleton files:
       | username |
@@ -275,7 +275,7 @@ Feature: edit users
       | email | alice@gmail.com |
     And the email address of user "Alice" should be "alice@gmail.com"
 
-  @notToImplementOnOCIS @skipOnOcV10.7 @skipOnOcV10.8 @skipOnOcV10.9.0 @skipOnOcV10.9.1
+  @notToImplementOnOCIS
   Scenario: Admin does not give access to users to change their email address, subadmin cannot change the email address of a user they are not subadmin of
     Given these users have been created with default attributes and without skeleton files:
       | username |
@@ -292,7 +292,7 @@ Feature: edit users
       | email | alice@example.org |
     And the email address of user "Alice" should not have changed
 
-  @skipOnOcV10.6 @skipOnOcV10.7 @skipOnOcV10.8.0
+
   Scenario: Admin gives access to users to change their display name
     Given user "Alice" has been created with default attributes and without skeleton files
     And the administrator has updated system config key "allow_user_to_change_display_name" with value "true" and type "boolean"
@@ -303,7 +303,7 @@ Feature: edit users
       | displayname | Alice Wonderland |
     And the display name of user "Alice" should be "Alice Wonderland"
 
-  @notToImplementOnOCIS @skipOnOcV10.6 @skipOnOcV10.7 @skipOnOcV10.8.0
+  @notToImplementOnOCIS
   Scenario: Admin does not give access to users to change their display name
     Given user "Alice" has been created with default attributes and without skeleton files
     And the administrator has updated system config key "allow_user_to_change_display_name" with value "false" and type "boolean"
@@ -314,7 +314,7 @@ Feature: edit users
       | displayname | Alice Hansen |
     And the display name of user "Alice" should not have changed
 
-  @notToImplementOnOCIS @skipOnOcV10.7 @skipOnOcV10.8 @skipOnOcV10.9.0 @skipOnOcV10.9.1
+  @notToImplementOnOCIS
   Scenario: Admin does not give access to users to change their display name, admin can still change display name
     Given user "Alice" has been created with default attributes and without skeleton files
     And the administrator has updated system config key "allow_user_to_change_display_name" with value "false" and type "boolean"
@@ -325,7 +325,7 @@ Feature: edit users
       | displayname | Alice Wonderland |
     And the display name of user "Alice" should be "Alice Wonderland"
 
-  @notToImplementOnOCIS @skipOnOcV10.7 @skipOnOcV10.8 @skipOnOcV10.9.0 @skipOnOcV10.9.1
+  @notToImplementOnOCIS
   Scenario: Admin does not give access to users to change their display name, admin can still change their own display name
     Given the administrator has updated system config key "allow_user_to_change_display_name" with value "false" and type "boolean"
     When the administrator changes the display name of user "admin" to "The Administrator" using the provisioning API
@@ -335,7 +335,7 @@ Feature: edit users
       | displayname | The Administrator |
     And the display name of user "admin" should be "The Administrator"
 
-  @notToImplementOnOCIS @skipOnOcV10.7 @skipOnOcV10.8 @skipOnOcV10.9.0 @skipOnOcV10.9.1
+  @notToImplementOnOCIS
   Scenario: Admin does not give access to users to change their display name, subadmin can still change the display name of a user they are subadmin of
     Given these users have been created with default attributes and without skeleton files:
       | username |
@@ -351,7 +351,7 @@ Feature: edit users
       | displayname | Alice Wonderland |
     And the display name of user "Alice" should be "Alice Wonderland"
 
-  @notToImplementOnOCIS @skipOnOcV10.7 @skipOnOcV10.8 @skipOnOcV10.9.0 @skipOnOcV10.9.1
+  @notToImplementOnOCIS
   Scenario: Admin does not give access to users to change their display name, subadmin cannot change the display name of a user they are not subadmin of
     Given these users have been created with default attributes and without skeleton files:
       | username |

--- a/tests/acceptance/features/apiProvisioning-v1/enableUser.feature
+++ b/tests/acceptance/features/apiProvisioning-v1/enableUser.feature
@@ -16,7 +16,7 @@ Feature: enable user
     And the HTTP status code should be "200"
     And user "Alice" should be enabled
 
-  @skipOnOcV10.3
+
   Scenario: admin enables an user with special characters in the username
     Given these users have been created without skeleton files:
       | username | email               |

--- a/tests/acceptance/features/apiProvisioning-v1/getApps.feature
+++ b/tests/acceptance/features/apiProvisioning-v1/getApps.feature
@@ -70,7 +70,7 @@ Feature: get apps
       | files_sharing        |
       | updatenotification   |
 
-  @comments-app-required @skipOnOcV10.3 @skipOnOcV10.4 @skipOnOcV10.5
+  @comments-app-required
   Scenario: admin gets all apps
     Given app "comments" has been disabled
     When the administrator gets all apps using the provisioning API

--- a/tests/acceptance/features/apiProvisioning-v1/getUser.feature
+++ b/tests/acceptance/features/apiProvisioning-v1/getUser.feature
@@ -7,7 +7,7 @@ Feature: get user
   Background:
     Given using OCS API version "1"
 
-  @smokeTest @skipOnOcV10.6 @skipOnOcV10.7 @skipOnOcV10.8.0
+  @smokeTest
   Scenario: admin gets an existing user
     Given these users have been created with default attributes and without skeleton files:
       | username       | displayname    |
@@ -20,7 +20,7 @@ Feature: get user
     And the free, used, total and relative quota returned by the API should exist and be valid numbers
     And the last login returned by the API should be a current Unix timestamp
 
-  @skipOnOcV10.6 @skipOnOcV10.7 @skipOnOcV10.8.0
+
   Scenario Outline: admin gets an existing user with special characters in the username
     Given these users have been created without skeleton files:
       | username   | displayname   | email   |
@@ -38,7 +38,7 @@ Feature: get user
       | a@-+_.b  | A weird b    | a.b@example.com     |
       | a space  | A Space Name | a.space@example.com |
 
-  @skipOnOcV10.6 @skipOnOcV10.7 @skipOnOcV10.8.0
+ 
   Scenario: admin gets an existing user, providing uppercase username in the URL
     Given these users have been created with default attributes and without skeleton files:
       | username       | displayname    |
@@ -58,7 +58,7 @@ Feature: get user
     And the HTTP status code should be "200"
     And the API should not return any data
 
-  @smokeTest @notToImplementOnOCIS @skipOnOcV10.6 @skipOnOcV10.7 @skipOnOcV10.8.0
+  @smokeTest @notToImplementOnOCIS
   Scenario: a subadmin gets information of a user in their group
     Given these users have been created with default attributes and without skeleton files:
       | username       | displayname |
@@ -99,7 +99,7 @@ Feature: get user
     And the HTTP status code should be "401"
     And the API should not return any data
 
-  @smokeTest @skipOnOcV10.6 @skipOnOcV10.7 @skipOnOcV10.8.0
+  @smokeTest
   Scenario: a normal user gets their own information
     Given these users have been created with default attributes and without skeleton files:
       | username       | displayname |
@@ -112,7 +112,7 @@ Feature: get user
     And the free, used, total and relative quota returned by the API should exist and be valid numbers
     And the last login returned by the API should be a current Unix timestamp
 
-  @skipOnOcV10.6 @skipOnOcV10.7 @skipOnOcV10.8.0
+ 
   Scenario Outline: a normal user gets their own information, providing uppercase username as authentication and in the URL
     Given these users have been created with default attributes and without skeleton files:
       | username       | displayname |
@@ -129,7 +129,7 @@ Feature: get user
       | BRAND-NEW-USER | brand-new-user |
       | brand-new-user | BRAND-NEW-USER |
 
-  @skipOnOcV10.6 @skipOnOcV10.7 @skipOnOcV10.8.0
+ 
   Scenario Outline: a mixed-case normal user gets their own information, providing lowercase and mixed-case username in the URL
     Given these users have been created with default attributes and without skeleton files:
       | username       | displayname |
@@ -146,7 +146,7 @@ Feature: get user
       | Brand-New-User | brand-new-user |
       | brand-new-user | Brand-New-User |
 
-  @skipOnOcV10.6 @skipOnOcV10.7 @skipOnOcV10.8.0
+ 
   Scenario: admin gets information of a user with admin permissions
     Given these users have been created with default attributes and without skeleton files:
       | username       | displayname    |
@@ -160,7 +160,7 @@ Feature: get user
     And the free, used, total and relative quota returned by the API should exist and be valid numbers
     And the last login returned by the API should be a current Unix timestamp
 
-  @notToImplementOnOCIS @skipOnOcV10.6 @skipOnOcV10.7 @skipOnOcV10.8.0
+  @notToImplementOnOCIS
   Scenario: a subadmin should be able to get information of a user with subadmin permissions in their group
     Given these users have been created with default attributes and without skeleton files:
       | username         |

--- a/tests/acceptance/features/apiProvisioning-v2/addUser.feature
+++ b/tests/acceptance/features/apiProvisioning-v2/addUser.feature
@@ -16,7 +16,7 @@ Feature: add user
     And user "brand-new-user" should exist
     And user "brand-new-user" should be able to upload file "filesForUpload/textfile.txt" to "/textfile.txt"
 
-  @skipOnOcV10.3
+
   Scenario: admin creates a user with special characters in the username
     Given the following users have been deleted
       | username |

--- a/tests/acceptance/features/apiProvisioning-v2/deleteUser.feature
+++ b/tests/acceptance/features/apiProvisioning-v2/deleteUser.feature
@@ -15,7 +15,7 @@ Feature: delete users
     And the HTTP status code should be "200"
     And user "brand-new-user" should not exist
 
-  @skipOnOcV10.3
+
   Scenario: Delete a user with special characters in the username
     Given these users have been created without skeleton files:
       | username | email               |

--- a/tests/acceptance/features/apiProvisioning-v2/disableUser.feature
+++ b/tests/acceptance/features/apiProvisioning-v2/disableUser.feature
@@ -15,7 +15,7 @@ Feature: disable user
     And the HTTP status code should be "200"
     And user "Alice" should be disabled
 
-  @skipOnOcV10.3
+
   Scenario: admin disables an user with special characters in the username
     Given these users have been created without skeleton files:
       | username | email               |
@@ -189,7 +189,7 @@ Feature: disable user
     When user "Alice" shares folder "/PARENT" with user "Brian" using the sharing API
     Then the HTTP status code should be "401"
 
-  @skipOnOcV10.6 @skipOnOcV10.7 @skipOnOcV10.8.0
+
   Scenario: getting shares shared by disabled user (to shares folder)
     Given the administrator has set the default folder for received shares to "Shares"
     And auto-accept shares has been disabled
@@ -216,7 +216,7 @@ Feature: disable user
     And as "Brian" file "/textfile0.txt" should exist
     And the content of file "/textfile0.txt" for user "Brian" should be "ownCloud test text file 0" plus end-of-line
 
-  @skipOnOcV10.6 @skipOnOcV10.7 @skipOnOcV10.8.0
+
   Scenario: getting shares shared by disabled user in a group (to shares folder)
     Given the administrator has set the default folder for received shares to "Shares"
     And auto-accept shares has been disabled

--- a/tests/acceptance/features/apiProvisioning-v2/editUser.feature
+++ b/tests/acceptance/features/apiProvisioning-v2/editUser.feature
@@ -15,7 +15,7 @@ Feature: edit users
     And the OCS status code should be "200"
     And the email address of user "brand-new-user" should be "brand-new-user@example.com"
 
-  @skipOnOcV10.3
+
   Scenario Outline: the administrator can edit a user email of an user with special characters in the username
     Given these users have been created without skeleton files:
       | username   | email   |
@@ -73,7 +73,7 @@ Feature: edit users
     And the HTTP status code should be "200"
     And the email address of user "brand-new-user" should be "brand-new-user@example.com"
 
-  @skipOnOcV10.3 @skipOnOcV10.4
+
   Scenario: the administrator can clear an existing user email
     Given user "brand-new-user" has been created with default attributes and without skeleton files
     And the administrator has changed the email of user "brand-new-user" to "brand-new-user@gmail.com"
@@ -201,7 +201,7 @@ Feature: edit users
     And the display name of user "Brian" should not have changed
     And the email address of user "Brian" should not have changed
 
-  @skipOnOcV10.6 @skipOnOcV10.7 @skipOnOcV10.8.0
+
   Scenario: Admin gives access to users to change their email address
     Given user "Alice" has been created with default attributes and without skeleton files
     And the administrator has updated system config key "allow_user_to_change_mail_address" with value "true" and type "boolean"
@@ -212,7 +212,7 @@ Feature: edit users
       | email | alice@gmail.com |
     And the email address of user "Alice" should be "alice@gmail.com"
 
-  @notToImplementOnOCIS @skipOnOcV10.6 @skipOnOcV10.7 @skipOnOcV10.8.0
+  @notToImplementOnOCIS
   Scenario: Admin does not give access to users to change their email address
     Given user "Alice" has been created with default attributes and without skeleton files
     And the administrator has updated system config key "allow_user_to_change_mail_address" with value "false" and type "boolean"
@@ -223,7 +223,7 @@ Feature: edit users
       | email | alice@example.org |
     And the email address of user "Alice" should not have changed
 
-  @notToImplementOnOCIS @skipOnOcV10.7 @skipOnOcV10.8 @skipOnOcV10.9.0 @skipOnOcV10.9.1
+  @notToImplementOnOCIS
   Scenario: Admin does not give access to users to change their email address, admin can still change the email address
     Given user "Alice" has been created with default attributes and without skeleton files
     When the administrator updates system config key "allow_user_to_change_mail_address" with value "false" and type "boolean" using the occ command
@@ -234,7 +234,7 @@ Feature: edit users
       | email | alice@gmail.com |
     And the email address of user "Alice" should be "alice@gmail.com"
 
-  @notToImplementOnOCIS @skipOnOcV10.7 @skipOnOcV10.8 @skipOnOcV10.9.0 @skipOnOcV10.9.1
+  @notToImplementOnOCIS
   Scenario: Admin does not give access to users to change their email address, admin can still change their own email address
     When the administrator updates system config key "allow_user_to_change_mail_address" with value "false" and type "boolean" using the occ command
     And the administrator changes the email of user "admin" to "something@example.com" using the provisioning API
@@ -244,7 +244,7 @@ Feature: edit users
       | email | something@example.com |
     And the email address of user "admin" should be "something@example.com"
 
-  @notToImplementOnOCIS @skipOnOcV10.7 @skipOnOcV10.8 @skipOnOcV10.9.0 @skipOnOcV10.9.1
+  @notToImplementOnOCIS
   Scenario: Admin does not give access to users to change their email address, subadmin can still change the email address of a user they are subadmin of
     Given these users have been created with default attributes and without skeleton files:
       | username |
@@ -261,7 +261,7 @@ Feature: edit users
       | email | alice@gmail.com |
     And the email address of user "Alice" should be "alice@gmail.com"
 
-  @notToImplementOnOCIS @skipOnOcV10.7 @skipOnOcV10.8 @skipOnOcV10.9.0 @skipOnOcV10.9.1
+  @notToImplementOnOCIS
   Scenario: Admin does not give access to users to change their email address, subadmin cannot change the email address of a user they are not subadmin of
     Given these users have been created with default attributes and without skeleton files:
       | username |
@@ -278,7 +278,7 @@ Feature: edit users
       | email | alice@example.org |
     And the email address of user "Alice" should not have changed
 
-  @skipOnOcV10.6 @skipOnOcV10.7 @skipOnOcV10.8.0
+
   Scenario: Admin gives access to users to change their display name
     Given user "Alice" has been created with default attributes and without skeleton files
     And the administrator has updated system config key "allow_user_to_change_display_name" with value "true" and type "boolean"
@@ -289,7 +289,7 @@ Feature: edit users
       | displayname | Alice Wonderland |
     And the display name of user "Alice" should be "Alice Wonderland"
 
-  @notToImplementOnOCIS @skipOnOcV10.6 @skipOnOcV10.7 @skipOnOcV10.8.0
+  @notToImplementOnOCIS
   Scenario: Admin does not give access to users to change their display name
     Given user "Alice" has been created with default attributes and without skeleton files
     And the administrator has updated system config key "allow_user_to_change_display_name" with value "false" and type "boolean"
@@ -300,7 +300,7 @@ Feature: edit users
       | displayname | Alice Hansen |
     And the display name of user "Alice" should not have changed
 
-  @notToImplementOnOCIS @skipOnOcV10.7 @skipOnOcV10.8 @skipOnOcV10.9.0 @skipOnOcV10.9.1
+  @notToImplementOnOCIS
   Scenario: Admin does not give access to users to change their display name, admin can still change display name
     Given user "Alice" has been created with default attributes and without skeleton files
     When the administrator updates system config key "allow_user_to_change_display_name" with value "false" and type "boolean" using the occ command
@@ -311,7 +311,7 @@ Feature: edit users
       | displayname | Alice Wonderland |
     And the display name of user "Alice" should be "Alice Wonderland"
 
-  @notToImplementOnOCIS @skipOnOcV10.7 @skipOnOcV10.8 @skipOnOcV10.9.0 @skipOnOcV10.9.1
+  @notToImplementOnOCIS
   Scenario: Admin does not give access to users to change their display name, admin can still change their own display name
     When the administrator updates system config key "allow_user_to_change_display_name" with value "false" and type "boolean" using the occ command
     And the administrator changes the display name of user "admin" to "The Administrator" using the provisioning API
@@ -321,7 +321,7 @@ Feature: edit users
       | displayname | The Administrator |
     And the display name of user "admin" should be "The Administrator"
 
-  @notToImplementOnOCIS @skipOnOcV10.7 @skipOnOcV10.8 @skipOnOcV10.9.0 @skipOnOcV10.9.1
+  @notToImplementOnOCIS
   Scenario: Admin does not give access to users to change their display name, subadmin can still change the display name of a user they are subadmin of
     Given these users have been created with default attributes and without skeleton files:
       | username |
@@ -337,7 +337,7 @@ Feature: edit users
       | displayname | Alice Wonderland |
     And the display name of user "Alice" should be "Alice Wonderland"
 
-  @notToImplementOnOCIS @skipOnOcV10.7 @skipOnOcV10.8 @skipOnOcV10.9.0 @skipOnOcV10.9.1
+  @notToImplementOnOCIS
   Scenario: Admin does not give access to users to change their display name, subadmin cannot change the display name of a user they are not subadmin of
     Given these users have been created with default attributes and without skeleton files:
       | username |

--- a/tests/acceptance/features/apiProvisioning-v2/enableUser.feature
+++ b/tests/acceptance/features/apiProvisioning-v2/enableUser.feature
@@ -16,7 +16,7 @@ Feature: enable user
     And the HTTP status code should be "200"
     And user "Alice" should be enabled
 
-  @skipOnOcV10.3
+
   Scenario: admin enables an user with special characters in the username
     Given these users have been created without skeleton files:
       | username | email               |

--- a/tests/acceptance/features/apiProvisioning-v2/getApps.feature
+++ b/tests/acceptance/features/apiProvisioning-v2/getApps.feature
@@ -70,7 +70,7 @@ Feature: get apps
       | files_sharing        |
       | updatenotification   |
 
-  @comments-app-required @skipOnOcV10.3 @skipOnOcV10.4 @skipOnOcV10.5
+  @comments-app-required
   Scenario: admin gets all apps
     Given app "comments" has been disabled
     When the administrator gets all apps using the provisioning API

--- a/tests/acceptance/features/apiProvisioning-v2/getUser.feature
+++ b/tests/acceptance/features/apiProvisioning-v2/getUser.feature
@@ -7,7 +7,7 @@ Feature: get user
   Background:
     Given using OCS API version "2"
 
-  @smokeTest @skipOnOcV10.6 @skipOnOcV10.7 @skipOnOcV10.8.0
+  @smokeTest
   Scenario: admin gets an existing user
     Given these users have been created with default attributes and without skeleton files:
       | username       | displayname    |
@@ -20,7 +20,7 @@ Feature: get user
     And the free, used, total and relative quota returned by the API should exist and be valid numbers
     And the last login returned by the API should be a current Unix timestamp
 
-  @skipOnOcV10.6 @skipOnOcV10.7 @skipOnOcV10.8.0
+
   Scenario Outline: admin gets an existing user with special characters in the username
     Given these users have been created without skeleton files:
       | username   | displayname   | email   |
@@ -38,7 +38,7 @@ Feature: get user
       | a@-+_.b  | A weird b    | a.b@example.com     |
       | a space  | A Space Name | a.space@example.com |
 
-  @skipOnOcV10.6 @skipOnOcV10.7 @skipOnOcV10.8.0
+ 
   Scenario: admin gets an existing user, providing uppercase username in the URL
     Given these users have been created with default attributes and without skeleton files:
       | username       | displayname    |
@@ -58,7 +58,7 @@ Feature: get user
     And the HTTP status code should be "404"
     And the API should not return any data
 
-  @smokeTest @notToImplementOnOCIS @skipOnOcV10.6 @skipOnOcV10.7 @skipOnOcV10.8.0
+  @smokeTest @notToImplementOnOCIS
   Scenario: a subadmin gets information of a user in their group
     Given these users have been created with default attributes and without skeleton files:
       | username       | displayname |
@@ -99,7 +99,7 @@ Feature: get user
     And the HTTP status code should be "401"
     And the API should not return any data
 
-  @smokeTest @skipOnOcV10.6 @skipOnOcV10.7 @skipOnOcV10.8.0
+  @smokeTest
   Scenario: a normal user gets their own information
     Given these users have been created with default attributes and without skeleton files:
       | username       | displayname |
@@ -112,7 +112,7 @@ Feature: get user
     And the free, used, total and relative quota returned by the API should exist and be valid numbers
     And the last login returned by the API should be a current Unix timestamp
 
-  @skipOnOcV10.6 @skipOnOcV10.7 @skipOnOcV10.8.0
+ 
   Scenario: a normal user gets their own information, providing uppercase username as authentication
     Given these users have been created with default attributes and without skeleton files:
       | username       | displayname |
@@ -125,7 +125,7 @@ Feature: get user
     And the free, used, total and relative quota returned by the API should exist and be valid numbers
     And the last login returned by the API should be a current Unix timestamp
 
-  @skipOnOcV10.6 @skipOnOcV10.7 @skipOnOcV10.8.0
+ 
   Scenario: a normal user gets their own information, providing uppercase username in the URL
     Given these users have been created with default attributes and without skeleton files:
       | username       | displayname |
@@ -138,7 +138,7 @@ Feature: get user
     And the free, used, total and relative quota returned by the API should exist and be valid numbers
     And the last login returned by the API should be a current Unix timestamp
 
-  @skipOnOcV10.6 @skipOnOcV10.7 @skipOnOcV10.8.0
+ 
   Scenario: a mixed-case normal user gets their own information, providing lowercase username in the URL
     Given these users have been created with default attributes and without skeleton files:
       | username       | displayname |
@@ -151,7 +151,7 @@ Feature: get user
     And the free, used, total and relative quota returned by the API should exist and be valid numbers
     And the last login returned by the API should be a current Unix timestamp
 
-  @skipOnOcV10.6 @skipOnOcV10.7 @skipOnOcV10.8.0
+ 
   Scenario: a mixed-case normal user gets their own information, providing the mixed-case username in the URL
     Given these users have been created with default attributes and without skeleton files:
       | username       | displayname |
@@ -164,7 +164,7 @@ Feature: get user
     And the free, used, total and relative quota returned by the API should exist and be valid numbers
     And the last login returned by the API should be a current Unix timestamp
 
-  @notToImplementOnOCIS @skipOnOcV10.6 @skipOnOcV10.7 @skipOnOcV10.8.0
+  @notToImplementOnOCIS
   Scenario: admin gets information of a user with admin permissions
     Given these users have been created with default attributes and without skeleton files:
       | username       | displayname    |
@@ -178,7 +178,7 @@ Feature: get user
     And the free, used, total and relative quota returned by the API should exist and be valid numbers
     And the last login returned by the API should be a current Unix timestamp
 
-  @notToImplementOnOCIS @skipOnOcV10.6 @skipOnOcV10.7 @skipOnOcV10.8.0
+  @notToImplementOnOCIS
   Scenario: a subadmin should be able to get information of a user with subadmin permissions in their group
     Given these users have been created with default attributes and without skeleton files:
       | username         |

--- a/tests/acceptance/features/apiProvisioningGroups-v1/addGroup.feature
+++ b/tests/acceptance/features/apiProvisioningGroups-v1/addGroup.feature
@@ -157,7 +157,7 @@ Feature: add groups
     And the HTTP status code should be "401"
     And group "another-new-group" should not exist
 
-  @skipOnOcV10.7 @skipOnOcV10.8 @skipOnOcV10.9.0 @skipOnOcV10.9.1
+
   Scenario: admin tries to create a group that has white space at the end of the name
     When the administrator sends a group creation request for group "white-space-at-end " using the provisioning API
     Then the OCS status code should be "101"
@@ -165,7 +165,7 @@ Feature: add groups
     And group "white-space-at-end " should not exist
     And group "white-space-at-end" should not exist
 
-  @skipOnOcV10.7 @skipOnOcV10.8 @skipOnOcV10.9.0 @skipOnOcV10.9.1
+
   Scenario: admin tries to create a group that has white space at the start of the name
     When the administrator sends a group creation request for group " white-space-at-start" using the provisioning API
     Then the OCS status code should be "101"
@@ -173,7 +173,7 @@ Feature: add groups
     And group " white-space-at-start" should not exist
     But group "white-space-at-start" should not exist
 
-  @skipOnOcV10.7 @skipOnOcV10.8 @skipOnOcV10.9.0 @skipOnOcV10.9.1
+
   Scenario: admin tries to create a group that is a single space
     When the administrator sends a group creation request for group " " using the provisioning API
     Then the OCS status code should be "101"

--- a/tests/acceptance/features/apiProvisioningGroups-v1/addToGroup.feature
+++ b/tests/acceptance/features/apiProvisioningGroups-v1/addToGroup.feature
@@ -199,7 +199,7 @@ Feature: add users to group
     And the HTTP status code should be "200"
     And user "brand-new-user" should not belong to group "brand-new-group"
 
-  @skipOnLDAP @skipOnOcV10.6 @skipOnOcV10.7 @skipOnOcV10.8.0 @notToImplementOnOCIS
+  @skipOnLDAP @notToImplementOnOCIS
   Scenario: a subadmin can add users to other groups the subadmin is responsible for
     Given these users have been created with default attributes and without skeleton files:
       | username         |

--- a/tests/acceptance/features/apiProvisioningGroups-v1/getSubAdminGroups.feature
+++ b/tests/acceptance/features/apiProvisioningGroups-v1/getSubAdminGroups.feature
@@ -21,7 +21,7 @@ Feature: get subadmin groups
       | brand-new-group |
       | 😅 😆           |
 
-  @skipOnOcV10.5 @skipOnOcV10.6.0
+
   Scenario: admin tries to get subadmin groups of a user which does not exist
     Given user "nonexistentuser" has been deleted
     And group "brand-new-group" has been created
@@ -30,7 +30,7 @@ Feature: get subadmin groups
     And the HTTP status code should be "200"
     And the API should not return any data
 
-  @issue-owncloud-sdk-658 @skipOnOcV10.5 @skipOnOcV10.6.0
+  @issue-owncloud-sdk-658
   Scenario: subadmin gets groups where he/she is subadmin
     Given user "Alice" has been created with default attributes and without skeleton files
     And group "brand-new-group" has been created

--- a/tests/acceptance/features/apiProvisioningGroups-v2/addGroup.feature
+++ b/tests/acceptance/features/apiProvisioningGroups-v2/addGroup.feature
@@ -153,7 +153,7 @@ Feature: add groups
     And the HTTP status code should be "401"
     And group "another-new-group" should not exist
 
-  @skipOnOcV10.7 @skipOnOcV10.8 @skipOnOcV10.9.0 @skipOnOcV10.9.1
+
   Scenario: admin tries to create a group that has white space at the end of the name
     When the administrator sends a group creation request for group "white-space-at-end " using the provisioning API
     Then the OCS status code should be "400"
@@ -161,7 +161,7 @@ Feature: add groups
     And group "white-space-at-end " should not exist
     And group "white-space-at-end" should not exist
 
-  @skipOnOcV10.7 @skipOnOcV10.8 @skipOnOcV10.9.0 @skipOnOcV10.9.1
+
   Scenario: admin tries to create a group that has white space at the start of the name
     When the administrator sends a group creation request for group " white-space-at-start" using the provisioning API
     Then the OCS status code should be "400"
@@ -169,7 +169,7 @@ Feature: add groups
     And group " white-space-at-start" should not exist
     And group "white-space-at-start" should not exist
 
-  @skipOnOcV10.7 @skipOnOcV10.8 @skipOnOcV10.9.0 @skipOnOcV10.9.1
+
   Scenario: admin tries to create a group that is a single space
     When the administrator sends a group creation request for group " " using the provisioning API
     Then the OCS status code should be "400"

--- a/tests/acceptance/features/apiProvisioningGroups-v2/addToGroup.feature
+++ b/tests/acceptance/features/apiProvisioningGroups-v2/addToGroup.feature
@@ -190,7 +190,7 @@ Feature: add users to group
     And the HTTP status code should be "403"
     And user "brand-new-user" should not belong to group "brand-new-group"
 
-  @skipOnLDAP @skipOnOcV10.6 @skipOnOcV10.7 @skipOnOcV10.8.0 @notToImplementOnOCIS
+  @skipOnLDAP @notToImplementOnOCIS
   Scenario: a subadmin can add users to other groups the subadmin is responsible for
     Given these users have been created with default attributes and without skeleton files:
       | username         |

--- a/tests/acceptance/features/apiProvisioningGroups-v2/getSubAdminGroups.feature
+++ b/tests/acceptance/features/apiProvisioningGroups-v2/getSubAdminGroups.feature
@@ -21,7 +21,7 @@ Feature: get subadmin groups
       | brand-new-group |
       | 😅 😆           |
 
-  @skipOnOcV10.5 @skipOnOcV10.6.0
+
   Scenario: admin tries to get subadmin groups of a user which does not exist
     Given user "nonexistentuser" has been deleted
     And group "brand-new-group" has been created
@@ -30,7 +30,7 @@ Feature: get subadmin groups
     And the HTTP status code should be "404"
     And the API should not return any data
 
-  @issue-owncloud-sdk-658 @skipOnOcV10.5 @skipOnOcV10.6.0
+  @issue-owncloud-sdk-658
   Scenario: subadmin gets groups where he/she is subadmin
     Given user "Alice" has been created with default attributes and without skeleton files
     And group "brand-new-group" has been created

--- a/tests/acceptance/features/apiShareCreateSpecialToRoot1/createShareExpirationDate.feature
+++ b/tests/acceptance/features/apiShareCreateSpecialToRoot1/createShareExpirationDate.feature
@@ -4,7 +4,7 @@ Feature: a default expiration date can be specified for shares with users or gro
   Background:
     Given user "Alice" has been created with default attributes and without skeleton files
 
-  @skipOnOcV10.3
+
   Scenario Outline: sharing with default expiration date enabled but not enforced for users, user shares without specifying expireDate
     Given using OCS API version "<ocs_api_version>"
     And parameter "shareapi_default_expire_date_user_share" of app "core" has been set to "yes"
@@ -22,7 +22,7 @@ Feature: a default expiration date can be specified for shares with users or gro
       | 1               | 100             |
       | 2               | 200             |
 
-  @skipOnOcV10.3
+
   Scenario Outline: sharing with default expiration date enabled but not enforced for users, user shares with expiration date
     Given using OCS API version "<ocs_api_version>"
     And parameter "shareapi_default_expire_date_user_share" of app "core" has been set to "yes"
@@ -49,7 +49,7 @@ Feature: a default expiration date can be specified for shares with users or gro
       | 1               | 100             |
       | 2               | 200             |
 
-  @skipOnOcV10.3
+
   Scenario Outline: sharing with default expiration date not enabled, user shares with expiration date set
     Given using OCS API version "<ocs_api_version>"
     And user "Brian" has been created with default attributes and without skeleton files
@@ -75,7 +75,7 @@ Feature: a default expiration date can be specified for shares with users or gro
       | 1               | 100             |
       | 2               | 200             |
 
-  @skipOnOcV10.3
+
   Scenario Outline: sharing with default expiration date enabled but not enforced for users, user shares with expiration date and then disables
     Given using OCS API version "<ocs_api_version>"
     And parameter "shareapi_default_expire_date_user_share" of app "core" has been set to "yes"
@@ -102,7 +102,7 @@ Feature: a default expiration date can be specified for shares with users or gro
       | 1               |
       | 2               |
 
-  @skipOnOcV10.3
+
   Scenario Outline: sharing with default expiration date enabled and enforced for users, user shares with expiration date and then disables
     Given using OCS API version "<ocs_api_version>"
     And parameter "shareapi_default_expire_date_user_share" of app "core" has been set to "yes"
@@ -129,7 +129,7 @@ Feature: a default expiration date can be specified for shares with users or gro
       | 1               |
       | 2               |
 
-  @skipOnOcV10.3
+
   Scenario Outline: sharing with default expiration date enabled but not enforced for groups, user shares without specifying expireDate
     Given using OCS API version "<ocs_api_version>"
     And parameter "shareapi_default_expire_date_group_share" of app "core" has been set to "yes"
@@ -149,7 +149,7 @@ Feature: a default expiration date can be specified for shares with users or gro
       | 1               | 100             |
       | 2               | 200             |
 
-  @skipOnOcV10.3
+
   Scenario Outline: sharing with default expiration date enabled but not enforced for groups, user shares with expiration date
     Given using OCS API version "<ocs_api_version>"
     And parameter "shareapi_default_expire_date_group_share" of app "core" has been set to "yes"
@@ -178,7 +178,7 @@ Feature: a default expiration date can be specified for shares with users or gro
       | 1               | 100             |
       | 2               | 200             |
 
-  @skipOnOcV10.3
+
   Scenario Outline: sharing with default expiration date not enabled for groups, user shares with expiration date set
     Given using OCS API version "<ocs_api_version>"
     And user "Brian" has been created with default attributes and without skeleton files
@@ -206,7 +206,7 @@ Feature: a default expiration date can be specified for shares with users or gro
       | 1               | 100             |
       | 2               | 200             |
 
-  @skipOnOcV10.3
+
   Scenario Outline: sharing with default expiration date enabled but not enforced for groups, user shares with expiration date and then disables
     Given using OCS API version "<ocs_api_version>"
     And parameter "shareapi_default_expire_date_group_share" of app "core" has been set to "yes"
@@ -235,7 +235,7 @@ Feature: a default expiration date can be specified for shares with users or gro
       | 1               |
       | 2               |
 
-  @skipOnOcV10.3
+
   Scenario Outline: sharing with default expiration date enabled and enforced for groups, user shares with expiration date and then disables
     Given using OCS API version "<ocs_api_version>"
     And parameter "shareapi_default_expire_date_group_share" of app "core" has been set to "yes"
@@ -265,7 +265,7 @@ Feature: a default expiration date can be specified for shares with users or gro
       | 1               |
       | 2               |
 
-  @skipOnOcV10.3
+
   Scenario Outline: sharing with default expiration date enabled and enforced for users, user shares without setting expiration date
     Given using OCS API version "<ocs_api_version>"
     And parameter "shareapi_default_expire_date_user_share" of app "core" has been set to "yes"
@@ -288,7 +288,7 @@ Feature: a default expiration date can be specified for shares with users or gro
       | 1               | 100             |
       | 2               | 200             |
 
-  @skipOnOcV10.3
+
   Scenario Outline: sharing with default expiration date enabled and enforced for users, user shares with expiration date more than the default
     Given using OCS API version "<ocs_api_version>"
     And parameter "shareapi_default_expire_date_user_share" of app "core" has been set to "yes"
@@ -310,7 +310,7 @@ Feature: a default expiration date can be specified for shares with users or gro
       | 1               | 200              |
       | 2               | 404              |
 
-  @skipOnOcV10.3
+
   Scenario Outline: sharing with default expiration date enabled and enforced for users/max expire date is set, user shares without setting expiration date
     Given using OCS API version "<ocs_api_version>"
     And parameter "shareapi_default_expire_date_user_share" of app "core" has been set to "yes"
@@ -334,7 +334,7 @@ Feature: a default expiration date can be specified for shares with users or gro
       | 1               | 100             |
       | 2               | 200             |
 
-  @skipOnOcV10.3
+
   Scenario Outline: sharing with default expiration date enabled and enforced for users/max expire date set, user shares with expiration date more than the max expire date
     Given using OCS API version "<ocs_api_version>"
     And parameter "shareapi_default_expire_date_user_share" of app "core" has been set to "yes"
@@ -357,7 +357,7 @@ Feature: a default expiration date can be specified for shares with users or gro
       | 1               | 200              |
       | 2               | 404              |
 
-  @skipOnOcV10.3
+
   Scenario Outline: sharing with default expiration date enabled and enforced for users/max expire date is set, user shares and changes the max expire date greater than the previous one
     Given using OCS API version "<ocs_api_version>"
     And parameter "shareapi_default_expire_date_user_share" of app "core" has been set to "yes"
@@ -374,7 +374,7 @@ Feature: a default expiration date can be specified for shares with users or gro
       | 1               |
       | 2               |
 
-  @skipOnOcV10.3
+
   Scenario Outline: sharing with default expiration date enabled for users/max expire date is set, user shares and changes max expire date less than the previous one
     Given using OCS API version "<ocs_api_version>"
     And parameter "shareapi_default_expire_date_user_share" of app "core" has been set to "yes"
@@ -392,7 +392,7 @@ Feature: a default expiration date can be specified for shares with users or gro
       | 1               |
       | 2               |
 
-  @skipOnOcV10.3
+
   Scenario Outline: sharing with default expiration date enabled and enforced for groups, user shares without setting expiration date
     Given using OCS API version "<ocs_api_version>"
     And parameter "shareapi_default_expire_date_group_share" of app "core" has been set to "yes"
@@ -417,7 +417,7 @@ Feature: a default expiration date can be specified for shares with users or gro
       | 1               | 100             |
       | 2               | 200             |
 
-  @skipOnOcV10.3
+
   Scenario Outline: sharing with default expiration date enabled and enforced for groups, user shares with expiration date more than the default
     Given using OCS API version "<ocs_api_version>"
     And parameter "shareapi_default_expire_date_group_share" of app "core" has been set to "yes"
@@ -441,7 +441,7 @@ Feature: a default expiration date can be specified for shares with users or gro
       | 1               | 200              |
       | 2               | 404              |
 
-  @skipOnOcV10.3
+
   Scenario Outline: sharing with default expiration date enabled and enforced for groups/max expire date is set, user shares without setting expiration date
     Given using OCS API version "<ocs_api_version>"
     And parameter "shareapi_default_expire_date_group_share" of app "core" has been set to "yes"
@@ -467,7 +467,7 @@ Feature: a default expiration date can be specified for shares with users or gro
       | 1               | 100             |
       | 2               | 200             |
 
-  @skipOnOcV10.3
+
   Scenario Outline: sharing with default expiration date enabled and enforced for groups/max expire date set, user shares with expiration date more than the max expire date
     Given using OCS API version "<ocs_api_version>"
     And parameter "shareapi_default_expire_date_group_share" of app "core" has been set to "yes"
@@ -492,7 +492,7 @@ Feature: a default expiration date can be specified for shares with users or gro
       | 1               | 200              |
       | 2               | 404              |
 
-  @skipOnOcV10.3
+
   Scenario Outline: sharing with default expiration date enabled for groups/max expire date is set, user shares and changes the max expire date greater than the previous one
     Given using OCS API version "<ocs_api_version>"
     And parameter "shareapi_default_expire_date_group_share" of app "core" has been set to "yes"
@@ -514,7 +514,7 @@ Feature: a default expiration date can be specified for shares with users or gro
       | 1               |
       | 2               |
 
-  @skipOnOcV10.3
+
   Scenario Outline: sharing with default expiration date enabled for groups/max expire date is set, user shares and changes max expire date less than the previous one
     Given using OCS API version "<ocs_api_version>"
     And parameter "shareapi_default_expire_date_group_share" of app "core" has been set to "yes"
@@ -536,7 +536,7 @@ Feature: a default expiration date can be specified for shares with users or gro
       | 1               |
       | 2               |
 
-  @skipOnOcV10.3
+
   Scenario Outline: sharing with default expiration date enforced for users, user shares to a group without setting an expiration date
     Given using OCS API version "<ocs_api_version>"
     And parameter "shareapi_default_expire_date_user_share" of app "core" has been set to "yes"
@@ -556,7 +556,7 @@ Feature: a default expiration date can be specified for shares with users or gro
       | 1               |
       | 2               |
 
-  @skipOnOcV10.3
+
   Scenario Outline: sharing with default expiration date enforced for groups, user shares to another user
     Given using OCS API version "<ocs_api_version>"
     And parameter "shareapi_default_expire_date_group_share" of app "core" has been set to "yes"
@@ -573,7 +573,7 @@ Feature: a default expiration date can be specified for shares with users or gro
       | 1               |
       | 2               |
 
-  @skipOnOcV10.3
+
   Scenario Outline: sharing with default expiration date enforced for users, user shares with invalid expiration date set
     Given using OCS API version "<ocs_api_version>"
     And parameter "shareapi_default_expire_date_user_share" of app "core" has been set to "yes"
@@ -595,7 +595,7 @@ Feature: a default expiration date can be specified for shares with users or gro
       | 1               | 404             | 200              |
       | 2               | 404             | 404              |
 
-  @skipOnOcV10.3
+
   Scenario Outline: sharing with default expiration date enforced for users, user shares with different time format
     Given using OCS API version "2"
     And parameter "shareapi_default_expire_date_user_share" of app "core" has been set to "yes"
@@ -621,7 +621,7 @@ Feature: a default expiration date can be specified for shares with users or gro
       | 11.12.2050          |
       | 11.12.2050 12:30:40 |
 
-  @skipOnOcV10.3
+
   Scenario Outline: user shares with humanized expiration date format
     Given using OCS API version "<ocs_api_version>"
     And parameter "shareapi_default_expire_date_user_share" of app "core" has been set to "<default>"
@@ -655,7 +655,7 @@ Feature: a default expiration date can be specified for shares with users or gro
       | 1               | tomorrow        | no      | no      | 100             |
       | 2               | tomorrow        | no      | no      | 200             |
 
-  @skipOnOcV10.3
+
   Scenario Outline: user shares with humanized expiration date format in past
     Given using OCS API version "<ocs_api_version>"
     And parameter "shareapi_default_expire_date_user_share" of app "core" has been set to "<default>"
@@ -681,7 +681,7 @@ Feature: a default expiration date can be specified for shares with users or gro
       | 1               | 404             | 200              | no      | no      |
       | 2               | 404             | 404              | no      | no      |
 
-  @skipOnOcV10.3
+
   Scenario Outline: user shares with invalid humanized expiration date
     Given using OCS API version "<ocs_api_version>"
     And parameter "shareapi_default_expire_date_user_share" of app "core" has been set to "<default>"
@@ -707,7 +707,7 @@ Feature: a default expiration date can be specified for shares with users or gro
       | 1               | 200              | no      | no      |
       | 2               | 404              | no      | no      |
 
-  @skipOnOcV10.3
+
   Scenario Outline: sharing with default expiration date enforced for users, user shares with past expiration date set
     Given using OCS API version "<ocs_api_version>"
     And parameter "shareapi_default_expire_date_user_share" of app "core" has been set to "yes"
@@ -729,7 +729,7 @@ Feature: a default expiration date can be specified for shares with users or gro
       | 1               | 200              |
       | 2               | 404              |
 
-  @skipOnOcV10.3 @issue-36569
+  @issue-36569
   Scenario Outline: sharing with default expiration date enforced for users, max expire date is 0, user shares without specifying expiration date
     Given using OCS API version "<ocs_api_version>"
     And parameter "shareapi_default_expire_date_user_share" of app "core" has been set to "yes"
@@ -753,7 +753,7 @@ Feature: a default expiration date can be specified for shares with users or gro
       | 1               | 100             |
       | 2               | 200             |
 
-  @skipOnOcV10.3
+
   Scenario Outline: sharing with default expiration date enforced for users, max expire date is 1, user shares without specifying expiration date
     Given using OCS API version "<ocs_api_version>"
     And parameter "shareapi_default_expire_date_user_share" of app "core" has been set to "yes"
@@ -777,7 +777,7 @@ Feature: a default expiration date can be specified for shares with users or gro
       | 1               | 100             |
       | 2               | 200             |
 
-  @skipOnOcV10.6 @skipOnOcV10.7
+
   Scenario: accessing a user share that is expired should not be possible
     Given these users have been created with default attributes and without skeleton files:
       | username |
@@ -797,7 +797,7 @@ Feature: a default expiration date can be specified for shares with users or gro
     And as "Brian" file "/textfile0.txt" should not exist
     And as "Alice" file "/textfile0.txt" should exist
 
-  @skipOnOcV10.6 @skipOnOcV10.7
+
   Scenario: accessing a group share that is expired should not be possible
     Given these users have been created with default attributes and without skeleton files:
       | username |
@@ -819,7 +819,7 @@ Feature: a default expiration date can be specified for shares with users or gro
     And as "Brian" file "/textfile0.txt" should not exist
     And as "Alice" file "/textfile0.txt" should exist
 
-  @skipOnOcV10.6 @skipOnOcV10.7
+
   Scenario: accessing a link share that is expired should not be possible
     Given these users have been created with default attributes and without skeleton files:
       | username |

--- a/tests/acceptance/features/apiShareCreateSpecialToRoot2/createShareDefaultFolderForReceivedShares.feature
+++ b/tests/acceptance/features/apiShareCreateSpecialToRoot2/createShareDefaultFolderForReceivedShares.feature
@@ -4,7 +4,7 @@ Feature: shares are received in the default folder for received shares
   Background:
     Given user "Alice" has been created with default attributes and without skeleton files
 
-  @skipOnOcV10.3.0 @skipOnOcV10.3.1
+
   Scenario Outline: Do not allow sharing of the entire share_folder
     Given using OCS API version "<ocs_api_version>"
     And user "Brian" has been created with default attributes and without skeleton files

--- a/tests/acceptance/features/apiShareCreateSpecialToRoot2/createShareGroupAndUserWithSameName.feature
+++ b/tests/acceptance/features/apiShareCreateSpecialToRoot2/createShareGroupAndUserWithSameName.feature
@@ -5,7 +5,7 @@ Feature: sharing works when a username and group name are the same
     Given user "Alice" has been created with default attributes and without skeleton files
     And user "Alice" has uploaded file with content "Random data" to "/randomfile.txt"
 
-  @skipOnLDAP @skipOnOcV10.3.0 @skipOnOcV10.3.1
+  @skipOnLDAP
   Scenario: creating a new share with user and a group having same name
     Given these users have been created without skeleton files:
       | username |
@@ -24,7 +24,7 @@ Feature: sharing works when a username and group name are the same
     And the content of file "randomfile.txt" for user "Brian" should be "Random data"
     And the content of file "randomfile.txt" for user "Carol" should be "Random data"
 
-  @skipOnLDAP @skipOnOcV10.3.0 @skipOnOcV10.3.1
+  @skipOnLDAP
   Scenario: creating a new share with group and a user having same name
     Given these users have been created without skeleton files:
       | username |

--- a/tests/acceptance/features/apiShareCreateSpecialToShares1/createShareExpirationDate.feature
+++ b/tests/acceptance/features/apiShareCreateSpecialToShares1/createShareExpirationDate.feature
@@ -1,4 +1,4 @@
-@api @files_sharing-app-required @issue-ocis-1328 @issue-ocis-1250 @skipOnOcV10.6 @skipOnOcV10.7 @skipOnOcV10.8.0
+@api @files_sharing-app-required @issue-ocis-1328 @issue-ocis-1250
 Feature: a default expiration date can be specified for shares with users or groups
 
   Background:
@@ -9,7 +9,7 @@ Feature: a default expiration date can be specified for shares with users or gro
       | Alice    |
       | Brian    |
 
-  @skipOnOcV10.3
+
   Scenario Outline: sharing with default expiration date enabled but not enforced for users, user shares without specifying expireDate
     Given using OCS API version "<ocs_api_version>"
     And parameter "shareapi_default_expire_date_user_share" of app "core" has been set to "yes"
@@ -27,7 +27,7 @@ Feature: a default expiration date can be specified for shares with users or gro
       | 1               | 100             | 200              |
       | 2               | 200             | 200              |
 
-  @skipOnOcV10.3 @skipOnOcV10.4 @skipOnOcV10.5
+
   Scenario Outline: sharing with default expiration date enabled but not enforced for users, user shares with expiration date
     Given using OCS API version "<ocs_api_version>"
     And parameter "shareapi_default_expire_date_user_share" of app "core" has been set to "yes"
@@ -52,7 +52,7 @@ Feature: a default expiration date can be specified for shares with users or gro
       | 1               |
       | 2               |
 
-  @skipOnOcV10.3 @skipOnOcV10.4 @skipOnOcV10.5
+
   Scenario Outline: sharing with default expiration date not enabled, user shares with expiration date set
     Given using OCS API version "<ocs_api_version>"
     And user "Alice" has created folder "/FOLDER"
@@ -76,7 +76,7 @@ Feature: a default expiration date can be specified for shares with users or gro
       | 1               |
       | 2               |
 
-  @skipOnOcV10.3
+
   Scenario Outline: sharing with default expiration date enabled but not enforced for users, user shares with expiration date and then disables
     Given using OCS API version "<ocs_api_version>"
     And parameter "shareapi_default_expire_date_user_share" of app "core" has been set to "yes"
@@ -102,7 +102,7 @@ Feature: a default expiration date can be specified for shares with users or gro
       | 1               |
       | 2               |
 
-  @skipOnOcV10.3
+
   Scenario Outline: sharing with default expiration date enabled and enforced for users, user shares with expiration date and then disables
     Given using OCS API version "<ocs_api_version>"
     And parameter "shareapi_default_expire_date_user_share" of app "core" has been set to "yes"
@@ -128,7 +128,7 @@ Feature: a default expiration date can be specified for shares with users or gro
       | 1               |
       | 2               |
 
-  @skipOnOcV10.3
+
   Scenario Outline: sharing with default expiration date enabled but not enforced for groups, user shares without specifying expireDate
     Given using OCS API version "<ocs_api_version>"
     And parameter "shareapi_default_expire_date_group_share" of app "core" has been set to "yes"
@@ -148,7 +148,7 @@ Feature: a default expiration date can be specified for shares with users or gro
       | 1               | 100             | 200              |
       | 2               | 200             | 200              |
 
-  @skipOnOcV10.3 @skipOnOcV10.4 @skipOnOcV10.5
+
   Scenario Outline: sharing with default expiration date enabled but not enforced for groups, user shares with expiration date
     Given using OCS API version "<ocs_api_version>"
     And parameter "shareapi_default_expire_date_group_share" of app "core" has been set to "yes"
@@ -175,7 +175,7 @@ Feature: a default expiration date can be specified for shares with users or gro
       | 1               |
       | 2               |
 
-  @skipOnOcV10.3 @skipOnOcV10.4 @skipOnOcV10.5
+
   Scenario Outline: sharing with default expiration date not enabled for groups, user shares with expiration date set
     Given using OCS API version "<ocs_api_version>"
     And group "grp1" has been created
@@ -201,7 +201,7 @@ Feature: a default expiration date can be specified for shares with users or gro
       | 1               |
       | 2               |
 
-  @skipOnOcV10.3
+
   Scenario Outline: sharing with default expiration date enabled but not enforced for groups, user shares with expiration date and then disables
     Given using OCS API version "<ocs_api_version>"
     And parameter "shareapi_default_expire_date_group_share" of app "core" has been set to "yes"
@@ -229,7 +229,7 @@ Feature: a default expiration date can be specified for shares with users or gro
       | 1               |
       | 2               |
 
-  @skipOnOcV10.3
+
   Scenario Outline: sharing with default expiration date enabled and enforced for groups, user shares with expiration date and then disables
     Given using OCS API version "<ocs_api_version>"
     And parameter "shareapi_default_expire_date_group_share" of app "core" has been set to "yes"
@@ -258,7 +258,7 @@ Feature: a default expiration date can be specified for shares with users or gro
       | 1               |
       | 2               |
 
-  @skipOnOcV10.3 @skipOnOcV10.4 @skipOnOcV10.5
+
   Scenario Outline: sharing with default expiration date enabled and enforced for users, user shares without setting expiration date
     Given using OCS API version "<ocs_api_version>"
     And parameter "shareapi_default_expire_date_user_share" of app "core" has been set to "yes"
@@ -279,7 +279,7 @@ Feature: a default expiration date can be specified for shares with users or gro
       | 1               |
       | 2               |
 
-  @skipOnOcV10.3
+
   Scenario Outline: sharing with default expiration date enabled and enforced for users, user shares with expiration date more than the default
     Given using OCS API version "<ocs_api_version>"
     And parameter "shareapi_default_expire_date_user_share" of app "core" has been set to "yes"
@@ -301,7 +301,7 @@ Feature: a default expiration date can be specified for shares with users or gro
       | 1               | 200              |
       | 2               | 404              |
 
-  @skipOnOcV10.3 @skipOnOcV10.4 @skipOnOcV10.5
+
   Scenario Outline: sharing with default expiration date enabled and enforced for users/max expire date is set, user shares without setting expiration date
     Given using OCS API version "<ocs_api_version>"
     And parameter "shareapi_default_expire_date_user_share" of app "core" has been set to "yes"
@@ -323,7 +323,7 @@ Feature: a default expiration date can be specified for shares with users or gro
       | 1               |
       | 2               |
 
-  @skipOnOcV10.3
+
   Scenario Outline: sharing with default expiration date enabled and enforced for users/max expire date set, user shares with expiration date more than the max expire date
     Given using OCS API version "<ocs_api_version>"
     And parameter "shareapi_default_expire_date_user_share" of app "core" has been set to "yes"
@@ -346,7 +346,7 @@ Feature: a default expiration date can be specified for shares with users or gro
       | 1               | 200              |
       | 2               | 404              |
 
-  @skipOnOcV10.3
+
   Scenario Outline: sharing with default expiration date enabled and enforced for users/max expire date is set, user shares and changes the max expire date greater than the previous one
     Given using OCS API version "<ocs_api_version>"
     And parameter "shareapi_default_expire_date_user_share" of app "core" has been set to "yes"
@@ -363,7 +363,7 @@ Feature: a default expiration date can be specified for shares with users or gro
       | 1               |
       | 2               |
 
-  @skipOnOcV10.3
+
   Scenario Outline: sharing with default expiration date enabled for users/max expire date is set, user shares and changes max expire date less than the previous one
     Given using OCS API version "<ocs_api_version>"
     And parameter "shareapi_default_expire_date_user_share" of app "core" has been set to "yes"
@@ -380,7 +380,7 @@ Feature: a default expiration date can be specified for shares with users or gro
       | 1               |
       | 2               |
 
-  @skipOnOcV10.3 @skipOnOcV10.4 @skipOnOcV10.5
+
   Scenario Outline: sharing with default expiration date enabled and enforced for groups, user shares without setting expiration date
     Given using OCS API version "<ocs_api_version>"
     And parameter "shareapi_default_expire_date_group_share" of app "core" has been set to "yes"
@@ -403,7 +403,7 @@ Feature: a default expiration date can be specified for shares with users or gro
       | 1               |
       | 2               |
 
-  @skipOnOcV10.3
+
   Scenario Outline: sharing with default expiration date enabled and enforced for groups, user shares with expiration date more than the default
     Given using OCS API version "<ocs_api_version>"
     And parameter "shareapi_default_expire_date_group_share" of app "core" has been set to "yes"
@@ -427,7 +427,7 @@ Feature: a default expiration date can be specified for shares with users or gro
       | 1               | 200              |
       | 2               | 404              |
 
-  @skipOnOcV10.3 @skipOnOcV10.4 @skipOnOcV10.5
+
   Scenario Outline: sharing with default expiration date enabled and enforced for groups/max expire date is set, user shares without setting expiration date
     Given using OCS API version "<ocs_api_version>"
     And parameter "shareapi_default_expire_date_group_share" of app "core" has been set to "yes"
@@ -451,7 +451,7 @@ Feature: a default expiration date can be specified for shares with users or gro
       | 1               |
       | 2               |
 
-  @skipOnOcV10.3
+
   Scenario Outline: sharing with default expiration date enabled and enforced for groups/max expire date set, user shares with expiration date more than the max expire date
     Given using OCS API version "<ocs_api_version>"
     And parameter "shareapi_default_expire_date_group_share" of app "core" has been set to "yes"
@@ -476,7 +476,7 @@ Feature: a default expiration date can be specified for shares with users or gro
       | 1               | 200              |
       | 2               | 404              |
 
-  @skipOnOcV10.3
+
   Scenario Outline: sharing with default expiration date enabled for groups/max expire date is set, user shares and changes the max expire date greater than the previous one
     Given using OCS API version "<ocs_api_version>"
     And parameter "shareapi_default_expire_date_group_share" of app "core" has been set to "yes"
@@ -497,7 +497,7 @@ Feature: a default expiration date can be specified for shares with users or gro
       | 1               |
       | 2               |
 
-  @skipOnOcV10.3
+
   Scenario Outline: sharing with default expiration date enabled for groups/max expire date is set, user shares and changes max expire date less than the previous one
     Given using OCS API version "<ocs_api_version>"
     And parameter "shareapi_default_expire_date_group_share" of app "core" has been set to "yes"
@@ -518,7 +518,7 @@ Feature: a default expiration date can be specified for shares with users or gro
       | 1               |
       | 2               |
 
-  @skipOnOcV10.3
+
   Scenario Outline: sharing with default expiration date enforced for users, user shares to a group without setting an expiration date
     Given using OCS API version "<ocs_api_version>"
     And parameter "shareapi_default_expire_date_user_share" of app "core" has been set to "yes"
@@ -537,7 +537,7 @@ Feature: a default expiration date can be specified for shares with users or gro
       | 1               |
       | 2               |
 
-  @skipOnOcV10.3
+
   Scenario Outline: sharing with default expiration date enforced for groups, user shares to another user
     Given using OCS API version "<ocs_api_version>"
     And parameter "shareapi_default_expire_date_group_share" of app "core" has been set to "yes"
@@ -554,7 +554,7 @@ Feature: a default expiration date can be specified for shares with users or gro
       | 1               |
       | 2               |
 
-  @skipOnOcV10.3
+
   Scenario Outline: sharing with default expiration date enforced for users, user shares with invalid expiration date set
     Given using OCS API version "<ocs_api_version>"
     And parameter "shareapi_default_expire_date_user_share" of app "core" has been set to "yes"
@@ -576,7 +576,7 @@ Feature: a default expiration date can be specified for shares with users or gro
       | 1               | 404             | 200              |
       | 2               | 404             | 404              |
 
-  @skipOnOcV10.3
+
   Scenario Outline: sharing with default expiration date enforced for users, user shares with different time format
     Given using OCS API version "2"
     And parameter "shareapi_default_expire_date_user_share" of app "core" has been set to "yes"
@@ -602,7 +602,7 @@ Feature: a default expiration date can be specified for shares with users or gro
       | 11.12.2050          |
       | 11.12.2050 12:30:40 |
 
-  @skipOnOcV10.3
+
   Scenario Outline: user shares with humanized expiration date format
     Given using OCS API version "<ocs_api_version>"
     And parameter "shareapi_default_expire_date_user_share" of app "core" has been set to "<default>"
@@ -634,7 +634,7 @@ Feature: a default expiration date can be specified for shares with users or gro
       | 1               | tomorrow        | no      | no      |
       | 2               | tomorrow        | no      | no      |
 
-  @skipOnOcV10.3
+
   Scenario Outline: user shares with humanized expiration date format in past
     Given using OCS API version "<ocs_api_version>"
     And parameter "shareapi_default_expire_date_user_share" of app "core" has been set to "<default>"
@@ -660,7 +660,7 @@ Feature: a default expiration date can be specified for shares with users or gro
       | 1               | 404             | 200              | no      | no      |
       | 2               | 404             | 404              | no      | no      |
 
-  @skipOnOcV10.3
+
   Scenario Outline: user shares with invalid humanized expiration date
     Given using OCS API version "<ocs_api_version>"
     And parameter "shareapi_default_expire_date_user_share" of app "core" has been set to "<default>"
@@ -686,7 +686,7 @@ Feature: a default expiration date can be specified for shares with users or gro
       | 1               | 404             | 200              | no      | no      |
       | 2               | 404             | 404              | no      | no      |
 
-  @skipOnOcV10.3
+
   Scenario Outline: sharing with default expiration date enforced for users, user shares with past expiration date set
     Given using OCS API version "<ocs_api_version>"
     And parameter "shareapi_default_expire_date_user_share" of app "core" has been set to "yes"
@@ -708,7 +708,7 @@ Feature: a default expiration date can be specified for shares with users or gro
       | 1               | 404             | 200              |
       | 2               | 404             | 404              |
 
-  @skipOnOcV10.3 @issue-36569
+  @issue-36569
   Scenario Outline: sharing with default expiration date enforced for users, max expire date is 0, user shares without specifying expiration date
     Given using OCS API version "<ocs_api_version>"
     And parameter "shareapi_default_expire_date_user_share" of app "core" has been set to "yes"
@@ -732,7 +732,7 @@ Feature: a default expiration date can be specified for shares with users or gro
       | 1               | 100             |
       | 2               | 200             |
 
-  @skipOnOcV10.3
+
   Scenario Outline: sharing with default expiration date enforced for users, max expire date is 1, user shares without specifying expiration date
     Given using OCS API version "<ocs_api_version>"
     And parameter "shareapi_default_expire_date_user_share" of app "core" has been set to "yes"

--- a/tests/acceptance/features/apiShareCreateSpecialToShares1/createShareResourceCaseSensitiveName.feature
+++ b/tests/acceptance/features/apiShareCreateSpecialToShares1/createShareResourceCaseSensitiveName.feature
@@ -1,4 +1,4 @@
-@api @files_sharing-app-required @skipOnOcV10.6 @skipOnOcV10.7 @skipOnOcV10.8.0
+@api @files_sharing-app-required
 Feature: Sharing resources with different case names with the sharee and checking the coexistence of resources on sharee/receivers side
 
   Background:

--- a/tests/acceptance/features/apiShareCreateSpecialToShares1/createShareUniqueReceivedNames.feature
+++ b/tests/acceptance/features/apiShareCreateSpecialToShares1/createShareUniqueReceivedNames.feature
@@ -1,4 +1,4 @@
-@api @files_sharing-app-required @skipOnOcV10.6 @skipOnOcV10.7 @skipOnOcV10.8.0
+@api @files_sharing-app-required
 Feature: resources shared with the same name are received with unique names
 
   Background:

--- a/tests/acceptance/features/apiShareCreateSpecialToShares2/createShareDefaultFolderForReceivedShares.feature
+++ b/tests/acceptance/features/apiShareCreateSpecialToShares2/createShareDefaultFolderForReceivedShares.feature
@@ -6,7 +6,7 @@ Feature: shares are received in the default folder for received shares
     And auto-accept shares has been disabled
     And user "Alice" has been created with default attributes and without skeleton files
 
-  @skipOnOcV10.6 @skipOnOcV10.7 @skipOnOcV10.8.0
+
   Scenario Outline: Do not allow sharing of the entire share_folder
     Given using OCS API version "<ocs_api_version>"
     And user "Brian" has been created with default attributes and without skeleton files

--- a/tests/acceptance/features/apiShareCreateSpecialToShares2/createShareGroupAndUserWithSameName.feature
+++ b/tests/acceptance/features/apiShareCreateSpecialToShares2/createShareGroupAndUserWithSameName.feature
@@ -1,4 +1,4 @@
-@api @files_sharing-app-required @skipOnOcV10.6 @skipOnOcV10.7 @skipOnOcV10.8.0
+@api @files_sharing-app-required
 Feature: sharing works when a username and group name are the same
 
   Background:

--- a/tests/acceptance/features/apiShareCreateSpecialToShares2/createShareGroupCaseSensitive.feature
+++ b/tests/acceptance/features/apiShareCreateSpecialToShares2/createShareGroupCaseSensitive.feature
@@ -1,4 +1,4 @@
-@api @files_sharing-app-required @skipOnOcV10.6 @skipOnOcV10.7 @skipOnOcV10.8.0 @notToImplementOnOCIS
+@api @files_sharing-app-required @notToImplementOnOCIS
 Feature: share with groups, group names are case-sensitive
 
   Background:

--- a/tests/acceptance/features/apiShareCreateSpecialToShares2/createShareReceivedInMultipleWays.feature
+++ b/tests/acceptance/features/apiShareCreateSpecialToShares2/createShareReceivedInMultipleWays.feature
@@ -1,4 +1,4 @@
-@api @files_sharing-app-required @skipOnOcV10.6 @skipOnOcV10.7 @skipOnOcV10.8.0
+@api @files_sharing-app-required
 Feature: share resources where the sharee receives the share in multiple ways
 
   Background:
@@ -65,7 +65,6 @@ Feature: share resources where the sharee receives the share in multiple ways
       | /Shares/PARENT/parent.txt |
       | /Shares/CHILD/            |
       | /Shares/CHILD/child.txt   |
-    @skipOnOcV10.6 @skipOnOcV10.7 @skipOnOcV10.8.0
     Examples:
       | ocs_api_version | ocs_status_code | pending_sub_share_path |
       | 1               | 100             | /CHILD                 |
@@ -83,7 +82,6 @@ Feature: share resources where the sharee receives the share in multiple ways
     And the HTTP status code should be "200"
     And user "Brian" should be able to accept pending share "<pending_share_path>" offered by user "Alice"
     And as "Brian" folder "/Shares/sub" should exist
-    @skipOnOcV10.6 @skipOnOcV10.7 @skipOnOcV10.8.0
     Examples:
       | ocs_api_version | ocs_status_code | pending_share_path |
       | 1               | 100             | /sub               |
@@ -102,7 +100,6 @@ Feature: share resources where the sharee receives the share in multiple ways
     And the HTTP status code should be "200"
     And user "Brian" should be able to accept pending share "<pending_share_path>" offered by user "Alice"
     And as "Brian" folder "/Shares/sub" should exist
-    @skipOnOcV10.6 @skipOnOcV10.7 @skipOnOcV10.8.0
     Examples:
       | ocs_api_version | ocs_status_code | pending_share_path |
       | 1               | 100             | /sub               |
@@ -240,7 +237,7 @@ Feature: share resources where the sharee receives the share in multiple ways
     And user "Brian" should be able to create folder "/Shares/parent/fo1"
     And user "Brian" should be able to create folder "/Shares/parent/child1/fo2"
     And user "Alice" should not be able to create folder "/Shares/child1/fo3"
-    @skipOnOcV10.6 @skipOnOcV10.7 @skipOnOcV10.8.0 @issue-2440
+    @issue-2440
     Examples:
       | path    |
       | /child1 |
@@ -275,7 +272,7 @@ Feature: share resources where the sharee receives the share in multiple ways
     And user "Brian" should be able to rename file "/Shares/parent/child1/child2/textfile-2.txt" to "/Shares/parent/child1/child2/rename.txt"
     And user "Brian" should not be able to rename file "/Shares/child1/child2/rename.txt" to "/Shares/child1/child2/rename2.txt"
     And user "Alice" should not be able to rename file "/Shares/child1/child2/rename.txt" to "/Shares/child1/child2/rename2.txt"
-    @skipOnOcV10.6 @skipOnOcV10.7 @skipOnOcV10.8.0 @issue-2440
+    @issue-2440
     Examples:
       | path    |
       | /child1 |
@@ -310,7 +307,7 @@ Feature: share resources where the sharee receives the share in multiple ways
     And user "Brian" should be able to delete file "/Shares/parent/child1/child2/textfile-2.txt"
     And user "Brian" should not be able to delete folder "/Shares/child1/child2"
     And user "Alice" should not be able to delete folder "/Shares/child1/child2"
-    @skipOnOcV10.6 @skipOnOcV10.7 @skipOnOcV10.8.0 @issue-2440
+    @issue-2440
     Examples:
       | path    |
       | /child1 |
@@ -350,7 +347,6 @@ Feature: share resources where the sharee receives the share in multiple ways
     And as "Brian" folder "/Shares/child1" should exist
     And as "Alice" folder "/Shares/child1" should exist
     And as "Alice" folder "/Shares/parent" should exist
-    @skipOnOcV10.6 @skipOnOcV10.7 @skipOnOcV10.8.0
     Examples:
       | path    |
       | /child1 |
@@ -386,7 +382,6 @@ Feature: share resources where the sharee receives the share in multiple ways
     But user "Brian" should not be able to create folder "/Shares/parent/fo3"
     And user "Brian" should not be able to create folder "/Shares/parent/fo3"
     And user "Alice" should not be able to create folder "/Shares/parent/fo3"
-    @skipOnOcV10.6 @skipOnOcV10.7 @skipOnOcV10.8.0
     Examples:
       | path    |
       | /child1 |
@@ -421,7 +416,7 @@ Feature: share resources where the sharee receives the share in multiple ways
     And user "Brian" should be able to rename file "/Shares/child1/child2/textfile-2.txt" to "/Shares/child1/child2/rename.txt"
     And user "Brian" should not be able to rename file "/Shares/parent/child1/child2/rename.txt" to "/Shares/parent/child1/child2/rename2.txt"
     And user "Alice" should not be able to rename file "/Shares/parent/child1/child2/rename.txt" to "/Shares/parent/child1/child2/rename2.txt"
-    @skipOnOcV10.6 @skipOnOcV10.7 @skipOnOcV10.8.0 @issue-ocis-2440
+    @issue-ocis-2440
     Examples:
       | path    |
       | /child1 |
@@ -456,7 +451,7 @@ Feature: share resources where the sharee receives the share in multiple ways
     And user "Brian" should be able to delete file "/Shares/child1/child2/textfile-2.txt"
     And user "Brian" should not be able to delete folder "/Shares/parent/child1"
     And user "Alice" should not be able to delete folder "/Shares/parent/child1"
-    @skipOnOcV10.6 @skipOnOcV10.7 @skipOnOcV10.8.0 @issue-ocis-2440
+    @issue-ocis-2440
     Examples:
       | path    |
       | /child1 |
@@ -492,7 +487,6 @@ Feature: share resources where the sharee receives the share in multiple ways
     And as "Brian" folder "/Shares/parent" should exist
     And as "Alice" folder "/Shares/parent" should exist
     And as "Alice" folder "/Shares/child1" should exist
-    @skipOnOcV10.6 @skipOnOcV10.7 @skipOnOcV10.8.0
     Examples:
       | path    |
       | /child1 |
@@ -538,7 +532,6 @@ Feature: share resources where the sharee receives the share in multiple ways
     And user "Brian" should not be able to create folder "/Shares/child1/child2/fo2"
     And user "Brian" should not be able to rename file "/Shares/child1/child2/rename.txt" to "/Shares/child1/child2/rename2.txt"
     And user "Brian" should not be able to share folder "/Shares/child1" with group "grp3" with permissions "read" using the sharing API
-    @skipOnOcV10.6 @skipOnOcV10.7 @skipOnOcV10.8.0
     Examples:
       | path    |
       | /child1 |

--- a/tests/acceptance/features/apiShareCreateSpecialToShares2/createShareReceivedMultipleWaysIssue39347.feature
+++ b/tests/acceptance/features/apiShareCreateSpecialToShares2/createShareReceivedMultipleWaysIssue39347.feature
@@ -1,4 +1,4 @@
-@api @files_sharing-app-required @skipOnOcV10.6 @skipOnOcV10.7 @skipOnOcV10.8.0 @notToImplementOnOCIS
+@api @files_sharing-app-required @notToImplementOnOCIS
 Feature: share resources where the sharee receives the share in multiple ways
 
   # These are the bug demonstration scenarios for https://github.com/owncloud/core/issues/39347

--- a/tests/acceptance/features/apiShareCreateSpecialToShares2/createShareWhenShareWithOnlyMembershipGroups.feature
+++ b/tests/acceptance/features/apiShareCreateSpecialToShares2/createShareWhenShareWithOnlyMembershipGroups.feature
@@ -27,7 +27,7 @@ Feature: cannot share resources outside the group when share with membership gro
       | 1               | 403             | 200              |
       | 2               | 403             | 403              |
 
-  @skipOnOcV10.6 @skipOnOcV10.7 @skipOnOcV10.8.0
+
   Scenario Outline: sharer should be able to share a folder to a user who is not member of sharer group when share with only member group is enabled
     Given using OCS API version "<ocs_api_version>"
     And parameter "shareapi_only_share_with_membership_groups" of app "core" has been set to "yes"
@@ -46,7 +46,7 @@ Feature: cannot share resources outside the group when share with membership gro
       | 1               | 100             |
       | 2               | 200             |
 
-  @skipOnOcV10.6 @skipOnOcV10.7 @skipOnOcV10.8.0
+
   Scenario Outline: sharer should be able to share a folder to a group which he/she is member of when share with only member group is enabled
     Given using OCS API version "<ocs_api_version>"
     And parameter "shareapi_only_share_with_membership_groups" of app "core" has been set to "yes"
@@ -87,7 +87,7 @@ Feature: cannot share resources outside the group when share with membership gro
       | 1               | 403             | 200              |
       | 2               | 403             | 403              |
 
-  @skipOnOcV10.6 @skipOnOcV10.7 @skipOnOcV10.8.0
+
   Scenario Outline: sharer should be able to share a file to a group which he/she is member of when share with only member group is enabled
     Given using OCS API version "<ocs_api_version>"
     And parameter "shareapi_only_share_with_membership_groups" of app "core" has been set to "yes"
@@ -107,7 +107,7 @@ Feature: cannot share resources outside the group when share with membership gro
       | 1               | 100             |
       | 2               | 200             |
 
-  @skipOnOcV10.6 @skipOnOcV10.7 @skipOnOcV10.8.0
+
   Scenario Outline: sharer should be able to share a file to a user who is not a member of sharer group when share with only member group is enabled
     Given using OCS API version "<ocs_api_version>"
     And parameter "shareapi_only_share_with_membership_groups" of app "core" has been set to "yes"

--- a/tests/acceptance/features/apiShareManagementBasicToRoot/createShareToRootFolder.feature
+++ b/tests/acceptance/features/apiShareManagementBasicToRoot/createShareToRootFolder.feature
@@ -4,7 +4,7 @@ Feature: sharing
   Background:
     Given user "Alice" has been created with default attributes and without skeleton files
 
-  @smokeTest @skipOnEncryptionType:user-keys @issue-32322 @skipOnOcV10.8 @skipOnOcV10.9.0 @skipOnOcV10.9.1
+  @smokeTest @skipOnEncryptionType:user-keys @issue-32322
   Scenario Outline: Creating a share of a file with a user, the default permissions are read(1)+update(2)+can-share(16)
     Given using OCS API version "<ocs_api_version>"
     And user "Brian" has been created with default attributes and without skeleton files
@@ -338,7 +338,7 @@ Feature: sharing
       | 1               | 100             |
       | 2               | 200             |
 
-  @skipOnOcV10.6 @skipOnOcV10.7 @skipOnOcV10.8.0
+
   Scenario: share with user when username contains capital letters
     Given these users have been created without skeleton files:
       | username |

--- a/tests/acceptance/features/apiShareManagementBasicToShares/createShareFromLocalStorageToSharesFolder.feature
+++ b/tests/acceptance/features/apiShareManagementBasicToShares/createShareFromLocalStorageToSharesFolder.feature
@@ -32,7 +32,6 @@ Feature: local-storage
     Then the OCS status code should be "<ocs_status_code>"
     And the HTTP status code should be "200"
     And as "Brian" file "/Shares/filetoshare.txt" should exist
-    @skipOnOcV10.6 @skipOnOcV10.7 @skipOnOcV10.8.0
     Examples:
       | ocs_api_version | ocs_status_code | pending_share_path  |
       | 1               | 100             | /filetoshare.txt    |

--- a/tests/acceptance/features/apiShareManagementBasicToShares/createShareToSharesFolder.feature
+++ b/tests/acceptance/features/apiShareManagementBasicToShares/createShareToSharesFolder.feature
@@ -6,7 +6,7 @@ Feature: sharing
     And auto-accept shares has been disabled
     And user "Alice" has been created with default attributes and without skeleton files
 
-  @smokeTest @skipOnOcV10.8 @skipOnOcV10.9.0 @skipOnOcV10.9.1 @skipOnEncryptionType:user-keys @issue-32322
+  @smokeTest @skipOnEncryptionType:user-keys @issue-32322
   Scenario Outline: Creating a share of a file with a user, the default permissions are read(1)+update(2)+can-share(16)
     Given using OCS API version "<ocs_api_version>"
     And user "Brian" has been created with default attributes and without skeleton files
@@ -36,7 +36,7 @@ Feature: sharing
       | 1               | 100             |
       | 2               | 200             |
 
-  @smokeTest @skipOnOcV10.6 @skipOnOcV10.7 @skipOnOcV10.8.0 @skipOnEncryptionType:user-keys @issue-32322 @issue-ocis-2133
+  @smokeTest @skipOnEncryptionType:user-keys @issue-32322 @issue-ocis-2133
   Scenario Outline: Creating a share of a file containing commas in the filename, with a user, the default permissions are read(1)+update(2)+can-share(16)
     Given using OCS API version "<ocs_api_version>"
     And user "Brian" has been created with default attributes and without skeleton files
@@ -207,7 +207,7 @@ Feature: sharing
       | 1               | 100             |
       | 2               | 200             |
 
-  @smokeTest @skipOnOcV10.6 @skipOnOcV10.7 @skipOnOcV10.8.0
+  @smokeTest
   Scenario Outline: Share of folder to a group
     Given using OCS API version "<ocs_api_version>"
     And these users have been created with default attributes and without skeleton files:
@@ -274,7 +274,7 @@ Feature: sharing
       | 1               | 100             |
       | 2               | 200             |
 
-  @skipOnOcV10.6 @skipOnOcV10.7 @skipOnOcV10.8.0
+ 
   Scenario Outline: sharing again an own file while belonging to a group
     Given using OCS API version "<ocs_api_version>"
     And user "Brian" has been created with default attributes and without skeleton files
@@ -326,7 +326,7 @@ Feature: sharing
       | 1               | 100             |
       | 2               | 200             |
 
-  @skipOnOcV10.6 @skipOnOcV10.7 @skipOnOcV10.8.0
+ 
   Scenario Outline: user shares a file with file name longer than 64 chars to another user
     Given using OCS API version "<ocs_api_version>"
     And user "Brian" has been created with default attributes and without skeleton files
@@ -342,7 +342,7 @@ Feature: sharing
       | 1               | 100             |
       | 2               | 200             |
 
-  @skipOnOcV10.6 @skipOnOcV10.7 @skipOnOcV10.8.0
+ 
   Scenario Outline: user shares a file with file name longer than 64 chars to a group
     Given using OCS API version "<ocs_api_version>"
     And group "grp1" has been created
@@ -360,7 +360,7 @@ Feature: sharing
       | 1               | 100             |
       | 2               | 200             |
 
-  @skipOnOcV10.6 @skipOnOcV10.7 @skipOnOcV10.8.0
+ 
   Scenario Outline: user shares a folder with folder name longer than 64 chars to another user
     Given using OCS API version "<ocs_api_version>"
     And user "Brian" has been created with default attributes and without skeleton files
@@ -377,7 +377,7 @@ Feature: sharing
       | 1               | 100             |
       | 2               | 200             |
 
-  @skipOnOcV10.6 @skipOnOcV10.7 @skipOnOcV10.8.0
+ 
   Scenario Outline: user shares a folder with folder name longer than 64 chars to a group
     Given using OCS API version "<ocs_api_version>"
     And group "grp1" has been created
@@ -396,7 +396,7 @@ Feature: sharing
       | 1               | 100             |
       | 2               | 200             |
 
-  @issue-ocis-reva-11 @skipOnOcV10.6 @skipOnOcV10.7 @skipOnOcV10.8.0
+  @issue-ocis-reva-11
   Scenario: share with user when username contains capital letters
     Given these users have been created without skeleton files:
       | username |
@@ -418,7 +418,7 @@ Feature: sharing
      | /Shares/randomfile.txt |
     And the content of file "Shares/randomfile.txt" for user "brian" should be "Random data"
 
-  @skipOnLDAP @skipOnOcV10.6 @skipOnOcV10.7 @skipOnOcV10.8.0
+  @skipOnLDAP
   Scenario: creating a new share with user of a group when username contains capital letters
     Given these users have been created without skeleton files:
       | username |
@@ -434,7 +434,7 @@ Feature: sharing
       | /Shares/randomfile.txt |
     And the content of file "/Shares/randomfile.txt" for user "Brian" should be "Random data"
 
-  @issue-ocis-reva-34 @skipOnOcV10.6 @skipOnOcV10.7 @skipOnOcV10.8.0
+  @issue-ocis-reva-34
   Scenario Outline: Share of folder to a group with emoji in the name
     Given using OCS API version "<ocs_api_version>"
     And these users have been created with default attributes and without skeleton files:
@@ -466,7 +466,7 @@ Feature: sharing
       | 1               | 100             |
       | 2               | 200             |
 
-  @skipOnEncryptionType:user-keys @encryption-issue-132 @skipOnLDAP @skipOnOcV10.6 @skipOnOcV10.7 @skipOnOcV10.8.0 @skipOnGraph
+  @skipOnEncryptionType:user-keys @encryption-issue-132 @skipOnLDAP @skipOnGraph
   Scenario Outline: share with a group and then add a user to that group
     Given using OCS API version "<ocs_api_version>"
     And these users have been created with default attributes and without skeleton files:
@@ -523,7 +523,7 @@ Feature: sharing
     And file "/textfile0.txt" should not be included as path in the response
     And as "Brian" file "/Shares/textfile0.txt" should not exist
     And as "Carol" file "/Shares/textfile0.txt" should not exist
-    @skipOnOcis @skipOnOcV10.6 @skipOnOcV10.7 @skipOnOcV10.8.0
+    @skipOnOcis
     Examples:
       | ocs_api_version | ocs_status_code | path                  |
       | 1               | 100             | /Shares/textfile0.txt |
@@ -534,7 +534,7 @@ Feature: sharing
       | 1               | 100             | /textfile0.txt |
       | 2               | 200             | /textfile0.txt |
 
-  @skipOnFilesClassifier @issue-files-classifier-291 @issue-ocis-2146 @skipOnOcV10.6 @skipOnOcV10.7 @skipOnOcV10.8.0
+  @skipOnFilesClassifier @issue-files-classifier-291 @issue-ocis-2146
   Scenario: Share a file by multiple channels and download from sub-folder and direct file share
     Given these users have been created with default attributes and without skeleton files:
       | username |
@@ -580,7 +580,6 @@ Feature: sharing
 #    Then the HTTP status code should be "405"
     And the sharing API should report to user "Brian" that no shares are in the pending state
     And as "Brian" folder "/Shares/userOneFolder" should not exist
-    @skipOnOcV10.6 @skipOnOcV10.7 @skipOnOcV10.8.0
     Examples:
       | pending_share_path |
       | /userOneFolder     |
@@ -602,7 +601,6 @@ Feature: sharing
 #    Then the HTTP status code should be "405"
     And the sharing API should report to user "Alice" that no shares are in the pending state
     And as "Alice" folder "/Shares/userOneFolder" should not exist
-    @skipOnOcV10.6 @skipOnOcV10.7 @skipOnOcV10.8.0
     Examples:
       | pending_share_path |
       | /userOneFolder     |
@@ -627,12 +625,11 @@ Feature: sharing
 #    Then the HTTP status code should be "405"
     And the sharing API should report to user "Carol" that no shares are in the pending state
     And as "Carol" folder "/Shares/userOneFolder" should not exist
-    @skipOnOcV10.6 @skipOnOcV10.7 @skipOnOcV10.8.0
     Examples:
       | pending_share_path |
       | /userOneFolder     |
 
-  @smokeTest @skipOnOcV10.6 @skipOnOcV10.7 @skipOnOcV10.8.0
+  @smokeTest
   Scenario Outline: Creating a share of a renamed file
     Given using OCS API version "<ocs_api_version>"
     And user "Brian" has been created with default attributes and without skeleton files
@@ -662,7 +659,7 @@ Feature: sharing
       | 1               | 100             |
       | 2               | 200             |
 
-  @skipOnOcV10.6 @skipOnOcV10.7 @skipOnOcV10.8.0 @issue-ocis-903
+  @issue-ocis-903
   Scenario Outline: shares to a deleted user should not be listed as shares for the sharer
     Given using OCS API version "<ocs_api_version>"
     And these users have been created with default attributes and without skeleton files:
@@ -685,7 +682,7 @@ Feature: sharing
       | 1               | 100             |
       | 2               | 200             |
 
-  @issue-ocis-719 @skipOnOcV10.6 @skipOnOcV10.7 @skipOnOcV10.8.0
+  @issue-ocis-719
   Scenario Outline: Creating a share of a renamed file when another share exists
     Given using OCS API version "<ocs_api_version>"
     And user "Brian" has been created with default attributes and without skeleton files
@@ -733,7 +730,7 @@ Feature: sharing
       | 1               | 200         |
       | 2               | 403         |
 
-  @issue-ocis-2215 @skipOnOcV10.6 @skipOnOcV10.7 @skipOnOcV10.8.0
+  @issue-ocis-2215
   Scenario Outline: Sharing the shares folder to users is not possible
     Given using OCS API version "<ocs-api-version>"
     And user "Brian" has been created with default attributes and without skeleton files
@@ -750,7 +747,7 @@ Feature: sharing
       | 1               | 200         |
       | 2               | 403         |
 
-  @issue-ocis-2215 @skipOnOcV10.6 @skipOnOcV10.7 @skipOnOcV10.8.0
+  @issue-ocis-2215
   Scenario Outline: Sharing the shares folder to groups is not possible
     Given using OCS API version "<ocs-api-version>"
     And user "Brian" has been created with default attributes and without skeleton files
@@ -769,7 +766,7 @@ Feature: sharing
       | 1               | 200         |
       | 2               | 403         |
 
-  @issue-ocis-2215 @skipOnOcV10.6 @skipOnOcV10.7 @skipOnOcV10.8.0
+  @issue-ocis-2215
   Scenario Outline: Sharing the shares folder as public link is not possible
     Given using OCS API version "<ocs-api-version>"
     And user "Brian" has been created with default attributes and without skeleton files

--- a/tests/acceptance/features/apiShareManagementBasicToShares/deleteShareFromShares.feature
+++ b/tests/acceptance/features/apiShareManagementBasicToShares/deleteShareFromShares.feature
@@ -1,4 +1,4 @@
-@api @files_sharing-app-required @issue-ocis-1328 @issue-ocis-1289 @skipOnOcV10.6 @skipOnOcV10.7 @skipOnOcV10.8.0
+@api @files_sharing-app-required @issue-ocis-1328 @issue-ocis-1289
 Feature: sharing
 
   Background:
@@ -55,7 +55,6 @@ Feature: sharing
     Then the HTTP status code should be "204"
     And as "Brian" folder "/Shares/sub" should not exist
     And as "Brian" folder "/sub" should not exist
-    @skipOnOcV10.6 @skipOnOcV10.7 @skipOnOcV10.8.0
     Examples:
       | pending_share_path |
       | /sub               |
@@ -111,7 +110,6 @@ Feature: sharing
     And the etag of element "/" of user "Brian" should have changed
     And the etag of element "/Shares" of user "Brian" should have changed
     And the etag of element "/PARENT" of user "Carol" should not have changed
-    @skipOnOcV10.6 @skipOnOcV10.7 @skipOnOcV10.8.0
     Examples:
       | pending_share_path |
       | /parent.txt        |
@@ -174,7 +172,6 @@ Feature: sharing
     And as "Alice" entry "<entry_to_share>" should exist
     And as "Brian" entry "<received_entry>" should exist
     And as "Carol" entry "<received_entry>" should exist
-    @skipOnOcV10.6 @skipOnOcV10.7 @skipOnOcV10.8.0
     Examples:
       | entry_to_share          | ocs_api_version | http_status_code | received_entry          | pending_entry           |
       | /shared/shared_file.txt | 1               | 200              | /Shares/shared_file.txt | /Shares/shared_file.txt |
@@ -194,7 +191,6 @@ Feature: sharing
     And the HTTP status code should be "<http_status_code>"
     And as "Alice" entry "<entry_to_share>" should exist
     And as "Brian" entry "<received_entry>" should exist
-    @skipOnOcV10.6 @skipOnOcV10.7 @skipOnOcV10.8.0
     Examples:
       | entry_to_share          | ocs_api_version | http_status_code | received_entry          | pending_entry           |
       | /shared/shared_file.txt | 1               | 200              | /Shares/shared_file.txt | /Shares/shared_file.txt |

--- a/tests/acceptance/features/apiShareManagementBasicToShares/excludeGroupFromReceivingSharesToSharesFolder.feature
+++ b/tests/acceptance/features/apiShareManagementBasicToShares/excludeGroupFromReceivingSharesToSharesFolder.feature
@@ -1,4 +1,4 @@
-@api @files_sharing-app-required @skipOnOcV10.6 @skipOnOcV10.7 @skipOnOcV10.8.0
+@api @files_sharing-app-required
 Feature: Exclude groups from receiving shares
   As an admin
   I want to exclude groups from receiving shares

--- a/tests/acceptance/features/apiShareManagementToRoot/acceptShares.feature
+++ b/tests/acceptance/features/apiShareManagementToRoot/acceptShares.feature
@@ -153,7 +153,6 @@ Feature: accept/decline shares coming from internal users
       | path                    |
       | <declined_share_path_1> |
       | <declined_share_path_2> |
-    @skipOnOcV10.6 @skipOnOcV10.7 @skipOnOcV10.8.0
     Examples:
       | declined_share_path_1 | declined_share_path_2 |
       | /PARENT (2)/          | /textfile0 (2).txt    |
@@ -177,7 +176,6 @@ Feature: accept/decline shares coming from internal users
       | path               |
       | /PARENT (2)/       |
       | /textfile0 (2).txt |
-    @skipOnOcV10.6 @skipOnOcV10.7 @skipOnOcV10.8.0
     Examples:
       | pending_share_path_1 | pending_share_path_2 |
       | /PARENT (2)          | /textfile0 (2).txt   |
@@ -198,7 +196,6 @@ Feature: accept/decline shares coming from internal users
       | path                    |
       | <declined_share_path_1> |
       | <declined_share_path_2> |
-    @skipOnOcV10.6 @skipOnOcV10.7 @skipOnOcV10.8.0
     Examples:
       | declined_share_path_1 | declined_share_path_2 |
       | /PARENT (2)/          | /textfile0 (2).txt    |
@@ -227,7 +224,6 @@ Feature: accept/decline shares coming from internal users
       | path               |
       | /PARENT (2)/       |
       | /textfile0 (2).txt |
-    @skipOnOcV10.6 @skipOnOcV10.7 @skipOnOcV10.8.0
     Examples:
       | declined_share_path_1 | declined_share_path_2 |
       | /PARENT (2)/          | /textfile0 (2).txt    |
@@ -247,7 +243,6 @@ Feature: accept/decline shares coming from internal users
     And the sharing API should report to user "Brian" that these shares are in the declined state
       | path                  |
       | <declined_share_path> |
-    @skipOnOcV10.6 @skipOnOcV10.7 @skipOnOcV10.8.0
     Examples:
       | declined_share_path |
       | /PARENT-renamed/    |
@@ -267,7 +262,6 @@ Feature: accept/decline shares coming from internal users
     And the sharing API should report to user "Brian" that these shares are in the accepted state
       | path             |
       | /PARENT-renamed/ |
-    @skipOnOcV10.6 @skipOnOcV10.7 @skipOnOcV10.8.0
     Examples:
       | declined_share_path |
       | /PARENT-renamed     |
@@ -289,7 +283,6 @@ Feature: accept/decline shares coming from internal users
     And the sharing API should report to user "Brian" that these shares are in the accepted state
       | path            |
       | /PARENT/shared/ |
-    @skipOnOcV10.6 @skipOnOcV10.7 @skipOnOcV10.8.0
     Examples:
       | declined_share_path |
       | /PARENT/shared      |
@@ -313,7 +306,6 @@ Feature: accept/decline shares coming from internal users
     And the sharing API should report to user "Brian" that these shares are in the accepted state
       | path     |
       | /shared/ |
-    @skipOnOcV10.6 @skipOnOcV10.7 @skipOnOcV10.8.0
     Examples:
       | declined_share_path |
       | /PARENT/shared      |
@@ -430,7 +422,7 @@ Feature: accept/decline shares coming from internal users
       | /PARENT (2)/       |
       | /textfile0 (2).txt |
 
-  @skipOnOcV10.6 @skipOnOcV10.7 @skipOnOcV10.8.0
+
   Scenario Outline: accept a pending share when there is a default folder for received shares
     Given parameter "shareapi_auto_accept_share" of app "core" has been set to "no"
     And the administrator has set the default folder for received shares to "<share_folder>"
@@ -535,7 +527,6 @@ Feature: accept/decline shares coming from internal users
       | path                    |
       | <declined_share_path_1> |
       | <declined_share_path_2> |
-    @skipOnOcV10.6 @skipOnOcV10.7 @skipOnOcV10.8.0
     Examples:
       | declined_share_path_1 | declined_share_path_2 |
       | /PARENT (2)/          | /textfile0 (2).txt    |
@@ -629,7 +620,6 @@ Feature: accept/decline shares coming from internal users
     And the content of file "/testfile.txt" for user "Carol" should be "Third file"
     And the content of file "/testfile (2).txt" for user "Carol" should be "Second file"
     And the content of file "/testfile (2) (2).txt" for user "Carol" should be "First file"
-    @skipOnOcV10.6 @skipOnOcV10.7 @skipOnOcV10.8.0
     Examples:
       | accepted_share_path |
       | /testfile (2).txt   |
@@ -658,7 +648,6 @@ Feature: accept/decline shares coming from internal users
       | /PARENT (2)/         | David     |
       | /PARENT (2) (2)/     | Carol     |
       | /PARENT (2) (2) (2)/ | Brian     |
-    @skipOnOcV10.6 @skipOnOcV10.7 @skipOnOcV10.8.0
     Examples:
       | accepted_share_path_1 | accepted_share_path_2 |
       | /PARENT (2)           | /PARENT (2) (2)       |
@@ -785,7 +774,7 @@ Feature: accept/decline shares coming from internal users
       | /textfile0.txt     |
       | /textfile0 (2).txt |
 
-  @skipOnLDAP @skipOnOcV10.5 @skipOnOcV10.6.0
+  @skipOnLDAP
   Scenario: user shares folder with matching folder name a user before that user has logged in
     Given these users have been created with small skeleton files but not initialized:
       | username |

--- a/tests/acceptance/features/apiShareManagementToRoot/moveReceivedShare.feature
+++ b/tests/acceptance/features/apiShareManagementToRoot/moveReceivedShare.feature
@@ -88,7 +88,7 @@ Feature: sharing
     And as "Alice" file "/folderToShare/renamedFile" should exist
     But as "Alice" file "/folderToShare/fileInside" should not exist
 
-  @skipOnOcV10.6 @skipOnOcV10.7
+
   Scenario: receiver tries to rename a received share with share, read permissions
     Given user "Alice" has created folder "folderToShare"
     And user "Alice" has uploaded file with content "thisIsAFileInsideTheSharedFolder" to "/folderToShare/fileInside"

--- a/tests/acceptance/features/apiShareManagementToShares/acceptShares.feature
+++ b/tests/acceptance/features/apiShareManagementToShares/acceptShares.feature
@@ -59,7 +59,7 @@ Feature: accept/decline shares coming from internal users
       | path                   |
       | <pending_share_path_1> |
       | <pending_share_path_2> |
-    @skipOnOcV10.6 @skipOnOcV10.7 @skipOnOcV10.8.0 @issue-ocis-2540
+    @issue-ocis-2540
     Examples:
       | pending_share_path_1 | pending_share_path_2  |
       | /Shares/PARENT/      | /Shares/textfile0.txt |
@@ -82,12 +82,12 @@ Feature: accept/decline shares coming from internal users
       | path                   |
       | <pending_share_path_1> |
       | <pending_share_path_2> |
-    @skipOnOcV10.6 @skipOnOcV10.7 @skipOnOcV10.8.0 @issue-ocis-2540
+    @issue-ocis-2540
     Examples:
       | pending_share_path_1 | pending_share_path_2  |
       | /Shares/PARENT/      | /Shares/textfile0.txt |
 
-  @smokeTest @issue-ocis-2131 @skipOnOcV10.6 @skipOnOcV10.7 @skipOnOcV10.8.0
+  @smokeTest @issue-ocis-2131
   Scenario: accept a pending share
     Given user "Alice" has shared folder "/PARENT" with user "Brian"
     And user "Alice" has shared file "/textfile0.txt" with user "Brian"
@@ -127,7 +127,7 @@ Feature: accept/decline shares coming from internal users
       | /Shares/PARENT        |
       | /Shares/textfile0.txt |
 
-  @notToImplementOnOCIS @skipOnOcV10.6 @skipOnOcV10.7 @skipOnOcV10.8.0
+  @notToImplementOnOCIS
   Scenario Outline: accept a pending share when there is a default folder for received shares
     Given the administrator has set the default folder for received shares to "<share_folder>"
     And user "Alice" has shared folder "/PARENT" with user "Brian"
@@ -175,7 +175,7 @@ Feature: accept/decline shares coming from internal users
       | ReceivedShares      | /ReceivedShares     | PARENT               | textfile0.txt          |
       | /My/Received/Shares | /My/Received/Shares | PARENT               | textfile0.txt          |
 
-  @skipOnOcV10.6 @skipOnOcV10.7 @skipOnOcV10.8.0
+ 
   Scenario: accept an accepted share
     Given user "Alice" has created folder "/shared"
     And user "Alice" has shared folder "/shared" with user "Brian"
@@ -208,7 +208,7 @@ Feature: accept/decline shares coming from internal users
       | path                    |
       | <declined_share_path_1> |
       | <declined_share_path_2> |
-    @skipOnOcV10.6 @skipOnOcV10.7 @skipOnOcV10.8.0 @issue-ocis-2540
+    @issue-ocis-2540
     Examples:
       | declined_share_path_1 | declined_share_path_2 |
       | /Shares/PARENT/       | /Shares/textfile0.txt |
@@ -231,7 +231,7 @@ Feature: accept/decline shares coming from internal users
       | path                    |
       | <declined_share_path_1> |
       | <declined_share_path_2> |
-    @skipOnOcV10.6 @skipOnOcV10.7 @skipOnOcV10.8.0 @issue-ocis-2540
+    @issue-ocis-2540
     Examples:
       | declined_share_path_1 | declined_share_path_2 |
       | /Shares/PARENT/       | /Shares/textfile0.txt |
@@ -269,12 +269,12 @@ Feature: accept/decline shares coming from internal users
       | path                  |
       | /Shares/PARENT/       |
       | /Shares/textfile0.txt |
-    @skipOnOcV10.6 @skipOnOcV10.7 @skipOnOcV10.8.0 @issue-ocis-2540
+    @issue-ocis-2540
     Examples:
       | pending_share_path_1 | pending_share_path_2  |
       | /Shares/PARENT/      | /Shares/textfile0.txt |
 
-  @issue-ocis-2131 @skipOnOcV10.6 @skipOnOcV10.7 @skipOnOcV10.8.0
+  @issue-ocis-2131
   Scenario: receive two shares with identical names from different users, accept one by one
     Given user "Alice" has created folder "/shared"
     And user "Alice" has created folder "/shared/Alice"
@@ -303,7 +303,7 @@ Feature: accept/decline shares coming from internal users
       | path                 |
       | <pending_share_path> |
     And the sharing API should report that no shares are shared with user "Alice"
-    @skipOnOcV10.6 @skipOnOcV10.7 @skipOnOcV10.8.0 @issue-ocis-2540
+    @issue-ocis-2540
     Examples:
       | pending_share_path |
       | /Shares/PARENT/    |
@@ -328,8 +328,7 @@ Feature: accept/decline shares coming from internal users
       | /Shares/testfile (2) (2).txt |
     And the content of file "/Shares/testfile.txt" for user "Carol" should be "Third file"
     And the content of file "/Shares/testfile (2).txt" for user "Carol" should be "Second file"
-    And the content of file "/Shares/testfile (2) (2).txt" for user "Carol" should be "First file"
-    @skipOnOcV10.6 @skipOnOcV10.7 @skipOnOcV10.8.0
+    And the content of file "/Shares/testfile (2) (2).txt" for user "Carol" should be "First file"   
     Examples:
       | accepted_share_path |
       | /testfile (2).txt   |
@@ -360,12 +359,11 @@ Feature: accept/decline shares coming from internal users
       | /Shares/PARENT (2)/         | David     |
       | /Shares/PARENT (2) (2)/     | Carol     |
       | /Shares/PARENT (2) (2) (2)/ | Brian     |
-    @skipOnOcV10.6 @skipOnOcV10.7 @skipOnOcV10.8.0
     Examples:
       | accepted_share_path_1 | accepted_share_path_2 |
       | /PARENT (2)           | /PARENT (2) (2)       |
 
-  @skipOnOcV10.6 @skipOnOcV10.7 @skipOnOcV10.8.0
+ 
   Scenario: user shares folder with matching folder-name for both user involved in sharing
     Given user "Alice" has uploaded file with content "uploaded content" to "/PARENT/abc.txt"
     And user "Alice" has uploaded file with content "uploaded content" to "/FOLDER/abc.txt"
@@ -388,7 +386,7 @@ Feature: accept/decline shares coming from internal users
     And the content of file "/Shares/PARENT/abc.txt" for user "Brian" should be "uploaded content"
     And the content of file "/Shares/FOLDER/abc.txt" for user "Brian" should be "uploaded content"
 
-  @skipOnOcV10.6 @skipOnOcV10.7 @skipOnOcV10.8.0
+ 
   Scenario: user shares folder in a group with matching folder-name for every users involved
     Given user "Alice" has uploaded file with content "uploaded content" to "/PARENT/abc.txt"
     And user "Alice" has uploaded file with content "uploaded content" to "/FOLDER/abc.txt"
@@ -427,7 +425,7 @@ Feature: accept/decline shares coming from internal users
     And the content of file "/Shares/PARENT/abc.txt" for user "Carol" should be "uploaded content"
     And the content of file "/Shares/FOLDER/abc.txt" for user "Carol" should be "uploaded content"
 
-  @skipOnOcV10.6 @skipOnOcV10.7 @skipOnOcV10.8.0
+ 
   Scenario: user shares files in a group with matching file-names for every users involved in sharing
     Given user "Alice" has uploaded file "filesForUpload/textfile.txt" to "textfile1.txt"
     And user "Brian" has uploaded file "filesForUpload/textfile.txt" to "textfile1.txt"
@@ -452,7 +450,7 @@ Feature: accept/decline shares coming from internal users
       | /Shares/textfile0.txt |
       | /Shares/textfile1.txt |
 
-  @skipOnOcV10.6 @skipOnOcV10.7 @skipOnOcV10.8.0
+ 
   Scenario: user shares resource with matching resource-name with another user when auto accept is disabled
     When user "Alice" shares folder "/PARENT" with user "Brian" using the sharing API
     And user "Alice" shares file "/textfile0.txt" with user "Brian" using the sharing API
@@ -474,7 +472,7 @@ Feature: accept/decline shares coming from internal users
       | /Shares/PARENT/       |
       | /Shares/textfile0.txt |
 
-  @skipOnOcV10.6 @skipOnOcV10.7 @skipOnOcV10.8.0
+ 
   Scenario: user shares file in a group with matching filename when auto accept is disabled
     Given user "Carol" has uploaded file "filesForUpload/textfile.txt" to "textfile0.txt"
     When user "Alice" shares file "/textfile0.txt" with group "grp1" using the sharing API
@@ -499,7 +497,7 @@ Feature: accept/decline shares coming from internal users
       | /textfile0.txt        |
       | /Shares/textfile0.txt |
 
-  @skipOnLDAP @skipOnOcV10.6 @skipOnOcV10.7 @skipOnOcV10.8.0
+  @skipOnLDAP
   Scenario: user shares folder with matching folder name to  a user before that user has logged in
     Given these users have been created without skeleton files and not initialized:
       | username |
@@ -525,12 +523,12 @@ Feature: accept/decline shares coming from internal users
     And the sharing API should report to user "Brian" that these shares are in the declined state
       | path                  |
       | <declined_share_path> |
-    @skipOnOcV10.6 @skipOnOcV10.7 @skipOnOcV10.8.0 @issue-ocis-2540
+    @issue-ocis-2540
     Examples:
       | declined_share_path |
       | /Shares/PARENT      |
 
-  @issue-ocis-765 @issue-ocis-2131 @skipOnOcV10.6 @skipOnOcV10.7 @skipOnOcV10.8.0
+  @issue-ocis-765 @issue-ocis-2131
   Scenario: shares exist after restoring already shared file to a previous version
     And user "Alice" has uploaded file with content "Test Content." to "/toShareFile.txt"
     And user "Alice" has uploaded file with content "Content Test Updated." to "/toShareFile.txt"
@@ -541,7 +539,7 @@ Feature: accept/decline shares coming from internal users
     And the content of file "/toShareFile.txt" for user "Alice" should be "Test Content."
     And the content of file "/Shares/toShareFile.txt" for user "Brian" should be "Test Content."
 
-  @skipOnOcV10.6 @skipOnOcV10.7 @skipOnOcV10.8.0 @issue-ocis-2131
+  @issue-ocis-2131
   Scenario: a user receives multiple group shares for matching file and folder name
     Given group "grp2" has been created
     And user "Alice" has been added to group "grp2"
@@ -606,7 +604,7 @@ Feature: accept/decline shares coming from internal users
     And the content of file "/Shares/PARENT (2).txt" for user "Brian" should be "from carol to grp1"
     And the content of file "/Shares/parent.txt" for user "Brian" should be "from carol to grp1"
 
-  @skipOnOcV10.6 @skipOnOcV10.7 @skipOnOcV10.8.0 @issue-ocis-2131
+  @issue-ocis-2131
   Scenario: a group receives multiple shares from non-member for matching file and folder name
     Given user "Brian" has been removed from group "grp1"
     And user "Alice" has created folder "/PaRent"

--- a/tests/acceptance/features/apiShareManagementToShares/acceptSharesToSharesFolder.feature
+++ b/tests/acceptance/features/apiShareManagementToShares/acceptSharesToSharesFolder.feature
@@ -1,4 +1,4 @@
-@api @files_sharing-app-required @skipOnOcV10.6 @skipOnOcV10.7 @skipOnOcV10.8.0
+@api @files_sharing-app-required
 Feature: accept/decline shares coming from internal users to the Shares folder
   As a user
   I want to have control of which received shares I accept
@@ -31,7 +31,7 @@ Feature: accept/decline shares coming from internal users to the Shares folder
     When user "Brian" accepts share "/PARENT" offered by user "Alice" using the sharing API
     Then the content of file "/Shares/PARENT/parent.txt" for user "Brian" should be "ownCloud test text file parent"
 
-  @skipOnOcV10.3 @skipOnOcV10.4 @skipOnOcV10.5
+
   Scenario: When accepting a share of a file, the response is valid
     Given user "Alice" has uploaded file with content "ownCloud test text file 0" to "textfile0.txt"
     And user "Alice" has shared file "/textfile0.txt" with user "Brian"
@@ -52,7 +52,7 @@ Feature: accept/decline shares coming from internal users to the Shares folder
       | share_type             | user                  |
     And the content of file "/Shares/textfile0.txt" for user "Brian" should be "ownCloud test text file 0"
 
-  @skipOnOcV10.3 @skipOnOcV10.4 @skipOnOcV10.5
+
   Scenario: When accepting a share of a folder, the response is valid
     Given user "Alice" has created folder "/PARENT"
     And user "Alice" has uploaded file with content "ownCloud test text file parent" to "PARENT/parent.txt"

--- a/tests/acceptance/features/apiShareManagementToShares/mergeShare.feature
+++ b/tests/acceptance/features/apiShareManagementToShares/mergeShare.feature
@@ -1,4 +1,4 @@
-@api @files_sharing-app-required @issue-ocis-reva-1328 @issues-ocis-1289 @skipOnOcV10.6 @skipOnOcV10.7 @skipOnOcV10.8.0
+@api @files_sharing-app-required @issue-ocis-reva-1328 @issues-ocis-1289
 Feature: sharing
 
   Background:

--- a/tests/acceptance/features/apiShareManagementToShares/moveReceivedShare.feature
+++ b/tests/acceptance/features/apiShareManagementToShares/moveReceivedShare.feature
@@ -1,4 +1,4 @@
-@api @files_sharing-app-required @issue-ocis-1289 @issue-ocis-1328 @skipOnOcV10.6 @skipOnOcV10.7 @skipOnOcV10.8.0
+@api @files_sharing-app-required @issue-ocis-1289 @issue-ocis-1328
 Feature: sharing
 
   Background:

--- a/tests/acceptance/features/apiShareManagementToShares/moveReceivedShareFromLocalStorage.feature
+++ b/tests/acceptance/features/apiShareManagementToShares/moveReceivedShareFromLocalStorage.feature
@@ -21,7 +21,6 @@ Feature: local-storage
     But as "Brian" file "/Shares/filetoshare.txt" should not exist
     And as "Alice" file "/local_storage/filetoshare.txt" should exist
     But as "Alice" file "/local_storage/newFile.txt" should not exist
-    @skipOnOcV10.6 @skipOnOcV10.7 @skipOnOcV10.8.0
     Examples:
       | ocs_api_version | pending_share_path |
       | 1               | /filetoshare.txt   |
@@ -39,7 +38,6 @@ Feature: local-storage
     But as "Brian" folder "/Shares/foo" should not exist
     And as "Alice" folder "/local_storage/foo" should exist
     But as "Alice" folder "/local_storage/newFolder" should not exist
-    @skipOnOcV10.6 @skipOnOcV10.7 @skipOnOcV10.8.0
     Examples:
       | ocs_api_version | pending_share_path |
       | 1               | /foo               |
@@ -65,7 +63,6 @@ Feature: local-storage
     But as "Brian" folder "/Shares/foo" should not exist
     And as "Alice" folder "/local_storage/foo" should exist
     But as "Alice" folder "/local_storage/newFolder" should not exist
-    @skipOnOcV10.6 @skipOnOcV10.7 @skipOnOcV10.8.0
     Examples:
       | ocs_api_version | pending_share_path |
       | 1               | /foo               |
@@ -86,7 +83,6 @@ Feature: local-storage
     But as "Brian" file "/Shares/filetoshare.txt" should not exist
     And as "Alice" file "/local_storage/filetoshare.txt" should exist
     But as "Alice" file "/local_storage/newFile.txt" should not exist
-    @skipOnOcV10.6 @skipOnOcV10.7 @skipOnOcV10.8.0
     Examples:
       | ocs_api_version | pending_share_path |
       | 1               | /filetoshare.txt   |

--- a/tests/acceptance/features/apiShareOperationsToRoot1/gettingSharesReceivedFiltered.feature
+++ b/tests/acceptance/features/apiShareOperationsToRoot1/gettingSharesReceivedFiltered.feature
@@ -1,4 +1,4 @@
-@api @files_sharing-app-required @notToImplementOnOCIS @skipOnOcV10.3 @skipOnOcV10.4 @skipOnOcV10.5
+@api @files_sharing-app-required @notToImplementOnOCIS
 Feature: get the received shares filtered by type (user, group etc)
   As a user
   I want to be able to know the shares that I have received of a particular type (user, group etc)

--- a/tests/acceptance/features/apiShareOperationsToRoot1/gettingSharesReceivedFilteredEmpty.feature
+++ b/tests/acceptance/features/apiShareOperationsToRoot1/gettingSharesReceivedFilteredEmpty.feature
@@ -1,4 +1,4 @@
-@api @files_sharing-app-required @notToImplementOnOCIS @skipOnOcV10.3 @skipOnOcV10.4 @skipOnOcV10.5
+@api @files_sharing-app-required @notToImplementOnOCIS
 Feature: get the received shares filtered by type (user, group etc)
   As a user
   I want to be able to know the shares that I have received of a particular type (user, group etc)

--- a/tests/acceptance/features/apiShareOperationsToRoot1/gettingSharesSharedFiltered.feature
+++ b/tests/acceptance/features/apiShareOperationsToRoot1/gettingSharesSharedFiltered.feature
@@ -1,4 +1,4 @@
-@api @files_sharing-app-required @notToImplementOnOCIS @skipOnOcV10.3 @skipOnOcV10.4 @skipOnOcV10.5
+@api @files_sharing-app-required @notToImplementOnOCIS
 Feature: get shares filtered by type (user, group etc)
   As a user
   I want to be able to know the shares that I have made of a particular type (user, group etc)

--- a/tests/acceptance/features/apiShareOperationsToRoot1/gettingSharesSharedFilteredEmpty.feature
+++ b/tests/acceptance/features/apiShareOperationsToRoot1/gettingSharesSharedFilteredEmpty.feature
@@ -1,4 +1,4 @@
-@api @files_sharing-app-required @notToImplementOnOCIS @skipOnOcV10.3 @skipOnOcV10.4 @skipOnOcV10.5
+@api @files_sharing-app-required @notToImplementOnOCIS
 Feature: get shares filtered by type (user, group etc)
   As a user
   I want to be able to know the shares that I have made of a particular type (user, group etc)

--- a/tests/acceptance/features/apiShareOperationsToShares1/accessToShare.feature
+++ b/tests/acceptance/features/apiShareOperationsToShares1/accessToShare.feature
@@ -1,4 +1,4 @@
-@api @files_sharing-app-required @skipOnOcV10.6 @skipOnOcV10.7 @skipOnOcV10.8.0
+@api @files_sharing-app-required
 Feature: sharing
 
   Background:

--- a/tests/acceptance/features/apiShareOperationsToShares1/accessToSharesFolder.feature
+++ b/tests/acceptance/features/apiShareOperationsToShares1/accessToSharesFolder.feature
@@ -1,4 +1,4 @@
-@api @files_sharing-app-required @notToImplementOnOCIS @skipOnOcV10.6 @skipOnOcV10.7 @skipOnOcV10.8.0
+@api @files_sharing-app-required @notToImplementOnOCIS
 Feature: write directly into the folder for received shares
   On ownCloud10 with the folder for received shares set, for example, to "Shares"
   A user should see a "Shares" folder when they have received a share.

--- a/tests/acceptance/features/apiShareOperationsToShares1/changingFilesShare.feature
+++ b/tests/acceptance/features/apiShareOperationsToShares1/changingFilesShare.feature
@@ -1,4 +1,4 @@
-@api @files_sharing-app-required @issue-ocis-1289 @issue-ocis-1328 @skipOnOcV10.6 @skipOnOcV10.7 @skipOnOcV10.8.0
+@api @files_sharing-app-required @issue-ocis-1289 @issue-ocis-1328
 Feature: sharing
 
   Background:

--- a/tests/acceptance/features/apiShareOperationsToShares1/gettingShares.feature
+++ b/tests/acceptance/features/apiShareOperationsToShares1/gettingShares.feature
@@ -1,4 +1,4 @@
-@api @files_sharing-app-required @skipOnOcV10.6 @skipOnOcV10.7 @skipOnOcV10.8.0
+@api @files_sharing-app-required
 Feature: sharing
 
   Background:
@@ -216,7 +216,6 @@ Feature: sharing
     Then the OCS status code should be "<ocs_status_code>"
     And the HTTP status code should be "200"
     And file "/Shares/parent.txt" should be included in the response
-    @skipOnOcV10.6 @skipOnOcV10.7 @skipOnOcV10.8.0
     Examples:
       | ocs_api_version | ocs_status_code | pending_share_path |
       | 1               | 100             | /parent.txt        |

--- a/tests/acceptance/features/apiShareOperationsToShares1/gettingSharesPendingFiltered.feature
+++ b/tests/acceptance/features/apiShareOperationsToShares1/gettingSharesPendingFiltered.feature
@@ -1,4 +1,4 @@
-@api @files_sharing-app-required @skipOnOcV10.6 @skipOnOcV10.7 @skipOnOcV10.8.0
+@api @files_sharing-app-required
 Feature: get the pending shares filtered by type (user, group etc)
   As a user
   I want to be able to know the pending shares that I have received of a particular type (user, group etc)

--- a/tests/acceptance/features/apiShareOperationsToShares1/gettingSharesReceivedFiltered.feature
+++ b/tests/acceptance/features/apiShareOperationsToShares1/gettingSharesReceivedFiltered.feature
@@ -1,4 +1,4 @@
-@api @files_sharing-app-required @skipOnOcV10.6 @skipOnOcV10.7 @skipOnOcV10.8.0
+@api @files_sharing-app-required
 Feature: get the received shares filtered by type (user, group etc)
   As a user
   I want to be able to know the shares that I have received of a particular type (user, group etc)

--- a/tests/acceptance/features/apiShareOperationsToShares1/gettingSharesReceivedFilteredEmpty.feature
+++ b/tests/acceptance/features/apiShareOperationsToShares1/gettingSharesReceivedFilteredEmpty.feature
@@ -1,4 +1,4 @@
-@api @files_sharing-app-required @skipOnOcV10.6 @skipOnOcV10.7 @skipOnOcV10.8.0
+@api @files_sharing-app-required
 Feature: get the received shares filtered by type (user, group etc)
   As a user
   I want to be able to know the shares that I have received of a particular type (user, group etc)

--- a/tests/acceptance/features/apiShareOperationsToShares1/gettingSharesSharedFiltered.feature
+++ b/tests/acceptance/features/apiShareOperationsToShares1/gettingSharesSharedFiltered.feature
@@ -1,4 +1,4 @@
-@api @files_sharing-app-required @skipOnOcV10.6 @skipOnOcV10.7 @skipOnOcV10.8.0
+@api @files_sharing-app-required
 Feature: get shares filtered by type (user, group etc)
   As a user
   I want to be able to know the shares that I have made of a particular type (user, group etc)
@@ -62,7 +62,7 @@ Feature: get shares filtered by type (user, group etc)
       | 1               | 100             |
       | 2               | 200             |
 
-  @skipOnOcV10.5 @skipOnOcV10.6.0
+
   Scenario Outline: getting shares shared to public links
     Given using OCS API version "<ocs_api_version>"
     When user "Alice" gets the public link shares shared by him using the sharing API

--- a/tests/acceptance/features/apiShareOperationsToShares1/gettingSharesSharedFilteredEmpty.feature
+++ b/tests/acceptance/features/apiShareOperationsToShares1/gettingSharesSharedFilteredEmpty.feature
@@ -1,4 +1,4 @@
-@api @files_sharing-app-required @skipOnOcV10.3 @skipOnOcV10.4 @skipOnOcV10.5
+@api @files_sharing-app-required
 Feature: get shares filtered by type (user, group etc)
   As a user
   I want to be able to know the shares that I have made of a particular type (user, group etc)

--- a/tests/acceptance/features/apiShareOperationsToShares2/getWebDAVSharePermissions.feature
+++ b/tests/acceptance/features/apiShareOperationsToShares2/getWebDAVSharePermissions.feature
@@ -1,4 +1,4 @@
-@api @files_sharing-app-required @skipOnOcV10.6 @skipOnOcV10.7 @skipOnOcV10.8.0
+@api @files_sharing-app-required
 Feature: sharing
 
   Background:

--- a/tests/acceptance/features/apiShareOperationsToShares2/shareAccessByID.feature
+++ b/tests/acceptance/features/apiShareOperationsToShares2/shareAccessByID.feature
@@ -9,7 +9,7 @@ Feature: share access by ID
       | Alice    |
       | Brian    |
 
-  @skipOnOcV10.6 @skipOnOcV10.7 @skipOnOcV10.8.0
+
   Scenario Outline: Get a share with a valid share ID
     Given using OCS API version "<ocs_api_version>"
     And user "Alice" has uploaded file with content "ownCloud test text file 0" to "/textfile0.txt"
@@ -118,7 +118,6 @@ Feature: share access by ID
     And the sharing API should report to user "Brian" that these shares are in the declined state
       | path                  |
       | <declined_share_path> |
-    @skipOnOcV10.6 @skipOnOcV10.7 @skipOnOcV10.8.0
     Examples:
       | ocs_api_version | ocs_status_code | declined_share_path   |
       | 1               | 100             | /Shares/textfile0.txt |

--- a/tests/acceptance/features/apiShareOperationsToShares2/uploadToShare.feature
+++ b/tests/acceptance/features/apiShareOperationsToShares2/uploadToShare.feature
@@ -1,4 +1,4 @@
-@api @files_sharing-app-required @skipOnOcV10.6 @skipOnOcV10.7 @skipOnOcV10.8.0
+@api @files_sharing-app-required
 Feature: sharing
 
   Background:

--- a/tests/acceptance/features/apiSharePublicLink1/accessToPublicLinkShare.feature
+++ b/tests/acceptance/features/apiSharePublicLink1/accessToPublicLinkShare.feature
@@ -6,7 +6,7 @@ Feature: accessing a public link share
       | username |
       | Alice    |
 
-  @skipOnOcV10.3
+
   Scenario: Access to the preview of password protected public link without providing the password is not allowed
     Given the administrator has enabled DAV tech_preview
     And user "Alice" has uploaded file "filesForUpload/testavatar.jpg" to "testavatar.jpg"
@@ -27,7 +27,7 @@ Feature: accessing a public link share
     When the public accesses the preview of file "testavatar.jpg" from the last shared public link using the sharing API
     Then the HTTP status code should be "200"
 
-  @skipOnOcV10.3
+
   Scenario: Access to the preview of password protected public shared file inside a folder without providing the password is not allowed
     Given the administrator has enabled DAV tech_preview
     And user "Alice" has created folder "FOLDER"

--- a/tests/acceptance/features/apiSharePublicLink1/createPublicLinkShare.feature
+++ b/tests/acceptance/features/apiSharePublicLink1/createPublicLinkShare.feature
@@ -100,7 +100,7 @@ Feature: create a public link share
       | 1               | 100             |
       | 2               | 200             |
 
-  @skipOnOcV10.9 @skipOnOcV10.10
+
   Scenario Outline: Create a new public link share of a file with edit permissions
     Given using OCS API version "<ocs_api_version>"
     And user "Alice" has uploaded file with content "Random data" to "/randomfile.txt"
@@ -299,7 +299,7 @@ Feature: create a public link share
       | 1               | 403             |
       | 2               | 403             |
 
-  @skipOnOcV10.7 @skipOnOcV10.8 @skipOnOcV10.9.0 @skipOnOcV10.9.1
+
   Scenario Outline: Updating a public link share with read+create permissions is forbidden when public upload is disabled globally
     Given using OCS API version "<ocs_api_version>"
     And user "Alice" has created folder "/afolder"
@@ -317,7 +317,7 @@ Feature: create a public link share
       | 1               | 403             |
       | 2               | 403             |
 
-  @issue-ocis-reva-41 @skipOnOcV10.7 @skipOnOcV10.8 @skipOnOcV10.9.0 @skipOnOcV10.9.1
+  @issue-ocis-reva-41
   Scenario Outline: Creating a link share with read+update+create permissions is forbidden when public upload is disabled globally
     Given using OCS API version "<ocs_api_version>"
     And parameter "shareapi_allow_public_upload" of app "core" has been set to "no"
@@ -548,7 +548,7 @@ Feature: create a public link share
       | public-webdav-api-version | response                   |
       | new                       | File not found: parent.txt |
 
-  @skipOnOcV10.3
+
   Scenario: Get the size of a file shared by public link
     Given user "Alice" has uploaded file with content "This is a test file" to "test-file.txt"
     And user "Alice" has created a public link share with settings

--- a/tests/acceptance/features/apiSharePublicLink1/createPublicLinkShareToShares.feature
+++ b/tests/acceptance/features/apiSharePublicLink1/createPublicLinkShareToShares.feature
@@ -6,7 +6,7 @@ Feature: create a public link share when share_folder is set to Shares
     And auto-accept shares has been disabled
     And user "Alice" has been created with default attributes and without skeleton files
 
-  @skipOnOcV10.5 @skipOnOcV10.6.0
+
   Scenario Outline: Creating a new public link share of a file gives the correct response
     Given using OCS API version "<ocs_api_version>"
     And user "Alice" has uploaded file with content "Random data" to "/randomfile.txt"

--- a/tests/acceptance/features/apiSharePublicLink2/reShareAsPublicLinkToSharesNewDav.feature
+++ b/tests/acceptance/features/apiSharePublicLink2/reShareAsPublicLinkToSharesNewDav.feature
@@ -1,4 +1,4 @@
-@api @files_sharing-app-required @public_link_share-feature-required @skipOnOcV10.6 @skipOnOcV10.7 @skipOnOcV10.8.0
+@api @files_sharing-app-required @public_link_share-feature-required
 Feature: reshare as public link
   As a user
   I want to create public link shares from files/folders shared with me

--- a/tests/acceptance/features/apiSharePublicLink2/reShareAsPublicLinkToSharesOldDav.feature
+++ b/tests/acceptance/features/apiSharePublicLink2/reShareAsPublicLinkToSharesOldDav.feature
@@ -1,4 +1,4 @@
-@api @files_sharing-app-required @public_link_share-feature-required @notToImplementOnOCIS @issue-ocis-2079 @skipOnOcV10.6 @skipOnOcV10.7 @skipOnOcV10.8.0
+@api @files_sharing-app-required @public_link_share-feature-required @notToImplementOnOCIS @issue-ocis-2079
 Feature: reshare as public link
   As a user
   I want to create public link shares from files/folders shared with me

--- a/tests/acceptance/features/apiSharePublicLink3/allowGroupToCreatePublicLinks.feature
+++ b/tests/acceptance/features/apiSharePublicLink3/allowGroupToCreatePublicLinks.feature
@@ -1,4 +1,4 @@
-@api @files_sharing-app-required @skipOnOcV10.6 @skipOnOcV10.7 @skipOnOcV10.8.0 @notToImplementOnOcis
+@api @files_sharing-app-required @notToImplementOnOcis
 Feature: public share sharers groups setting
   As an admin
   I should be able to allow only certain groups to create public links

--- a/tests/acceptance/features/apiSharePublicLink3/updatePublicLinkShare.feature
+++ b/tests/acceptance/features/apiSharePublicLink3/updatePublicLinkShare.feature
@@ -343,7 +343,7 @@ Feature: update a public link share
     And uploading a file should not work using the old public WebDAV API
     And uploading a file should not work using the new public WebDAV API
 
-    @issue-ocis-2079 @skipOnOcV10.6 @skipOnOcV10.7 @skipOnOcV10.8.0
+    @issue-ocis-2079
     Examples:
       | ocs_api_version | http_status_code |
       | 1               | 200              |
@@ -367,7 +367,7 @@ Feature: update a public link share
     And uploading a file should work using the old public WebDAV API
     And uploading a file should work using the new public WebDAV API
 
-    @issue-ocis-2079 @skipOnOcV10.6 @skipOnOcV10.7 @skipOnOcV10.8.0
+    @issue-ocis-2079
     Examples:
       | ocs_api_version | ocs_status_code |
       | 1               | 100             |
@@ -392,7 +392,7 @@ Feature: update a public link share
     And uploading a file should not work using the old public WebDAV API
     And uploading a file should not work using the new public WebDAV API
 
-    @issue-ocis-2079 @skipOnOcV10.6 @skipOnOcV10.7 @skipOnOcV10.8.0
+    @issue-ocis-2079
     Examples:
       | ocs_api_version | http_status_code |
       | 1               | 200              |
@@ -417,7 +417,7 @@ Feature: update a public link share
     And uploading a file should work using the old public WebDAV API
     And uploading a file should work using the new public WebDAV API
 
-  @issue-ocis-2079 @skipOnOcV10.6 @skipOnOcV10.7 @skipOnOcV10.8.0
+  @issue-ocis-2079
     Examples:
       | ocs_api_version | ocs_status_code |
       | 1               | 100             |

--- a/tests/acceptance/features/apiSharePublicLink3/uploadToPublicLinkShare.feature
+++ b/tests/acceptance/features/apiSharePublicLink3/uploadToPublicLinkShare.feature
@@ -50,7 +50,7 @@ Feature: upload to a public link share
       | old      | old                       |
       | new      | old                       |
 
-    @skipOnOcV10.3 @skipOnOcV10.4 @issue-ocis-reva-290
+    @issue-ocis-reva-290
     Examples:
       | dav-path | public-webdav-api-version |
       | old      | new                       |

--- a/tests/acceptance/features/apiShareReshareToRoot3/reShareWithExpiryDate.feature
+++ b/tests/acceptance/features/apiShareReshareToRoot3/reShareWithExpiryDate.feature
@@ -8,7 +8,7 @@ Feature: resharing a resource with an expiration date
       | Brian    |
     And user "Alice" has uploaded file "filesForUpload/textfile.txt" to "/textfile0.txt"
 
-  @skipOnOcV10.3
+
   Scenario Outline: User should be able to set expiration while resharing a file with user
     Given using OCS API version "<ocs_api_version>"
     And user "Carol" has been created with default attributes and without skeleton files
@@ -30,7 +30,7 @@ Feature: resharing a resource with an expiration date
       | 1               | 100             |
       | 2               | 200             |
 
-  @skipOnOcV10.3 @issue-ocis-reva-194
+  @issue-ocis-reva-194
   Scenario Outline: User should be able to set expiration while resharing a file with group
     Given using OCS API version "<ocs_api_version>"
     And user "Carol" has been created with default attributes and without skeleton files
@@ -54,7 +54,7 @@ Feature: resharing a resource with an expiration date
       | 1               | 100             |
       | 2               | 200             |
 
-  @skipOnOcV10.3
+
   Scenario Outline: resharing with user using the sharing API with expire days set and combinations of default/enforce expire date enabled
     Given using OCS API version "<ocs_api_version>"
     And parameter "shareapi_default_expire_date_user_share" of app "core" has been set to "<default-expire-date>"
@@ -80,7 +80,7 @@ Feature: resharing a resource with an expiration date
       | 1               | no                  | yes                 |                      | 100             |
       | 2               | no                  | yes                 |                      | 200             |
 
-  @skipOnOcV10.3 @issue-ocis-reva-194
+  @issue-ocis-reva-194
   Scenario Outline: resharing with group using the sharing API with expire days set and combinations of default/enforce expire date enabled
     Given using OCS API version "<ocs_api_version>"
     And parameter "shareapi_default_expire_date_group_share" of app "core" has been set to "<default-expire-date>"
@@ -108,7 +108,7 @@ Feature: resharing a resource with an expiration date
       | 1               | no                  | yes                 |                      | 100             |
       | 2               | no                  | yes                 |                      | 200             |
 
-  @skipOnOcV10.3
+
   Scenario Outline: resharing with user using the sharing API without expire days set and with combinations of default/enforce expire date enabled
     Given using OCS API version "<ocs_api_version>"
     And parameter "shareapi_default_expire_date_user_share" of app "core" has been set to "<default-expire-date>"
@@ -133,7 +133,7 @@ Feature: resharing a resource with an expiration date
       | 1               | no                  | yes                 |                      | 100             |
       | 2               | no                  | yes                 |                      | 200             |
 
-  @skipOnOcV10.3 @issue-ocis-reva-194
+  @issue-ocis-reva-194
   Scenario Outline: resharing with group using the sharing API without expire days set and with combinations of default/enforce expire date enabled
     Given using OCS API version "<ocs_api_version>"
     And parameter "shareapi_default_expire_date_group_share" of app "core" has been set to "<default-expire-date>"
@@ -160,7 +160,7 @@ Feature: resharing a resource with an expiration date
       | 1               | no                  | yes                 |                      | 100             |
       | 2               | no                  | yes                 |                      | 200             |
 
-  @skipOnOcV10.3
+
   Scenario Outline: resharing with user using the sharing API with expire days set and with combinations of default/enforce expire date enabled and specify expire date in share
     Given using OCS API version "<ocs_api_version>"
     And parameter "shareapi_default_expire_date_user_share" of app "core" has been set to "<default-expire-date>"
@@ -187,7 +187,7 @@ Feature: resharing a resource with an expiration date
       | 1               | no                  | yes                 | 100             |
       | 2               | no                  | yes                 | 200             |
 
-  @skipOnOcV10.3 @issue-ocis-reva-194
+  @issue-ocis-reva-194
   Scenario Outline: resharing with group using the sharing API with expire days set and with combinations of default/enforce expire date enabled and specify expire date in share
     Given using OCS API version "<ocs_api_version>"
     And parameter "shareapi_default_expire_date_group_share" of app "core" has been set to "<default-expire-date>"
@@ -216,7 +216,7 @@ Feature: resharing a resource with an expiration date
       | 1               | no                  | yes                 | 100             |
       | 2               | no                  | yes                 | 200             |
 
-  @skipOnOcV10.3
+
   Scenario Outline: Setting default expiry date and enforcement after the share is created
     Given using OCS API version "<ocs_api_version>"
     And user "Carol" has been created with default attributes and without skeleton files
@@ -239,7 +239,7 @@ Feature: resharing a resource with an expiration date
       | 1               | no                  | yes                 | 100             |
       | 2               | no                  | yes                 | 200             |
 
-  @skipOnOcV10.3 @issue-ocis-reva-194
+  @issue-ocis-reva-194
   Scenario Outline: resharing group share with user using the sharing API with default expire date set and with combinations of default/enforce expire date enabled
     Given using OCS API version "<ocs_api_version>"
     And parameter "shareapi_default_expire_date_user_share" of app "core" has been set to "<default-expire-date>"
@@ -267,7 +267,7 @@ Feature: resharing a resource with an expiration date
       | 1               | no                  | yes                 |                      | 100             |
       | 2               | no                  | yes                 |                      | 200             |
 
-  @skipOnOcV10.3 @issue-ocis-reva-194
+  @issue-ocis-reva-194
   Scenario Outline: resharing group share with user using the sharing API with default expire date set and specifying expiration on share and with combinations of default/enforce expire date enabled
     Given using OCS API version "<ocs_api_version>"
     And parameter "shareapi_default_expire_date_user_share" of app "core" has been set to "<default-expire-date>"
@@ -296,7 +296,7 @@ Feature: resharing a resource with an expiration date
       | 1               | no                  | yes                 | +20 days             | 100             |
       | 2               | no                  | yes                 | +20 days             | 200             |
 
-  @skipOnOcV10.3
+
   Scenario Outline: resharing using the sharing API with default expire date set but not enforced
     Given using OCS API version "<ocs_api_version>"
     And parameter "shareapi_default_expire_date_user_share" of app "core" has been set to "<default-expire-date>"
@@ -322,7 +322,7 @@ Feature: resharing a resource with an expiration date
       | 1               | no                  | no                  | 100             |
       | 2               | no                  | no                  | 200             |
 
-  @skipOnOcV10.3 @issue-37013
+  @issue-37013
   Scenario Outline: reshare extends the received expiry date up to the default by default
     Given using OCS API version "<ocs_api_version>"
     And parameter "shareapi_default_expire_date_user_share" of app "core" has been set to "<default-expire-date>"
@@ -355,7 +355,7 @@ Feature: resharing a resource with an expiration date
       | 1               | no                  | no                  |                    | 100             |
       | 2               | no                  | no                  |                    | 200             |
 
-  @skipOnOcV10.3 @issue-37013
+  @issue-37013
   Scenario Outline: reshare can extend the received expiry date further into the future
     Given using OCS API version "<ocs_api_version>"
     And parameter "shareapi_default_expire_date_user_share" of app "core" has been set to "<default-expire-date>"
@@ -387,7 +387,7 @@ Feature: resharing a resource with an expiration date
       | 1               | no                  | 100             |
       | 2               | no                  | 200             |
 
-  @skipOnOcV10.3 @issue-37013
+  @issue-37013
   Scenario Outline: reshare cannot extend the received expiry date past the default when the default is enforced
     Given using OCS API version "<ocs_api_version>"
     And parameter "shareapi_default_expire_date_user_share" of app "core" has been set to "<default-expire-date>"

--- a/tests/acceptance/features/apiShareReshareToShares1/reShare.feature
+++ b/tests/acceptance/features/apiShareReshareToShares1/reShare.feature
@@ -1,4 +1,4 @@
-@api @files_sharing-app-required @issue-ocis-1328 @skipOnOcV10.6 @skipOnOcV10.7 @skipOnOcV10.8.0
+@api @files_sharing-app-required @issue-ocis-1328
 Feature: sharing
 
   Background:
@@ -137,7 +137,7 @@ Feature: sharing
       | 1               | 200              | 17                   | 15                  |
       | 2               | 404              | 17                   | 15                  |
 
-  @skipOnOcV10.3 @skipOnOcV10.4 @skipOnOcV10.5
+
   Scenario Outline: User is allowed to reshare file and set create (4) or delete (8) permissions bits, which get ignored
     Given using OCS API version "<ocs_api_version>"
     And user "Alice" has uploaded file "filesForUpload/textfile.txt" to "/textfile0.txt"

--- a/tests/acceptance/features/apiShareReshareToShares2/reShareChain.feature
+++ b/tests/acceptance/features/apiShareReshareToShares2/reShareChain.feature
@@ -25,7 +25,6 @@ Feature: resharing can be done on a reshared resource
     Then the HTTP status code should be "204"
     And the content of file "/Shares/textfile0_shared.txt" for user "Carol" should be "ownCloud test text file 0"
     And the content of file "/Shares/textfile0_shared.txt" for user "David" should be "ownCloud test text file 0"
-    @skipOnOcV10.6 @skipOnOcV10.7 @skipOnOcV10.8.0
     Examples:
       | pending_share_path    |
       | /textfile0_shared.txt |

--- a/tests/acceptance/features/apiShareReshareToShares2/reShareDisabled.feature
+++ b/tests/acceptance/features/apiShareReshareToShares2/reShareDisabled.feature
@@ -1,4 +1,4 @@
-@api @files_sharing-app-required @issue-ocis-1328 @skipOnOcV10.6 @skipOnOcV10.7 @skipOnOcV10.8.0
+@api @files_sharing-app-required @issue-ocis-1328
 Feature: resharing can be disabled
 
   Background:

--- a/tests/acceptance/features/apiShareReshareToShares2/reShareSubfolder.feature
+++ b/tests/acceptance/features/apiShareReshareToShares2/reShareSubfolder.feature
@@ -1,4 +1,4 @@
-@api @files_sharing-app-required @issue-ocis-1328 @skipOnOcV10.6 @skipOnOcV10.7 @skipOnOcV10.8.0
+@api @files_sharing-app-required @issue-ocis-1328
 Feature: a subfolder of a received share can be reshared
 
   Background:
@@ -23,7 +23,6 @@ Feature: a subfolder of a received share can be reshared
     And user "Carol" should be able to accept pending share "<pending_sub_share_path>" offered by user "Brian"
     And as "Carol" folder "/Shares/SUB" should exist
     And as "Brian" folder "/Shares/TMP/SUB" should exist
-    @skipOnOcV10.6 @skipOnOcV10.7 @skipOnOcV10.8.0
     Examples:
       | ocs_api_version | ocs_status_code | pending_sub_share_path |
       | 1               | 100             | /SUB                   |
@@ -104,7 +103,6 @@ Feature: a subfolder of a received share can be reshared
     But user "Carol" should not be able to upload file "filesForUpload/textfile.txt" to "/Shares/SUB/textfile.txt"
     And as "Brian" folder "/Shares/TMP/SUB" should exist
     And user "Brian" should be able to upload file "filesForUpload/textfile.txt" to "/Shares/TMP/SUB/textfile.txt"
-    @skipOnOcV10.6 @skipOnOcV10.7 @skipOnOcV10.8.0
     Examples:
       | ocs_api_version | ocs_status_code | pending_sub_share_path |
       | 1               | 100             | /SUB                   |
@@ -128,7 +126,6 @@ Feature: a subfolder of a received share can be reshared
     And user "Carol" should be able to upload file "filesForUpload/textfile.txt" to "/Shares/SUB/textfile.txt"
     And as "Brian" folder "/Shares/TMP/SUB" should exist
     And user "Brian" should be able to upload file "filesForUpload/textfile.txt" to "/Shares/TMP/SUB/textfile.txt"
-    @skipOnOcV10.6 @skipOnOcV10.7 @skipOnOcV10.8.0
     Examples:
       | ocs_api_version | ocs_status_code | pending_sub_share_path |
       | 1               | 100             | /SUB                   |
@@ -152,7 +149,6 @@ Feature: a subfolder of a received share can be reshared
     But user "Carol" should not be able to upload file "filesForUpload/textfile.txt" to "/Shares/SUB/textfile.txt"
     And as "Brian" folder "/Shares/TMP/SUB" should exist
     But user "Brian" should not be able to upload file "filesForUpload/textfile.txt" to "/Shares/TMP/SUB/textfile.txt"
-    @skipOnOcV10.6 @skipOnOcV10.7 @skipOnOcV10.8.0
     Examples:
       | ocs_api_version | http_status_code | pending_sub_share_path |
       | 1               | 200              | /SUB                   |

--- a/tests/acceptance/features/apiShareReshareToShares2/reShareWhenShareWithOnlyMembershipGroups.feature
+++ b/tests/acceptance/features/apiShareReshareToShares2/reShareWhenShareWithOnlyMembershipGroups.feature
@@ -1,4 +1,4 @@
-@api @files_sharing-app-required @issue-ocis-1289 @issue-ocis-reva-194 @issue-ocis-1328 @skipOnOcV10.6 @skipOnOcV10.7 @skipOnOcV10.8.0 @skipOnOcis
+@api @files_sharing-app-required @issue-ocis-1289 @issue-ocis-reva-194 @issue-ocis-1328 @skipOnOcis
 Feature: resharing a resource with an expiration date
 
   Background:

--- a/tests/acceptance/features/apiShareReshareToShares3/reShareUpdate.feature
+++ b/tests/acceptance/features/apiShareReshareToShares3/reShareUpdate.feature
@@ -1,4 +1,4 @@
-@api @files_sharing-app-required @issue-ocis-1328 @skipOnOcV10.6 @skipOnOcV10.7 @skipOnOcV10.8.0
+@api @files_sharing-app-required @issue-ocis-1328
 Feature: sharing
 
   Background:

--- a/tests/acceptance/features/apiShareReshareToShares3/reShareWithExpiryDate.feature
+++ b/tests/acceptance/features/apiShareReshareToShares3/reShareWithExpiryDate.feature
@@ -1,4 +1,4 @@
-@api @files_sharing-app-required @issue-ocis-1328 @skipOnOcV10.6 @skipOnOcV10.7 @skipOnOcV10.8.0
+@api @files_sharing-app-required @issue-ocis-1328
 Feature: resharing a resource with an expiration date
 
   Background:
@@ -10,7 +10,7 @@ Feature: resharing a resource with an expiration date
       | Brian    |
     And user "Alice" has uploaded file "filesForUpload/textfile.txt" to "/textfile0.txt"
 
-  @skipOnOcV10.3
+
   Scenario Outline: User should be able to set expiration while resharing a file with user
     Given using OCS API version "<ocs_api_version>"
     And user "Carol" has been created with default attributes and without skeleton files
@@ -34,7 +34,7 @@ Feature: resharing a resource with an expiration date
       | 1               | 100             |
       | 2               | 200             |
 
-  @skipOnOcV10.3 @issue-ocis-reva-194
+  @issue-ocis-reva-194
   Scenario Outline: User should be able to set expiration while resharing a file with group
     Given using OCS API version "<ocs_api_version>"
     And user "Carol" has been created with default attributes and without skeleton files
@@ -60,7 +60,7 @@ Feature: resharing a resource with an expiration date
       | 1               | 100             |
       | 2               | 200             |
 
-  @skipOnOcV10.3
+
   Scenario Outline: resharing with user using the sharing API with expire days set and combinations of default/enforce expire date enabled
     Given using OCS API version "<ocs_api_version>"
     And parameter "shareapi_default_expire_date_user_share" of app "core" has been set to "<default-expire-date>"
@@ -88,7 +88,7 @@ Feature: resharing a resource with an expiration date
       | 1               | no                  |                      | 100             |
       | 2               | no                  |                      | 200             |
 
-  @skipOnOcV10.3 @issue-ocis-reva-194
+  @issue-ocis-reva-194
   Scenario Outline: resharing with group using the sharing API with expire days set and combinations of default/enforce expire date enabled
     Given using OCS API version "<ocs_api_version>"
     And parameter "shareapi_default_expire_date_group_share" of app "core" has been set to "<default-expire-date>"
@@ -118,7 +118,7 @@ Feature: resharing a resource with an expiration date
       | 1               | no                  |                      | 100             |
       | 2               | no                  |                      | 200             |
 
-  @skipOnOcV10.3
+
   Scenario Outline: resharing with user using the sharing API without expire days set and with combinations of default/enforce expire date enabled
     Given using OCS API version "<ocs_api_version>"
     And parameter "shareapi_default_expire_date_user_share" of app "core" has been set to "<default-expire-date>"
@@ -145,7 +145,7 @@ Feature: resharing a resource with an expiration date
       | 1               | no                  |                      | 100             |
       | 2               | no                  |                      | 200             |
 
-  @skipOnOcV10.3 @issue-ocis-reva-194
+  @issue-ocis-reva-194
   Scenario Outline: resharing with group using the sharing API without expire days set and with combinations of default/enforce expire date enabled
     Given using OCS API version "<ocs_api_version>"
     And parameter "shareapi_default_expire_date_group_share" of app "core" has been set to "<default-expire-date>"
@@ -174,7 +174,7 @@ Feature: resharing a resource with an expiration date
       | 1               | no                  |                      | 100             |
       | 2               | no                  |                      | 200             |
 
-  @skipOnOcV10.3
+
   Scenario Outline: resharing with user using the sharing API with expire days set and with combinations of default/enforce expire date enabled and specify expire date in share
     Given using OCS API version "<ocs_api_version>"
     And parameter "shareapi_default_expire_date_user_share" of app "core" has been set to "<default-expire-date>"
@@ -203,7 +203,7 @@ Feature: resharing a resource with an expiration date
       | 1               | no                  | 100             |
       | 2               | no                  | 200             |
 
-  @skipOnOcV10.3 @issue-ocis-reva-194
+  @issue-ocis-reva-194
   Scenario Outline: resharing with group using the sharing API with expire days set and with combinations of default/enforce expire date enabled and specify expire date in share
     Given using OCS API version "<ocs_api_version>"
     And parameter "shareapi_default_expire_date_group_share" of app "core" has been set to "<default-expire-date>"
@@ -234,7 +234,7 @@ Feature: resharing a resource with an expiration date
       | 1               | no                  | 100             |
       | 2               | no                  | 200             |
 
-  @skipOnOcV10.3
+
   Scenario Outline: Setting default expiry date and enforcement after the share is created
     Given using OCS API version "<ocs_api_version>"
     And user "Carol" has been created with default attributes and without skeleton files
@@ -259,7 +259,7 @@ Feature: resharing a resource with an expiration date
       | 1               | no                  | 100             |
       | 2               | no                  | 200             |
 
-  @skipOnOcV10.3 @issue-ocis-reva-194
+  @issue-ocis-reva-194
   Scenario Outline: resharing group share with user using the sharing API with default expire date set and with combinations of default/enforce expire date enabled
     Given using OCS API version "<ocs_api_version>"
     And parameter "shareapi_default_expire_date_user_share" of app "core" has been set to "<default-expire-date>"
@@ -289,7 +289,7 @@ Feature: resharing a resource with an expiration date
       | 1               | no                  |                      | 100             |
       | 2               | no                  |                      | 200             |
 
-  @skipOnOcV10.3 @issue-ocis-reva-194
+  @issue-ocis-reva-194
   Scenario Outline: resharing group share with user using the sharing API with default expire date set and specifying expiration on share and with combinations of default/enforce expire date enabled
     Given using OCS API version "<ocs_api_version>"
     And parameter "shareapi_default_expire_date_user_share" of app "core" has been set to "<default-expire-date>"
@@ -320,7 +320,7 @@ Feature: resharing a resource with an expiration date
       | 1               | no                  | 100             |
       | 2               | no                  | 200             |
 
-  @skipOnOcV10.3
+
   Scenario Outline: resharing using the sharing API with default expire date set but not enforced
     Given using OCS API version "<ocs_api_version>"
     And parameter "shareapi_default_expire_date_user_share" of app "core" has been set to "<default-expire-date>"
@@ -348,7 +348,7 @@ Feature: resharing a resource with an expiration date
       | 1               | no                  | 100             |
       | 2               | no                  | 200             |
 
-  @skipOnOcV10 @skipOnOcV10.3 @issue-37013
+  @skipOnOcV10 @issue-37013
   Scenario Outline: reshare extends the received expiry date up to the default by default
     Given using OCS API version "<ocs_api_version>"
     And parameter "shareapi_default_expire_date_user_share" of app "core" has been set to "<default-expire-date>"
@@ -383,7 +383,7 @@ Feature: resharing a resource with an expiration date
       | 1               | no                  | no                  | 100             |
       | 2               | no                  | no                  | 200             |
 
-  @skipOnOcV10 @skipOnOcV10.3 @issue-37013
+  @skipOnOcV10 @issue-37013
   Scenario Outline: reshare cannot extend the received expiry date further into the future
     Given using OCS API version "<ocs_api_version>"
     And parameter "shareapi_default_expire_date_user_share" of app "core" has been set to "<default-expire-date>"
@@ -415,7 +415,7 @@ Feature: resharing a resource with an expiration date
       | 1               | no                  |
       | 2               | no                  |
 
-  @skipOnOcV10 @skipOnOcV10.3 @issue-37013
+  @skipOnOcV10 @issue-37013
   Scenario Outline: reshare cannot extend the received expiry date past the default when the default is enforced
     Given using OCS API version "<ocs_api_version>"
     And parameter "shareapi_default_expire_date_user_share" of app "core" has been set to "yes"

--- a/tests/acceptance/features/apiShareReshareToShares3/reShareWithExpiryDateOc10Issue37013.feature
+++ b/tests/acceptance/features/apiShareReshareToShares3/reShareWithExpiryDateOc10Issue37013.feature
@@ -1,4 +1,4 @@
-@api @files_sharing-app-required @issue-ocis-1250 @skipOnOcV10.6 @skipOnOcV10.7 @skipOnOcV10.8.0 @notToImplementOnOCIS
+@api @files_sharing-app-required @issue-ocis-1250 @notToImplementOnOCIS
 Feature: resharing a resource with an expiration date
 
   Background:
@@ -10,7 +10,7 @@ Feature: resharing a resource with an expiration date
       | Brian    |
     And user "Alice" has uploaded file "filesForUpload/textfile.txt" to "/textfile0.txt"
 
-  @skipOnOcV10.3 @issue-37013
+  @issue-37013
   Scenario Outline: reshare extends the received expiry date up to the default by default
     Given using OCS API version "<ocs_api_version>"
     And parameter "shareapi_default_expire_date_user_share" of app "core" has been set to "<default-expire-date>"
@@ -45,7 +45,7 @@ Feature: resharing a resource with an expiration date
       | 1               | no                  | no                  |                    | 100             |
       | 2               | no                  | no                  |                    | 200             |
 
-  @skipOnOcV10.3 @issue-37013
+  @issue-37013
   Scenario Outline: reshare can extend the received expiry date further into the future
     Given using OCS API version "<ocs_api_version>"
     And parameter "shareapi_default_expire_date_user_share" of app "core" has been set to "<default-expire-date>"
@@ -79,7 +79,7 @@ Feature: resharing a resource with an expiration date
       | 1               | no                  | 100             |
       | 2               | no                  | 200             |
 
-  @skipOnOcV10.3 @issue-37013
+  @issue-37013
   Scenario Outline: reshare cannot extend the received expiry date past the default when the default is enforced
     Given using OCS API version "<ocs_api_version>"
     And parameter "shareapi_default_expire_date_user_share" of app "core" has been set to "yes"

--- a/tests/acceptance/features/apiShareUpdateToShares/updateShare.feature
+++ b/tests/acceptance/features/apiShareUpdateToShares/updateShare.feature
@@ -1,4 +1,4 @@
-@api @files_sharing-app-required @skipOnOcV10.6 @skipOnOcV10.7 @skipOnOcV10.8.0
+@api @files_sharing-app-required
 Feature: sharing
 
   Background:
@@ -189,7 +189,6 @@ Feature: sharing
       | mimetype          | httpd/unix-directory |
     And as "Alice" folder "/Shares/folder1/folder2" should not exist
     And as "Carol" folder "/Shares/folder2" should exist
-    @skipOnOcV10.6 @skipOnOcV10.7 @skipOnOcV10.8.0
     Examples:
       | folder2_share_path |
       | /folder2           |
@@ -235,7 +234,7 @@ Feature: sharing
       | path          |
       | /Carol-folder |
 
-  @skipOnOcV10.3 @skipOnOcV10.4 @toFixOnOCIS @toFixOnOcV10 @issue-ocis-reva-349 @issue-ocis-reva-350 @issue-ocis-reva-352 @issue-37653
+  @toFixOnOCIS @toFixOnOcV10 @issue-ocis-reva-349 @issue-ocis-reva-350 @issue-ocis-reva-352 @issue-37653
   #after fixing all the issues merge this scenario with the one below
   Scenario Outline: API responds with a full set of parameters when owner changes the permission of a share
     Given using OCS API version "<ocs_api_version>"

--- a/tests/acceptance/features/apiShareUpdateToShares/updateShareGroupAndUserWithSameName.feature
+++ b/tests/acceptance/features/apiShareUpdateToShares/updateShareGroupAndUserWithSameName.feature
@@ -1,4 +1,4 @@
-@api @files_sharing-app-required @issue-ocis-1289 @issue-ocis-1328 @skipOnOcV10.6 @skipOnOcV10.7 @skipOnOcV10.8.0
+@api @files_sharing-app-required @issue-ocis-1289 @issue-ocis-1328
 Feature: updating shares to users and groups that have the same name
 
   Background:

--- a/tests/acceptance/features/apiSharees/sharees.feature
+++ b/tests/acceptance/features/apiSharees/sharees.feature
@@ -583,7 +583,7 @@ Feature: sharees
       | 1               | 100        | 200         |
       | 2               | 200        | 200         |
 
-  @notToImplementOnOCIS @issue-ocis-1317 @issue-ocis-1328 @skipOnOcV10.6 @skipOnOcV10.7 @skipOnOcV10.8.0
+  @notToImplementOnOCIS @issue-ocis-1317 @issue-ocis-1328
   Scenario Outline: empty search for sharees when search min length is set to 0
     Given the administrator has updated system config key "user.search_min_length" with value "0"
     And user "sharee2" has been created with default attributes and without skeleton files
@@ -609,7 +609,7 @@ Feature: sharees
       | 1               | 100        | 200         |
       | 2               | 200        | 200         |
 
-  @skipOnOcV10.5 @skipOnOcV10.6.0 @notToImplementOnOCIS @issue-ocis-1317 @issue-ocis-1328
+  @notToImplementOnOCIS @issue-ocis-1317 @issue-ocis-1328
   Scenario Outline: empty search for sharees when search min length is set to 2
     Given the administrator has updated system config key "user.search_min_length" with value "2"
     And user "sharee2" has been created with default attributes and without skeleton files
@@ -680,7 +680,7 @@ Feature: sharees
       | 1               | 100        | 200         |
       | 2               | 200        | 200         |
 
-  @notToImplementOnOCIS @issue-ocis-1317 @issue-ocis-1328 @skipOnOcV10.6 @skipOnOcV10.7 @skipOnOcV10.8.0
+  @notToImplementOnOCIS @issue-ocis-1317 @issue-ocis-1328
   Scenario Outline: search for sharees without search when min length is set to 0
     Given the administrator has updated system config key "user.search_min_length" with value "0"
     And user "sharee2" has been created with default attributes and without skeleton files
@@ -705,7 +705,7 @@ Feature: sharees
       | 1               | 100        | 200         |
       | 2               | 200        | 200         |
 
-  @skipOnOcV10.5 @skipOnOcV10.6.0 @notToImplementOnOCIS @issue-ocis-1317 @issue-ocis-1328
+  @notToImplementOnOCIS @issue-ocis-1317 @issue-ocis-1328
   Scenario Outline: search for sharees without search when min length is set to 2
     Given the administrator has updated system config key "user.search_min_length" with value "2"
     And user "sharee2" has been created with default attributes and without skeleton files

--- a/tests/acceptance/features/apiTags/assignTags.feature
+++ b/tests/acceptance/features/apiTags/assignTags.feature
@@ -33,7 +33,7 @@ Feature: Assign tags to file/folder
       | name       | type   |
       | MyFirstTag | normal |
 
-  @skipOnOcV10.6 @skipOnOcV10.7
+
   Scenario: Assigning a not user-assignable tag to a file shared by someone else as regular user should fail
     Given the administrator has created a "normal" tag with name "MyFirstTag"
     And the administrator has created a "not user-assignable" tag with name "MySecondTag"
@@ -46,7 +46,7 @@ Feature: Assign tags to file/folder
       | name       | type   |
       | MyFirstTag | normal |
 
-  @skipOnOcV10.6 @skipOnOcV10.7
+
   Scenario: Assigning a not user-assignable tag to a file shared by someone else as regular user belongs to tag's groups should work
     Given group "grp1" has been created
     And user "Brian" has been added to group "grp1"
@@ -72,7 +72,7 @@ Feature: Assign tags to file/folder
       | name          | type   |
       | StaticTagName | static |
 
-  @skipOnOcV10.6 @skipOnOcV10.7
+
   Scenario: Assigning a not user-visible tag to a file shared by someone else as regular user should fail
     Given the administrator has created a "normal" tag with name "MyFirstTag"
     And the administrator has created a "not user-visible" tag with name "MySecondTag"
@@ -85,7 +85,7 @@ Feature: Assign tags to file/folder
       | name       | type   |
       | MyFirstTag | normal |
 
-  @skipOnOcV10.6 @skipOnOcV10.7
+
   Scenario: Assigning a static tag to a file shared by someone else as regular user does not belong to tag's group should fail
     Given group "hash#group" has been created
     And user "Alice" has been added to group "hash#group"
@@ -100,7 +100,7 @@ Feature: Assign tags to file/folder
       | name      | type   |
       | NormalTag | normal |
 
-  @skipOnOcV10.6 @skipOnOcV10.7
+
   Scenario: Assigning a not user-visible tag to a file shared by someone else as admin user should work
     Given the administrator has created a "normal" tag with name "MyFirstTag"
     And the administrator has created a "not user-visible" tag with name "MySecondTag"
@@ -117,7 +117,7 @@ Feature: Assign tags to file/folder
       | name       | type   |
       | MyFirstTag | normal |
 
-  @skipOnOcV10.6 @skipOnOcV10.7
+
   Scenario: Assigning a not user-assignable tag to a file shared by someone else as admin user should work
     Given the administrator has created a "normal" tag with name "MyFirstTag"
     And the administrator has created a "not user-assignable" tag with name "MySecondTag"

--- a/tests/acceptance/features/apiTags/assignTagsGroup.feature
+++ b/tests/acceptance/features/apiTags/assignTagsGroup.feature
@@ -6,7 +6,7 @@ Feature: Assign tag to groups
   Background:
     Given user "Alice" has been created with default attributes and without skeleton files
 
-  @skipOnOcV10.6 @skipOnOcV10.7
+
   Scenario: User can assign tags when in the tag's groups
     Given group "grp1" has been created
     And user "Alice" has been added to group "grp1"
@@ -22,7 +22,7 @@ Feature: Assign tag to groups
     Then the HTTP status code should be "201"
     And user "Alice" should be able to assign the "static" tag with name "TagWithGroups"
 
-  @skipOnOcV10.6 @skipOnOcV10.7
+
   Scenario: User cannot assign tags when not in the tag's groups
     When the administrator creates a "not user-assignable" tag with name "TagWithGroups" and groups "grp2|group2" using the WebDAV API
     Then the HTTP status code should be "201"

--- a/tests/acceptance/features/apiTags/createTags.feature
+++ b/tests/acceptance/features/apiTags/createTags.feature
@@ -37,25 +37,25 @@ Feature: Creation of tags
       | name       | type   |
       | RegularTag | normal |
 
-  @skipOnOcV10.6 @skipOnOcV10.7
+
   Scenario: Creating a not user-assignable tag as regular user should fail
     When user "Alice" creates a "not user-assignable" tag with name "JustARegularTagName" using the WebDAV API
     Then the HTTP status code should be "400"
     And tag "JustARegularTagName" should not exist for the administrator
 
-  @skipOnOcV10.6 @skipOnOcV10.7
+
   Scenario: Creating a static tag as regular user should fail
     When user "Alice" creates a "static" tag with name "StaticTagName" using the WebDAV API
     Then the HTTP status code should be "400"
     And tag "StaticTagName" should not exist for the administrator
 
-  @skipOnOcV10.6 @skipOnOcV10.7
+
   Scenario: Creating a not user-visible tag as regular user should fail
     When user "Alice" creates a "not user-visible" tag with name "JustARegularTagName" using the WebDAV API
     Then the HTTP status code should be "400"
     And tag "JustARegularTagName" should not exist for the administrator
 
-  @skipOnOcV10.6 @skipOnOcV10.7
+
   Scenario Outline: Creating a tag as administrator should work
     When the administrator creates a "<tag_type>" tag with name "JustARegularTagName" sending <sending_style> in the request using the WebDAV API
     Then the HTTP status code should be "201"
@@ -73,7 +73,7 @@ Feature: Creation of tags
       | static              | true-false-strings |
       | static              | numbers            |
 
-  @smokeTest @skipOnOcV10.6 @skipOnOcV10.7
+  @smokeTest
   Scenario: Creating a not user-assignable tag with groups as admin should work
     When the administrator creates a "not user-assignable" tag with name "TagWithGroups" and groups "group1|group2" using the WebDAV API
     Then the HTTP status code should be "201"

--- a/tests/acceptance/features/apiTags/deleteTags.feature
+++ b/tests/acceptance/features/apiTags/deleteTags.feature
@@ -23,7 +23,7 @@ Feature: Deletion of tags
     And tag "JustARegularTagName" should not exist for the administrator
     And file "/myFileToTag.txt" should have no tags for user "Alice"
 
-  @skipOnOcV10.6 @skipOnOcV10.7
+
   Scenario: Deleting a not user-assignable tag as regular user should fail
     Given the administrator has created a "not user-assignable" tag with name "JustARegularTagName"
     When user "Alice" deletes the tag with name "JustARegularTagName" using the WebDAV API
@@ -32,7 +32,7 @@ Feature: Deletion of tags
       | name                | type                |
       | JustARegularTagName | not user-assignable |
 
-  @skipOnOcV10.6 @skipOnOcV10.7
+
   Scenario: Deleting a not user-visible tag as regular user should fail
     Given the administrator has created a "not user-visible" tag with name "JustARegularTagName"
     When user "Alice" deletes the tag with name "JustARegularTagName" using the WebDAV API
@@ -41,7 +41,7 @@ Feature: Deletion of tags
       | name                | type             |
       | JustARegularTagName | not user-visible |
 
-  @skipOnOcV10.6 @skipOnOcV10.7
+
   Scenario: Deleting a static tag as regular user should fail
     Given the administrator has created a "static" tag with name "StaticTagName"
     When user "Alice" deletes the tag with name "StaticTagName" using the WebDAV API

--- a/tests/acceptance/features/apiTags/editTags.feature
+++ b/tests/acceptance/features/apiTags/editTags.feature
@@ -20,7 +20,7 @@ Feature: Editing the tags
       | 😀                  |
       | सिमप्ले             |
 
-  @skipOnOcV10.6 @skipOnOcV10.7
+
   Scenario: Renaming a not user-assignable tag as regular user should fail
     Given the administrator has created a "not user-assignable" tag with name "JustARegularTagName"
     When user "Alice" edits the tag with name "JustARegularTagName" and sets its name to "AnotherTagName" using the WebDAV API
@@ -29,7 +29,7 @@ Feature: Editing the tags
       | name                | type                |
       | JustARegularTagName | not user-assignable |
 
-  @skipOnOcV10.6 @skipOnOcV10.7
+
   Scenario: Renaming a static tag as regular user should fail
     Given the administrator has created a "static" tag with name "StaticTagName"
     When user "Alice" edits the tag with name "StaticTagName" and sets its name to "AnotherTagName" using the WebDAV API
@@ -38,7 +38,7 @@ Feature: Editing the tags
       | name          | type   |
       | StaticTagName | static |
 
-  @skipOnOcV10.6 @skipOnOcV10.7
+
   Scenario: Renaming a not user-visible tag as regular user should fail
     Given the administrator has created a "not user-visible" tag with name "JustARegularTagName"
     When user "Alice" edits the tag with name "JustARegularTagName" and sets its name to "AnotherTagName" using the WebDAV API
@@ -47,7 +47,7 @@ Feature: Editing the tags
       | name                | type             |
       | JustARegularTagName | not user-visible |
 
-  @skipOnOcV10.6 @skipOnOcV10.7
+
   Scenario: Renaming a not user-assignable tag as administrator should work
     Given the administrator has created a "not user-assignable" tag with name "JustARegularTagName"
     When the administrator edits the tag with name "JustARegularTagName" and sets its name to "AnotherTagName" using the WebDAV API
@@ -57,7 +57,7 @@ Feature: Editing the tags
       | AnotherTagName | not user-assignable |
     And tag "JustARegularTagName" should not exist for the administrator
 
-  @skipOnOcV10.6 @skipOnOcV10.7
+
   Scenario: Renaming a not user-visible tag as administrator should work
     Given the administrator has created a "not user-visible" tag with name "JustARegularTagName"
     When the administrator edits the tag with name "JustARegularTagName" and sets its name to "AnotherTagName" using the WebDAV API
@@ -77,21 +77,21 @@ Feature: Editing the tags
       | AnotherTagName | static |
     And tag "StaticTagName" should not exist for the administrator
 
-  @skipOnOcV10.6 @skipOnOcV10.7
+
   Scenario: Editing tag groups as admin should work
     Given the administrator has created a "not user-assignable" tag with name "TagWithGroups" and groups "group1|group2"
     When the administrator edits the tag with name "TagWithGroups" and sets its groups to "group1|group3" using the WebDAV API
     Then the HTTP status code should be "207"
     And the "not user-assignable" tag with name "TagWithGroups" should have the groups "group1|group3"
 
-  @skipOnOcV10.6 @skipOnOcV10.7
+
   Scenario: Editing static tag groups as admin should work
     Given the administrator has created a "static" tag with name "StaticTagWithGroups" and groups "group1|group2"
     When the administrator edits the tag with name "StaticTagWithGroups" and sets its groups to "group1|group3" using the WebDAV API
     Then the HTTP status code should be "207"
     And the "static" tag with name "StaticTagWithGroups" should have the groups "group1|group3"
 
-  @skipOnOcV10.6 @skipOnOcV10.7
+
   Scenario: Editing tag groups as regular user should fail
     Given the administrator has created a "not user-assignable" tag with name "TagWithGroups" and groups "group1|group2"
     When user "Alice" edits the tag with name "TagWithGroups" and sets its groups to "group1|group3" using the WebDAV API

--- a/tests/acceptance/features/apiTags/unassignTags.feature
+++ b/tests/acceptance/features/apiTags/unassignTags.feature
@@ -37,7 +37,7 @@ Feature: Unassigning tags from file/folder
       | MyFirstTag  | normal |
       | MySecondTag | normal |
 
-  @skipOnOcV10.6 @skipOnOcV10.7
+
   Scenario: Unassigning a not user-visible tag from a file shared by someone else as regular user should fail
     Given the administrator has created a "not user-visible" tag with name "MyFirstTag"
     And the administrator has created a "normal" tag with name "MySecondTag"
@@ -56,7 +56,7 @@ Feature: Unassigning tags from file/folder
       | MyFirstTag  | not user-visible |
       | MySecondTag | normal           |
 
-  @skipOnOcV10.6 @skipOnOcV10.7
+
   Scenario: Unassigning a static tag from a file and not part of static tags group shared by someone else as regular user should fail
     Given the administrator has created a "static" tag with name "StaticTag"
     And user "Alice" has created a "normal" tag with name "MySecondTag"
@@ -125,7 +125,7 @@ Feature: Unassigning tags from file/folder
     When the administrator removes tag "MyFirstTag" from file "/myFileToTag.txt" shared by "Alice" using the WebDAV API
     Then the HTTP status code should be "404"
 
-  @skipOnOcV10.6 @skipOnOcV10.7
+
   Scenario: Unassigning a not user-assignable tag from a file shared by someone else as regular user should fail
     Given the administrator has created a "not user-assignable" tag with name "MyFirstTag"
     And the administrator has created a "normal" tag with name "MySecondTag"

--- a/tests/acceptance/features/apiTrashbin/trashbinDelete.feature
+++ b/tests/acceptance/features/apiTrashbin/trashbinDelete.feature
@@ -84,7 +84,7 @@ Feature: files and folders can be deleted from the trashbin
       | dav-path |
       | spaces   |
 
-  @skipOnOcV10.3
+
   Scenario Outline: User tries to delete another user's trashbin
     Given using <dav-path> DAV path
     And user "Brian" has been created with default attributes and without skeleton files

--- a/tests/acceptance/features/apiTrashbin/trashbinFilesFolders.feature
+++ b/tests/acceptance/features/apiTrashbin/trashbinFilesFolders.feature
@@ -176,7 +176,7 @@ Feature: files and folders exist in the trashbin after being deleted
       | dav-path |
       | spaces   |
 
-  @issue-ocis-3561 @skipOnLDAP @skip_on_objectstore @skipOnOcV10.3
+  @issue-ocis-3561 @skipOnLDAP @skip_on_objectstore
   Scenario Outline: Listing other user's trashbin is prohibited
     Given using <dav-path> DAV path
     And user "testtrashbin100" has been created with default attributes and without skeleton files
@@ -198,7 +198,7 @@ Feature: files and folders exist in the trashbin after being deleted
       | new      | 404         |
       | spaces   | 404         |
 
-  @issue-ocis-3561 @smokeTest @skipOnLDAP @skip_on_objectstore @skipOnOcV10.3
+  @issue-ocis-3561 @smokeTest @skipOnLDAP @skip_on_objectstore
   Scenario Outline: Listing other user's trashbin is prohibited with multiple files on trashbin
     Given using <dav-path> DAV path
     And user "testtrashbin101" has been created with default attributes and without skeleton files
@@ -223,7 +223,7 @@ Feature: files and folders exist in the trashbin after being deleted
       | new      | 404         |
       | spaces   | 404         |
 
-  @issue-ocis-3561 @skipOnLDAP @skip_on_objectstore @skipOnOcV10.3  @provisioning_api-app-required
+  @issue-ocis-3561 @skipOnLDAP @skip_on_objectstore  @provisioning_api-app-required
   Scenario Outline: Listing other user's trashbin is prohibited for newly recreated user with same name
     Given using <dav-path> DAV path
     And user "testtrashbin102" has been created with default attributes and without skeleton files

--- a/tests/acceptance/features/apiTrashbin/trashbinSharingToRoot.feature
+++ b/tests/acceptance/features/apiTrashbin/trashbinSharingToRoot.feature
@@ -140,7 +140,7 @@ Feature: using trashbin together with sharing
       | dav-path |
       | new      |
 
-  @skipOnOcV10.6 @skipOnOcV10.7 @skipOnOcV10.8.0
+
   Scenario Outline: restoring a file to a read-only folder is not allowed
     Given using <dav-path> DAV path
     And user "Brian" has been created with default attributes and without skeleton files
@@ -158,7 +158,7 @@ Feature: using trashbin together with sharing
       | dav-path |
       | new      |
 
-  @skipOnOcV10.6 @skipOnOcV10.7 @skipOnOcV10.8.0
+
   Scenario Outline: restoring a file to a read-only sub-folder is not allowed
     Given using <dav-path> DAV path
     And user "Brian" has been created with default attributes and without skeleton files

--- a/tests/acceptance/features/apiTrashbin/trashbinSharingToShares.feature
+++ b/tests/acceptance/features/apiTrashbin/trashbinSharingToShares.feature
@@ -1,4 +1,4 @@
-@api @files_trashbin-app-required @files_sharing-app-required @skipOnOcV10.6 @skipOnOcV10.7 @skipOnOcV10.8.0
+@api @files_trashbin-app-required @files_sharing-app-required
 Feature: using trashbin together with sharing
 
   Background:

--- a/tests/acceptance/features/apiTrashbin/trashbinSkip.feature
+++ b/tests/acceptance/features/apiTrashbin/trashbinSkip.feature
@@ -1,4 +1,4 @@
-@api @files_trashbin-app-required @notToImplementOnOCIS @skipOnOcV10.6 @skipOnOcV10.7
+@api @files_trashbin-app-required @notToImplementOnOCIS
 Feature: files and folders can be deleted completely skipping the trashbin
   As an admin
   I want to configure some files to be deleted without the trashbin

--- a/tests/acceptance/features/apiTrashbinRestore/trashbinRestore.feature
+++ b/tests/acceptance/features/apiTrashbinRestore/trashbinRestore.feature
@@ -183,7 +183,7 @@ Feature: Restore deleted files/folders
     And as "Alice" the folder with original path "/local_storage/tmp/textfile0.txt" should not exist in the trashbin
     And the content of file "/local_storage/tmp/textfile0.txt" for user "Alice" should be "AA"
 
-  @smokeTest @skipOnOcV10.3
+  @smokeTest
   Scenario Outline: A deleted file cannot be restored by a different user
     Given using <dav-path> DAV path
     And user "Brian" has been created with default attributes and without skeleton files
@@ -502,7 +502,7 @@ Feature: Restore deleted files/folders
       | old      |
       | new      |
 
-  @skipOnOcV10.6 @skipOnOcV10.7 @skipOnOcV10.8.0
+
   Scenario Outline: A deleted file inside a nested folder cannot be restored without the destination
     Given using <dav-path> DAV path
     And user "Alice" has created folder "/parent_folder"
@@ -521,7 +521,7 @@ Feature: Restore deleted files/folders
       | old      |
       | new      |
 
-  @skipOnOcV10.6 @skipOnOcV10.7 @skipOnOcV10.8.0
+
   Scenario Outline: A deleted file cannot be restored without the destination
     Given using <dav-path> DAV path
     And user "Alice" has uploaded file with content "parent text" to "/parent.txt"

--- a/tests/acceptance/features/apiVersions/fileVersionAuthor.feature
+++ b/tests/acceptance/features/apiVersions/fileVersionAuthor.feature
@@ -10,7 +10,7 @@ Feature: file versions remember the author of each version
     And user "Carol" has been created with default attributes and without skeleton files
     And the administrator has enabled the file version storage feature
 
-  @skip_on_objectstore @skipOnOcV10.6 @skipOnOcV10.7 @skipOnOcV10.8.0
+  @skip_on_objectstore
   Scenario: enable file versioning and check the history of changes from multiple users
     Given user "David" has been created with default attributes and without skeleton files
     And user "Alice" has created folder "/test"
@@ -33,7 +33,7 @@ Feature: file versions remember the author of each version
       | 2     | Brian  |
       | 3     | Alice  |
 
-  @skip_on_objectstore @skipOnOcV10.6 @skipOnOcV10.7 @skipOnOcV10.8.0
+  @skip_on_objectstore
   Scenario: enable file versioning and check the history of changes from multiple users for shared folder in the group
     Given user "Alice" has created folder "/test"
     And group "grp1" has been created
@@ -54,7 +54,7 @@ Feature: file versions remember the author of each version
       | 1     | Brian  |
       | 2     | Alice  |
 
-  @skip_on_objectstore @skipOnOcV10.6 @skipOnOcV10.7 @skipOnOcV10.8.0
+  @skip_on_objectstore
   Scenario: enable file versioning and check the history of changes from multiple users for shared file in the group
     Given group "grp1" has been created
     And user "Alice" has been added to group "grp1"
@@ -74,7 +74,7 @@ Feature: file versions remember the author of each version
       | 1     | Brian  |
       | 2     | Alice  |
 
-  @skip_on_objectstore @skipOnOcV10.6 @skipOnOcV10.7 @skipOnOcV10.8.0 @skipOnEncryption @issue-encryption-321
+  @skip_on_objectstore @skipOnEncryption @issue-encryption-321
   Scenario: enable file versioning and check the history of changes from multiple users while moving file in/out of a subfolder
     Given user "Alice" has created folder "/test"
     And group "grp1" has been created
@@ -100,7 +100,7 @@ Feature: file versions remember the author of each version
       | 2     | Brian  |
       | 3     | Alice  |
 
-  @skip_on_objectstore @skipOnOcV10.6 @skipOnOcV10.7 @skipOnOcV10.8.0
+  @skip_on_objectstore
   Scenario: enable file versioning and check the history of changes from multiple users after renaming file by sharer
     Given group "grp1" has been created
     And user "Alice" has been added to group "grp1"
@@ -125,7 +125,7 @@ Feature: file versions remember the author of each version
       | 1     | Brian  |
       | 2     | Alice  |
 
-  @skip_on_objectstore @skipOnOcV10.6 @skipOnOcV10.7 @skipOnOcV10.8.0
+  @skip_on_objectstore
   Scenario: enable file versioning and check the history of changes in sharer after renaming file by sharee
     Given group "grp1" has been created
     And user "Alice" has been added to group "grp1"
@@ -150,7 +150,7 @@ Feature: file versions remember the author of each version
       | 1     | Brian  |
       | 2     | Alice  |
 
-  @skip_on_objectstore @skipOnOcV10.6 @skipOnOcV10.7 @skipOnOcV10.8.0
+  @skip_on_objectstore
   Scenario: enable file versioning and check the history of changes from multiple users when reshared after unshared by sharer
     Given user "Alice" has created folder "/test"
     And group "grp1" has been created
@@ -176,7 +176,7 @@ Feature: file versions remember the author of each version
       | 2     | Brian  |
       | 3     | Alice  |
 
-  @skip_on_objectstore @skipOnOcV10.6 @skipOnOcV10.7 @skipOnOcV10.8.0
+  @skip_on_objectstore
   Scenario: enable file versioning and check the history of changes from multiple users who have a matching folder/file
     Given user "David" has been created with default attributes and without skeleton files
     And user "Brian" has created folder "/test"
@@ -219,7 +219,7 @@ Feature: file versions remember the author of each version
     Then the HTTP status code should be "207"
     And the number of versions should be "0"
 
-  @skip_on_objectstore @skipOnOcV10.6 @skipOnOcV10.7 @skipOnOcV10.8.0
+  @skip_on_objectstore
   Scenario: enable file versioning and check the history of changes from multiple users who have a matching file
     Given user "David" has been created with default attributes and without skeleton files
     And user "Brian" has uploaded file with content "duplicate brian" to "/textfile0.txt"

--- a/tests/acceptance/features/apiVersions/fileVersions.feature
+++ b/tests/acceptance/features/apiVersions/fileVersions.feature
@@ -361,7 +361,7 @@ Feature: dav-versions
       | old         | Brian |
       | new         | Brian |
 
-  @skipOnOcV10.3.0 @files_sharing-app-required @issue-ocis-1238 @notToImplementOnOCIS
+  @files_sharing-app-required @issue-ocis-1238 @notToImplementOnOCIS
   Scenario: Receiver tries to get file versions of unshared file from the sharer
     Given user "Brian" has been created with default attributes and without skeleton files
     And user "Alice" has uploaded file with content "textfile0" to "textfile0.txt"

--- a/tests/acceptance/features/apiVersions/fileVersionsSharingToShares.feature
+++ b/tests/acceptance/features/apiVersions/fileVersionsSharingToShares.feature
@@ -1,4 +1,4 @@
-@api @files_versions-app-required @issue-ocis-reva-275 @skipOnOcV10.6 @skipOnOcV10.7 @skipOnOcV10.8.0
+@api @files_versions-app-required @issue-ocis-reva-275
 
 Feature: dav-versions
 
@@ -159,7 +159,7 @@ Feature: dav-versions
     And the content of file "/sharefile.txt" for user "Alice" should be "old content"
     And the content of file "/received/sharefile.txt" for user "Brian" should be "old content"
 
-  @files_sharing-app-required @notToImplementOnOCIS @skipOnOcV10.6 @skipOnOcV10.7 @skipOnOcV10.8.0
+  @files_sharing-app-required @notToImplementOnOCIS
   Scenario: sharee can restore a shared file created and modified by sharer, when the file has been moved by the sharee (file is inside a folder of the sharer)
     Given user "Brian" has been created with default attributes and without skeleton files
     And user "Alice" has created folder "/sharingfolder"
@@ -255,7 +255,7 @@ Feature: dav-versions
       | old         | Brian | /testshare |
       | new         | Brian | /testshare |
 
-  @skipOnOcV10.3.0 @files_sharing-app-required
+  @files_sharing-app-required
   Scenario: Receiver tries to get file versions of unshared file from the sharer
     Given user "Brian" has been created with default attributes and without skeleton files
     And user "Alice" has uploaded file with content "textfile0" to "textfile0.txt"
@@ -302,7 +302,7 @@ Feature: dav-versions
     And the version folder of file "/Shares/sharefile.txt" for user "Brian" should contain "1" element
     And the version folder of file "/sharefile.txt" for user "Alice" should contain "1" element
 
-  @skipOnOcV10.6 @skipOnOcV10.7 @skipOnOcV10.8.0
+
   Scenario: download old versions of a shared file as share receiver
     Given user "Brian" has been created with default attributes and without skeleton files
     And user "Alice" has uploaded file with content "uploaded content" to "textfile0.txt"

--- a/tests/acceptance/features/apiWebdavEtagPropagation1/deleteFileFolder.feature
+++ b/tests/acceptance/features/apiWebdavEtagPropagation1/deleteFileFolder.feature
@@ -83,7 +83,7 @@ Feature: propagation of etags when deleting a file or folder
       | dav_version |
       | spaces      |
 
-  @skipOnOcV10.6 @skipOnOcV10.7 @skipOnOcV10.8.0
+
   Scenario Outline: as share receiver deleting a file changes the etags of all parents for all collaborators
     Given user "Brian" has been created with default attributes and without skeleton files
     And using <dav_version> DAV path
@@ -114,7 +114,7 @@ Feature: propagation of etags when deleting a file or folder
       | old         |
       | new         |
 
-  @skipOnOcV10.6 @skipOnOcV10.7 @skipOnOcV10.8.0
+
   Scenario Outline: as sharer deleting a file changes the etags of all parents for all collaborators
     Given user "Brian" has been created with default attributes and without skeleton files
     And using <dav_version> DAV path
@@ -145,7 +145,7 @@ Feature: propagation of etags when deleting a file or folder
       | old         |
       | new         |
 
-  @issue-product-280 @skipOnOcV10.6 @skipOnOcV10.7 @skipOnOcV10.8.0
+  @issue-product-280
   Scenario Outline: as share receiver deleting a folder changes the etags of all parents for all collaborators
     Given user "Brian" has been created with default attributes and without skeleton files
     And the administrator has set the default folder for received shares to "Shares"
@@ -178,7 +178,7 @@ Feature: propagation of etags when deleting a file or folder
       | old         |
       | new         |
 
-  @issue-product-280 @skipOnOcV10.6 @skipOnOcV10.7 @skipOnOcV10.8.0
+  @issue-product-280
   Scenario Outline: as sharer deleting a folder changes the etags of all parents for all collaborators
     Given user "Brian" has been created with default attributes and without skeleton files
     And the administrator has set the default folder for received shares to "Shares"

--- a/tests/acceptance/features/apiWebdavEtagPropagation1/moveFileFolder.feature
+++ b/tests/acceptance/features/apiWebdavEtagPropagation1/moveFileFolder.feature
@@ -154,7 +154,7 @@ Feature: propagation of etags when moving files or folders
       | dav_version |
       | spaces      |
 
-  @skipOnOcV10.6 @skipOnOcV10.7 @skipOnOcV10.8.0
+
   Scenario Outline: as share receiver renaming a file inside a folder changes its etag for all collaborators
     Given user "Brian" has been created with default attributes and without skeleton files
     And the administrator has set the default folder for received shares to "Shares"
@@ -183,7 +183,7 @@ Feature: propagation of etags when moving files or folders
       | old         |
       | new         |
 
-  @skipOnOcV10.6 @skipOnOcV10.7 @skipOnOcV10.8.0
+
   Scenario Outline: as sharer renaming a file inside a folder changes its etag for all collaborators
     Given user "Brian" has been created with default attributes and without skeleton files
     And the administrator has set the default folder for received shares to "Shares"
@@ -212,7 +212,7 @@ Feature: propagation of etags when moving files or folders
       | old         |
       | new         |
 
-  @issue-product-280 @skipOnOcV10.6 @skipOnOcV10.7 @skipOnOcV10.8.0
+  @issue-product-280
   Scenario Outline: as sharer moving a file from one folder to an other changes the etags of both folders for all collaborators
     Given user "Brian" has been created with default attributes and without skeleton files
     And the administrator has set the default folder for received shares to "Shares"
@@ -248,7 +248,7 @@ Feature: propagation of etags when moving files or folders
       | old         |
       | new         |
 
-  @skipOnOcV10.6 @skipOnOcV10.7 @skipOnOcV10.8.0
+
   Scenario Outline: as share receiver moving a file from one folder to an other changes the etags of both folders for all collaborators
     Given user "Brian" has been created with default attributes and without skeleton files
     And the administrator has set the default folder for received shares to "Shares"
@@ -284,7 +284,7 @@ Feature: propagation of etags when moving files or folders
       | old         |
       | new         |
 
-  @issue-product-280 @skipOnOcV10.6 @skipOnOcV10.7 @skipOnOcV10.8.0
+  @issue-product-280
   Scenario Outline: as sharer moving a folder from one folder to an other changes the etags of both folders for all collaborators
     Given user "Brian" has been created with default attributes and without skeleton files
     And the administrator has set the default folder for received shares to "Shares"
@@ -320,7 +320,7 @@ Feature: propagation of etags when moving files or folders
       | old         |
       | new         |
 
-  @skipOnOcV10.6 @skipOnOcV10.7 @skipOnOcV10.8.0
+
   Scenario Outline: as share receiver moving a folder from one folder to an other changes the etags of both folders for all collaborators
     Given user "Brian" has been created with default attributes and without skeleton files
     And the administrator has set the default folder for received shares to "Shares"

--- a/tests/acceptance/features/apiWebdavEtagPropagation2/copyFileFolder.feature
+++ b/tests/acceptance/features/apiWebdavEtagPropagation2/copyFileFolder.feature
@@ -151,7 +151,7 @@ Feature: propagation of etags when copying files or folders
       | dav_version |
       | spaces      |
 
-  @skipOnOcV10.6 @skipOnOcV10.7 @skipOnOcV10.8.0
+
   Scenario Outline: as share receiver copying a file inside a folder changes its etag for all collaborators
     Given user "Brian" has been created with default attributes and without skeleton files
     And the administrator has set the default folder for received shares to "Shares"
@@ -190,7 +190,7 @@ Feature: propagation of etags when copying files or folders
       | old         |
       | new         |
 
-  @issue-product-280 @skipOnOcV10.6 @skipOnOcV10.7 @skipOnOcV10.8.0
+  @issue-product-280
   Scenario Outline: as sharer copying a file inside a folder changes its etag for all collaborators
     Given user "Brian" has been created with default attributes and without skeleton files
     And the administrator has set the default folder for received shares to "Shares"

--- a/tests/acceptance/features/apiWebdavEtagPropagation2/createFolder.feature
+++ b/tests/acceptance/features/apiWebdavEtagPropagation2/createFolder.feature
@@ -53,7 +53,7 @@ Feature: propagation of etags when creating folders
       | dav_version |
       | spaces      |
 
-  @issue-product-280 @skipOnOcV10.6 @skipOnOcV10.7 @skipOnOcV10.8.0
+  @issue-product-280
   Scenario Outline: as share receiver creating a folder inside a folder received as a share changes its etag for all collaborators
     Given user "Brian" has been created with default attributes and without skeleton files
     And using <dav_version> DAV path
@@ -79,7 +79,7 @@ Feature: propagation of etags when creating folders
       | old         |
       | new         |
 
-  @issue-product-280 @skipOnOcV10.6 @skipOnOcV10.7 @skipOnOcV10.8.0
+  @issue-product-280
   Scenario Outline: as a sharer creating a folder inside a shared folder changes etag for all collaborators
     Given user "Brian" has been created with default attributes and without skeleton files
     And using <dav_version> DAV path

--- a/tests/acceptance/features/apiWebdavEtagPropagation2/upload.feature
+++ b/tests/acceptance/features/apiWebdavEtagPropagation2/upload.feature
@@ -52,7 +52,7 @@ Feature: propagation of etags when uploading data
       | dav_version |
       | spaces      |
 
-  @issue-product-280 @skipOnOcV10.6 @skipOnOcV10.7 @skipOnOcV10.8.0
+  @issue-product-280
   Scenario Outline: as share receiver uploading a file inside a received shared folder should update etags for all collaborators
     Given user "Brian" has been created with default attributes and without skeleton files
     And using <dav_version> DAV path
@@ -77,7 +77,7 @@ Feature: propagation of etags when uploading data
       | old         |
       | new         |
 
-  @issue-product-280 @skipOnOcV10.6 @skipOnOcV10.7 @skipOnOcV10.8.0
+  @issue-product-280
   Scenario Outline: as sharer uploading a file inside a shared folder should update etags for all collaborators
     Given user "Brian" has been created with default attributes and without skeleton files
     And using <dav_version> DAV path
@@ -102,7 +102,7 @@ Feature: propagation of etags when uploading data
       | old         |
       | new         |
 
-  @skipOnOcV10.6 @skipOnOcV10.7 @skipOnOcV10.8.0
+
   Scenario Outline: as share receiver overwriting a file inside a received shared folder should update etags for all collaborators
     Given user "Brian" has been created with default attributes and without skeleton files
     And using <dav_version> DAV path
@@ -128,7 +128,7 @@ Feature: propagation of etags when uploading data
       | old         |
       | new         |
 
-  @skipOnOcV10.6 @skipOnOcV10.7 @skipOnOcV10.8.0
+
   Scenario Outline: as sharer overwriting a file inside a shared folder should update etags for all collaborators
     Given user "Brian" has been created with default attributes and without skeleton files
     And using <dav_version> DAV path

--- a/tests/acceptance/features/apiWebdavLocks/publicLink.feature
+++ b/tests/acceptance/features/apiWebdavLocks/publicLink.feature
@@ -24,16 +24,12 @@ Feature: persistent-locking in case of a public link
       | old      | exclusive  | old                       |
       | new      | shared     | old                       |
       | new      | exclusive  | old                       |
-
-    @skipOnOcV10.6 @skipOnOcV10.7
-    Examples:
-      | dav-path | lock-scope | public-webdav-api-version |
       | old      | shared     | new                       |
       | old      | exclusive  | new                       |
       | new      | shared     | new                       |
       | new      | exclusive  | new                       |
 
-  @skipOnOcV10.6 @skipOnOcV10.7
+
   Scenario Outline: Uploading a file into a locked subfolder of a public folder
     Given user "Alice" has created a public link share of folder "PARENT" with change permission
     And user "Alice" has locked folder "PARENT/CHILD" setting the following properties
@@ -48,7 +44,7 @@ Feature: persistent-locking in case of a public link
       | new                       | shared     |
       | new                       | exclusive  |
 
-  @smokeTest @skipOnOcV10.6 @skipOnOcV10.7
+  @smokeTest
   Scenario Outline: Overwrite a file inside a locked public folder
     Given user "Alice" has created a public link share of folder "PARENT" with change permission
     And user "Alice" has locked folder "PARENT" setting the following properties
@@ -66,7 +62,7 @@ Feature: persistent-locking in case of a public link
       | new                       | shared     |
       | new                       | exclusive  |
 
-  @skipOnOcV10.6 @skipOnOcV10.7
+
   Scenario Outline: Overwrite a file inside a locked subfolder of a public folder
     Given user "Alice" has created a public link share of folder "PARENT" with change permission
     And user "Alice" has locked folder "PARENT/CHILD" setting the following properties
@@ -86,7 +82,7 @@ Feature: persistent-locking in case of a public link
       | new                       | shared     |
       | new                       | exclusive  |
 
-  @smokeTest @skipOnOcV10.3
+  @smokeTest
   Scenario Outline: Public locking is not supported
     Given user "Alice" has created a public link share of folder "PARENT" with change permission
     When the public locks "/CHILD" in the last public link shared folder using the <public-webdav-api-version> public WebDAV API setting the following properties

--- a/tests/acceptance/features/apiWebdavLocks/requestsWithToken.feature
+++ b/tests/acceptance/features/apiWebdavLocks/requestsWithToken.feature
@@ -98,10 +98,6 @@ Feature: actions on a locked item are possible if the token is sent with the req
       | lock-scope | webdav_api_version | http_status_code |
       | shared     | old                | 423              |
       | exclusive  | old                | 423              |
-
-    @skipOnOcV10.6 @skipOnOcV10.7
-    Examples:
-      | lock-scope | webdav_api_version | http_status_code |
       | shared     | new                | 423              |
       | exclusive  | new                | 423              |
 

--- a/tests/acceptance/features/apiWebdavLocks/requestsWithTokenOc10Issue34338.feature
+++ b/tests/acceptance/features/apiWebdavLocks/requestsWithTokenOc10Issue34338.feature
@@ -1,7 +1,7 @@
 @api @notToImplementOnOCIS @issue-ocis-reva-172
 Feature: actions on a locked item are possible if the token is sent with the request
 
-  @issue-34338 @files_sharing-app-required @skipOnOcV10.6 @skipOnOcV10.7 @skipOnOcV10.8.0
+  @issue-34338 @files_sharing-app-required
   Scenario Outline: share receiver cannot rename a file in a folder locked by the owner even when sending the locktoken
     Given these users have been created with default attributes and without skeleton files:
       | username |

--- a/tests/acceptance/features/apiWebdavLocks2/resharedSharesToRoot.feature
+++ b/tests/acceptance/features/apiWebdavLocks2/resharedSharesToRoot.feature
@@ -52,7 +52,7 @@ Feature: lock should propagate correctly if a share is reshared
       | new      | shared     |
       | new      | exclusive  |
 
-  @skipOnOcV10.6 @skipOnOcV10.7
+
   Scenario Outline: public uploads to a reshared share that was locked by original owner
     Given using <dav-path> DAV path
     And user "Alice" has shared folder "PARENT" with user "Brian"

--- a/tests/acceptance/features/apiWebdavLocks2/resharedSharesToShares.feature
+++ b/tests/acceptance/features/apiWebdavLocks2/resharedSharesToShares.feature
@@ -1,4 +1,4 @@
-@api @files_sharing-app-required @issue-ocis-reva-172 @issue-ocis-reva-11 @skipOnOcV10.6 @skipOnOcV10.7 @skipOnOcV10.8.0 @notToImplementOnOCIS
+@api @files_sharing-app-required @issue-ocis-reva-172 @issue-ocis-reva-11 @notToImplementOnOCIS
 Feature: lock should propagate correctly if a share is reshared
 
   Background:
@@ -58,7 +58,7 @@ Feature: lock should propagate correctly if a share is reshared
       | new      | shared     |
       | new      | exclusive  |
 
-  @skipOnOcV10.6 @skipOnOcV10.7
+
   Scenario Outline: public uploads to a reshared share that was locked by original owner
     Given using <dav-path> DAV path
     And user "Alice" has shared folder "PARENT" with user "Brian"

--- a/tests/acceptance/features/apiWebdavLocks2/setTimeout.feature
+++ b/tests/acceptance/features/apiWebdavLocks2/setTimeout.feature
@@ -7,7 +7,7 @@ Feature: set timeouts of LOCKS
     And user "Alice" has created folder "PARENT/CHILD"
     And user "Alice" has uploaded file "filesForUpload/textfile.txt" to "PARENT/parent.txt"
 
-  @skipOnOcV10.3 @skipOnOcV10.4
+
   Scenario Outline: do not set timeout on folder and check the default timeout
     Given using <dav-path> DAV path
     And parameter "lock_timeout_default" of app "core" has been set to "<default-timeout>"
@@ -64,7 +64,7 @@ Feature: set timeouts of LOCKS
       | spaces   | second--1       | /Second-\d{5}$/ |
       | spaces   | second-0        | /Second-\d{4}$/ |
 
-  @skipOnOcV10.3 @skipOnOcV10.4
+
   Scenario Outline: set timeout over the maximum on folder
     Given using <dav-path> DAV path
     And parameter "lock_timeout_default" of app "core" has been set to "<default-timeout>"

--- a/tests/acceptance/features/apiWebdavLocks2/setTimeoutSharesToShares.feature
+++ b/tests/acceptance/features/apiWebdavLocks2/setTimeoutSharesToShares.feature
@@ -1,4 +1,4 @@
-@api @smokeTest @public_link_share-feature-required @files_sharing-app-required @issue-ocis-reva-172 @skipOnOcV10.6 @skipOnOcV10.7 @skipOnOcV10.8.0 @notToImplementOnOCIS
+@api @smokeTest @public_link_share-feature-required @files_sharing-app-required @issue-ocis-reva-172 @notToImplementOnOCIS
 Feature: set timeouts of LOCKS on shares
 
   Background:

--- a/tests/acceptance/features/apiWebdavLocks3/independentLocksShareToShares.feature
+++ b/tests/acceptance/features/apiWebdavLocks3/independentLocksShareToShares.feature
@@ -1,4 +1,4 @@
-@api @issue-ocis-reva-172 @skipOnOcV10.6 @skipOnOcV10.7 @skipOnOcV10.8.0
+@api @issue-ocis-reva-172
 Feature: independent locks
   Make sure all locks are independent and don't interact with other items that have the same name
 

--- a/tests/acceptance/features/apiWebdavLocksUnlock/lockBreakersGroups.feature
+++ b/tests/acceptance/features/apiWebdavLocksUnlock/lockBreakersGroups.feature
@@ -1,4 +1,4 @@
-@api @skipOnOcV10.7 @skipOnOcV10.8.0 @issue-ocis-2413 @notToImplementOnOCIS
+@api @issue-ocis-2413 @notToImplementOnOCIS
 Feature: UNLOCK locked items
 
   Background:

--- a/tests/acceptance/features/apiWebdavLocksUnlock/unlock.feature
+++ b/tests/acceptance/features/apiWebdavLocksUnlock/unlock.feature
@@ -64,7 +64,7 @@ Feature: UNLOCK locked items
       | new      | shared     |
       | new      | exclusive  |
 
-  @skipOnOcV10 @issue-34302 @files_sharing-app-required @skipOnOcV10.3
+  @skipOnOcV10 @issue-34302 @files_sharing-app-required
   Scenario Outline: as public unlocking a file in a share that was locked by the file owner is not possible. To unlock use the owners locktoken
     Given user "Alice" has created folder "PARENT"
     And user "Alice" has uploaded file "filesForUpload/textfile.txt" to "PARENT/parent.txt"

--- a/tests/acceptance/features/apiWebdavLocksUnlock/unlockOc10Issue34302.feature
+++ b/tests/acceptance/features/apiWebdavLocksUnlock/unlockOc10Issue34302.feature
@@ -1,7 +1,7 @@
 @api @notToImplementOnOCIS @issue-ocis-reva-172
 Feature: UNLOCK locked items
 
-  @issue-34302 @files_sharing-app-required @skipOnOcV10.3
+  @issue-34302 @files_sharing-app-required
   Scenario Outline: as public unlocking a file in a share that was locked by the file owner is not possible. To unlock use the owners locktoken
     Given user "Alice" has been created with default attributes and without skeleton files
     And user "Alice" has created folder "PARENT"

--- a/tests/acceptance/features/apiWebdavLocksUnlock/unlockSharingToShares.feature
+++ b/tests/acceptance/features/apiWebdavLocksUnlock/unlockSharingToShares.feature
@@ -1,4 +1,4 @@
-@api @issue-ocis-reva-172 @files_sharing-app-required @skipOnOcV10.6 @skipOnOcV10.7 @skipOnOcV10.8.0
+@api @issue-ocis-reva-172 @files_sharing-app-required
 Feature: UNLOCK locked items (sharing)
 
   Background:
@@ -22,7 +22,6 @@ Feature: UNLOCK locked items (sharing)
     Then the HTTP status code should be "403"
     And 1 locks should be reported for file "PARENT/parent.txt" of user "Alice" by the WebDAV API
     And 1 locks should be reported for file "Shares/parent.txt" of user "Brian" by the WebDAV API
-    @skipOnOcV10.6 @skipOnOcV10.7 @skipOnOcV10.8.0
     Examples:
       | dav-path | lock-scope | pending_share_path |
       | old      | shared     | /parent.txt        |
@@ -95,7 +94,6 @@ Feature: UNLOCK locked items (sharing)
     Then the HTTP status code should be "204"
     And 0 locks should be reported for file "PARENT/parent.txt" of user "Alice" by the WebDAV API
     And 0 locks should be reported for file "Shares/parent.txt" of user "Brian" by the WebDAV API
-    @skipOnOcV10.6 @skipOnOcV10.7 @skipOnOcV10.8.0
     Examples:
       | dav-path | lock-scope | pending_share_path |
       | old      | shared     | /parent.txt        |
@@ -120,7 +118,6 @@ Feature: UNLOCK locked items (sharing)
     Then the HTTP status code should be "403"
     And 1 locks should be reported for file "PARENT/parent.txt" of user "Alice" by the WebDAV API
     And 1 locks should be reported for file "Shares/parent.txt" of user "Brian" by the WebDAV API
-    @skipOnOcV10.6 @skipOnOcV10.7 @skipOnOcV10.8.0
     Examples:
       | dav-path | lock-scope | pending_share_path |
       | old      | shared     | /parent.txt        |

--- a/tests/acceptance/features/apiWebdavMove1/moveFileToBlacklistedNameAsync.feature
+++ b/tests/acceptance/features/apiWebdavMove1/moveFileToBlacklistedNameAsync.feature
@@ -25,7 +25,7 @@ Feature: users cannot move (rename) a file to a blacklisted name
     And user "Alice" should see the following elements
       | /textfile0.txt |
 
-  @skipOnOcV10.3
+
   Scenario: rename a file to a filename that matches (or not) blacklisted_files_regex
     Given user "Alice" has created folder "FOLDER"
     # Note: we have to write JSON for the value, and to get a backslash in the double-quotes we have to escape it

--- a/tests/acceptance/features/apiWebdavMove1/moveFileToExcludedDirectoryAsync.feature
+++ b/tests/acceptance/features/apiWebdavMove1/moveFileToExcludedDirectoryAsync.feature
@@ -27,7 +27,7 @@ Feature: users cannot move (rename) a file to or into an excluded directory
     And user "Alice" should see the following elements
       | /textfile0.txt |
 
-  @skipOnOcV10.3
+
   Scenario: rename a file to a filename that matches (or not) excluded_directories_regex
     Given user "Alice" has created folder "FOLDER"
     # Note: we have to write JSON for the value, and to get a backslash in the double-quotes we have to escape it

--- a/tests/acceptance/features/apiWebdavMove1/moveFolderToBlacklistedName.feature
+++ b/tests/acceptance/features/apiWebdavMove1/moveFolderToBlacklistedName.feature
@@ -45,7 +45,7 @@ Feature: users cannot move (rename) a folder to a blacklisted name
       | dav_version |
       | spaces      |
 
-  @skipOnOcV10.3
+
   Scenario Outline: rename a folder to a folder name that matches (or not) blacklisted_files_regex
     Given using <dav_version> DAV path
     And user "Brian" has been created with default attributes and without skeleton files

--- a/tests/acceptance/features/apiWebdavMove1/moveFolderToExcludedDirectory.feature
+++ b/tests/acceptance/features/apiWebdavMove1/moveFolderToExcludedDirectory.feature
@@ -47,7 +47,7 @@ Feature: users cannot move (rename) a folder to or into an excluded directory
       | dav_version |
       | spaces      |
 
-  @skipOnOcV10.3
+
   Scenario Outline: rename a folder to a folder name that matches (or not) excluded_directories_regex
     Given using <dav_version> DAV path
     And user "Alice" has created folder "/testshare"

--- a/tests/acceptance/features/apiWebdavMove2/moveFile.feature
+++ b/tests/acceptance/features/apiWebdavMove2/moveFile.feature
@@ -465,7 +465,7 @@ Feature: move (rename) file
       | dav_version |
       | spaces      |
 
-  @skipOnOcV10.8 @skipOnOcV10.9.0 @skipOnOcV10.9.1
+
   Scenario Outline: Moving a file (deep moves with various folder and file names)
     Given using <dav_version> DAV path
     And user "Alice" has created folder "<source_folder>"
@@ -507,7 +507,7 @@ Feature: move (rename) file
       | spaces      | texta         | file.txt    | textb         | 0           |
       | spaces      | texta         | file.txt    | textb         | 1           |
 
-  @skipOnOcV10.8 @skipOnOcV10.9.0 @skipOnOcV10.9.1
+
   Scenario Outline: Moving a file from a folder to the root
     Given using <dav_version> DAV path
     And user "Alice" has created folder "<source_folder>"

--- a/tests/acceptance/features/apiWebdavMove2/moveFileToBlacklistedName.feature
+++ b/tests/acceptance/features/apiWebdavMove2/moveFileToBlacklistedName.feature
@@ -40,7 +40,7 @@ Feature: users cannot move (rename) a file to a blacklisted name
       | dav_version |
       | spaces      |
 
-  @skipOnOcV10.3
+
   Scenario Outline: rename a file to a filename that matches (or not) blacklisted_files_regex
     Given using <dav_version> DAV path
     And user "Alice" has created folder "FOLDER"

--- a/tests/acceptance/features/apiWebdavMove2/moveFileToExcludedDirectory.feature
+++ b/tests/acceptance/features/apiWebdavMove2/moveFileToExcludedDirectory.feature
@@ -42,7 +42,7 @@ Feature: users cannot move (rename) a file to or into an excluded directory
       | dav_version |
       | spaces      |
 
-  @skipOnOcV10.3
+
   Scenario Outline: rename a file to a filename that matches (or not) excluded_directories_regex
     Given using <dav_version> DAV path
     And user "Alice" has created folder "FOLDER"

--- a/tests/acceptance/features/apiWebdavOperations/downloadFile.feature
+++ b/tests/acceptance/features/apiWebdavOperations/downloadFile.feature
@@ -59,7 +59,7 @@ Feature: download file
       | dav_version |
       | spaces      |
 
-  @smokeTest @skipOnOcV10.5 @skipOnOcV10.6.0 @notToImplementOnOCIS
+  @smokeTest @notToImplementOnOCIS
   Scenario Outline: Downloading a file should serve security headers
     Given using <dav_version> DAV path
     When user "Alice" downloads file "/welcome.txt" using the WebDAV API

--- a/tests/acceptance/features/apiWebdavOperations/listFiles.feature
+++ b/tests/acceptance/features/apiWebdavOperations/listFiles.feature
@@ -373,7 +373,7 @@ Feature: list files
       | dav_version |
       | spaces      |
 
-  @depthInfinityPropfindDisabled @skipOnOcV10.8 @skipOnOcV10.9.0 @skipOnOcV10.9.1
+  @depthInfinityPropfindDisabled
   Scenario Outline: Get the list of resources in the root folder with depth infinity when depth infinity is not allowed
     Given using <dav_version> DAV path
     When user "Alice" lists the resources in "/" with depth "infinity" using the WebDAV API
@@ -388,7 +388,7 @@ Feature: list files
       | dav_version |
       | spaces      |
 
-  @depthInfinityPropfindDisabled @skipOnOcV10.8 @skipOnOcV10.9.0 @skipOnOcV10.9.1
+  @depthInfinityPropfindDisabled
   Scenario Outline: Get the list of resources in a folder shared through public link with depth infinity when depth infinity is not allowed
     Given using <dav_version> DAV path
     And user "Alice" has created the following folders
@@ -412,7 +412,7 @@ Feature: list files
       | dav_version |
       | spaces      |
 
-  @depthInfinityPropfindDisabled @skipOnOcV10.8 @skipOnOcV10.9.0 @skipOnOcV10.9.1
+  @depthInfinityPropfindDisabled
   Scenario Outline: Get the list of files in the trashbin with depth infinity when depth infinity is not allowed
     Given using <dav_version> DAV path
     And user "Alice" has deleted the following resources

--- a/tests/acceptance/features/apiWebdavOperations/propfind.feature
+++ b/tests/acceptance/features/apiWebdavOperations/propfind.feature
@@ -23,12 +23,12 @@ Feature: PROPFIND
       | header | value   |
       | depth  | <depth> |
     Then the HTTP status code should be "<http_status>"
-    @skipOnOcV10.6 @skipOnOcV10.7 @skipOnOcV10.8.0 @notToImplementOnOCIS @depthInfinityPropfindEnabled
+    @notToImplementOnOCIS @depthInfinityPropfindEnabled
     Examples:
       | dav_path                    | depth_infinity_allowed | depth    | http_status |
       | /remote.php/dav/files/alice | 1                      | 0        | 207         |
       | /remote.php/dav/files/alice | 1                      | infinity | 207         |
-    @skipOnOcV10.6 @skipOnOcV10.7 @skipOnOcV10.8.0 @notToImplementOnOCIS @depthInfinityPropfindDisabled @skipOnOcV10.9.0 @skipOnOcV10.9.1
+    @notToImplementOnOCIS @depthInfinityPropfindDisabled
     Examples:
       | dav_path                    | depth_infinity_allowed | depth    | http_status |
       | /remote.php/dav/files/alice | 0                      | 0        | 207         |

--- a/tests/acceptance/features/apiWebdavPreviews/previews.feature
+++ b/tests/acceptance/features/apiWebdavPreviews/previews.feature
@@ -77,7 +77,7 @@ Feature: previews of files downloaded through the webdav API
     Then the HTTP status code should be "200"
     And the downloaded image should be "32" pixels wide and "32" pixels high
 
-  @skipOnOcV10.6 @skipOnOcV10.7 @skipOnOcV10.8.0
+
   Scenario: download previews of shared files (to shares folder)
     Given the administrator has set the default folder for received shares to "Shares"
     And auto-accept shares has been disabled
@@ -184,7 +184,7 @@ Feature: previews of files downloaded through the webdav API
     Then the HTTP status code should be "204"
     And as user "Alice" the preview of "/parent.txt" with width "32" and height "32" should have been changed
 
-  @notToImplementOnOCIS @skipOnOcV10.6 @skipOnOcV10.7 @skipOnOcV10.8.0
+  @notToImplementOnOCIS
   Scenario: when owner updates a shared file, previews for sharee are also updated
     Given user "Brian" has been created with default attributes and without skeleton files
     And user "Alice" has uploaded file "filesForUpload/lorem.txt" to "/parent.txt"
@@ -194,7 +194,7 @@ Feature: previews of files downloaded through the webdav API
     Then the HTTP status code should be "204"
     And as user "Brian" the preview of "/parent.txt" with width "32" and height "32" should have been changed
 
-  @issue-ocis-2538 @skipOnOcV10.6 @skipOnOcV10.7 @skipOnOcV10.8.0
+  @issue-ocis-2538
   Scenario: when owner updates a shared file, previews for sharee are also updated (to shared folder)
     Given the administrator has set the default folder for received shares to "Shares"
     And auto-accept shares has been disabled
@@ -207,7 +207,7 @@ Feature: previews of files downloaded through the webdav API
     Then the HTTP status code should be "204"
     And as user "Brian" the preview of "/Shares/parent.txt" with width "32" and height "32" should have been changed
 
-  @skipOnOcV10.6 @skipOnOcV10.7 @skipOnOcV10.8.0
+
   Scenario: it should update the preview content if the file content is updated (content with UTF chars)
     Given user "Alice" has uploaded file "filesForUpload/lorem.txt" to "/lorem.txt"
     And user "Alice" has uploaded file with content "सिमसिमे पानी" to "/lorem.txt"
@@ -216,7 +216,7 @@ Feature: previews of files downloaded through the webdav API
     And the downloaded image should be "32" pixels wide and "32" pixels high
     And the downloaded preview content should match with "सिमसिमे-पानी.png" fixtures preview content
 
-  @skipOnOcV10.6 @skipOnOcV10.7 @skipOnOcV10.8.0
+
   Scenario: updates to a file should change the preview for both sharees and sharers
     Given the administrator has set the default folder for received shares to "Shares"
     And auto-accept shares has been disabled
@@ -236,7 +236,7 @@ Feature: previews of files downloaded through the webdav API
     And as user "Alice" the preview of "/FOLDER/lorem.txt" with width "32" and height "32" should have been changed
     And as user "Brian" the preview of "Shares/FOLDER/lorem.txt" with width "32" and height "32" should have been changed
 
-  @skipOnOcV10.6 @skipOnOcV10.7 @skipOnOcV10.8.0
+
   Scenario: updates to a group shared file should change the preview for both sharees and sharers
     Given the administrator has set the default folder for received shares to "Shares"
     And auto-accept shares has been disabled
@@ -264,7 +264,7 @@ Feature: previews of files downloaded through the webdav API
     And as user "Brian" the preview of "Shares/FOLDER/lorem.txt" with width "32" and height "32" should have been changed
     And as user "Carol" the preview of "Shares/FOLDER/lorem.txt" with width "32" and height "32" should have been changed
 
-  @skipOnOcV10.6 @skipOnOcV10.7 @skipOnOcV10.8.0 @notToImplementOnOCIS
+  @notToImplementOnOCIS
   Scenario: JPEG preview quality can be determined by config
     Given user "Alice" has uploaded file "filesForUpload/testavatar.jpg" to "/testavatar_low.jpg"
     And the administrator has updated system config key "previewJPEGImageDisplayQuality" with value "1"

--- a/tests/acceptance/features/apiWebdavProperties1/copyFile.feature
+++ b/tests/acceptance/features/apiWebdavProperties1/copyFile.feature
@@ -63,7 +63,7 @@ Feature: copy file
       | dav_version |
       | spaces      |
 
-  @files_sharing-app-required @issue-ocis-reva-11 @skipOnOcV10.6 @skipOnOcV10.7 @skipOnOcV10.8.0
+  @files_sharing-app-required @issue-ocis-reva-11
   Scenario Outline: Copying a file to a folder with no permissions
     Given using <dav_version> DAV path
     And user "Brian" has been created with default attributes and without skeleton files
@@ -82,7 +82,7 @@ Feature: copy file
       | old         |
       | new         |
 
-  @files_sharing-app-required @issue-ocis-reva-11 @skipOnOcV10.6 @skipOnOcV10.7 @skipOnOcV10.8.0
+  @files_sharing-app-required @issue-ocis-reva-11
   Scenario Outline: Copying a file to overwrite a file into a folder with no permissions
     Given using <dav_version> DAV path
     And user "Brian" has been created with default attributes and without skeleton files
@@ -255,7 +255,7 @@ Feature: copy file
       | dav_version |
       | spaces      |
 
-  @issue-ocis-1239 @skipOnOcV10.6 @skipOnOcV10.7 @skipOnOcV10.8.0
+  @issue-ocis-1239
   Scenario Outline: copy a file over the top of an existing folder received as a user share
     Given using <dav_version> DAV path
     And user "Brian" has been created with default attributes and without skeleton files
@@ -274,7 +274,7 @@ Feature: copy file
       | old         |
       | new         |
 
-  @issue-ocis-1239 @skipOnOcV10.6 @skipOnOcV10.7 @skipOnOcV10.8.0
+  @issue-ocis-1239
   Scenario Outline: copy a folder over the top of an existing file received as a user share
     Given using <dav_version> DAV path
     And user "Brian" has been created with default attributes and without skeleton files
@@ -292,7 +292,7 @@ Feature: copy file
       | old         |
       | new         |
 
-  @issue-ocis-1239 @skipOnOcV10.6 @skipOnOcV10.7 @skipOnOcV10.8.0
+  @issue-ocis-1239
   Scenario Outline: copy a folder into another folder at different level which is received as a user share
     Given using <dav_version> DAV path
     And user "Brian" has been created with default attributes and without skeleton files
@@ -315,7 +315,7 @@ Feature: copy file
       | old         |
       | new         |
 
-  @issue-ocis-1239 @skipOnOcV10.6 @skipOnOcV10.7 @skipOnOcV10.8.0
+  @issue-ocis-1239
   Scenario Outline: copy a file into a folder at different level received as a user share
     Given using <dav_version> DAV path
     And user "Brian" has been created with default attributes and without skeleton files
@@ -340,7 +340,7 @@ Feature: copy file
       | old         |
       | new         |
 
-  @issue-ocis-1239 @skipOnOcV10.6 @skipOnOcV10.7 @skipOnOcV10.8.0
+  @issue-ocis-1239
   Scenario Outline: copy a file into a file at different level received as a user share
     Given using <dav_version> DAV path
     And user "Brian" has been created with default attributes and without skeleton files
@@ -364,7 +364,7 @@ Feature: copy file
       | old         |
       | new         |
 
-  @issue-ocis-1239 @skipOnOcV10.6 @skipOnOcV10.7 @skipOnOcV10.8.0
+  @issue-ocis-1239
   Scenario Outline: copy a folder into a file at different level received as a user share
     Given using <dav_version> DAV path
     And user "Brian" has been created with default attributes and without skeleton files
@@ -388,7 +388,7 @@ Feature: copy file
       | old         |
       | new         |
 
-  @issue-ocis-1239 @skipOnOcV10.6 @skipOnOcV10.7 @skipOnOcV10.8.0
+  @issue-ocis-1239
   Scenario Outline: copy a file over the top of an existing folder received as a group share
     Given using <dav_version> DAV path
     And user "Brian" has been created with default attributes and without skeleton files
@@ -415,7 +415,7 @@ Feature: copy file
       | dav_version |
       | spaces      |
 
-  @issue-ocis-1239 @skipOnOcV10.6 @skipOnOcV10.7 @skipOnOcV10.8.0
+  @issue-ocis-1239
   Scenario Outline: copy a folder over the top of an existing file received as a group share
     Given using <dav_version> DAV path
     And user "Brian" has been created with default attributes and without skeleton files
@@ -441,7 +441,7 @@ Feature: copy file
       | dav_version |
       | spaces      |
 
-  @issue-ocis-1239 @skipOnOcV10.6 @skipOnOcV10.7 @skipOnOcV10.8.0
+  @issue-ocis-1239
   Scenario Outline: copy a folder into another folder at different level which is received as a group share
     Given using <dav_version> DAV path
     And user "Brian" has been created with default attributes and without skeleton files
@@ -467,7 +467,7 @@ Feature: copy file
       | old         |
       | new         |
 
-  @issue-ocis-1239 @skipOnOcV10.6 @skipOnOcV10.7 @skipOnOcV10.8.0
+  @issue-ocis-1239
   Scenario Outline: copy a file into a folder at different level received as a group share
     Given using <dav_version> DAV path
     And user "Brian" has been created with default attributes and without skeleton files
@@ -495,7 +495,7 @@ Feature: copy file
       | old         |
       | new         |
 
-  @issue-ocis-1239 @skipOnOcV10.6 @skipOnOcV10.7 @skipOnOcV10.8.0
+  @issue-ocis-1239
   Scenario Outline: copy a file into a file at different level received as a group share
     Given using <dav_version> DAV path
     And user "Brian" has been created with default attributes and without skeleton files
@@ -522,7 +522,7 @@ Feature: copy file
       | old         |
       | new         |
 
-  @issue-ocis-1239 @skipOnOcV10.6 @skipOnOcV10.7 @skipOnOcV10.8.0
+  @issue-ocis-1239
   Scenario Outline: copy a folder into a file at different level received as a group share
     Given using <dav_version> DAV path
     And user "Brian" has been created with default attributes and without skeleton files

--- a/tests/acceptance/features/apiWebdavProperties1/setFileProperties.feature
+++ b/tests/acceptance/features/apiWebdavProperties1/setFileProperties.feature
@@ -25,7 +25,7 @@ Feature: set file properties
       | dav_version |
       | spaces      |
 
-  @skipOnOcV10.3 @skipOnOcV10.4 @issue-ocis-reva-217
+  @issue-ocis-reva-217
   Scenario Outline: Setting custom complex DAV property and reading it
     Given using <dav_version> DAV path
     And user "Alice" has uploaded file "filesForUpload/textfile.txt" to "/testcustomprop.txt"

--- a/tests/acceptance/features/apiWebdavProperties2/getFileProperties.feature
+++ b/tests/acceptance/features/apiWebdavProperties2/getFileProperties.feature
@@ -369,7 +369,7 @@ Feature: get file properties
       | dav_version |
       | spaces      |
 
-  @issue-36920 @skipOnOcV10.3 @skipOnOcV10.4.0 @issue-ocis-reva-217
+  @issue-36920 @issue-ocis-reva-217
   Scenario Outline: add multiple properties to files inside a folder and do a propfind of the parent folder
     Given using <dav_version> DAV path
     And user "Alice" has created folder "/TestFolder"

--- a/tests/acceptance/features/apiWebdavUpload1/uploadFile.feature
+++ b/tests/acceptance/features/apiWebdavUpload1/uploadFile.feature
@@ -149,7 +149,7 @@ Feature: upload file
       | spaces      | /folder ?2.txt    | file ?2.txt  |
       | spaces      | /?fi=le&%#2 . txt | # %ab ab?=ed |
 
-  @skipOnOcV10.3 @skipOnOcV10.4 @skipOnOcV10.5
+
   Scenario Outline: attempt to upload a file into a nonexistent folder
     Given using <dav_version> DAV path
     When user "Alice" uploads file with content "uploaded content" to "nonexistent-folder/new-file.txt" using the WebDAV API

--- a/tests/acceptance/features/apiWebdavUpload1/uploadFileToBlacklistedName.feature
+++ b/tests/acceptance/features/apiWebdavUpload1/uploadFileToBlacklistedName.feature
@@ -36,7 +36,7 @@ Feature: users cannot upload a file to a blacklisted name
       | dav_version |
       | spaces      |
 
-  @skipOnOcV10.3 @issue-ocis-reva-54
+  @issue-ocis-reva-54
   Scenario Outline: upload a file to a filename that matches (or not) blacklisted_files_regex
     Given using <dav_version> DAV path
     And user "Alice" has created folder "FOLDER"

--- a/tests/acceptance/features/apiWebdavUpload1/uploadFileToBlacklistedNameAsyncUsingNewChunking.feature
+++ b/tests/acceptance/features/apiWebdavUpload1/uploadFileToBlacklistedNameAsyncUsingNewChunking.feature
@@ -32,7 +32,7 @@ Feature: users cannot upload a file to a blacklisted name using new chunking
     Then the HTTP status code should be "403"
     And as "Alice" file "/blacklisted-file.txt" should not exist
 
-  @skipOnOcV10.3
+
   Scenario Outline: upload a file to a filename that matches blacklisted_files_regex using new chunking and async MOVE
     # Note: we have to write JSON for the value, and to get a backslash in the double-quotes we have to escape it
     # The actual regular expressions end up being .*\.ext$ and ^bannedfilename\..+
@@ -50,7 +50,7 @@ Feature: users cannot upload a file to a blacklisted name using new chunking
       | bannedfilename.txt            |
       | this-ContainsBannedString.txt |
 
-  @skipOnOcV10.3
+
   Scenario: upload a file to a filename that does not match blacklisted_files_regex using new chunking and async MOVE
     # Note: we have to write JSON for the value, and to get a backslash in the double-quotes we have to escape it
     # The actual regular expressions end up being .*\.ext$ and ^bannedfilename\..+

--- a/tests/acceptance/features/apiWebdavUpload1/uploadFileToExcludedDirectory.feature
+++ b/tests/acceptance/features/apiWebdavUpload1/uploadFileToExcludedDirectory.feature
@@ -44,7 +44,7 @@ Feature: users cannot upload a file to or into an excluded directory
       | dav_version |
       | spaces      |
 
-  @skipOnOcV10.3 @issue-ocis-reva-54
+  @issue-ocis-reva-54
   Scenario Outline: upload a file to a filename that matches (or not) excluded_directories_regex
     Given using <dav_version> DAV path
     And user "Alice" has created folder "FOLDER"

--- a/tests/acceptance/features/apiWebdavUpload1/uploadFileToExcludedDirectoryAsyncUsingNewChunking.feature
+++ b/tests/acceptance/features/apiWebdavUpload1/uploadFileToExcludedDirectoryAsyncUsingNewChunking.feature
@@ -35,7 +35,7 @@ Feature: users cannot upload a file to or into an excluded directory using new c
     And as "Alice" folder "/FOLDER" should exist
     But as "Alice" file "/FOLDER/.github" should not exist
 
-  @skipOnOcV10.3
+
   Scenario Outline: upload a file to a filename that matches excluded_directories_regex using new chunking and async MOVE
     # Note: we have to write JSON for the value, and to get a backslash in the double-quotes we have to escape it
     # The actual regular expressions end up being endswith\.bad$ and ^\.git
@@ -53,7 +53,7 @@ Feature: users cannot upload a file to or into an excluded directory using new c
       | .github                         |
       | this-containsvirusinthename.txt |
 
-  @skipOnOcV10.3
+
   Scenario: upload a file to a filename that does not match excluded_directories_regex using new chunking and async MOVE
     # Note: we have to write JSON for the value, and to get a backslash in the double-quotes we have to escape it
     # The actual regular expressions end up being endswith\.bad$ and ^\.git

--- a/tests/acceptance/features/apiWebdavUpload2/uploadFileToBlacklistedNameUsingNewChunking.feature
+++ b/tests/acceptance/features/apiWebdavUpload2/uploadFileToBlacklistedNameUsingNewChunking.feature
@@ -30,7 +30,7 @@ Feature: users cannot upload a file to a blacklisted name using new chunking
     Then the HTTP status code should be "403"
     And as "Alice" file "blacklisted-file.txt" should not exist
 
-  @skipOnOcV10.3
+
   Scenario Outline: upload a file to a filename that matches blacklisted_files_regex using new chunking
     # Note: we have to write JSON for the value, and to get a backslash in the double-quotes we have to escape it
     # The actual regular expressions end up being .*\.ext$ and ^bannedfilename\..+
@@ -48,7 +48,7 @@ Feature: users cannot upload a file to a blacklisted name using new chunking
       | bannedfilename.txt            |
       | this-ContainsBannedString.txt |
 
-  @skipOnOcV10.3
+
   Scenario: upload a file to a filename that does not match blacklisted_files_regex using new chunking
     # Note: we have to write JSON for the value, and to get a backslash in the double-quotes we have to escape it
     # The actual regular expressions end up being .*\.ext$ and ^bannedfilename\..+

--- a/tests/acceptance/features/apiWebdavUpload2/uploadFileToBlacklistedNameUsingOldChunking.feature
+++ b/tests/acceptance/features/apiWebdavUpload2/uploadFileToBlacklistedNameUsingOldChunking.feature
@@ -22,7 +22,7 @@ Feature: users cannot upload a file to a blacklisted name using old chunking
     Then the HTTP status code should be "403"
     And as "Alice" file "blacklisted-file.txt" should not exist
 
-  @skipOnOcV10 @skipOnOcV10.3 @issue-36645
+  @skipOnOcV10 @issue-36645
   Scenario Outline: upload a file to a filename that matches blacklisted_files_regex using old chunking
     # Note: we have to write JSON for the value, and to get a backslash in the double-quotes we have to escape it
     # The actual regular expressions end up being .*\.ext$ and ^bannedfilename\..+
@@ -36,7 +36,7 @@ Feature: users cannot upload a file to a blacklisted name using old chunking
       | bannedfilename.txt            | 403         |
       | this-ContainsBannedString.txt | 403         |
 
-  @skipOnOcV10.3
+
   Scenario: upload a file to a filename that does not match blacklisted_files_regex using old chunking
     # Note: we have to write JSON for the value, and to get a backslash in the double-quotes we have to escape it
     # The actual regular expressions end up being .*\.ext$ and ^bannedfilename\..+

--- a/tests/acceptance/features/apiWebdavUpload2/uploadFileToBlacklistedNameUsingOldChunkingOc10Issue36645.feature
+++ b/tests/acceptance/features/apiWebdavUpload2/uploadFileToBlacklistedNameUsingOldChunkingOc10Issue36645.feature
@@ -24,7 +24,7 @@ Feature: users cannot upload a file to a blacklisted name using old chunking
 #    Then the HTTP status code should be "403"
     And as "Alice" file "blacklisted-file.txt" should not exist
 
-  @skipOnOcV10.3 @issue-36645
+  @issue-36645
   Scenario Outline: upload a file to a filename that matches blacklisted_files_regex using old chunking
     # Note: we have to write JSON for the value, and to get a backslash in the double-quotes we have to escape it
     # The actual regular expressions end up being .*\.ext$ and ^bannedfilename\..+

--- a/tests/acceptance/features/apiWebdavUpload2/uploadFileToExcludedDirectoryUsingNewChunking.feature
+++ b/tests/acceptance/features/apiWebdavUpload2/uploadFileToExcludedDirectoryUsingNewChunking.feature
@@ -33,7 +33,7 @@ Feature: users cannot upload a file to or into an excluded directory using new c
     And as "Alice" folder "/FOLDER" should exist
     But as "Alice" file "/FOLDER/.github" should not exist
 
-  @skipOnOcV10.3
+
   Scenario Outline: upload a file to a filename that matches excluded_directories_regex using new chunking
     # Note: we have to write JSON for the value, and to get a backslash in the double-quotes we have to escape it
     # The actual regular expressions end up being endswith\.bad$ and ^\.git
@@ -51,7 +51,7 @@ Feature: users cannot upload a file to or into an excluded directory using new c
       | .github                         |
       | this-containsvirusinthename.txt |
 
-  @skipOnOcV10.3
+
   Scenario: upload a file to a filename that does not match excluded_directories_regex using new chunking
     # Note: we have to write JSON for the value, and to get a backslash in the double-quotes we have to escape it
     # The actual regular expressions end up being endswith\.bad$ and ^\.git

--- a/tests/acceptance/features/apiWebdavUpload2/uploadFileToExcludedDirectoryUsingOldChunking.feature
+++ b/tests/acceptance/features/apiWebdavUpload2/uploadFileToExcludedDirectoryUsingOldChunking.feature
@@ -25,7 +25,7 @@ Feature: users cannot upload a file to or into an excluded directory using old c
     And as "Alice" folder "/FOLDER" should exist
     But as "Alice" file "/FOLDER/.github" should not exist
 
-  @skipOnOcV10 @skipOnOcV10.3 @issue-36645
+  @skipOnOcV10 @issue-36645
   Scenario Outline: upload a file to a filename that matches excluded_directories_regex using old chunking
     # Note: we have to write JSON for the value, and to get a backslash in the double-quotes we have to escape it
     # The actual regular expressions end up being endswith\.bad$ and ^\.git
@@ -39,7 +39,7 @@ Feature: users cannot upload a file to or into an excluded directory using old c
       | .github                         | 403         |
       | this-containsvirusinthename.txt | 403         |
 
-  @skipOnOcV10.3
+
   Scenario: upload a file to a filename that does not match excluded_directories_regex using old chunking
     # Note: we have to write JSON for the value, and to get a backslash in the double-quotes we have to escape it
     # The actual regular expressions end up being endswith\.bad$ and ^\.git

--- a/tests/acceptance/features/apiWebdavUpload2/uploadFileToExcludedDirectoryUsingOldChunkingOc10Issue36645.feature
+++ b/tests/acceptance/features/apiWebdavUpload2/uploadFileToExcludedDirectoryUsingOldChunkingOc10Issue36645.feature
@@ -27,7 +27,7 @@ Feature: users cannot upload a file to or into an excluded directory using old c
     And as "Alice" folder "/FOLDER" should exist
     But as "Alice" file "/FOLDER/.github" should not exist
 
-  @skipOnOcV10.3 @issue-36645
+  @issue-36645
   Scenario Outline: upload a file to a filename that matches excluded_directories_regex using old chunking
     # Note: we have to write JSON for the value, and to get a backslash in the double-quotes we have to escape it
     # The actual regular expressions end up being endswith\.bad$ and ^\.git

--- a/tests/acceptance/features/apiWebdavUpload2/uploadFileUsingNewChunking.feature
+++ b/tests/acceptance/features/apiWebdavUpload2/uploadFileUsingNewChunking.feature
@@ -85,7 +85,7 @@ Feature: upload file using new chunking
     When user "Alice" creates a new chunking upload with id "chunking-42" using the WebDAV API
     Then the HTTP status code should be "409"
 
-  @skipOnOcV10.3 @skipOnOcV10.4 @skipOnOcV10.5
+
   Scenario: New chunked upload PUT using old DAV path should fail
     Given user "Alice" has created a new chunking upload with id "chunking-42"
     When using old DAV path

--- a/tests/acceptance/features/cliExternalStorage/cliIncomingShares.feature
+++ b/tests/acceptance/features/cliExternalStorage/cliIncomingShares.feature
@@ -4,7 +4,7 @@ Feature: poll incoming shares
   I want to be able to poll incoming shares manually
   So that I can make sure all shares are up-to-date
 
-  @files_sharing-app-required @skipOnOcV10.6 @skipOnOcV10.7.0
+  @files_sharing-app-required
   Scenario: poll incoming share with a federation share of deep nested folders when there is a file change in remote end
     Given using server "REMOTE"
     And user "Alice" has been created with default attributes and small skeleton files
@@ -27,7 +27,7 @@ Feature: poll incoming shares
     When the administrator invokes occ command "incoming-shares:poll"
     Then the etag of element "/" of user "Brian" should have changed
 
-  @files_sharing-app-required @skipOnOcV10.6 @skipOnOcV10.7.0
+  @files_sharing-app-required
   Scenario: poll incoming share with a federation share and no file change
     Given using server "REMOTE"
     And user "Alice" has been created with default attributes and small skeleton files

--- a/tests/acceptance/features/cliLocalStorage/importLocalStorage.feature
+++ b/tests/acceptance/features/cliLocalStorage/importLocalStorage.feature
@@ -9,7 +9,7 @@ Feature: import exported local storage mounts from the command line
       | username |
       | Alice    |
 
-  @skipOnOcV10.3 @skipOnOcV10.4 @skipOnEncryption @issue-encryption-203
+  @skipOnEncryption @issue-encryption-203
   Scenario: import local storage mounts from a file
     Given the administrator has created the local storage mount "local_storage2"
     And the administrator has uploaded file with content "this is a file in local storage2" to "/local_storage2/file-in-local-storage2.txt"
@@ -25,7 +25,7 @@ Feature: import exported local storage mounts from the command line
     And as "Alice" folder "/local_storage2" should exist
     And the content of file "/local_storage2/file-in-local-storage2.txt" for user "Alice" should be "this is a file in local storage2"
 
-  @skipOnOcV10.3 @skipOnOcV10.4 @skipOnEncryption @issue-encryption-203
+  @skipOnEncryption @issue-encryption-203
   Scenario: import local storage mounts from a file with various user and group settings
     Given these users have been created with default attributes and without skeleton files:
       | username |

--- a/tests/acceptance/features/cliLocalStorage/propfindOnLocalStorage.feature
+++ b/tests/acceptance/features/cliLocalStorage/propfindOnLocalStorage.feature
@@ -1,4 +1,4 @@
-@cli @local_storage @files_external-app-required @skipOnOcV10.6 @skipOnOcV10.7 @skipOnOcV10.8.0
+@cli @local_storage @files_external-app-required
 Feature: get file info using PROPFIND
 
   Background:
@@ -113,7 +113,7 @@ Feature: get file info using PROPFIND
       | old         |
       | new         |
 
-  @depthInfinityPropfindDisabled @skipOnEncryptionType:user-keys @issue-encryption-320 @skipOnOcV10.8 @skipOnOcV10.9.0 @skipOnOcV10.9.1
+  @depthInfinityPropfindDisabled @skipOnEncryptionType:user-keys @issue-encryption-32
   Scenario Outline: list files on root folder with external storage using depth infinity when depth infinity is not allowed
     Given using <dav_version> DAV path
     When user "Alice" lists the resources in "/" with depth "infinity" using the WebDAV API
@@ -123,7 +123,7 @@ Feature: get file info using PROPFIND
       | old         |
       | new         |
 
-  @depthInfinityPropfindDisabled @skipOnEncryptionType:user-keys @issue-encryption-320 @skipOnOcV10.8 @skipOnOcV10.9.0 @skipOnOcV10.9.1
+  @depthInfinityPropfindDisabled @skipOnEncryptionType:user-keys @issue-encryption-32
   Scenario Outline: list files on external storage when depth infinity is not allowed
     Given using <dav_version> DAV path
     When user "Alice" lists the resources in "/local_storage2" with depth "infinity" using the WebDAV API

--- a/tests/acceptance/features/cliLocalStorage/propfindOnLocalStorageOc10Issue39470.feature
+++ b/tests/acceptance/features/cliLocalStorage/propfindOnLocalStorageOc10Issue39470.feature
@@ -1,4 +1,4 @@
-@cli @local_storage @files_external-app-required @skipOnOcV10.6 @skipOnOcV10.7 @skipOnOcV10.8.0
+@cli @local_storage @files_external-app-required
 Feature: get file info using PROPFIND
 
   Background:
@@ -55,7 +55,7 @@ Feature: get file info using PROPFIND
       | old         |
       | new         |
 
-  @depthInfinityPropfindDisabled @skipOnEncryptionType:user-keys @issue-encryption-320 @skipOnOcV10.8 @skipOnOcV10.9.0 @skipOnOcV10.9.1
+  @depthInfinityPropfindDisabled @skipOnEncryptionType:user-keys @issue-encryption-320
   Scenario Outline: list files on external storage that is currently unavailable when depth infinity is not allowed
     Given using <dav_version> DAV path
     When the local storage mount for "/local_storage2" is renamed to "/new_local_storage"
@@ -66,7 +66,7 @@ Feature: get file info using PROPFIND
       | old         |
       | new         |
 
-  @depthInfinityPropfindDisabled @skipOnEncryptionType:user-keys @issue-encryption-320 @skipOnOcV10.8 @skipOnOcV10.9.0 @skipOnOcV10.9.1
+  @depthInfinityPropfindDisabled @skipOnEncryptionType:user-keys @issue-encryption-320
   Scenario Outline: list files on root folder with depth infinity not allowed when the external storage folder is unavailable
     Given using <dav_version> DAV path
     When the local storage mount for "/local_storage2" is renamed to "/new_local_storage"

--- a/tests/acceptance/features/cliMain/configKey.feature
+++ b/tests/acceptance/features/cliMain/configKey.feature
@@ -41,19 +41,19 @@ Feature: add and delete app configs using occ command
     And the command output should contain the text 'System config value con set to empty string'
     And system config key "con" should have value ""
 
-  @skipOnOcV10.6 @skipOnOcV10.7 @skipOnOcV10.8.0
+
   Scenario: admin tries to add an empty config key for an app using the occ command
     When the administrator adds config key "''" with value "conkey" in app "core" using the occ command
     Then the command should have failed with exit code 1
     And the command output should contain the text 'Config name must not be empty.'
 
-  @skipOnOcV10.6 @skipOnOcV10.7 @skipOnOcV10.8.0
+
   Scenario: admin tries to add a config key and specifying the empty string as the app name using the occ command
     When the administrator adds config key "con" with value "conkey" in app "''" using the occ command
     Then the command should have failed with exit code 1
     And the command output should contain the text 'App name must not be empty.'
 
-  @skipOnOcV10.6 @skipOnOcV10.7 @skipOnOcV10.8.0
+
   Scenario: admin tries to add an empty system config key using the occ command
     When the administrator adds system config key "''" with value "conkey" using the occ command
     Then the command should have failed with exit code 1

--- a/tests/acceptance/features/cliMain/occMigrationStatus.feature
+++ b/tests/acceptance/features/cliMain/occMigrationStatus.feature
@@ -1,4 +1,4 @@
-@cli @skipOnOcV10.8 @skipOnOcV10.9 @skipOnOcV10.10.0
+@cli @skipOnOcV10.10.0
 Feature: Migration status of apps
   As an admin I want to be able to see the migration status of an app
   So that I can know the current and previous version

--- a/tests/acceptance/features/cliMain/securityCertificates.feature
+++ b/tests/acceptance/features/cliMain/securityCertificates.feature
@@ -1,4 +1,4 @@
-@cli @skipOnOcV10.3 @skipOnOcV10.4 @temporary_storage_on_server
+@cli @temporary_storage_on_server
 Feature: security certificates
   As an admin
   I want to be able to manage the ownCloud security certificates
@@ -15,7 +15,7 @@ Feature: security certificates
       | table_column        |
       | goodCertificate.crt |
 
-  @skipOnOcV10.5.0
+
   Scenario: Import a security certificate specifying a file that does not exist
     When the administrator imports security certificate from file "aFileThatDoesNotExist.crt" in temporary storage on the system under test
     Then the command should have failed with exit code 1
@@ -46,7 +46,7 @@ Feature: security certificates
       | table_column       |
       | badCertificate.crt |
 
-  @skipOnOcV10.5.0
+
   Scenario: Remove a security certificate that is not installed
     When the administrator removes the security certificate "someCertificate.crt"
     Then the command should have failed with exit code 1

--- a/tests/acceptance/features/cliMain/transferOwnership.feature
+++ b/tests/acceptance/features/cliMain/transferOwnership.feature
@@ -324,7 +324,7 @@ Feature: transfer-ownership
     Then the command output should contain the text "No files/folders to transfer"
     And the command should have failed with exit code 1
 
-  @skipOnEncryptionType:user-keys @skipOnOcV10.3 @skipOnOcV10.4 @skipOnOcV10.5
+  @skipOnEncryptionType:user-keys
   Scenario: troubleshoot transfer ownerships for all with share and reshare
     Given user "Alice" has been created with default attributes and small skeleton files
     And user "Brian" has been created with default attributes and small skeleton files
@@ -343,7 +343,7 @@ Feature: transfer-ownership
     And the command output should contain the text "Searching for shares that have invalid uid_owner"
     And the command output should contain the text "Found 0 invalid share owners"
 
-  @skipOnEncryptionType:user-keys @skipOnOcV10.3 @skipOnOcV10.4 @skipOnOcV10.5
+  @skipOnEncryptionType:user-keys
   Scenario: troubleshoot transfer ownerships for invalid-initiator with reshare
     Given user "Alice" has been created with default attributes and small skeleton files
     And user "Brian" has been created with default attributes and small skeleton files
@@ -358,7 +358,7 @@ Feature: transfer-ownership
     And the command output should contain the text "Searching for reshares that have invalid uid_initiator"
     And the command output should contain the text "Found 0 invalid initiator reshares"
 
-  @skipOnEncryptionType:user-keys @skipOnOcV10.3 @skipOnOcV10.4 @skipOnOcV10.5
+  @skipOnEncryptionType:user-keys
   Scenario: troubleshoot transfer ownerships for invalid-owner with share
     Given user "Alice" has been created with default attributes and small skeleton files
     And user "Brian" has been created with default attributes and small skeleton files

--- a/tests/acceptance/features/cliProvisioning/addGroup.feature
+++ b/tests/acceptance/features/cliProvisioning/addGroup.feature
@@ -37,7 +37,7 @@ Feature: add group
     Then the command should have failed with exit code 1
     And the command output should contain the text 'The group "brand-new-group" already exists'
 
-  @skipOnOcV10.7 @skipOnOcV10.8 @skipOnOcV10.9.0 @skipOnOcV10.9.1
+
   Scenario: admin tries to create a group that has white space at the end of the name
     When the administrator creates group "white-space-at-end " using the occ command
     Then the command should have failed with exit code 1
@@ -45,7 +45,7 @@ Feature: add group
     And group "white-space-at-end " should not exist
     And group "white-space-at-end" should not exist
 
-  @skipOnOcV10.7 @skipOnOcV10.8 @skipOnOcV10.9.0 @skipOnOcV10.9.1
+
   Scenario: admin tries to create a group that has white space at the start of the name
     When the administrator creates group " white-space-at-start" using the occ command
     Then the command should have failed with exit code 1
@@ -53,14 +53,14 @@ Feature: add group
     And group " white-space-at-start" should not exist
     And group "white-space-at-start" should not exist
 
-  @skipOnOcV10.7 @skipOnOcV10.8 @skipOnOcV10.9.0 @skipOnOcV10.9.1
+
   Scenario: admin tries to create a group that is a single space
     When the administrator creates group " " using the occ command
     Then the command should have failed with exit code 1
     And the command output should contain the text 'Group " " could not be created'
     And group " " should not exist
 
-  @skipOnOcV10.7 @skipOnOcV10.8 @skipOnOcV10.9.0 @skipOnOcV10.9.1
+
   Scenario: admin tries to create a group that is the empty string
     When the administrator creates group "" using the occ command
     Then the command should have failed with exit code 1

--- a/tests/acceptance/features/cliProvisioning/editUser.feature
+++ b/tests/acceptance/features/cliProvisioning/editUser.feature
@@ -14,7 +14,7 @@ Feature: edit users
     And the user attributes returned by the API should include
       | email | brand-new-user@example.com |
 
-  @skipOnOcV10.3 @skipOnOcV10.4
+
   Scenario: the administrator can clear a user email
     Given user "brand-new-user" has been created with default attributes and small skeleton files
     And the administrator has changed the email of user "brand-new-user" to "brand-new-user@example.com"
@@ -35,7 +35,7 @@ Feature: edit users
     And the user attributes returned by the API should include
       | displayname | A New User |
 
-  @skipOnOcV10.3 @skipOnOcV10.4
+
   Scenario: the administrator can clear a user display name and then it defaults to the username
     Given user "brand-new-user" has been created with default attributes and small skeleton files
     And the administrator has changed the display name of user "brand-new-user" to "A New User"

--- a/tests/acceptance/features/cliProvisioning/resetUserPassword.feature
+++ b/tests/acceptance/features/cliProvisioning/resetUserPassword.feature
@@ -45,7 +45,7 @@ Feature: reset user password
     Then the command should have failed with exit code 1
     And the command output should contain the text "Email address is not set for the user %username%" about user "brand-new-user"
 
-  @skipOnOcV10.3
+
   Scenario: administrator gets error message while trying to reset specifying user password with send email when the email address of the user is not setup
     Given these users have been created with small skeleton files:
       | username       | password  | displayname |

--- a/tests/acceptance/features/webUIAddUsers/addUsers.feature
+++ b/tests/acceptance/features/webUIAddUsers/addUsers.feature
@@ -24,14 +24,14 @@ Feature: add users
       | null     | %regular% |
       | nil      | %regular% |
 
-  @skipOnOcV10.3
+
   Scenario: use the webUI to create a user with special valid characters
     When the administrator creates a user with the name "@-+_.'" and the password "%regular%" using the webUI
     And the administrator logs out of the webUI
     And user "@-+_.'" logs in using the webUI
     Then the user should be redirected to a webUI page with the title "Files - %productname%"
 
-  @skipOnOcV10.3
+
   Scenario: use the webUI to create a user with special invalid characters
     When the administrator attempts to create these users then the notifications should be as listed
       | user | password    | notification                                                                                                    |
@@ -41,7 +41,7 @@ Feature: add users
       | a(=  | "%alt3%"    | Error creating user: Only the following characters are allowed in a username: "a-z", "A-Z", "0-9", and "+_.@-'" |
       | a`*^ | "%alt4%"    | Error creating user: Only the following characters are allowed in a username: "a-z", "A-Z", "0-9", and "+_.@-'" |
 
-  @skipOnOcV10.3 @skipOnOcV10.4
+
   Scenario: use the webUI to create a user with special invalid username
     When the administrator attempts to create these users then the notifications should be as listed
       | user | password | notification                                                  |
@@ -76,7 +76,7 @@ Feature: add users
       Access it:
       """
 
-  @smokeTest @skipOnLDAP @skipOnOcV10.3
+  @smokeTest @skipOnLDAP
   Scenario Outline: user sets his own password after being created with an Email address only
     When the administrator creates a user with the name "<username>" and the email "guiusr1@owncloud" without a password using the webUI
     And the administrator logs out of the webUI
@@ -94,7 +94,7 @@ Feature: add users
       | guiusr1  | simple user-name      |
       | a@-+_.'b | complicated user-name |
 
-  @smokeTest @skipOnLDAP @skipOnOcV10.6 @skipOnOcV10.7
+  @smokeTest @skipOnLDAP
   Scenario Outline: user sets his own password after being created with an Email address only and invitation link resend
     When the administrator creates a user with the name "<username>" and the email "guiusr1@owncloud" without a password using the webUI
     And the administrator resends the invitation email for user "<username>" using the webUI
@@ -115,7 +115,7 @@ Feature: add users
       | guiusr1  | simple user-name      |
       | a@-+_.'b | complicated user-name |
 
-  @skipOnOcV10.3
+
   Scenario Outline: user sets his own password but retypes it wrongly after being created with an Email address only
     When the administrator creates a user with the name "<username>" and the email "guiusr1@owncloud" without a password using the webUI
     And the administrator logs out of the webUI

--- a/tests/acceptance/features/webUIAddUsers/addUsersBySubAdmin.feature
+++ b/tests/acceptance/features/webUIAddUsers/addUsersBySubAdmin.feature
@@ -46,7 +46,7 @@ Feature: add users
     When the user logs in with username "guiusr1" and password "%regular%" using the webUI
     Then the user should be redirected to a webUI page with the title "Files - %productname%"
 
-  @skipOnLDAP @skipOnOcV10.6 @skipOnOcV10.7 @skipOnOcV10.8.0
+  @skipOnLDAP
   Scenario: user sets his own password after being created with an Email address only and invitation link resent by a subadmin
     When the subadmin creates a user with the name "guiusr1" and the email "guiusr1@owncloud" without a password using the webUI
     And the subadmin resends the invitation email for user "guiusr1" using the webUI

--- a/tests/acceptance/features/webUIAdminSettings/adminGeneralSettings.feature
+++ b/tests/acceptance/features/webUIAdminSettings/adminGeneralSettings.feature
@@ -7,7 +7,7 @@ Feature: admin general settings
   Background:
     Given the administrator has changed their own email address to "admin@owncloud.com"
 
-  @smokeTest @skipOnOcV10.6 @skipOnOcV10.7 @skipOnOcV10.8.0
+  @smokeTest
   Scenario: administrator sets email server settings
     Given the administrator has browsed to the admin general settings page
     When the administrator sets the following email server settings using the webUI
@@ -26,7 +26,7 @@ Feature: admin general settings
       If you received this email, the settings seem to be correct.
       """
 
-  @skipOnOcV10.7 @skipOnOcV10.8 @skipOnOcV10.9.0 @skipOnOcV10.9.1
+
   Scenario: administrator sets email server credentials and re-displays them
     Given the administrator has browsed to the admin general settings page
     When the administrator sets the following email server settings using the webUI

--- a/tests/acceptance/features/webUIAdminSettings/adminSharingSettings.feature
+++ b/tests/acceptance/features/webUIAdminSettings/adminSharingSettings.feature
@@ -187,7 +187,7 @@ Feature: admin sharing settings
     When the administrator enables default expiration date for group shares using the webUI
     Then the config key "shareapi_default_expire_date_group_share" of app "core" should have value "yes"
 
-  @skipOnOcV10.6 @skipOnOcV10.7 @skipOnOcV10.8.0
+
   Scenario: enable default expiration date for federated shares
     Given the administrator has browsed to the admin sharing settings page
     When the administrator enables default expiration date for federated shares using the webUI
@@ -207,7 +207,7 @@ Feature: admin sharing settings
     And the administrator updates the group share expiration date to "11" days using the webUI
     Then the config key "shareapi_expire_after_n_days_group_share" of app "core" should have value "11"
 
-  @skipOnOcV10.6 @skipOnOcV10.7 @skipOnOcV10.8.0
+
   Scenario: set a different default expiration days for federated shares
     Given the administrator has browsed to the admin sharing settings page
     When the administrator enables default expiration date for federated shares using the webUI
@@ -228,7 +228,7 @@ Feature: admin sharing settings
     And the administrator enforces maximum expiration date for group shares using the webUI
     Then the config key "shareapi_enforce_expire_date_group_share" of app "core" should have value "yes"
 
-  @skipOnOcV10.6 @skipOnOcV10.7 @skipOnOcV10.8.0
+
   Scenario: set default expiration days for federated shares and enforce as maximum expiration days
     Given the administrator has browsed to the admin sharing settings page
     When the administrator enables default expiration date for federated shares using the webUI
@@ -249,7 +249,7 @@ Feature: admin sharing settings
     Then the default expiration date checkbox for group shares should be enabled on the webUI
     And the expiration date for group shares should set to "7" days on the webUI
 
-  @skipOnOcV10.6 @skipOnOcV10.7 @skipOnOcV10.8.0
+
   Scenario: check previously set default expiration days for federated shares
     Given parameter "shareapi_default_expire_date_remote_share" of app "core" has been set to "yes"
     When the administrator browses to the admin sharing settings page
@@ -270,7 +270,7 @@ Feature: admin sharing settings
     When the administrator browses to the admin sharing settings page
     Then the enforce maximum expiration date checkbox for group shares should be enabled on the webUI
 
-  @skipOnOcV10.6 @skipOnOcV10.7 @skipOnOcV10.8.0
+
   Scenario: check previously enforced maximum expiration days for federated shares
     Given parameter "shareapi_default_expire_date_remote_share" of app "core" has been set to "yes"
     And parameter "shareapi_enforce_expire_date_remote_share" of app "core" has been set to "yes"
@@ -291,7 +291,7 @@ Feature: admin sharing settings
     When the administrator browses to the admin sharing settings page
     Then the expiration date for group shares should set to "5" days on the webUI
 
-  @skipOnOcV10.6 @skipOnOcV10.7 @skipOnOcV10.8.0
+
   Scenario: check previously set expiration days for federated shares
     Given parameter "shareapi_default_expire_date_remote_share" of app "core" has been set to "yes"
     And parameter "shareapi_expire_after_n_days_remote_share" of app "core" has been set to "5"

--- a/tests/acceptance/features/webUIAdminSettings/adminStorageSettings.feature
+++ b/tests/acceptance/features/webUIAdminSettings/adminStorageSettings.feature
@@ -1,4 +1,4 @@
-@webUI @insulated @disablePreviews @admin_settings-feature-required @local_storage @files_external-app-required @skipOnOcV10.6 @skipOnOcV10.7
+@webUI @insulated @disablePreviews @admin_settings-feature-required @local_storage @files_external-app-required
 Feature: admin storage settings
   As an admin
   I want to be able to manage external storages on the ownCloud server
@@ -33,7 +33,7 @@ Feature: admin storage settings
     And user "Alice" should be able to delete file "/local_storage1/another-name.txt"
     And folder "local_storage1" should be listed on the webUI
 
-  @skipOnOcV10.3
+
   Scenario: administrator creates a read-only local storage mount
     Given user "Alice" has been created with default attributes and without skeleton files
     And the administrator has enabled the external storage

--- a/tests/acceptance/features/webUIAdminSettings/adminStorageSettingsOC10Issue36803.feature
+++ b/tests/acceptance/features/webUIAdminSettings/adminStorageSettingsOC10Issue36803.feature
@@ -1,4 +1,4 @@
-@webUI @insulated @disablePreviews @admin_settings-feature-required @local_storage @files_external-app-required @notToImplementOnOCIS @skipOnOcV10.6 @skipOnOcV10.7
+@webUI @insulated @disablePreviews @admin_settings-feature-required @local_storage @files_external-app-required @notToImplementOnOCIS
 Feature: admin storage settings
   As an admin
   I want to be able to manage external storages on the ownCloud server

--- a/tests/acceptance/features/webUIAdminSettings/helpAndTips.feature
+++ b/tests/acceptance/features/webUIAdminSettings/helpAndTips.feature
@@ -7,7 +7,7 @@ Feature: Help and tips page
   Background:
     Given the administrator has browsed to the help and tips page
 
-  @skipOnOcV10.6 @skipOnOcV10.7
+
   Scenario Outline: Admin can view links in help and tips page
     Then the link for "<linkName>" should be shown on the webUI
     And the link for "<linkName>" should be valid

--- a/tests/acceptance/features/webUICreateDelete/createFolders.feature
+++ b/tests/acceptance/features/webUICreateDelete/createFolders.feature
@@ -20,7 +20,7 @@ Feature: create folders
       | folder-!@#$%^&* ! |
       | नेपालि            |
 
-  @skipOnOcV10.6 @skipOnOcV10.7 @skipOnOcV10.8.0
+
   Scenario Outline: Create a folder using the create button
     When the user creates a folder with the name "<folder-name>" using the webUI via create button
     Then folder "<folder-name>" should be listed on the webUI
@@ -30,7 +30,7 @@ Feature: create folders
       | folder-name       |
       | folder-!@#$%^&*( ! |
 
-  @skipOnOcV10.6 @skipOnOcV10.7 @skipOnOcV10.8.0
+
   Scenario: Abort create folder using the cancel button
     When the user opens the newFileMenu using the webUI
     Then the newFileMenu should be displayed on the webUI

--- a/tests/acceptance/features/webUIFileActionsMenu/fileActionsMenu.feature
+++ b/tests/acceptance/features/webUIFileActionsMenu/fileActionsMenu.feature
@@ -9,13 +9,13 @@ Feature: File actions menu
     And user "Alice" has logged in using the webUI
     And the user has browsed to the files page
 
-  @skipOnOcV10.4 @skipOnOcV10.5 @skipOnOcV10.6.0
+
   Scenario: show the file actions application select menu with both Collabora and the Files Texteditor
     When the user clicks on the file "lorem.txt"
     Then the file actions application select menu should be displayed with these items on the webUI
       | Open in Text Editor | Open in Collabora |
 
-  @skipOnOcV10.4 @skipOnOcV10.5 @skipOnOcV10.6.0
+
   Scenario: show the actions for Collabora and the Files Texteditor in the file action menu
     And the user opens the file action menu of file "lorem.txt" on the webUI
     Then the file actions menu should be displayed with these items on the webUI

--- a/tests/acceptance/features/webUIFiles/download.feature
+++ b/tests/acceptance/features/webUIFiles/download.feature
@@ -20,7 +20,7 @@ Feature: Download resource
     And the user clicks the download button on the webUI
     Then file "simple-folder.zip" should be downloaded
 
-  @skipOnOcV10.6 @skipOnOcV10.7 @skipOnOcV10.8.0
+
   Scenario: download multiple folders
     Given user "Alice" has created folder "simple-folder"
     And user "Alice" has created folder "simple-folder1"
@@ -38,7 +38,7 @@ Feature: Download resource
       | simple-folder1 |
       | simple-folder2 |
 
-  @skipOnOcV10.6 @skipOnOcV10.7 @skipOnOcV10.8.0
+
   Scenario: download all files and folder
     Given user "Alice" has uploaded file with content "ownCloud test text file 0" to "textfile0.txt"
     And user "Alice" has created folder "simple-folder"

--- a/tests/acceptance/features/webUIFiles/fileDetails.feature
+++ b/tests/acceptance/features/webUIFiles/fileDetails.feature
@@ -107,7 +107,7 @@ Feature: User can open the details panel for any file or folder
     When the user switches to the "comments" tab in the details panel using the webUI
     Then the "comments" details panel should be visible
 
-  @skipOnOcV10.6 @skipOnOcV10.7 @skipOnOcV10.8.0
+
   Scenario Outline: Breadcrumb through folders
     Given user "Alice" has created folder "<grand-parent>"
     And user "Alice" has created folder "<grand-parent>/<parent>"

--- a/tests/acceptance/features/webUIFiles/lockFile.feature
+++ b/tests/acceptance/features/webUIFiles/lockFile.feature
@@ -1,4 +1,4 @@
-@webUI @insulated @disablePreviews @skipOnOcV10.3 @skipOnOcV10.4
+@webUI @insulated @disablePreviews
 Feature: Manually lock a file
   As a user
   I want to be able to manually lock a file

--- a/tests/acceptance/features/webUIFiles/versions.feature
+++ b/tests/acceptance/features/webUIFiles/versions.feature
@@ -92,7 +92,7 @@ Feature: Versions of a file
     And the user browses directly to display the "versions" details of file "randomfile.txt" in folder "/"
     Then the versions list should contain 0 entries
 
-  @skipOnStorage:ceph @files_primary_s3-issue-67 @skipOnOcV10.6 @skipOnOcV10.7 @skipOnOcV10.8.0
+  @skipOnStorage:ceph @files_primary_s3-issue-67
   Scenario: versions author is displayed
     Given the administrator has enabled the file version storage feature
     And user "Alice" has uploaded file with content "some content" to "/randomfile.txt"
@@ -106,7 +106,7 @@ Feature: Versions of a file
       | 1     | Alice  |
       | 2     | Alice  |
 
-  @skipOnStorage:ceph @files_primary_s3-issue-67 @skipOnOcV10.6 @skipOnOcV10.7 @skipOnOcV10.8.0
+  @skipOnStorage:ceph @files_primary_s3-issue-67
   Scenario: sharee can see the versions' respective author
     Given the administrator has enabled the file version storage feature
     And user "Brian" has been created with default attributes and without skeleton files
@@ -126,7 +126,7 @@ Feature: Versions of a file
       | 2     | Alice  |
       | 3     | Alice  |
 
-  @skipOnStorage:ceph @files_primary_s3-issue-67 @skipOnOcV10.6 @skipOnOcV10.7 @skipOnOcV10.8.0
+  @skipOnStorage:ceph @files_primary_s3-issue-67
   Scenario: sharee can see the versions' respective author after version restore
     Given the administrator has enabled the file version storage feature
     And user "Brian" has been created with default attributes and without skeleton files

--- a/tests/acceptance/features/webUILogin/login.feature
+++ b/tests/acceptance/features/webUILogin/login.feature
@@ -8,13 +8,13 @@ Feature: login users
   I want only authorised users to log in
   So that unauthorised access is impossible
 
-  @skipOnOcV10.6 @skipOnOcV10.7
+
   Scenario: login page username and password field placeholder text
     When the user browses to the login page
     Then the username field on the login page should have label text "Username or email"
     And the password field on the login page should have label text "Password"
 
-  @skipOnOcV10.6 @skipOnOcV10.7
+
   Scenario: login page username and password field placeholder text when strict_login_enforced is set
     Given the administrator has added system config key "strict_login_enforced" with value "true" and type "boolean"
     When the user browses to the login page
@@ -29,7 +29,7 @@ Feature: login users
     When user "Alice" logs in using the webUI
     Then the user should be redirected to a webUI page with the title "Files - %productname%"
 
-  @skipOnOcV10.3 @skipOnOcV10.4
+
   Scenario: simple user login should work when strict_login_enforced is set
     Given these users have been created with default attributes and without skeleton files:
       | username |

--- a/tests/acceptance/features/webUILogin/loginWithEmailAddress.feature
+++ b/tests/acceptance/features/webUILogin/loginWithEmailAddress.feature
@@ -24,7 +24,7 @@ Feature: login users
     When user "Alice" logs in with email and invalid password "%alt2%" using the webUI
     Then the user should be redirected to a webUI page with the title "%productname%"
 
-  @skipOnOcV10.3 @skipOnOcV10.4
+
   Scenario: user login with email address should fail when strict_login_enforced is set
     Given the administrator has added system config key "strict_login_enforced" with value "true" and type "boolean"
     When user "Alice" logs in with their email address using the webUI

--- a/tests/acceptance/features/webUIManageUsersGroups/addGroup.feature
+++ b/tests/acceptance/features/webUIManageUsersGroups/addGroup.feature
@@ -63,7 +63,7 @@ Feature: Add group
       | "⛷"       |
       | "⛹"       |
 
-  @skipOnLDAP @skipOnOcV10.6 @skipOnOcV10.7 @skipOnOcV10.8.0
+  @skipOnLDAP
   Scenario: adding multiple users to a group
     Given these users have been created without skeleton files:
       | username |
@@ -80,7 +80,7 @@ Feature: Add group
     When the administrator reloads the users page
     Then the user count of group "grp1" should display 3 users on the webUI
 
-  @skipOnOcV10.8 @skipOnOcV10.9 @skipOnOcV10.10
+  @skipOnOcV10.10
   Scenario: Cannot add group with white-space in the name
     When the administrator adds group "whitespace " using the webUI
     Then a notification should be displayed on the webUI with the text "Error creating group: Unable to add group."

--- a/tests/acceptance/features/webUIManageUsersGroups/editUsers.feature
+++ b/tests/acceptance/features/webUIManageUsersGroups/editUsers.feature
@@ -120,7 +120,7 @@ Feature: edit users
       | new-group | NEW-GROUP | New-Group |
       | NEW-GROUP | New-Group | new-group |
 
-  @skipOnOcV10.6 @skipOnOcV10.7 @skipOnOcV10.8.0
+
   Scenario: removing multiple users from a group
     Given these users have been created without skeleton files:
       | username |

--- a/tests/acceptance/features/webUIPersonalSettings/accessToChangeEmailAddressThroughConfig.feature
+++ b/tests/acceptance/features/webUIPersonalSettings/accessToChangeEmailAddressThroughConfig.feature
@@ -17,7 +17,7 @@ Feature: Control access to edit email address of user through config file
     Then the attributes of user "Alice" returned by the API should include
       | email | new-address@owncloud.com |
 
-  @skipOnOcV10.6 @skipOnOcV10.7 @skipOnOcV10.8.0
+
   Scenario: Admin does not give access to users to change their email address
     Given the administrator has updated system config key "allow_user_to_change_mail_address" with value "false" and type "boolean"
     When the user browses to the personal general settings page

--- a/tests/acceptance/features/webUIRenameFiles/renameFile.feature
+++ b/tests/acceptance/features/webUIRenameFiles/renameFile.feature
@@ -77,7 +77,7 @@ Feature: rename files
     And the user reloads the current page of the webUI
     Then file "aaaaaa.txt" should be listed on the webUI
 
-  @skipOnOcV10.6 @skipOnOcV10.7 @skipOnOcV10.8.0
+
   Scenario: Rename a file using spaces at front and/or back of file name and type
     Given user "Alice" has uploaded file with content "some content" to "/randomfile.txt"
     And user "Alice" has logged in using the webUI
@@ -137,7 +137,7 @@ Feature: rename files
       | Could not rename "randomfile.txt" |
     And file "randomfile.txt" should be listed on the webUI
 
-  @skipOnOcV10.3
+
   Scenario: Rename a file to a filename that matches (or not) blacklisted_files_regex
     Given user "Alice" has uploaded file with content "some content" to "/randomfile.txt"
     # Note: we have to write JSON for the value, and to get a backslash in the double-quotes we have to escape it
@@ -178,7 +178,7 @@ Feature: rename files
       | Could not rename "randomfile.txt" |
     And file "randomfile.txt" should be listed on the webUI
 
-  @skipOnOcV10.3
+
   Scenario: Rename a file to a filename that matches (or not) excluded_directories_regex
     Given user "Alice" has uploaded file with content "some content" to "/randomfile.txt"
     # Note: we have to write JSON for the value, and to get a backslash in the double-quotes we have to escape it

--- a/tests/acceptance/features/webUIRenameFiles/renameFileToBlacklistedName.feature
+++ b/tests/acceptance/features/webUIRenameFiles/renameFileToBlacklistedName.feature
@@ -7,7 +7,7 @@ Feature: users cannot rename a file to a blacklisted name
   Background:
     Given user "Alice" has been created with default attributes and without skeleton files
 
-  @skipOnOcV10.3
+
   Scenario: Rename a file to a filename that matches (or not) blacklisted_files_regex
     Given user "Alice" has uploaded file with content "some content" to "/randomfile.txt"
     # Note: we have to write JSON for the value, and to get a backslash in the double-quotes we have to escape it

--- a/tests/acceptance/features/webUIRenameFiles/renameFileToExcludedDirectory.feature
+++ b/tests/acceptance/features/webUIRenameFiles/renameFileToExcludedDirectory.feature
@@ -31,7 +31,7 @@ Feature: users cannot rename a file to or into an excluded directory
       | Could not rename "randomfile.txt" |
     And file "randomfile.txt" should be listed on the webUI
 
-  @skipOnOcV10.3
+
   Scenario: Rename a file to a filename that matches (or not) excluded_directories_regex
     Given user "Alice" has uploaded file with content "some content" to "/randomfile.txt"
     # Note: we have to write JSON for the value, and to get a backslash in the double-quotes we have to escape it

--- a/tests/acceptance/features/webUIRenameFolders/renameFolders.feature
+++ b/tests/acceptance/features/webUIRenameFolders/renameFolders.feature
@@ -51,7 +51,7 @@ Feature: rename folders
     And the user reloads the current page of the webUI
     Then folder "hash#And&QuestionMark?At@FolderName" should be listed on the webUI
 
-  @skipOnOcV10.6 @skipOnOcV10.7 @skipOnOcV10.8.0
+
   Scenario: Rename a folder using spaces at front and/or back of the name
     Given user "Alice" has created folder "a-folder"
     And user "Alice" has logged in using the webUI
@@ -131,7 +131,7 @@ Feature: rename folders
     When the user renames folder "a-folder" to "a.part" using the webUI
     Then near folder "a-folder" a tooltip with the text '"a.part" has a forbidden file type/extension.' should be displayed on the webUI
 
-  @skipOnOcV10.6 @skipOnOcV10.7
+
   Scenario: Rename a folder which is received as a share (without change permission)
     Given user "Brian" has been created with default attributes and without skeleton files
     And user "Brian" has created folder "RandomFolder"

--- a/tests/acceptance/features/webUIRenameFolders/renameFoldersToBlacklistedName.feature
+++ b/tests/acceptance/features/webUIRenameFolders/renameFoldersToBlacklistedName.feature
@@ -7,7 +7,7 @@ Feature: users cannot rename a folder to a blacklisted name
   Background:
     Given user "Alice" has been created with default attributes and without skeleton files
 
-  @skipOnOcV10.3
+
   Scenario: Rename a folder to a foldername that matches (or not) blacklisted_files_regex
     Given user "Alice" has created folder "a-folder"
     # Note: we have to write JSON for the value, and to get a backslash in the double-quotes we have to escape it

--- a/tests/acceptance/features/webUIRenameFolders/renameFoldersToExcludedDirectory.feature
+++ b/tests/acceptance/features/webUIRenameFolders/renameFoldersToExcludedDirectory.feature
@@ -31,7 +31,7 @@ Feature: users cannot rename a folder to or into an excluded directory
       | Could not rename "a-folder" |
     And folder "a-folder" should be listed on the webUI
 
-  @skipOnOcV10.3
+
   Scenario: Rename a folder to a foldername that matches (or not) excluded_directories_regex
     Given user "Alice" has created folder "a-folder"
     # Note: we have to write JSON for the value, and to get a backslash in the double-quotes we have to escape it

--- a/tests/acceptance/features/webUIRestrictSharing/restrictReSharing.feature
+++ b/tests/acceptance/features/webUIRestrictSharing/restrictReSharing.feature
@@ -19,7 +19,7 @@ Feature: restrict resharing
     And user "Brian" has created folder "simple-folder"
     And user "Brian" has logged in using the webUI
 
-  @skipOnMICROSOFTEDGE @skipOnFIREFOX @files_sharing-app-required @smokeTest @skipOnOcV10.3
+  @skipOnMICROSOFTEDGE @skipOnFIREFOX @files_sharing-app-required @smokeTest
   Scenario: share a folder with another internal user and prohibit resharing
     Given the setting "Allow resharing" in the section "Sharing" has been enabled
     And the user has browsed to the files page

--- a/tests/acceptance/features/webUIRestrictSharing/restrictSharing.feature
+++ b/tests/acceptance/features/webUIRestrictSharing/restrictSharing.feature
@@ -60,7 +60,7 @@ Feature: restrict Sharing
     And the user re-logs in as "Alice" using the webUI
     Then folder "simple-folder (2)" should be listed on the webUI
 
-  @skipOnOcV10.3
+
   Scenario: Editing share permission of existing share when sharing with groups is forbidden
     Given the user has shared folder "simple-folder" with group "grp1"
     And the setting "Allow sharing with groups" in the section "Sharing" has been disabled
@@ -75,7 +75,7 @@ Feature: restrict Sharing
     Then the following permissions are seen for "simple-folder" in the sharing dialog for group "grp1"
       | share | yes |
 
-  @skipOnOcV10.3
+
   Scenario: Editing create permission of existing share when sharing with groups is forbidden
     Given the user has shared folder "simple-folder" with group "grp1"
     And the setting "Allow sharing with groups" in the section "Sharing" has been disabled

--- a/tests/acceptance/features/webUISharingExternal1/federationSharing.feature
+++ b/tests/acceptance/features/webUISharingExternal1/federationSharing.feature
@@ -20,7 +20,7 @@ Feature: Federation Sharing - sharing with users on other cloud storages
     And user "Alice" has logged in using the webUI
     And parameter "auto_accept_trusted" of app "federatedfilesharing" has been set to "no"
 
-  @skipOnMICROSOFTEDGE @skipOnOcV10.3
+  @skipOnMICROSOFTEDGE
   Scenario: share a folder with a federated user and prohibit deleting - local server shares - remote server receives
     Given using server "REMOTE"
     And user "Alice" from server "REMOTE" has shared "simple-folder" with user "Alice" from server "LOCAL"
@@ -186,7 +186,7 @@ Feature: Federation Sharing - sharing with users on other cloud storages
     When the user opens folder "simple-folder (2)" using the webUI
     Then it should not be possible to delete file "lorem.txt" using the webUI
 
-  @skipOnOcV10.3
+  
   Scenario: test resharing folder and set it as readonly by owner
     Given using server "LOCAL"
     And user "Brian" has been created with default attributes and without skeleton files
@@ -205,7 +205,7 @@ Feature: Federation Sharing - sharing with users on other cloud storages
     When the user opens folder "simple-folder (2)" using the webUI
     Then it should not be possible to delete file "lorem.txt" using the webUI
 
-  @skipOnOcV10.3 @skipOnFedOcV10.3 @skipOnOcV10.4 @skipOnFedOcV10.4 @skipOnOcV10.5.0 @skipOnFedOcV10.5.0
+  
   Scenario: test sharing long file names with federation share
     When user "Alice" moves file "/lorem.txt" to "/averylongfilenamefortestingthatfileswithlongfilenamescannotbeshared.txt" using the WebDAV API
     And the user has reloaded the current page of the webUI

--- a/tests/acceptance/features/webUISharingExternal2/acceptDeclineFederatedShares.feature
+++ b/tests/acceptance/features/webUISharingExternal2/acceptDeclineFederatedShares.feature
@@ -92,7 +92,7 @@ Feature: Federation Sharing - sharing with users on other cloud storages
     Then user "Alice" should see the following elements
       | /lorem (2).txt |
 
-  @skipOnOcV10.3 @skipOnOcV10.4.0
+
   Scenario: Local user accepts a pending federated share on the webUI
     Given user "Alice" from server "REMOTE" has shared "/lorem.txt" with user "Alice" from server "LOCAL"
     When the user browses to the shared-with-you page

--- a/tests/acceptance/features/webUISharingExternal2/createFederationSharing.feature
+++ b/tests/acceptance/features/webUISharingExternal2/createFederationSharing.feature
@@ -31,7 +31,7 @@ Feature: Federation Sharing - sharing with users on other cloud storages
     And as "Alice" file "/simple-folder (2)/lorem.txt" should exist
     And as "Alice" folder "/simple-empty-folder (2)" should exist
 
-  @skipOnOcV10.6 @skipOnOcV10.7 @skipOnOcV10.8.0
+
   Scenario: test the single steps of receiving a federation share
     Given using server "REMOTE"
     And these users have been created with default attributes and without skeleton files:
@@ -87,7 +87,7 @@ Feature: Federation Sharing - sharing with users on other cloud storages
     Then the following resources should have share indicators on the webUI
       | sub-folder |
 
-  @skipOnOcV10.6 @skipOnOcV10.7 @skipOnOcV10.8.0
+
   Scenario: sharing details inside folder shared using federated sharing
     Given user "Alice" has created folder "/simple-folder/sub-folder"
     And user "Alice" has uploaded file "filesForUpload/textfile.txt" to "/simple-folder/textfile.txt"
@@ -99,7 +99,7 @@ Feature: Federation Sharing - sharing with users on other cloud storages
     When the user opens the share dialog for file "textfile.txt"
     Then federated user "Alice" with displayname "%username%@%remote_server% (Federated share)" should be listed as share receiver via "simple-folder" on the webUI
 
-  @skipOnOcV10.6 @skipOnOcV10.7 @skipOnOcV10.8.0
+
   Scenario: sharing details of items inside a shared folder shared with local user and federated user
     Given user "Brian" has been created with default attributes and without skeleton files
     And user "Alice" has created folder "/simple-folder/sub-folder"

--- a/tests/acceptance/features/webUISharingInternalGroups1/shareWithGroups.feature
+++ b/tests/acceptance/features/webUISharingInternalGroups1/shareWithGroups.feature
@@ -137,7 +137,7 @@ Feature: Sharing files and folders with internal groups
     Then a tooltip with the text "No users or groups found for system-group" should be shown near the share-with-field on the webUI
     And the autocomplete list should not be displayed on the webUI
 
-  @skipOnOcV10.3 @skipOnEncryptionType:user-keys @issue-encryption-126 @email
+  @skipOnEncryptionType:user-keys @issue-encryption-126 @email
   Scenario: user should be able to send notification by email when allow share mail notification has been enabled
     Given parameter "shareapi_allow_mail_notification" of app "core" has been set to "yes"
     And user "Carol" has logged in using the webUI
@@ -154,7 +154,7 @@ Feature: Sharing files and folders with internal groups
       just letting you know that %displayname% shared lorem.txt with you.
       """
 
-  @email @skipOnOcV10.3
+  @email
   Scenario: user should not be able to send notification by email more than once
     Given parameter "shareapi_allow_mail_notification" of app "core" has been set to "yes"
     And user "Carol" has logged in using the webUI
@@ -166,7 +166,7 @@ Feature: Sharing files and folders with internal groups
     And the user opens the share dialog for file "lorem.txt"
     Then the user should not be able to send the share notification by email for group "grp1" using the webUI
 
-  @skipOnOcV10.3
+
   Scenario: user should not be able to send notification by email when allow share mail notification has been disabled
     Given parameter "shareapi_allow_mail_notification" of app "core" has been set to "no"
     And user "Carol" has logged in using the webUI
@@ -174,7 +174,7 @@ Feature: Sharing files and folders with internal groups
     When the user opens the share dialog for file "lorem.txt"
     Then the user should not be able to send the share notification by email for group "grp1" using the webUI
 
-  @email @skipOnLDAP @skipOnOcV10.3
+  @email @skipOnLDAP
   Scenario: user should not get an email notification if the user is added to the group after the mail notification was sent
     Given parameter "shareapi_allow_mail_notification" of app "core" has been set to "yes"
     And user "David" has been created with default attributes and without skeleton files
@@ -186,7 +186,7 @@ Feature: Sharing files and folders with internal groups
     When the administrator adds user "David" to group "grp1" using the provisioning API
     Then the email address "david@example.org" should not have received an email
 
-  @skipOnOcV10.3 @skipOnEncryptionType:user-keys @issue-encryption-126 @email
+  @skipOnEncryptionType:user-keys @issue-encryption-126 @email
   Scenario: user should get an error message when trying to send notification by email to the group where some user have set up their email and others haven't
     Given parameter "shareapi_allow_mail_notification" of app "core" has been set to "yes"
     And these users have been created without skeleton files:
@@ -331,7 +331,7 @@ Feature: Sharing files and folders with internal groups
     And the user opens the share dialog for file "lorem.txt"
     Then the group "grp1" should not be in share with group list
 
-  @skipOnOcV10.3
+
   Scenario: sharing indicator of items inside a shared folder
     Given user "Alice" has created folder "/simple-folder"
     And user "Alice" has created folder "/simple-folder/simple-empty-folder"
@@ -343,7 +343,7 @@ Feature: Sharing files and folders with internal groups
       | simple-empty-folder |
       | lorem.txt           |
 
-  @skipOnOcV10.3
+
   Scenario: sharing indicator of items inside a shared folder two levels down
     Given user "Alice" has created folder "/simple-folder"
     And user "Alice" has created folder "/simple-folder/simple-empty-folder/"
@@ -357,7 +357,7 @@ Feature: Sharing files and folders with internal groups
       | new-folder |
       | lorem.txt  |
 
-  @skipOnOcV10.3
+
   Scenario: sharing indicator of items inside a re-shared folder
     Given user "Alice" has created folder "/simple-folder"
     And user "Alice" has created folder "/simple-folder/simple-empty-folder"
@@ -370,7 +370,7 @@ Feature: Sharing files and folders with internal groups
       | simple-empty-folder |
       | lorem.txt           |
 
-  @skipOnOcV10.3
+
   Scenario: no sharing indicator of items inside a not shared folder
     Given user "Alice" has created folder "/simple-folder"
     And user "Alice" has created folder "/simple-folder/simple-sub-folder"
@@ -381,7 +381,7 @@ Feature: Sharing files and folders with internal groups
       | simple-sub-folder |
       | lorem.txt         |
 
-  @skipOnOcV10.3
+
   Scenario: sharing indicator for file uploaded inside a shared folder
     Given user "Carol" has created folder "/simple-empty-folder"
     And user "Carol" has shared folder "/simple-empty-folder" with group "grp1"
@@ -391,7 +391,7 @@ Feature: Sharing files and folders with internal groups
     Then the following resources should have share indicators on the webUI
       | new-lorem.txt |
 
-  @skipOnOcV10.3
+
   Scenario: sharing indicator for folder created inside a shared folder
     Given user "Carol" has created folder "/simple-empty-folder"
     And user "Carol" has shared folder "/simple-empty-folder" with group "grp1"
@@ -401,7 +401,7 @@ Feature: Sharing files and folders with internal groups
     Then the following resources should have share indicators on the webUI
       | sub-folder |
 
-  @skipOnOcV10.3
+
   Scenario: sharing details of items inside a shared folder shared with user and group
     Given user "Carol" has created folder "/simple-folder/sub-folder"
     And user "Carol" has uploaded file "filesForUpload/lorem.txt" to "/simple-folder/sub-folder/lorem.txt"

--- a/tests/acceptance/features/webUISharingInternalGroups2/shareWithGroupUsingExpirationDate.feature
+++ b/tests/acceptance/features/webUISharingInternalGroups2/shareWithGroupUsingExpirationDate.feature
@@ -1,4 +1,4 @@
-@webUI @insulated @disablePreviews @skipOnOcV10.3
+@webUI @insulated @disablePreviews
 Feature: Sharing files and folders with internal groups with expiration date set/unset
   As a user
   I want to share files and folders with groups and set an expiration date

--- a/tests/acceptance/features/webUISharingInternalGroups2/shareWithGroupsEdgeCases.feature
+++ b/tests/acceptance/features/webUISharingInternalGroups2/shareWithGroupsEdgeCases.feature
@@ -41,7 +41,7 @@ Feature: Sharing files and folders with internal groups
       | ?\?@#%@,; |
       | नेपाली    |
 
-  @skipOnOcV10.3.0 @skipOnOcV10.3.1
+
   Scenario: Share file with a user and a group with same name
     Given these groups have been created:
       | groupname |
@@ -56,7 +56,7 @@ Feature: Sharing files and folders with internal groups
     When the user re-logs in as "Brian" using the webUI
     Then folder "simple-folder" should be marked as shared with "Alice" by "Carol" on the webUI
 
-  @skipOnOcV10.3.0 @skipOnOcV10.3.1
+
   Scenario: Share file with a group and a user with same name
     Given these groups have been created:
       | groupname |
@@ -99,7 +99,7 @@ Feature: Sharing files and folders with internal groups
     When the user re-logs in as "Brian" using the webUI
     Then folder "simple-folder" should be marked as shared with "Alice" by "Carol" on the webUI
 
-  @skipOnOcV10.3
+
   Scenario: Share file with a user and a group with same name and change sharing permissions of the group
     Given these groups have been created:
       | groupname |
@@ -130,7 +130,7 @@ Feature: Sharing files and folders with internal groups
       | share_with  | Alice          |
       | permissions | 7              |
 
-  @skipOnOcV10.3
+
   Scenario: Share file with a user and a group with same name and change sharing permissions of the user
     Given these groups have been created:
       | groupname |
@@ -161,7 +161,7 @@ Feature: Sharing files and folders with internal groups
       | share_with  | Alice          |
       | permissions | 31             |
 
-  @skipOnOcV10.3
+
   Scenario: Share file with a user and a group with same name and change sharing permissions of both user and group
     Given these groups have been created:
       | groupname |
@@ -193,7 +193,7 @@ Feature: Sharing files and folders with internal groups
       | share_with  | Alice          |
       | permissions | 23             |
 
-  @skipOnOcV10.3
+
   Scenario: Share file with a user and a group with same name and change sharing permissions and expiration date of the group
     Given these groups have been created:
       | groupname |
@@ -224,7 +224,7 @@ Feature: Sharing files and folders with internal groups
       | permissions | 31             |
       | expiration  |                |
 
-  @skipOnOcV10.3
+
   Scenario: Share file with a user and a group with same name and change sharing permissions and expiration date of the user
     Given these groups have been created:
       | groupname |
@@ -255,7 +255,7 @@ Feature: Sharing files and folders with internal groups
       | permissions | 31             |
       | expiration  |                |
 
-  @skipOnOcV10.3
+
   Scenario: Share file with a user and a group with same name and change sharing permissions and expiration date of both user and group
     Given these groups have been created:
       | groupname |
@@ -293,7 +293,7 @@ Feature: Sharing files and folders with internal groups
       | share_with  | Alice          |
       | permissions | 23             |
 
-  @skipOnOcV10.3
+
   Scenario: Check share permissions and expiration date of a group and the member of the same group
     Given these groups have been created:
       | groupname |
@@ -322,7 +322,7 @@ Feature: Sharing files and folders with internal groups
       | expiration  |                |
       | permissions | 31             |
 
-  @skipOnOcV10.3
+
   Scenario: share with multiple groups and change the sharing permissions and expiration date
     Given these groups have been created:
       | groupname |
@@ -356,7 +356,7 @@ Feature: Sharing files and folders with internal groups
       | share_with  | grp2           |
       | permissions | 7              |
 
-  @skipOnOcV10.3 @skipOnOcV10.4 @skipOnOcV10.5 @skipOnOcV10.6 @skipOnOcV10.7.0
+
   Scenario: Reshare with group that user is member of should not create mount in the root folder of resharer
     Given these groups have been created:
       | groupname |
@@ -375,7 +375,7 @@ Feature: Sharing files and folders with internal groups
     And as "Alice" folder "/simple-empty-folder" should not exist
     And user "Alice" should be able to create folder "/simple-empty-folder"
 
-  @skipOnOcV10.3 @skipOnOcV10.4 @skipOnOcV10.5 @skipOnOcV10.6 @skipOnOcV10.7.0
+
   Scenario: Reshare with group that user is member of should allow for downgrading and upgrading permissions
     Given these groups have been created:
       | groupname |
@@ -405,7 +405,7 @@ Feature: Sharing files and folders with internal groups
     And user "Brian" should not be able to upload file "filesForUpload/textfile.txt" to "simple-folder/textfile.txt"
     And user "Brian" should be able to upload file "filesForUpload/textfile.txt" to "simple-empty-folder/textfile.txt"
 
-  @skipOnOcV10.3 @skipOnOcV10.4 @skipOnOcV10.5 @skipOnOcV10.6 @skipOnOcV10.7.0
+
   Scenario: Reshare mount received from multiple group reshare by different users and different subfolders
     Given these groups have been created:
       | groupname |
@@ -431,7 +431,7 @@ Feature: Sharing files and folders with internal groups
       | edit  | yes |
       | share | yes |
 
-  @skipOnOcV10.6 @skipOnOcV10.7.0
+
   Scenario: Simple share of a file within nested folders to a group
     Given these groups have been created:
       | groupname |
@@ -451,7 +451,7 @@ Feature: Sharing files and folders with internal groups
       | share_with  | grp1            |
       | permissions | 19              |
 
-  @skipOnOcV10.6 @skipOnOcV10.7.0
+
   Scenario: Reshares with groups where the same file ends up in different mountpoints should have correct permissions
     Given these groups have been created:
       | groupname |
@@ -482,7 +482,7 @@ Feature: Sharing files and folders with internal groups
       | share_with  | grp3            |
       | permissions | 19              |
 
-  @skipOnOcV10.6 @skipOnOcV10.7
+
   Scenario: Reshares with groups of subfolder with lower permissions
     Given these groups have been created:
       | groupname |
@@ -512,7 +512,7 @@ Feature: Sharing files and folders with internal groups
       | share_with  | grp3                 |
       | permissions | 31                   |
 
-  @skipOnOcV10.6 @skipOnOcV10.7 @skipOnOcV10.8.0
+
   Scenario: Reshares with groups where the same file ends up in different mountpoints that are renamed should have correct permissions
     Given these groups have been created:
       | groupname |

--- a/tests/acceptance/features/webUISharingInternalUsers1/createShareWithUsers.feature
+++ b/tests/acceptance/features/webUISharingInternalUsers1/createShareWithUsers.feature
@@ -67,7 +67,7 @@ Feature: Sharing files and folders with internal users
     And file "lorem.txt" should not be listed in shared-with-others page on the webUI
     And as "Brian" file "lorem.txt" should not exist
 
-  @skipOnOcV10.3 @skipOnOcV10.4
+
   Scenario Outline: user shares a file with another user with unusual usernames
     Given user "Alice" has been created with default attributes and without skeleton files
     And these users have been created without skeleton files:
@@ -175,7 +175,7 @@ Feature: Sharing files and folders with internal users
     And the user shares file "lorem.txt" with user "Brian" using the webUI
     Then as "Brian" file "/lorem.txt" should exist
 
-  @skipOnOcV10.3
+
   Scenario: Create share with share permission only
     Given these users have been created with default attributes and without skeleton files:
       | username |
@@ -204,7 +204,7 @@ Feature: Sharing files and folders with internal users
     And the user shares file "simple-folder/lorem.txt" with user "Carol" using the webUI
     Then as "Carol" file "lorem.txt" should exist
 
-  @skipOnOcV10.3
+
   Scenario: Create share with share and create permission only
     Given these users have been created with default attributes and without skeleton files:
       | username |
@@ -225,7 +225,7 @@ Feature: Sharing files and folders with internal users
     Then as "Alice" file "simple-folder/textfile.txt" should exist
     And the content of "textfile.txt" should be the same as the local "textfile.txt"
 
-  @skipOnOcV10.3
+
   Scenario: Create share with share and change permission only
     Given these users have been created with default attributes and without skeleton files:
       | username |
@@ -246,7 +246,7 @@ Feature: Sharing files and folders with internal users
     Then as "Alice" file "simple-folder/textfile.txt" should not exist
     And file "textfile.txt" should not be listed on the webUI
 
-  @skipOnOcV10.3
+
   Scenario: Create share with share and delete permission only
     Given these users have been created with default attributes and without skeleton files:
       | username |
@@ -267,7 +267,7 @@ Feature: Sharing files and folders with internal users
     Then as "Alice" file "simple-folder/textfile.txt" should not exist
     And file "textfile.txt" should not be listed on the webUI
 
-  @skipOnOcV10.3
+
   Scenario: Create share with edit and without share permissions
     Given these users have been created with default attributes and without skeleton files:
       | username |
@@ -291,7 +291,7 @@ Feature: Sharing files and folders with internal users
     And the content of "textfile.txt" should be the same as the local "textfile.txt"
     And it should not be possible to share file "textfile.txt" using the webUI
 
-  @skipOnOcV10.3 @skipOnOcV10.4.0
+
   Scenario: reshare indicators of public links to the original share owner
     Given these users have been created with default attributes and without skeleton files:
       | username |
@@ -307,7 +307,7 @@ Feature: Sharing files and folders with internal users
     And the user opens the public link share tab
     Then a public link share with name "Public link" should be visible on the webUI
 
-  @skipOnOcV10.3 @skipOnOcV10.4.0
+
   Scenario: reshare indicators of multiple public links with same name to the original share owner
     Given these users have been created with default attributes and without skeleton files:
       | username |

--- a/tests/acceptance/features/webUISharingInternalUsers1/miscShareWithUsers.feature
+++ b/tests/acceptance/features/webUISharingInternalUsers1/miscShareWithUsers.feature
@@ -80,7 +80,7 @@ Feature: misc scenarios on sharing with internal users
     Then file "lorem.txt" should be listed on the webUI
     And the content of file "/new-simple-folder/lorem.txt" for user "Brian" should be "some content"
 
-  @skipOnMICROSOFTEDGE @skipOnOcV10.3
+  @skipOnMICROSOFTEDGE
   Scenario: share a folder with another internal user and prohibit deleting
     Given these users have been created with default attributes and without skeleton files:
       | username |
@@ -245,7 +245,7 @@ Feature: misc scenarios on sharing with internal users
     And the share-with field should not be visible in the details panel
     And user "Alice" should not be able to share file "testimage.jpg" with user "Carol" using the sharing API
 
-  @skipOnOcV10.3 @skipOnEncryptionType:user-keys @issue-encryption-126 @email
+  @skipOnEncryptionType:user-keys @issue-encryption-126 @email
   Scenario: user should be able to send notification by email when allow share mail notification has been enabled
     Given parameter "shareapi_allow_mail_notification" of app "core" has been set to "yes"
     And these users have been created with default attributes and without skeleton files:
@@ -263,7 +263,7 @@ Feature: misc scenarios on sharing with internal users
       just letting you know that %displayname% shared lorem.txt with you.
       """
 
-  @email @skipOnOcV10.3
+  @email
   Scenario: user should get and error message when trying to send notification by email to a user who has not setup their email
     Given parameter "shareapi_allow_mail_notification" of app "core" has been set to "yes"
     And these users have been created without skeleton files:
@@ -279,7 +279,7 @@ Feature: misc scenarios on sharing with internal users
       | title                       | content                                                  | user  |
       | Email notification not sent | Couldn't send mail to following recipient(s): %username% | Brian |
 
-  @email @skipOnOcV10.3
+  @email
   Scenario: user should not be able to send notification by email more than once
     Given parameter "shareapi_allow_mail_notification" of app "core" has been set to "yes"
     And these users have been created with default attributes and without skeleton files:
@@ -296,7 +296,7 @@ Feature: misc scenarios on sharing with internal users
     And the user opens the share dialog for file "lorem.txt"
     Then the user should not be able to send the share notification by email for user "Brian" using the webUI
 
-  @skipOnOcV10.3
+
   Scenario: user should not be able to send notification by email when allow share mail notification has been disabled
     Given parameter "shareapi_allow_mail_notification" of app "core" has been set to "no"
     And these users have been created without skeleton files:
@@ -309,7 +309,7 @@ Feature: misc scenarios on sharing with internal users
     When the user opens the share dialog for file "lorem.txt"
     Then the user should not be able to send the share notification by email for user "Brian" using the webUI
 
-  @email @skipOnOcV10.3
+  @email
   Scenario: user without email should be able to send notification by email when allow share mail notification has been enabled
     Given parameter "shareapi_allow_mail_notification" of app "core" has been set to "yes"
     And these users have been created without skeleton files:
@@ -340,7 +340,7 @@ Feature: misc scenarios on sharing with internal users
     When the user re-logs in as "Alice" using the webUI
     And the content of file "lorem.txt" for user "Alice" should be "edited original content"
 
-  @skipOnOcV10.3
+
   Scenario: share with two users having same display name
     Given these users have been created with default attributes and without skeleton files:
       | username |

--- a/tests/acceptance/features/webUISharingInternalUsers2/adminDisablesSharePermissions.feature
+++ b/tests/acceptance/features/webUISharingInternalUsers2/adminDisablesSharePermissions.feature
@@ -4,7 +4,7 @@ Feature: Sharing files and folders with internal users where admin disables diff
   I want to share files and folders with other users
   So that those users can access the files and folders
 
-  @skipOnOcV10.3
+
   Scenario: Create share when admin disables delete in share permissions
     Given these users have been created with default attributes and without skeleton files:
       | username |
@@ -33,7 +33,7 @@ Feature: Sharing files and folders with internal users where admin disables diff
     And the user shares file "simple-folder/lorem.txt" with user "Carol" using the webUI
     Then as "Carol" file "lorem.txt" should exist
 
-  @skipOnOcV10.3
+
   Scenario: Create share when admin disables change in share permissions
     Given these users have been created with default attributes and without skeleton files:
       | username |
@@ -62,7 +62,7 @@ Feature: Sharing files and folders with internal users where admin disables diff
     Then as "Carol" file "lorem.txt" should exist
     And the option to delete file "lorem.txt" should be available on the webUI
 
-  @skipOnOcV10.3
+
   Scenario: Create share when admin disables create and share in share permissions
     Given these users have been created with default attributes and without skeleton files:
       | username |
@@ -87,7 +87,7 @@ Feature: Sharing files and folders with internal users where admin disables diff
     And the option to rename file "lorem.txt" should be available on the webUI
     And it should be possible to delete file "lorem.txt" using the webUI
 
-  @skipOnOcV10.3
+
   Scenario: Create share when admin disables delete in share permissions but then user enables the permission
     Given these users have been created with default attributes and without skeleton files:
       | username |
@@ -108,7 +108,7 @@ Feature: Sharing files and folders with internal users where admin disables diff
     And it should not be possible to share file "lorem.txt" using the webUI
     And the option to delete file "lorem.txt" should be available on the webUI
 
-  @skipOnOcV10.3
+
   Scenario: Create share when admin disables multiple default share permissions but then user enables a disabled permission
     Given these users have been created with default attributes and without skeleton files:
       | username |

--- a/tests/acceptance/features/webUISharingInternalUsers2/shareWithUserUsingExpirationDate.feature
+++ b/tests/acceptance/features/webUISharingInternalUsers2/shareWithUserUsingExpirationDate.feature
@@ -1,4 +1,4 @@
-@webUI @insulated @disablePreviews @skipOnOcV10.3
+@webUI @insulated @disablePreviews
 Feature: Sharing files and folders with internal users with expiration date set/unset
   As a user
   I want to share files and folders with users with expiration date set

--- a/tests/acceptance/features/webUISharingInternalUsers2/webUIShareDetails.feature
+++ b/tests/acceptance/features/webUISharingInternalUsers2/webUIShareDetails.feature
@@ -4,7 +4,7 @@ Feature: WebUI share details for shares created using internal users
   I want to share files and folders with other users
   So that those users can access the files and folders
 
-  @skipOnOcV10.3
+
   Scenario: sharing indicator of items inside a shared folder
     Given these users have been created without skeleton files:
       | username |
@@ -20,7 +20,7 @@ Feature: WebUI share details for shares created using internal users
       | simple-empty-folder |
       | lorem.txt           |
 
-  @skipOnOcV10.3
+
   Scenario: sharing indicator of items inside a shared folder two levels down
     Given these users have been created without skeleton files:
       | username |
@@ -38,7 +38,7 @@ Feature: WebUI share details for shares created using internal users
       | new-folder |
       | lorem.txt  |
 
-  @skipOnOcV10.3
+
   Scenario: sharing indicator of items inside a re-shared folder
     Given these users have been created without skeleton files:
       | username |
@@ -56,7 +56,7 @@ Feature: WebUI share details for shares created using internal users
       | simple-empty-folder |
       | lorem.txt           |
 
-  @skipOnOcV10.3
+
   Scenario: no sharing indicator of items inside a not shared folder
     Given user "Alice" has been created with default attributes and without skeleton files
     And user "Alice" has created folder "simple-folder"
@@ -68,7 +68,7 @@ Feature: WebUI share details for shares created using internal users
       | simple-empty-folder |
       | lorem.txt           |
 
-  @skipOnOcV10.3
+
   Scenario: sharing details of items inside a shared folder
     Given these users have been created without skeleton files:
       | username |
@@ -85,7 +85,7 @@ Feature: WebUI share details for shares created using internal users
     When the user opens the sharing tab from the file action menu of file "lorem.txt" using the webUI
     Then user "Brian" should be listed as share receiver via "simple-folder" on the webUI
 
-  @skipOnOcV10.3
+
   Scenario: sharing details of items inside a re-shared folder
     Given these users have been created without skeleton files:
       | username |
@@ -104,7 +104,7 @@ Feature: WebUI share details for shares created using internal users
     When the user opens the sharing tab from the file action menu of file "lorem.txt" using the webUI
     Then user "Carol" should be listed as share receiver via "simple-folder" on the webUI
 
-  @skipOnOcV10.3
+
   Scenario: sharing indicator for file uploaded inside a shared folder
     Given these users have been created with default attributes and without skeleton files:
       | username |
@@ -118,7 +118,7 @@ Feature: WebUI share details for shares created using internal users
     Then the following resources should have share indicators on the webUI
       | new-lorem.txt |
 
-  @skipOnOcV10.3
+
   Scenario: sharing indicator for folder created inside a shared folder
     Given these users have been created with default attributes and without skeleton files:
       | username |
@@ -132,7 +132,7 @@ Feature: WebUI share details for shares created using internal users
     Then the following resources should have share indicators on the webUI
       | sub-folder |
 
-  @skipOnOcV10.3
+
   Scenario: sharing details of items inside a shared folder shared with multiple users
     Given these users have been created with default attributes and without skeleton files:
       | username |

--- a/tests/acceptance/features/webUISharingPublic1/createPublicLinkShares.feature
+++ b/tests/acceptance/features/webUISharingPublic1/createPublicLinkShares.feature
@@ -256,7 +256,7 @@ Feature: Share by public link
     Then the fields of the last response to user "Alice" should include
       | expiration |  |
 
-  @skipOnOcV10.3
+
   Scenario: user creates a new public link using webUI removing expiration date when default expire date is set and enforced
     Given parameter "shareapi_default_expire_date" of app "core" has been set to "yes"
     And parameter "shareapi_enforce_expire_date" of app "core" has been set to "yes"
@@ -317,7 +317,7 @@ Feature: Share by public link
       | -123     |
       | 0.0      |
 
-  @skipOnOcV10.8.0
+
   Scenario: read only public link quick action works when enabled
     Given the administrator has "enabled" public link quick action
     And user "Alice" has created folder "/simple-folder"
@@ -329,7 +329,7 @@ Feature: Share by public link
     And the public accesses the last created public link using the webUI
     Then file "lorem.txt" should be listed on the webUI
 
-  @skipOnOcV10.8.0
+
   Scenario: read only public link quick action does not work when disabled
     Given the administrator has "disabled" public link quick action
     And user "Alice" has created folder "/simple-folder"
@@ -337,7 +337,7 @@ Feature: Share by public link
     When the user browses to the files page
     Then the public link quick action button should not be displayed for folder "simple-folder" on the webUI
 
-  @skipOnOcV10.8.0
+
   Scenario: quick action is not displayed when password is enforced in read only link
     Given parameter "shareapi_enforce_links_password_read_only" of app "core" has been set to "yes"
     And the administrator has "enabled" public link quick action
@@ -346,7 +346,7 @@ Feature: Share by public link
     When the user browses to the files page
     Then the public link quick action button should not be displayed for folder "simple-folder" on the webUI
 
-  @skipOnOcV10.8.0
+
   Scenario: no new public quick link is created for a resource with already a public quick link
     Given the administrator has "enabled" public link quick action
     And user "Alice" has created folder "/simple-folder"
@@ -357,7 +357,7 @@ Feature: Share by public link
     When the user creates a read only public link for folder "simple-folder" using the quick action button
     Then the number of public links should be 1
 
-  @skipOnOcV10.8.0
+
   Scenario: no new public quick link is created for a resource with already a public quick link (after a login)
     Given the administrator has "enabled" public link quick action
     And user "Alice" has created folder "/simple-folder"

--- a/tests/acceptance/features/webUISharingPublic1/permissionsShareFileByPublicLink.feature
+++ b/tests/acceptance/features/webUISharingPublic1/permissionsShareFileByPublicLink.feature
@@ -20,7 +20,7 @@ Feature: Share a file by public link
     And uploading content to a public link shared file should not work using the old public WebDAV API
     And uploading content to a public link shared file should not work using the new public WebDAV API
 
-  @skipOnOcV10.9 @skipOnOcV10.10
+  @skipOnOcV10.10
   Scenario: creating a public link with read & write permissions
     Given user "Alice" has uploaded file with content "text to test public links" to "/lorem.txt"
     And user "Alice" has logged in using the webUI

--- a/tests/acceptance/features/webUISharingPublic2/allowGroupToCreatePublicLinks.feature
+++ b/tests/acceptance/features/webUISharingPublic2/allowGroupToCreatePublicLinks.feature
@@ -1,4 +1,4 @@
-@webUI @files_sharing-app-required @skipOnOcV10.6 @skipOnOcV10.7 @skipOnOcV10.8.0 @notToImplementOnOcis
+@webUI @files_sharing-app-required @notToImplementOnOcis
 Feature: public share sharers groups setting
   As an admin
   I should be able to allow only certain groups to create public links

--- a/tests/acceptance/features/webUISharingPublic2/reShareByPublicLink.feature
+++ b/tests/acceptance/features/webUISharingPublic2/reShareByPublicLink.feature
@@ -48,7 +48,7 @@ Feature: Reshare by public link
     And the public accesses the last created public link using the webUI
     Then the text preview of the public link should contain "some content"
 
-  @skipOnOcV10.3.0 @skipOnOcV10.3.1
+
   Scenario: user reshares a public link of a received share via email
     Given user "Alice" has created folder "/simple-folder"
     And user "Alice" has shared folder "/simple-folder" with user "Brian" with permissions "share,read"
@@ -62,7 +62,7 @@ Feature: Reshare by public link
       """
     And the email address "foo@bar.co" should have received an email containing the last shared public link
 
-  @skipOnOcV10.3.0 @skipOnOcV10.3.1
+
   Scenario: user reshares a public link of a file in a received shared folder via email
     Given user "Alice" has created folder "/simple-folder"
     And user "Alice" has uploaded file with content "some content" to "/simple-folder/randomfile.txt"
@@ -77,7 +77,7 @@ Feature: Reshare by public link
       """
     And the email address "foo@bar.co" should have received an email containing the last shared public link
 
-  @skipOnOcV10.3.0 @skipOnOcV10.3.1
+
   Scenario: user reshares a public link of a received shared file via email
     Given user "Alice" has uploaded file with content "some content" to "/randomfile.txt"
     And user "Alice" has shared file "/randomfile.txt" with user "Brian" with permissions "share,read"
@@ -91,7 +91,7 @@ Feature: Reshare by public link
       """
     And the email address "foo@bar.co" should have received an email containing the last shared public link
 
-  @skipOnOcV10.3.0 @skipOnOcV10.3.1
+
   Scenario: user reshares a public link of a received shared folder via email with multiple addresses
     Given user "Alice" has created folder "/simple-folder"
     And user "Alice" has shared folder "/simple-folder" with user "Brian" with permissions "share,read"
@@ -110,7 +110,7 @@ Feature: Reshare by public link
     And the email address "foo@bar.co" should have received an email containing the last shared public link
     And the email address "goo@barr.co" should have received an email containing the last shared public link
 
-  @skipOnOcV10.3.0 @skipOnOcV10.3.1
+
   Scenario: user reshares a public link of a received shared folder via email with a personal message
     Given user "Alice" has created folder "/simple-folder"
     And user "Alice" has shared folder "/simple-folder" with user "Brian" with permissions "share,read"

--- a/tests/acceptance/features/webUISharingPublic2/savePublicLinkShare.feature
+++ b/tests/acceptance/features/webUISharingPublic2/savePublicLinkShare.feature
@@ -8,7 +8,7 @@ Feature: Save public shares created by oC users
     Given using server "LOCAL"
     And user "Alice" has been created with default attributes and without skeleton files
 
-  @skipOnOcV10.6 @skipOnOcV10.7
+
   Scenario: mount public link share of a folder to local server
     Given user "Brian" has been created with default attributes and without skeleton files
     And user "Alice" has created folder "/PARENT"
@@ -27,7 +27,7 @@ Feature: Save public shares created by oC users
     But user "Brian" should not be able to upload file "filesForUpload/textfile.txt" to "/PARENT/textfile.txt"
     And user "Brian" should not be able to delete file "PARENT/lorem.txt"
 
-  @skipOnOcV10.6 @skipOnOcV10.7
+
   Scenario: mount public link share of a file to local server
     Given user "Brian" has been created with default attributes and without skeleton files
     And user "Alice" has uploaded file with content "original content" to "lorem.txt"
@@ -42,7 +42,7 @@ Feature: Save public shares created by oC users
     And user "Brian" should be able to upload file "filesForUpload/textfile.txt" to "/textfile.txt"
     But user "Brian" should not be able to upload file "filesForUpload/textfile.txt" to "lorem.txt"
 
-  @skipOnOcV10.6 @skipOnOcV10.7
+
   Scenario: mount public link share of a folder (all permissions set) to local server
     Given user "Brian" has been created with default attributes and without skeleton files
     And user "Alice" has created folder "/PARENT"
@@ -68,7 +68,7 @@ Feature: Save public shares created by oC users
     When the user deletes file "lorem.txt" using the webUI
     Then file "lorem.txt" should not be listed on the webUI
 
-  @skipOnOcV10.6 @skipOnOcV10.7
+
   Scenario: mount public link share of a file (all permissions set) to local server
     Given user "Brian" has been created with default attributes and without skeleton files
     And user "Alice" has uploaded file with content "original content" to "lorem.txt"
@@ -85,7 +85,7 @@ Feature: Save public shares created by oC users
     Then file "lorem.txt" should be listed on the webUI
     And the content of "lorem.txt" should be the same as the local "lorem.txt"
 
-  @skipOnOcV10.6 @skipOnOcV10.7
+
   Scenario: mount public link share of a folder that exist in local server
     Given user "Brian" has been created with default attributes and without skeleton files
     And user "Brian" has created folder "/PARENT"
@@ -102,7 +102,7 @@ Feature: Save public shares created by oC users
     Then file "lorem.txt" should be listed on the webUI
     And the content of file "PARENT (2)/lorem.txt" for user "Brian" should be "original content"
 
-  @skipOnOcV10.6 @skipOnOcV10.7
+
   Scenario: mount public link share of a file that already exists in local server
     Given user "Brian" has been created with default attributes and without skeleton files
     And user "Brian" has uploaded file with content "file in local server" to "lorem.txt"
@@ -116,7 +116,7 @@ Feature: Save public shares created by oC users
     Then folder "lorem (2).txt" should be listed on the webUI
     And the content of file "lorem (2).txt" for user "Brian" should be "original content"
 
-  @skipOnOcV10.6 @skipOnOcV10.7
+
   Scenario: unshare mounted public link share in local server
     Given user "Brian" has been created with default attributes and without skeleton files
     And user "Alice" has created folder "/PARENT"
@@ -154,7 +154,7 @@ Feature: Save public shares created by oC users
     And the user browses to the files page
     Then folder "PARENT" should not be listed on the webUI
 
-  @skipOnOcV10.6 @skipOnOcV10.7
+
   Scenario: mount public link share of a folder that already exists in remote server
     Given using server "REMOTE"
     And user "Brian" has been created with default attributes and without skeleton files
@@ -173,7 +173,7 @@ Feature: Save public shares created by oC users
     Then file "lorem.txt" should be listed on the webUI
     And the content of file "PARENT (2)/lorem.txt" for user "Brian" on server "REMOTE" should be "original content"
 
-  @skipOnOcV10.6 @skipOnOcV10.7
+
   Scenario: unshare mounted public link share in remote server
     Given using server "REMOTE"
     And user "Brian" has been created with default attributes and without skeleton files

--- a/tests/acceptance/features/webUISharingPublic2/savePublicLinkShareOc10Issue38763.feature
+++ b/tests/acceptance/features/webUISharingPublic2/savePublicLinkShareOc10Issue38763.feature
@@ -12,7 +12,7 @@ Feature: Save public shares created by oC users
     Given using server "LOCAL"
     And user "Alice" has been created with default attributes and without skeleton files
 
-  @issue-38763 @notToImplementOnOCIS @skipOnOcV10.6 @skipOnOcV10.7
+  @issue-38763 @notToImplementOnOCIS
   Scenario: mount public link share of a folder and the sharer deletes the folder
     Given user "Brian" has been created with default attributes and without skeleton files
     And user "Alice" has created folder "/PARENT"
@@ -34,7 +34,7 @@ Feature: Save public shares created by oC users
     When the user browses to the files page
     Then folder "PARENT" should not be listed on the webUI
 
-  @issue-38763 @notToImplementOnOCIS @skipOnOcV10.6 @skipOnOcV10.7
+  @issue-38763 @notToImplementOnOCIS
   Scenario: mount public link share of a folder in remote server and the sharer deletes the folder
     Given using server "REMOTE"
     And user "Brian" has been created with default attributes and without skeleton files

--- a/tests/acceptance/features/webUISharingPublic2/shareByPublicLink.feature
+++ b/tests/acceptance/features/webUISharingPublic2/shareByPublicLink.feature
@@ -11,7 +11,7 @@ Feature: Share by public link
   Background:
     Given user "Alice" has been created with default attributes and without skeleton files
 
-  @skipOnINTERNETEXPLORER @skipOnMICROSOFTEDGE @issue-30392 @skipOnOcV10.6 @skipOnOcV10.7
+  @skipOnINTERNETEXPLORER @skipOnMICROSOFTEDGE @issue-30392
   Scenario: mount public link of a folder
     Given using server "REMOTE"
     And user "Brian" has been created with default attributes and without skeleton files
@@ -33,7 +33,7 @@ Feature: Share by public link
     And user "Brian" should be able to upload file "filesForUpload/textfile.txt" to "/file-in-my-own-storage.txt"
     But user "Brian" should not be able to upload file "filesForUpload/textfile.txt" to "/simple-folder/new-file-in-read-only-public-link.txt"
 
-  @skipOnINTERNETEXPLORER @skipOnMICROSOFTEDGE @issue-30392 @skipOnOcV10.6 @skipOnOcV10.7
+  @skipOnINTERNETEXPLORER @skipOnMICROSOFTEDGE @issue-30392
   Scenario: mount public link of a file
     Given using server "REMOTE"
     And user "Brian" has been created with default attributes and without skeleton files
@@ -51,7 +51,7 @@ Feature: Share by public link
     And user "Brian" should be able to upload file "filesForUpload/textfile.txt" to "/file-in-my-own-storage.txt"
     But user "Brian" should not be able to upload file "filesForUpload/textfile.txt" to "/file-shared-by-public-link.txt"
 
-  @skipOnINTERNETEXPLORER @skipOnMICROSOFTEDGE @issue-30392 @skipOnOcV10.6 @skipOnOcV10.7
+  @skipOnINTERNETEXPLORER @skipOnMICROSOFTEDGE @issue-30392
   Scenario: mount public link and overwrite file
     Given using server "REMOTE"
     And user "Brian" has been created with default attributes and without skeleton files
@@ -192,7 +192,7 @@ Feature: Share by public link
     And the public accesses the last created public link using the webUI
     Then the content of the file shared by the last public link should be the same as "lorem.txt"
 
-  @skipOnOcV10.5 @skipOnOcV10.6
+
   Scenario: User renames a subfolder among subfolders with same names which are shared by public links
     Given user "Alice" has created folder "nf1"
     And user "Alice" has created folder "nf1/newfolder"
@@ -213,7 +213,7 @@ Feature: Share by public link
     And folder "newfolder" should be listed on the webUI
     And folder "test" should be listed on the webUI
 
-  @skipOnOcV10.6 @skipOnOcV10.7 @skipOnOcV10.8.0
+
   Scenario: User renames folders with different path in Shared by link page
     Given user "Alice" has created folder "nf1"
     And user "Alice" has created folder "nf1/test"
@@ -227,7 +227,7 @@ Feature: Share by public link
     When the user renames folder "test" to "newfolder" using the webUI
     Then folder "newfolder" with path "nf1/newfolder" should be listed on the webUI
 
-  @skipOnOcV10.3
+
   Scenario: user tries to deletes the expiration date of already existing public link using webUI when expiration date is enforced
     Given parameter "shareapi_default_expire_date" of app "core" has been set to "yes"
     And parameter "shareapi_enforce_expire_date" of app "core" has been set to "yes"
@@ -259,7 +259,7 @@ Feature: Share by public link
     And the fields of the last response to user "Alice" should include
       | expiration |  |
 
-  @email @skipOnOcV10.3
+  @email
   Scenario: user without email shares a public link via email
     Given these users have been created without skeleton files:
       | username | password |
@@ -275,7 +275,7 @@ Feature: Share by public link
 			"""
     And the email address "foo@bar.co" should have received an email containing the last shared public link
 
-  @skipOnOcV10.3
+
   Scenario: sharing indicator inside a shared folder
     Given user "Alice" has created folder "/simple-folder"
     And user "Alice" has created folder "/simple-folder/sub-folder"
@@ -288,7 +288,7 @@ Feature: Share by public link
       | sub-folder   |
       | textfile.txt |
 
-  @skipOnOcV10.3
+
   Scenario: sharing indicator for file uploaded inside a shared folder
     Given user "Alice" has created folder "/simple-folder"
     And user "Alice" has created a public link share with settings
@@ -299,7 +299,7 @@ Feature: Share by public link
     Then the following resources should have share indicators on the webUI
       | new-lorem.txt |
 
-  @skipOnOcV10.3
+
   Scenario: sharing indicator for folder created inside a shared folder
     Given user "Alice" has created folder "/simple-folder"
     And user "Alice" has created a public link share with settings
@@ -310,7 +310,7 @@ Feature: Share by public link
     Then the following resources should have share indicators on the webUI
       | sub-folder |
 
-  @skipOnOcV10.3
+
   Scenario: sharing details of items inside a shared folder
     Given user "Alice" has created folder "/simple-folder"
     And user "Alice" has created folder "/simple-folder/sub-folder"
@@ -324,7 +324,7 @@ Feature: Share by public link
     And the user opens the public link share tab
     Then public link "Public Link" should be listed as share receiver via "simple-folder" on the webUI
 
-  @skipOnOcV10.3
+
   Scenario: sharing details of multiple public link shares with different link names
     Given user "Alice" has created folder "/simple-folder"
     And user "Alice" has created folder "/simple-folder/sub-folder"
@@ -346,7 +346,7 @@ Feature: Share by public link
     Then public link "strängé लिंक नाम (#2 &).नेपाली" should be listed as share receiver via "sub-folder" on the webUI
     And public link "Public Link" should be listed as share receiver via "simple-folder" on the webUI
 
-  @skipOnOcV10.3
+
   Scenario: sharing detail of items on the webUI shared by public links with empty name
     Given user "Alice" has created folder "/simple-folder"
     And user "Alice" has uploaded file "filesForUpload/textfile.txt" to "/simple-folder/textfile.txt"
@@ -368,7 +368,7 @@ Feature: Share by public link
     And the public accesses the last created public link using the webUI
     Then add to your owncloud button should be displayed on the webUI
 
-  @skipOnOcV10.3 @skipOnOcV10.4.0 @skipOnOcV10.4.1
+
   Scenario: add to your owncloud button is not present
     Given user "Alice" has created folder "/simple-folder"
     And parameter "outgoing_server2server_share_enabled" of app "files_sharing" has been set to "no"

--- a/tests/acceptance/features/webUITags/createTags.feature
+++ b/tests/acceptance/features/webUITags/createTags.feature
@@ -1,4 +1,4 @@
-@webUI @insulated @disablePreviews @systemtags-app-required @skipOnOcV10.4 @skipOnOcV10.5 @skipOnOcV10.6.0
+@webUI @insulated @disablePreviews @systemtags-app-required
 Feature: Creation of tags for the files and folders
   As a user
   I want to create tags for the files/folders

--- a/tests/acceptance/features/webUITags/deleteTags.feature
+++ b/tests/acceptance/features/webUITags/deleteTags.feature
@@ -1,4 +1,4 @@
-@webUI @insulated @disablePreviews @systemtags-app-required @skipOnOcV10.6 @skipOnOcV10.7 @skipOnOcV10.8.0
+@webUI @insulated @disablePreviews @systemtags-app-required
 Feature: Deletion of existing tags from files and folders
   As a user
   I want to delete tags from files and folders

--- a/tests/acceptance/features/webUITags/editTags.feature
+++ b/tests/acceptance/features/webUITags/editTags.feature
@@ -1,4 +1,4 @@
-@webUI @insulated @disablePreviews @systemtags-app-required @skipOnOcV10.6 @skipOnOcV10.7 @skipOnOcV10.8.0
+@webUI @insulated @disablePreviews @systemtags-app-required
 Feature: Edit tags for files and folders
   As a user
   I want to edit tags for files/folders

--- a/tests/acceptance/features/webUITags/removeTags.feature
+++ b/tests/acceptance/features/webUITags/removeTags.feature
@@ -1,4 +1,4 @@
-@webUI @insulated @disablePreviews @systemtags-app-required @skipOnOcV10.4 @skipOnOcV10.5 @skipOnOcV10.6.0
+@webUI @insulated @disablePreviews @systemtags-app-required
 Feature: Removal of already existing tags from files and folders
   As a user
   I want to remove tags from files and folders

--- a/tests/acceptance/features/webUITags/tagsSuggestion.feature
+++ b/tests/acceptance/features/webUITags/tagsSuggestion.feature
@@ -1,4 +1,4 @@
-@webUI @insulated @disablePreviews @systemtags-app-required @skipOnOcV10.4 @skipOnOcV10.5 @skipOnOcV10.6.0
+@webUI @insulated @disablePreviews @systemtags-app-required
 Feature: Suggestion for matching tag names
   As a user
   I want to get suggestions for adding tags from already existing tags
@@ -20,7 +20,7 @@ Feature: Suggestion for matching tag names
     And the administrator has created a "not user-assignable" tag with name "sponsored"
     And user "Alice" has logged in using the webUI
 
-  @skipOnOcV10.6 @skipOnOcV10.7
+
   Scenario: User should get suggestion from already existing tags
     Given user "Alice" has created folder "a-folder"
     And user "Alice" has uploaded file with content "some content" to "/a-folder/randomfile.txt"

--- a/tests/acceptance/features/webUIWebdavLocks/lockBreakerGroup.feature
+++ b/tests/acceptance/features/webUIWebdavLocks/lockBreakerGroup.feature
@@ -1,4 +1,4 @@
-@webUI @insulated @disablePreviews @skipOnOcV10.7 @skipOnOcV10.8.0
+@webUI @insulated @disablePreviews
 Feature: Unlock locked files and folders
   As a member of a lock breaker group
   I would like to be able to unlock files and folders

--- a/tests/acceptance/features/webUIWebdavLocks/unlock.feature
+++ b/tests/acceptance/features/webUIWebdavLocks/unlock.feature
@@ -1,4 +1,4 @@
-@webUI @insulated @disablePreviews @skipOnOcV10.3  @skipOnOcV10.4
+@webUI @insulated @disablePreviews
 Feature: Unlock locked files and folders
   As a user
   I would like to be able to unlock files and folders
@@ -242,7 +242,7 @@ Feature: Unlock locked files and folders
     And 2 locks should be reported for folder "FOLDER_TO_SHARE" of user "receiver1" by the WebDAV API
     And 2 locks should be reported for folder "FOLDER_TO_SHARE" of user "receiver2" by the WebDAV API
 
-  @files_sharing-app-required @skipOnLDAP @skipOnOcV10.3 @skipOnOcV10.4 @skipOnOcV10.5
+  @files_sharing-app-required @skipOnLDAP
   Scenario Outline: deleting a lock that was created by an other user
     Given these users have been created without skeleton files:
       | username       |


### PR DESCRIPTION
## Description
This PR removes the tags `@skipOnOcV10.*` for versions before 10.10. This should cleanup the tagging a lot, which will reduce future confusion.

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
This is a part of
- https://github.com/owncloud/core/issues/40443

## Motivation and Context

## How Has This Been Tested?
- CI
- Locally

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Database schema changes (next release will require increase of minor version instead of patch)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [x] Tests only (no source changes)

## Checklist:
<!-- Tick the checkboxes when done. -->
<!-- Raise documentation ticket in https://github.com/owncloud/documentation -->
- [ ] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 
- [ ] Changelog item, see [TEMPLATE](https://github.com/owncloud/core/blob/master/changelog/TEMPLATE)
