### PR TITLE
[tests-only] [full-ci] Revert "Remove fsweb.test.owncloud.com SMB PHP unit test pipeline"

### DIFF
--- a/.drone.star
+++ b/.drone.star
@@ -91,7 +91,7 @@ config = {
                 "oracle",
             ],
         },
-        "external-samba": {
+        "external-samba-windows": {
             "phpVersions": [
                 DEFAULT_PHP_VERSION,
             ],
@@ -100,6 +100,7 @@ config = {
             ],
             "externalTypes": [
                 "samba",
+                "windows",
             ],
             "coverage": True,
             "extraCommandsBeforeTestRun": [

--- a/.drone.star
+++ b/.drone.star
@@ -133,6 +133,9 @@ config = {
                 "SMB_WINDOWS_DOMAIN": {
                     "from_secret": "SMB_WINDOWS_DOMAIN",
                 },
+                "SMB_WINDOWS_SHARE_NAME": {
+                    "from_secret": "SMB_WINDOWS_SHARE_NAME",
+                },
             },
             "extraCommandsBeforeTestRun": [
                 "ls -l /var/cache",

--- a/.drone.star
+++ b/.drone.star
@@ -1443,6 +1443,16 @@ def phpTests(ctx, testType, withCoverage):
                     for app, command in params["extraApps"].items():
                         extraAppsDict[app] = command
 
+                    environment = {}
+                    for env in params["extraEnvironment"]:
+                        environment[env] = params["extraEnvironment"][env]
+
+                    environment["COVERAGE"] = params["coverage"]
+                    environment["DB_TYPE"] = getDbName(db)
+                    environment["FILES_EXTERNAL_TYPE"] = filesExternalType
+                    environment["PRIMARY_OBJECTSTORE"] = primaryObjectStore
+                    environment["SCALITY"] = needScality
+
                     result = {
                         "kind": "pipeline",
                         "type": "docker",
@@ -1463,13 +1473,7 @@ def phpTests(ctx, testType, withCoverage):
                                      {
                                          "name": "%s-tests" % testType,
                                          "image": OC_CI_PHP % phpVersion,
-                                         "environment": {
-                                             "COVERAGE": params["coverage"],
-                                             "DB_TYPE": getDbName(db),
-                                             "FILES_EXTERNAL_TYPE": filesExternalType,
-                                             "PRIMARY_OBJECTSTORE": primaryObjectStore,
-                                             "SCALITY": needScality,
-                                         },
+                                         "environment": environment,
                                          "commands": params["extraCommandsBeforeTestRun"] + [
                                              command,
                                          ],

--- a/.drone.star
+++ b/.drone.star
@@ -91,7 +91,7 @@ config = {
                 "oracle",
             ],
         },
-        "external-samba-windows": {
+        "external-samba": {
             "phpVersions": [
                 DEFAULT_PHP_VERSION,
             ],
@@ -100,9 +100,40 @@ config = {
             ],
             "externalTypes": [
                 "samba",
+            ],
+            "coverage": True,
+            "extraCommandsBeforeTestRun": [
+                "ls -l /var/cache",
+                "mkdir /var/cache/samba",
+                "ls -l /var/cache",
+                "ls -l /var/cache/samba",
+            ],
+        },
+        "external-windows": {
+            "phpVersions": [
+                DEFAULT_PHP_VERSION,
+            ],
+            "databases": [
+                "sqlite",
+            ],
+            "externalTypes": [
                 "windows",
             ],
             "coverage": True,
+            "extraEnvironment": {
+                "SMB_WINDOWS_HOST": {
+                    "from_secret": "SMB_WINDOWS_HOST",
+                },
+                "SMB_WINDOWS_USERNAME": {
+                    "from_secret": "SMB_WINDOWS_USERNAME",
+                },
+                "SMB_WINDOWS_PWD": {
+                    "from_secret": "SMB_WINDOWS_PWD",
+                },
+                "SMB_WINDOWS_DOMAIN": {
+                    "from_secret": "SMB_WINDOWS_DOMAIN",
+                },
+            },
             "extraCommandsBeforeTestRun": [
                 "ls -l /var/cache",
                 "mkdir /var/cache/samba",

--- a/tests/drone/configs/config.files_external.smb-windows.php
+++ b/tests/drone/configs/config.files_external.smb-windows.php
@@ -1,10 +1,39 @@
 <?php
+$envVarsSet = true;
+$smbHost = \getenv('SMB_WINDOWS_HOST');
+if ($smbHost === false) {
+	$envVarsSet = false;
+	echo __FILE__ . " SMB_WINDOWS_HOST has not been set";
+}
+$smbUserName = \getenv('SMB_WINDOWS_USERNAME');
+if ($smbUserName === false) {
+	$envVarsSet = false;
+	echo __FILE__ . " SMB_WINDOWS_USERNAME has not been set";
+}
+$smbUserPassword = \getenv('SMB_WINDOWS_PWD');
+if ($smbUserPassword === false) {
+	$envVarsSet = false;
+	echo __FILE__ . " SMB_WINDOWS_PWD has not been set";
+}
+$smbShareName = \getenv('SMB_WINDOWS_SHARE_NAME');
+if ($smbShareName === false) {
+	$envVarsSet = false;
+	echo __FILE__ . " SMB_WINDOWS_SHARE_NAME has not been set";
+}
+$smbDomain = \getenv('SMB_WINDOWS_DOMAIN');
+if ($smbDomain === false) {
+	$envVarsSet = false;
+	echo __FILE__ . " SMB_WINDOWS_DOMAIN has not been set";
+}
+if ($envVarsSet === false) {
+	echo __FILE__ . " the above environment variables must be set when running the SMB WIndows PHP unit tests";
+}
 return [
-	'run'=>true,
-	'host'=>'fsweb.test.owncloud.com',
-	'user'=>'test100',
-	'password'=>'Password123!',
-	'root'=>'',
-	'share'=>'test100',
-	'domain'=>'WORKGROUP',
+	'run' => true,
+	'host' => $smbHost,
+	'user' => $smbUserName,
+	'password' => $smbUserPassword,
+	'root' => '',
+	'share' => $smbShareName,
+	'domain' => $smbDomain,
 ];

--- a/tests/drone/test-phpunit.sh
+++ b/tests/drone/test-phpunit.sh
@@ -28,7 +28,7 @@ set_up_external_storage() {
       FILES_EXTERNAL_TEST_TO_RUN=SmbTest.php
       ;;
     windows)
-      wait-for-it -t 600 fsweb.test.owncloud.com:445
+      wait-for-it -t 600 ${SMB_WINDOWS_HOST}:445
       cp tests/drone/configs/config.files_external.smb-windows.php apps/files_external/tests/config.smb.php
       FILES_EXTERNAL_TEST_TO_RUN=SmbTest.php
       ;;


### PR DESCRIPTION
## Description
This reverts commit 9158e2346ea726d36cfb379e42a9c22eeca01d50.

The Windows SMB-based PHP unit test pipeline was temporarily removed by PR #40426 

1) revert the commit, so that the pipeline runs again
2) point the pipeline config to the new test Windows SMB server.

The values used to access the test Windows SMB server are stored in secrets in the drone owncloud/core repo settings, so that they are not generally available for people to use to store their own files!

```
SMB_WINDOWS_DOMAIN
SMB_WINDOWS_HOST
SMB_WINDOWS_USERNAME
SMB_WINDOWS_PWD
SMB_WINDOWS_SHARE_NAME
```

The test pipeline feeds the values of these secrets into the config that files_external uses to access the test Windows SMB share.

## How Has This Been Tested?
CI

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Database schema changes (next release will require increase of minor version instead of patch)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [x] Tests only (no source changes)

## Checklist:
- [ ] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 
- [ ] Changelog item, see [TEMPLATE](https://github.com/owncloud/core/blob/master/changelog/TEMPLATE)
