### PR TITLE
Fully initialize the FS in the cleanup command (upload folder is moun…

### DIFF
--- a/apps/dav/lib/Command/CleanupChunks.php
+++ b/apps/dav/lib/Command/CleanupChunks.php
@@ -73,7 +73,7 @@ class CleanupChunks extends Command {
 		$output->writeln("Cleaning chunks older than $d days({$cutOffTime->format('c')})");
 		$this->userManager->callForSeenUsers(function (IUser $user) use ($output, $cutOffTime, $checkUploadExistsLocal) {
 			\OC_Util::tearDownFS();
-			\OC_Util::setupFS($user->getUID(), false);
+			\OC_Util::setupFS($user->getUID());
 
 			$view = new View('/' . $user->getUID() . '/uploads');
 			$home = new UploadHome(['user' => $user]);

--- a/changelog/unreleased/40571
+++ b/changelog/unreleased/40571
@@ -1,0 +1,12 @@
+Bugfix: Fix the dav:cleanup-chunks command to work with a configured folder
+
+The ownCloud's FS was initialized partially to prevent contacting the LDAP
+server if it was configured. This was causing problems because the upload
+folder where the chunks were expected was a mountpoint, and due to the
+partial FS initialization such mountpoint was missing, so we were checking
+a different folder (the default one).
+
+Now, the ownCloud's FS will be fully initialized instead, so the mountpoint
+will be present and we check the right location.
+
+https://github.com/owncloud/core/pull/40571


### PR DESCRIPTION
…ted)

<!--
Thanks for submitting a change to ownCloud!

This is the bug tracker for the Server component. Find other components at https://github.com/owncloud/core/blob/master/.github/CONTRIBUTING.md#guidelines

For fixing potential security issues please see https://owncloud.com/security/

To make it possible for us to get your change reviewed and merged please carefully fill out the requested information below.

Please note that any kind of change needs first be submitted to the master branch which holds the next version of ownCloud.

Please set the following labels:

- Set label "3 - To review" for review or "2 - Development" if the PR still has open tasks
- Assignment: assign to self
- Milestone: set the same as the ticket this PR fixes, or "development" by default
- Reviewers: pick at least one
-->

## Description
`occ dav:cleanup-chunks` command wasn't working when the chunk location wasn't the default. This was caused by a partial initialization of the FS (without mount points) even though the uploads location was mounted (not a regular folder)

## Related Issue
https://github.com/owncloud/enterprise/issues/5498

## Motivation and Context
Otherwise it isn't possible to remove obsolete chunks from the uploads directory via the occ command if a different location is configured.

## How Has This Been Tested?
Followed steps described in the ticket

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Database schema changes (next release will require increase of minor version instead of patch)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [ ] Tests only (no source changes)

## Checklist:
<!-- Tick the checkboxes when done. -->
<!-- Raise documentation ticket in https://github.com/owncloud/documentation -->
- [x] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 
- [ ] Changelog item, see [TEMPLATE](https://github.com/owncloud/core/blob/master/changelog/TEMPLATE)
