### PR TITLE
[tests-only][full-ci] Add API test scenarios for non-existent public links

### DIFF
--- a/tests/acceptance/features/apiSharePublicLink1/accessToPublicLinkShare.feature
+++ b/tests/acceptance/features/apiSharePublicLink1/accessToPublicLinkShare.feature
@@ -57,3 +57,14 @@ Feature: accessing a public link share
       | testavatar.jpg |
       | textfile0.txt  |
     Then the HTTP status code of responses on all endpoints should be "200"
+
+
+  Scenario Outline: Request to non-existent public link
+    When a user requests "<endpoint>" with "<method>" and no authentication
+    Then the HTTP status code should be "404"
+    Examples: 
+      | endpoint                                        | method   |
+      | /remote.php/dav/public-files/thisWillNeverExist | GET      |
+      | /remote.php/dav/public-files/thisWillNeverExist | PUT      |
+      | /remote.php/dav/public-files/thisWillNeverExist | PROPFIND |
+      | /s/thisWillNeverExist                           | GET      |


### PR DESCRIPTION
## Description
This will add acceptances tests for non-existing public links. HTTP status 404 should be returned for all non-existent public links.

## Related Issue

- Issue #40313

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
- Locally
- CI

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Database schema changes (next release will require increase of minor version instead of patch)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [x] Tests only (no source changes)

## Checklist:
<!-- Tick the checkboxes when done. -->
<!-- Raise documentation ticket in https://github.com/owncloud/documentation -->
- [ ] Code changes
- [ ] Unit tests added
- [x] Acceptance tests added
- [ ] Documentation ticket raised: <link> 
- [ ] Changelog item, see [TEMPLATE](https://github.com/owncloud/core/blob/master/changelog/TEMPLATE)
