### PR TITLE
[tests-only][full-ci] Add tests for checking file versions uploaded with same mtime

### DIFF
--- a/tests/acceptance/features/apiVersions/fileVersions.feature
+++ b/tests/acceptance/features/apiVersions/fileVersions.feature
@@ -531,3 +531,26 @@ Feature: dav-versions
     When user "Alice" restores version index "1" of file "/davtest.txt" using the WebDAV API
     Then the HTTP status code should be "204"
     And the content of file "/davtest.txt" for user "Alice" should be "Old Test Content."
+
+  @issue-ocis-5010
+  Scenario: Upload the same file twice with the same mtime and a version is available
+    Given user "Alice" has uploaded file "filesForUpload/textfile.txt" to "file.txt" with mtime "Thu, 08 Aug 2019 04:18:13 GMT" using the WebDAV API
+    When user "Alice" uploads file "filesForUpload/textfile.txt" to "file.txt" with mtime "Thu, 08 Aug 2019 04:18:13 GMT" using the WebDAV API
+    Then the HTTP status code should be "204"
+    And the version folder of file "/file.txt" for user "Alice" should contain "1" element
+
+  @issue-ocis-5010
+  Scenario: Upload the same file more than twice with the same mtime and only one version is available
+    Given user "Alice" has uploaded file "filesForUpload/textfile.txt" to "file.txt" with mtime "Thu, 08 Aug 2019 04:18:13 GMT" using the WebDAV API
+    And user "Alice" has uploaded file "filesForUpload/textfile.txt" to "file.txt" with mtime "Thu, 08 Aug 2019 04:18:13 GMT" using the WebDAV API
+    When user "Alice" uploads file "filesForUpload/textfile.txt" to "file.txt" with mtime "Thu, 08 Aug 2019 04:18:13 GMT" using the WebDAV API
+    Then the HTTP status code should be "204"
+    And the version folder of file "/file.txt" for user "Alice" should contain "1" element
+
+  @issue-ocis-5010
+  Scenario: Upload the same file twice with the same mtime and no version after restoring
+    Given user "Alice" has uploaded file "filesForUpload/textfile.txt" to "file.txt" with mtime "Thu, 08 Aug 2019 04:18:13 GMT" using the WebDAV API
+    And user "Alice" has uploaded file "filesForUpload/textfile.txt" to "file.txt" with mtime "Thu, 08 Aug 2019 04:18:13 GMT" using the WebDAV API
+    When user "Alice" restores version index "1" of file "/file.txt" using the WebDAV API
+    Then the HTTP status code should be "204"
+    And the version folder of file "/file.txt" for user "Alice" should contain "0" element


### PR DESCRIPTION
## Description
Same as https://github.com/owncloud/ocis/pull/5379
Added these scenarios:
```feature
Scenario: Upload the same file twice with the same mtime and a version is available
Scenario: Upload the same file more than twice with the same mtime and only one version is available
Scenario: Upload the same file twice with the same mtime and no version after restoring
```


## Related Issue
Tests for https://github.com/owncloud/ocis/issues/5010

## Motivation and Context

## How Has This Been Tested?

## Screenshots (if appropriate):

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Database schema changes (next release will require increase of minor version instead of patch)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [ ] Tests only (no source changes)

## Checklist:
- [ ] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 
- [ ] Changelog item, see [TEMPLATE](https://github.com/owncloud/core/blob/master/changelog/TEMPLATE)
