### PR TITLE
fix: set length of oc_calendars.components to 255

### DIFF
--- a/changelog/unreleased/40563
+++ b/changelog/unreleased/40563
@@ -1,0 +1,4 @@
+Bugfix: set length of oc_calendars.components to 255
+
+https://github.com/owncloud/core/pull/40563
+https://github.com/owncloud/core/issues/40537

--- a/core/Migrations/Version20230105001100.php
+++ b/core/Migrations/Version20230105001100.php
@@ -1,0 +1,21 @@
+<?php
+
+namespace OC\Migrations;
+
+use Doctrine\DBAL\Schema\Schema;
+use OCP\Migration\ISchemaMigration;
+
+class Version20230105001100 implements ISchemaMigration {
+	public function changeSchema(Schema $schema, array $options) {
+		$prefix = $options['tablePrefix'];
+
+		if ($schema->hasTable("${prefix}calendars")) {
+			$calendarsTable = $schema->getTable("${prefix}calendars");
+
+			if ($calendarsTable->hasColumn('components')) {
+				$components = $calendarsTable->getColumn('components');
+				$components->setOptions(['length' => 255]);
+			}
+		}
+	}
+}


### PR DESCRIPTION
## Description
Column is too small - see issue

## Related Issue
- Fixes https://github.com/owncloud/core/issues/40537

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
- test environment:
- test case 1:
- test case 2:
- ...

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Database schema changes (next release will require increase of minor version instead of patch)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [ ] Tests only (no source changes)

## Checklist:
<!-- Tick the checkboxes when done. -->
<!-- Raise documentation ticket in https://github.com/owncloud/documentation -->
- [x] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 
- [x] Changelog item, see [TEMPLATE](https://github.com/owncloud/core/blob/master/changelog/TEMPLATE)
