### PR TITLE
Add support for login policies

### DIFF
--- a/changelog/unreleased/40574
+++ b/changelog/unreleased/40574
@@ -1,0 +1,15 @@
+Enhancement: Add support for login policies
+
+Support for login policies has been added in order to block
+the login of users under some circumstances. By default, there
+isn't any restriction, so any user can login normally (assuming
+the password is correct)
+
+A group login policy has been added. This policy allows or denies
+the user from login based on the login type being used by the user
+(username + password, openidconnect, etc) and whether he belongs
+to specific groups. This can be used to ensure a group of users
+are always authenticated using a determined authentication
+mechanism.
+
+https://github.com/owncloud/core/pull/40574

--- a/config/config.sample.php
+++ b/config/config.sample.php
@@ -143,7 +143,7 @@ $CONFIG = [
 /**
  * Define the ownCloud database user
  * This must be unique across ownCloud instances using the same SQL database.
- * This is setup during installation, so you shouldn't need to change it.
+ * This is set up during installation, so you shouldn't need to change it.
  */
 'dbuser' => '',
 
@@ -224,7 +224,7 @@ $CONFIG = [
  * The web UI might send a "heartbeat" based on the activity happening
  * in order to extend the session lifetime and keeping it from timing out
  * prematurely. If there is no activity happening and the lifetime is
- * reached, you'll have to login again.
+ * reached, you'll have to log in again.
  * The default is 20 minutes, expressed in seconds.
  */
 'session_lifetime' => 60 * 20,
@@ -417,7 +417,7 @@ $CONFIG = [
 
 /**
  * Define the IP address of your mail server host
- * Depends on `mail_smtpmode`. May contain multiple hosts separated by a semi-colon.
+ * Depends on `mail_smtpmode`. May contain multiple hosts separated by a semicolon.
  * If you need to specify the port number, append it to the IP address separated by
  * a colon, like this: `127.0.0.1:24`.
  */
@@ -518,7 +518,7 @@ $CONFIG = [
  * As an example, alerts shown in the browser to upgrade an app are triggered by
  * a cron background process and therefore uses the url of this key, even if the user
  * has logged on via a different domain defined in key `trusted_domains`. When the
- * user clicks an alert like this, they will be redirected to that URL and must logon again.
+ * user clicks an alert like this, they will be redirected to that URL and must log on again.
  */
 'overwrite.cli.url' => '',
 
@@ -702,7 +702,7 @@ $CONFIG = [
  *     rules. Please refer to https://doc.owncloud.com/server/latest/admin_manual/configuration/files/file_versioning.html
  *    for more information.
  * * `D, auto`
- *     keep versions at least for D days, apply expire rules to all versions
+ *     keep versions at least for D days, apply expiry rules to all versions
  *     that are older than D days
  * * `auto, D`
  *     delete all versions that are older than D days automatically, delete
@@ -898,7 +898,7 @@ $CONFIG = [
 /**
  * Alternate Code Locations
  *
- * Some of the ownCloud code may be stored in alternate locations.
+ * Some ownCloud code may be stored in alternate locations.
  */
 
 /**
@@ -1165,7 +1165,7 @@ $CONFIG = [
 	'host' => 'localhost', // can also be a unix domain socket: '/tmp/redis.sock'
 	'port' => 6379,
 	'timeout' => 0.0,
-	'password' => '', // Optional, if not defined no password will be used.
+	'password' => '', // Optional, if not defined, no password will be used.
 	'dbindex' => 0,   // Optional, if undefined SELECT will not run and will use Redis Server's default DB Index. Out of the box, every Redis instance supports 16 databases so `<dbIndex>` has to be set between 0 and 15.
 	 // Optional config option
 	 // In order to use connection_parameters php-redis extension >= 5.3.0 is required
@@ -1196,14 +1196,14 @@ $CONFIG = [
  *  - \RedisCluster::FAILOVER_DISTRIBUTE - randomly distribute read commands across primary and replica nodes
  */
 'redis.cluster' => [
-	'seeds' => [ // provide some/all of the cluster servers to bootstrap discovery, port required
+	'seeds' => [ // provide some/all the cluster servers to bootstrap discovery, port required
 	  'localhost:7000',
 	  'localhost:7001'
 	],
 	'timeout' => 0.0,
 	'read_timeout' => 0.0,
 	'failover_mode' => \RedisCluster::FAILOVER_DISTRIBUTE,
-	'password' => '', // Optional, if not defined no password will be used.
+	'password' => '', // Optional, if not defined, no password will be used.
 	 // Optional config option
 	 // In order to use connection_parameters php-redis extension >= 5.3.0 is required
 	 // In order to use SSL/TLS redis server >= 6.0 is required
@@ -1491,7 +1491,7 @@ $CONFIG = [
  * The list of apps that are allowed and must not have a signature.json file present.
  * Besides ownCloud apps, this is particularly useful when creating ownCloud themes,
  * because themes are treated as apps. The app is identified with it´s app-id.
- * The app-id can be identified by the foldername of the app in your apps directory.
+ * The app-id can be identified by the folder name of the app in your apps directory.
  * The following example allows app-1 and theme-2 to have no signature.json file.
  */
 'integrity.ignore.missing.app.signature' => [
@@ -1675,7 +1675,7 @@ $CONFIG = [
 'upgrade.disable-web' => false,
 
 /**
- * Define whether or not to enable automatic update of market apps
+ * Define whether to enable automatic update of market apps
  * Set to `false` to disable.
  */
 'upgrade.automatic-app-update' => true,
@@ -1788,7 +1788,7 @@ $CONFIG = [
 
 /**
  * Configuration of the Group Login Policy
- * Povide configuration for the
+ * Provide configuration for the
  * 'OC\Authentication\LoginPolicies\GroupLoginPolicy' policy.
  *
  * The configuration will be something like:
@@ -1808,11 +1808,11 @@ $CONFIG = [
  * ],
  *
  * Each login type can have a list of groups that will be the ones
- * only allowed to login using that login type, and also a list of
+ * only allowed to log in using that login type, and also a list of
  * groups that will be rejected from using that login type.
- * Note that this applies to users beloging to thos groups. If a user
+ * Note that this applies to users belonging to those groups. If a user
  * is member of an "allowOnly" group and also of a "reject" group,
- * the "reject" will take priority, so the user won't be able to login
+ * the "reject" will take priority, so the user won't be able to log in
  * using that login type.
  *
  * List of known login types:

--- a/config/config.sample.php
+++ b/config/config.sample.php
@@ -1760,4 +1760,72 @@ $CONFIG = [
  */
 'grace_period.demo_key.link' => 'https://owncloud.com/try-enterprise/',
 
+/**
+ * The order of the login policies that will be checked, if any.
+ * Policies must be registered in order to use / activate them. This is usually
+ * done automatically by core or the app containing the policy.
+ *
+ * The names of the policies must be documented if they come from an app.
+ * Core provide the following list of policies (only one for now):
+ * - 'OC\Authentication\LoginPolicies\GroupLoginPolicy'
+ *
+ * In order to use / activate the policy, include the name in the policy
+ * order below, such as:
+ * 'loginPolicy.order' => ['OC\Authentication\LoginPolicies\GroupLoginPolicy'],
+ *
+ * Multiple policies could be use as long as they're registered (the
+ * "SubnetPolicy" is just an example):
+ * 'loginPolicy.order' => [
+ *   'OC\Authentication\LoginPolicies\GroupLoginPolicy',
+ *   'OCA\CustomPolicies\SubnetPolicy'
+ * ],
+ *
+ * The configuration of the policies depends on the policy itself, so they could
+ * be configured in multiple and different ways. We won't cover them here.
+ */
+'loginPolicy.order' => [],
+
+/**
+ * Povide configuration for the
+ * 'OC\Authentication\LoginPolicies\GroupLoginPolicy' policy.
+ *
+ * The configuration will be something like:
+ * 'loginPolicy.groupLoginPolicy.forbidMap' => [
+ *   'password' => [
+ *     'allowOnly' => ['group1', 'group2'],
+ *     'reject' => ['group3'],
+ *   ],
+ * ],
+ *
+ * In a more generic way:
+ * 'loginPolicy.groupLoginPolicy.forbidMap' => [
+ *   '<loginType>' => [
+ *     'allowOnly' => ['<group1>', ......, '<groupN>'],
+ *     'reject' => ['<group1>', ........, '<groupN>'],
+ *   ],
+ * ],
+ *
+ * Each login type can have a list of groups that will be the ones
+ * only allowed to login using that login type, and also a list of
+ * groups that will be rejected from using that login type.
+ * Note that this applies to users beloging to thos groups. If a user
+ * is member of an "allowOnly" group and also of a "reject" group,
+ * the "reject" will take priority, so the user won't be able to login
+ * using that login type.
+ *
+ * List of known login types:
+ * - 'password' -> for the login page and basic auth (for webdav, for example)
+ * - 'token' -> for app passwords (using an app password in the login page will
+ * be considered as 'token' login type, not 'password')
+ * Coming from different apps (you'll have to install those):
+ * - 'apache' -> for the user_shibboleth app (data comes from the apache server)
+ * - 'OCA\OAuth2\AuthModule' -> for oAuth2
+ * - 'OCA\OpenIdConnect\OpenIdConnectAuthModule' -> for openidconnect
+ * - 'OCA\Kerberos\AuthModule' -> for kerberos
+ *
+ * In some weird circumstances, the login type could be the empty string.
+ * This could happen in earlier versions of the openidconnect app when using
+ * the web UI.
+ */
+'loginPolicy.groupLoginPolicy.forbidMap' => [],
 ];

--- a/config/config.sample.php
+++ b/config/config.sample.php
@@ -1774,7 +1774,7 @@ $CONFIG = [
  * order below, such as:
  * 'loginPolicy.order' => ['OC\Authentication\LoginPolicies\GroupLoginPolicy'],
  *
- * Multiple policies could be use as long as they're registered (the
+ * Multiple policies could be used as long as they're registered (the
  * "SubnetPolicy" is just an example):
  * 'loginPolicy.order' => [
  *   'OC\Authentication\LoginPolicies\GroupLoginPolicy',

--- a/config/config.sample.php
+++ b/config/config.sample.php
@@ -1761,6 +1761,7 @@ $CONFIG = [
 'grace_period.demo_key.link' => 'https://owncloud.com/try-enterprise/',
 
 /**
+ * Order of login policies
  * The order of the login policies that will be checked, if any.
  * Policies must be registered in order to use / activate them. This is usually
  * done automatically by core or the app containing the policy.
@@ -1786,6 +1787,7 @@ $CONFIG = [
 'loginPolicy.order' => [],
 
 /**
+ * Configuration of the Group Login Policy
  * Povide configuration for the
  * 'OC\Authentication\LoginPolicies\GroupLoginPolicy' policy.
  *

--- a/lib/private/Authentication/LoginPolicies/GroupLoginPolicy.php
+++ b/lib/private/Authentication/LoginPolicies/GroupLoginPolicy.php
@@ -68,16 +68,14 @@ class GroupLoginPolicy implements ILoginPolicy {
 			return true;
 		}
 
-		if (isset($policyConfig[$loginType])) {
-			$policyForType = $policyConfig[$loginType];
+		$policyForType = $policyConfig[$loginType] ?? [];  // empty map if not defined: reject and allowOnly won't be set
 
-			if (isset($policyForType['reject'])) {
-				$this->checkRejectGroupPolicy($user, $policyForType['reject']);
-			}
+		if (isset($policyForType['reject'])) {
+			$this->checkRejectGroupPolicy($user, $policyForType['reject']);
+		}
 
-			if (isset($policyForType['allowOnly'])) {
-				return $this->checkAllowGroupPolicy($user, $policyForType['allowOnly']);
-			}
+		if (isset($policyForType['allowOnly'])) {
+			return $this->checkAllowGroupPolicy($user, $policyForType['allowOnly']);
 		}
 
 		return true;

--- a/lib/private/Authentication/LoginPolicies/GroupLoginPolicy.php
+++ b/lib/private/Authentication/LoginPolicies/GroupLoginPolicy.php
@@ -1,0 +1,106 @@
+<?php
+/**
+ *
+ * @copyright Copyright (c) 2023, ownCloud GmbH
+ * @license AGPL-3.0
+ *
+ * This code is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License, version 3,
+ * as published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License, version 3,
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>
+ *
+ */
+namespace OC\Authentication\LoginPolicies;
+
+use OCP\IGroupManager;
+use OCP\IConfig;
+use OCP\IUser;
+use OCP\IL10N;
+use OCP\Authentication\LoginPolicies\ILoginPolicy;
+use OC\User\LoginException;
+
+/**
+ * A login policy to allow or deny access based on groups.
+ * A specific group could be allowed only via token. Another group could
+ * be denied to access via username + password.
+ *
+ * Configuration is done via config.php file
+ * ```
+ * loginPolicy.groupLoginPolicy.forbidMap => [
+ *  'password' => [
+ *    'allowOnly' => ['group1, group2'],
+ *    'reject' => ['group3'],
+ *  ],
+ *  'token' => [
+ *    'reject' => ['admin'],
+ *  ],
+ *  '' => [
+ *    'allowOnly' => ['group2'],
+ *  ],
+ * ]
+ * ```
+ */
+class GroupLoginPolicy implements ILoginPolicy {
+	/** @var IGroupManager */
+	private $groupManager;
+	/** @var IConfig */
+	private $config;
+	/** @var IL10N */
+	private $l10n;
+
+	public function __construct(IGroupManager $groupManager, IConfig $config, IL10N $l10n) {
+		$this->groupManager = $groupManager;
+		$this->config = $config;
+		$this->l10n = $l10n;
+	}
+
+	public function checkPolicy(string $loginType, IUser $user): bool {
+		$policyConfig = $this->config->getSystemValue('loginPolicy.groupLoginPolicy.forbidMap', []);
+		if (!\is_array($policyConfig)) {
+			// if not properly configured, allow access
+			return true;
+		}
+
+		if (isset($policyConfig[$loginType])) {
+			$policyForType = $policyConfig[$loginType];
+
+			if (isset($policyForType['reject'])) {
+				$this->checkRejectGroupPolicy($user, $policyForType['reject']);
+			}
+
+			if (isset($policyForType['allowOnly'])) {
+				return $this->checkAllowGroupPolicy($user, $policyForType['allowOnly']);
+			}
+		}
+
+		return true;
+	}
+
+	private function checkRejectGroupPolicy(IUser $user, array $rejectGroups) {
+		foreach ($rejectGroups as $rejectGroup) {
+			if ($this->groupManager->isInGroup($user->getUID(), $rejectGroup)) {
+				throw new LoginException(
+					$this->l10n->t("%s is member of a group not allowed to access through this login mechanism", [$user->getDisplayName()])
+				);
+			}
+		}
+	}
+
+	private function checkAllowGroupPolicy(IUser $user, array $allowOnlyGroups) {
+		foreach ($allowOnlyGroups as $allowOnlyGroup) {
+			if ($this->groupManager->isInGroup($user->getUID(), $allowOnlyGroup)) {
+				return true;
+			}
+		}
+		throw new LoginException(
+			$this->l10n->t("%s isn't member of a group allowed to access through this login mechanism", [$user->getDisplayName()])
+		);
+	}
+}

--- a/lib/private/Authentication/LoginPolicies/LoginPolicyManager.php
+++ b/lib/private/Authentication/LoginPolicies/LoginPolicyManager.php
@@ -1,0 +1,107 @@
+<?php
+/**
+ *
+ * @copyright Copyright (c) 2023, ownCloud GmbH
+ * @license AGPL-3.0
+ *
+ * This code is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License, version 3,
+ * as published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License, version 3,
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>
+ *
+ */
+namespace OC\Authentication\LoginPolicies;
+
+use OCP\IConfig;
+use OCP\ILogger;
+use OCP\IL10N;
+use OCP\IUser;
+use OCP\Authentication\LoginPolicies\ILoginPolicy;
+use OC\User\LoginException;
+
+class LoginPolicyManager {
+	/** @var IConfig */
+	private $config;
+	/** @var ILogger */
+	private $logger;
+	/** @var IL10N */
+	private $l10n;
+	/** @var Array<string, ILoginPolicy> */
+	private $registeredPolicies = [];
+
+	public function __construct(IConfig $config, ILogger $logger, IL10N $l10n) {
+		$this->config = $config;
+		$this->logger = $logger;
+		$this->l10n = $l10n;
+	}
+
+	/**
+	 * Register the policy.
+	 * The registration checks the classname of the policy to prevent
+	 * duplications. Multiple policies can be registered as long as the
+	 * classnames are different
+	 */
+	public function registerPolicy(ILoginPolicy $loginPolicy) {
+		$classname = \get_class($loginPolicy);
+		$this->registeredPolicies[$classname] = $loginPolicy;
+
+		$this->logger->debug("{$classname} policy registered", ['app' => 'core']);
+	}
+
+	/**
+	 * Get the policies that have been registered and will be used based on the
+	 * configured order. Not all the registered policies might be used.
+	 * The policies will be returned sorted based on the configured list
+	 */
+	private function getPolicyOrder() {
+		$policyOrder = $this->config->getSystemValue('loginPolicy.order', []);
+		if (!\is_array($policyOrder)) {
+			return [];
+		}
+
+		$realPolicyOrder = [];
+		foreach ($policyOrder as $configuredPolicyName) {
+			if (isset($this->registeredPolicies[$configuredPolicyName])) {
+				$realPolicyOrder[] = $this->registeredPolicies[$configuredPolicyName];
+			} else {
+				$this->logger->debug("{$configuredPolicyName} policy not found registered", ['app' => 'core']);
+			}
+		}
+
+		return $realPolicyOrder;
+	}
+
+	/**
+	 * Check if the user is allowed to login based on the configured policies.
+	 * This method will throw a LoginException if the user is rejected. If the
+	 * user is allowed, this method won't return anything.
+	 * @throws LoginException if the user is rejected
+	 */
+	public function checkUserLogin(string $loginType, IUser $user) {
+		$policies = $this->getPolicyOrder();
+
+		foreach ($policies as $policy) {
+			// checkPolicy can throw a LoginException with a better message
+			$policyOk = true;
+			try {
+				$policyOk = $policy->checkPolicy($loginType, $user);
+			} catch (LoginException $e) {
+				$this->logger->warning(\get_class($policy) . " policy has rejected user {$user->getUID()}", ['app' => 'core']);
+				throw $e;
+			}
+
+			if (!$policyOk) {
+				// policy failed -> throw LoginException
+				$this->logger->warning(\get_class($policy) . " policy has rejected user {$user->getUID()}", ['app' => 'core']);
+				throw new LoginException($this->l10n->t('A login policy has blocked the login'));
+			}
+		}
+	}
+}

--- a/lib/private/Server.php
+++ b/lib/private/Server.php
@@ -1747,7 +1747,7 @@ class Server extends ServerContainer implements IServerContainer, IServiceLoader
 	}
 
 	/**
-	 * @return ILoginPolicyManager
+	 * @return \OCP\Authentication\LoginPolicies\ILoginPolicyManager
 	 */
 	public function getLoginPolicyManager() {
 		return $this->query(LoginPolicyManager::class);

--- a/lib/private/Server.php
+++ b/lib/private/Server.php
@@ -45,6 +45,8 @@ use OC\AppFramework\Http\Request;
 use OC\AppFramework\Db\Db;
 use OC\AppFramework\Utility\TimeFactory;
 use OC\Authentication\AccountModule\Manager as AccountModuleManager;
+use OC\Authentication\LoginPolicies\LoginPolicyManager;
+use OC\Authentication\LoginPolicies\GroupLoginPolicy;
 use OC\Command\AsyncBus;
 use OC\Diagnostics\EventLogger;
 use OC\Diagnostics\QueryLogger;
@@ -332,6 +334,9 @@ class Server extends ServerContainer implements IServerContainer, IServiceLoader
 
 			$userSyncService = new SyncService($c->getConfig(), $c->getLogger(), $c->getAccountMapper());
 
+			// The LoginPolicyManager in the userSession can't be injected
+			// due to a cyclic dependency: LoginPolicyManager needs L10N to translate
+			// the error messages, and L10N depends on the userSession
 			$userSession = new Session(
 				$manager,
 				$session,
@@ -946,6 +951,23 @@ class Server extends ServerContainer implements IServerContainer, IServiceLoader
 				$c->getTimeFactory(),
 				$c->getLogger()
 			);
+		});
+
+		$this->registerService(LoginPolicyManager::class, function ($c) {
+			$policyManager = new LoginPolicyManager(
+				$c->getConfig(),
+				$c->getLogger(),
+				$c->getL10N('lib')
+			);
+			// register basic core login policies
+			$policyManager->registerPolicy(
+				new GroupLoginPolicy(
+					$c->getGroupManager(),
+					$c->getConfig(),
+					$c->getL10N('lib')
+				)
+			);
+			return $policyManager;
 		});
 	}
 
@@ -1722,5 +1744,12 @@ class Server extends ServerContainer implements IServerContainer, IServiceLoader
 
 	public function getLicenseManager() {
 		return $this->query(ILicenseManager::class);
+	}
+
+	/**
+	 * @return ILoginPolicyManager
+	 */
+	public function getLoginPolicyManager() {
+		return $this->query(LoginPolicyManager::class);
 	}
 }

--- a/lib/private/User/Session.php
+++ b/lib/private/User/Session.php
@@ -933,10 +933,11 @@ class Session implements IUserSession, Emitter {
 	 *
 	 * @param IUser $user The user
 	 * @param String $password The user's password
+	 * @param string $authModuleClass the classname of the module used to login
 	 * @return boolean True if the user can be authenticated, false otherwise
 	 * @throws LoginException if an app canceled the login process or the user is not enabled
 	 */
-	public function loginUser(IUser $user = null, $password = null, $authModuleClass = null) {
+	public function loginUser(IUser $user = null, $password = null, $authModuleClass = '') {
 		if ($user === null) {
 			$this->emitFailedLogin(null);
 			return false;

--- a/lib/public/Authentication/LoginPolicies/ILoginPolicy.php
+++ b/lib/public/Authentication/LoginPolicies/ILoginPolicy.php
@@ -24,6 +24,8 @@ use OCP\IUser;
 /**
  * Interface for a login policy, for example "users belonging to group A must
  * login by username and password"
+ *
+ * @since 10.12.0
  */
 interface ILoginPolicy {
 	/**
@@ -34,6 +36,8 @@ interface ILoginPolicy {
 	 * the user is rejected. If such thing isn't possible, returning false is an
 	 * alternative; the LoginPolicyManager should throw a LoginException on
 	 * its behalf along with a generic error message.
+	 *
+	 * @since 10.12.0
 	 *
 	 * @param string $loginType the login type the user is using to access ownCloud
 	 * @param IUser $user the user accessing

--- a/lib/public/Authentication/LoginPolicies/ILoginPolicy.php
+++ b/lib/public/Authentication/LoginPolicies/ILoginPolicy.php
@@ -1,0 +1,44 @@
+<?php
+/**
+ *
+ * @copyright Copyright (c) 2023, ownCloud GmbH
+ * @license AGPL-3.0
+ *
+ * This code is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License, version 3,
+ * as published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License, version 3,
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>
+ *
+ */
+namespace OCP\Authentication\LoginPolicies;
+
+use OCP\IUser;
+
+/**
+ * Interface for a login policy, for example "users belonging to group A must
+ * login by username and password"
+ */
+interface ILoginPolicy {
+	/**
+	 * Check if the $user accessing via $loginType can login. This method must
+	 * return true if the check passes and the user is allowed to login.
+	 *
+	 * The method should usually throw a LoginException with a proper message if
+	 * the user is rejected. If such thing isn't possible, returning false is an
+	 * alternative; the LoginPolicyManager should throw a LoginException on
+	 * its behalf along with a generic error message.
+	 *
+	 * @param string $loginType the login type the user is using to access ownCloud
+	 * @param IUser $user the user accessing
+	 * @throws \OC\User\LoginException if the user isn't allowed to access
+	 * @return bool true if the user is allowed, false otherwise
+	 */
+	public function checkPolicy(string $loginType, IUser $user): bool;
+}

--- a/lib/public/Authentication/LoginPolicies/ILoginPolicyManager.php
+++ b/lib/public/Authentication/LoginPolicies/ILoginPolicyManager.php
@@ -21,10 +21,17 @@ namespace OCP\Authentication\LoginPolicies;
 
 use OCP\IUser;
 
+/**
+ * Manage the login policies
+ *
+ * @since 10.12.0
+ */
 interface ILoginPolicyManager {
 	/**
 	 * Register the policy. The implementation should be sure that the
 	 * policy isn't duplicated
+	 *
+	 * @since 10.12.0
 	 */
 	public function registerPolicy(ILoginPolicy $loginPolicy);
 
@@ -32,6 +39,9 @@ interface ILoginPolicyManager {
 	 * Check if the user is allowed to login based on the configured policies.
 	 * This method will throw a LoginException if the user is rejected. If the
 	 * user is allowed, this method won't return anything.
+	 *
+	 * @since 10.12.0
+	 *
 	 * @throws LoginException if the user is rejected
 	 */
 	public function checkUserLogin(string $loginType, IUser $user);

--- a/lib/public/Authentication/LoginPolicies/ILoginPolicyManager.php
+++ b/lib/public/Authentication/LoginPolicies/ILoginPolicyManager.php
@@ -1,0 +1,38 @@
+<?php
+/**
+ *
+ * @copyright Copyright (c) 2023, ownCloud GmbH
+ * @license AGPL-3.0
+ *
+ * This code is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License, version 3,
+ * as published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License, version 3,
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>
+ *
+ */
+namespace OCP\Authentication\LoginPolicies;
+
+use OCP\IUser;
+
+interface ILoginPolicyManager {
+	/**
+	 * Register the policy. The implementation should be sure that the
+	 * policy isn't duplicated
+	 */
+	public function registerPolicy(ILoginPolicy $loginPolicy);
+
+	/**
+	 * Check if the user is allowed to login based on the configured policies.
+	 * This method will throw a LoginException if the user is rejected. If the
+	 * user is allowed, this method won't return anything.
+	 * @throws LoginException if the user is rejected
+	 */
+	public function checkUserLogin(string $loginType, IUser $user);
+}

--- a/lib/public/IServerContainer.php
+++ b/lib/public/IServerContainer.php
@@ -548,4 +548,10 @@ interface IServerContainer extends IContainer {
 	 * @since 10.5.0
 	 */
 	public function getLicenseManager();
+
+	/**
+	 * @return \OCP\Authentication\LoginPolicies\ILoginPolicyManager
+	 * @since 10.12.0
+	 */
+	public function getLoginPolicyManager();
 }

--- a/tests/lib/Authentication/LoginPolicies/GroupLoginPolicyTest.php
+++ b/tests/lib/Authentication/LoginPolicies/GroupLoginPolicyTest.php
@@ -1,0 +1,190 @@
+<?php
+/**
+ * @copyright Copyright (c) 2023, ownCloud GmbH
+ * @license AGPL-3.0
+ *
+ * This code is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License, version 3,
+ * as published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License, version 3,
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>
+ *
+ */
+
+namespace Test\Authentication\LoginPolicies;
+
+use OCP\IGroupManager;
+use OCP\IConfig;
+use OCP\IL10N;
+use OCP\IUser;
+use OC\Authentication\LoginPolicies\GroupLoginPolicy;
+use OC\User\LoginException;
+use Test\TestCase;
+
+class GroupLoginPolicyTest extends TestCase {
+	/** @var IGroupManager */
+	private $groupManager;
+	/** @var IConfig */
+	private $config;
+	/** @var IL10N */
+	private $l10n;
+	/** @var GroupLoginPolicy */
+	private $groupLoginPolicy;
+
+	protected function setUp(): void {
+		parent::setUp();
+
+		$this->groupManager = $this->createMock(IGroupManager::class);
+		$this->config = $this->createMock(IConfig::class);
+		$this->l10n = $this->createMock(IL10N::class);
+
+		$this->groupLoginPolicy = new GroupLoginPolicy($this->groupManager, $this->config, $this->l10n);
+	}
+
+	public function testCheckPolicyWrongConfig() {
+		$user = $this->createMock(IUser::class);
+		$user->method('getUID')->willReturn('myuserid');
+
+		$this->assertTrue($this->groupLoginPolicy->checkPolicy('customLogin', $user));
+	}
+
+	public function testCheckPolicyNoConfig() {
+		$user = $this->createMock(IUser::class);
+		$user->method('getUID')->willReturn('myuserid');
+
+		$this->config->expects($this->once())
+			->method('getSystemValue')
+			->with('loginPolicy.groupLoginPolicy.forbidMap', [])
+			->willReturn([]);
+
+		$this->assertTrue($this->groupLoginPolicy->checkPolicy('customLogin', $user));
+	}
+
+	public function testCheckPolicyNoMatchingConfig() {
+		$user = $this->createMock(IUser::class);
+		$user->method('getUID')->willReturn('myuserid');
+
+		$this->config->expects($this->once())
+			->method('getSystemValue')
+			->with('loginPolicy.groupLoginPolicy.forbidMap', [])
+			->willReturn([
+				'anotherLogin' => [
+					'reject' => ['g1'],
+				],
+			]);
+
+		$this->assertTrue($this->groupLoginPolicy->checkPolicy('customLogin', $user));
+	}
+
+	public function testCheckPolicyInRejectGroup() {
+		$this->expectException(LoginException::class);
+
+		$user = $this->createMock(IUser::class);
+		$user->method('getUID')->willReturn('myuserid');
+
+		$this->config->expects($this->once())
+			->method('getSystemValue')
+			->with('loginPolicy.groupLoginPolicy.forbidMap', [])
+			->willReturn([
+				'customLogin' => [
+					'reject' => ['g1', 'g2'],
+				],
+			]);
+
+		$this->groupManager->method('isInGroup')
+			->will($this->returnCallback(function ($userid, $groupid) {
+				return $userid === 'myuserid' && $groupid === 'g2';
+			}));
+
+		$this->groupLoginPolicy->checkPolicy('customLogin', $user);
+	}
+
+	public function testCheckPolicyNotInRejectGroup() {
+		$user = $this->createMock(IUser::class);
+		$user->method('getUID')->willReturn('myuserid');
+
+		$this->config->expects($this->once())
+			->method('getSystemValue')
+			->with('loginPolicy.groupLoginPolicy.forbidMap', [])
+			->willReturn([
+				'customLogin' => [
+					'reject' => ['g1', 'g2'],
+				],
+			]);
+
+		$this->groupManager->method('isInGroup')->willReturn(false);
+
+		$this->assertTrue($this->groupLoginPolicy->checkPolicy('customLogin', $user));
+	}
+
+	public function testCheckPolicyInAllowOnlyGroup() {
+		$user = $this->createMock(IUser::class);
+		$user->method('getUID')->willReturn('myuserid');
+
+		$this->config->expects($this->once())
+			->method('getSystemValue')
+			->with('loginPolicy.groupLoginPolicy.forbidMap', [])
+			->willReturn([
+				'customLogin' => [
+					'allowOnly' => ['g1', 'g2'],
+				],
+			]);
+
+		$this->groupManager->method('isInGroup')
+			->will($this->returnCallback(function ($userid, $groupid) {
+				return $userid === 'myuserid' && $groupid === 'g2';
+			}));
+
+		$this->assertTrue($this->groupLoginPolicy->checkPolicy('customLogin', $user));
+	}
+
+	public function testCheckPolicyNotInAllowOnlyGroup() {
+		$this->expectException(LoginException::class);
+
+		$user = $this->createMock(IUser::class);
+		$user->method('getUID')->willReturn('myuserid');
+
+		$this->config->expects($this->once())
+			->method('getSystemValue')
+			->with('loginPolicy.groupLoginPolicy.forbidMap', [])
+			->willReturn([
+				'customLogin' => [
+					'allowOnly' => ['g1', 'g2'],
+				],
+			]);
+
+		$this->groupManager->method('isInGroup')->willReturn(false);
+
+		$this->groupLoginPolicy->checkPolicy('customLogin', $user);
+	}
+
+	public function testCheckPolicyInRejectAndAllowOnlyGroup() {
+		$this->expectException(LoginException::class);
+
+		$user = $this->createMock(IUser::class);
+		$user->method('getUID')->willReturn('myuserid');
+
+		$this->config->expects($this->once())
+			->method('getSystemValue')
+			->with('loginPolicy.groupLoginPolicy.forbidMap', [])
+			->willReturn([
+				'customLogin' => [
+					'reject' => ['g3'],
+					'allowOnly' => ['g1', 'g2'],
+				],
+			]);
+
+		$this->groupManager->method('isInGroup')
+			->will($this->returnCallback(function ($userid, $groupid) {
+				return $userid === 'myuserid' && ($groupid === 'g2' || $groupid === 'g3');
+			}));
+
+		$this->groupLoginPolicy->checkPolicy('customLogin', $user);
+	}
+}

--- a/tests/lib/Authentication/LoginPolicies/LoginPolicyManagerTest.php
+++ b/tests/lib/Authentication/LoginPolicies/LoginPolicyManagerTest.php
@@ -1,0 +1,273 @@
+<?php
+/**
+ * @copyright Copyright (c) 2023, ownCloud GmbH
+ * @license AGPL-3.0
+ *
+ * This code is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License, version 3,
+ * as published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License, version 3,
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>
+ *
+ */
+
+namespace Test\Authentication\LoginPolicies;
+
+use OCP\ILogger;
+use OCP\IConfig;
+use OCP\IL10N;
+use OCP\IUser;
+use OCP\Authentication\LoginPolicies\ILoginPolicy;
+use OC\Authentication\LoginPolicies\LoginPolicyManager;
+use OC\User\LoginException;
+use Test\TestCase;
+
+class LoginPolicyManagerTest extends TestCase {
+	/** @var IConfig */
+	private $config;
+	/** @var ILogger */
+	private $logger;
+	/** @var IL10N */
+	private $l10n;
+	/** @var LoginPolicyManager */
+	private $loginPolicyManager;
+
+	protected function setUp(): void {
+		parent::setUp();
+
+		$this->config = $this->createMock(IConfig::class);
+		$this->logger = $this->createMock(ILogger::class);
+		$this->l10n = $this->createMock(IL10N::class);
+
+		$this->loginPolicyManager = new LoginPolicyManager($this->config, $this->logger, $this->l10n);
+	}
+
+	public function testRegisterPolicy() {
+		$policy = $this->createMock(ILoginPolicy::class);
+		$this->assertNull($this->loginPolicyManager->registerPolicy($policy));
+	}
+
+	public function testCheckUserLogin() {
+		$user = $this->createMock(IUser::class);
+		$user->method('getUID')->willReturn('myuserid');
+
+		$policy = $this->createMock(ILoginPolicy::class);
+		$policy->expects($this->once())
+			->method('checkPolicy')
+			->willReturn(true);
+
+		$this->loginPolicyManager->registerPolicy($policy);
+
+		$this->config->method('getSystemValue')
+			->with('loginPolicy.order', [])
+			->willReturn([\get_class($policy)]);
+
+		$this->assertNull($this->loginPolicyManager->checkUserLogin('mycustomLogin', $user));
+	}
+
+	public function testCheckUserLoginNoActivePolicy() {
+		$user = $this->createMock(IUser::class);
+		$user->method('getUID')->willReturn('myuserid');
+
+		$policy = $this->createMock(ILoginPolicy::class);
+		$policy->expects($this->never())
+			->method('checkPolicy')
+			->willReturn(true);
+
+		$this->loginPolicyManager->registerPolicy($policy);
+
+		$this->config->method('getSystemValue')
+			->with('loginPolicy.order', [])
+			->willReturn([]);
+
+		$this->assertNull($this->loginPolicyManager->checkUserLogin('mycustomLogin', $user));
+	}
+
+	public function testCheckUserLoginMultiplePolicies() {
+		$user = $this->createMock(IUser::class);
+		$user->method('getUID')->willReturn('myuserid');
+
+		// policies will require different class names
+		$policy1 = $this->getMockBuilder(ILoginPolicy::class)
+			->setMockClassName('ILoginPolicy_Policy1')
+			->getMock();
+		$policy1->expects($this->once())
+			->method('checkPolicy')
+			->willReturn(true);
+
+		$policy2 = $this->getMockBuilder(ILoginPolicy::class)
+			->setMockClassName('ILoginPolicy_Policy2')
+			->getMock();
+		$policy2->expects($this->once())
+			->method('checkPolicy')
+			->willReturn(true);
+
+		$this->loginPolicyManager->registerPolicy($policy1);
+		$this->loginPolicyManager->registerPolicy($policy2);
+
+		$this->config->method('getSystemValue')
+			->with('loginPolicy.order', [])
+			->willReturn([\get_class($policy1), \get_class($policy2)]);
+
+		$this->assertNull($this->loginPolicyManager->checkUserLogin('mycustomLogin', $user));
+	}
+
+	public function testCheckUserLoginMultiplePoliciesFirstFail() {
+		$this->expectException(LoginException::class);
+
+		$user = $this->createMock(IUser::class);
+		$user->method('getUID')->willReturn('myuserid');
+
+		// policies will require different class names
+		$policy1 = $this->getMockBuilder(ILoginPolicy::class)
+			->setMockClassName('ILoginPolicy_Policy1')
+			->getMock();
+		$policy1->expects($this->once())
+			->method('checkPolicy')
+			->willReturn(false);
+
+		$policy2 = $this->getMockBuilder(ILoginPolicy::class)
+			->setMockClassName('ILoginPolicy_Policy2')
+			->getMock();
+		$policy2->expects($this->never())  // first policy fails, this won't be checked
+			->method('checkPolicy')
+			->willReturn(true);
+
+		$this->loginPolicyManager->registerPolicy($policy1);
+		$this->loginPolicyManager->registerPolicy($policy2);
+
+		$this->config->method('getSystemValue')
+			->with('loginPolicy.order', [])
+			->willReturn([\get_class($policy1), \get_class($policy2)]);
+
+		$this->loginPolicyManager->checkUserLogin('mycustomLogin', $user);
+	}
+
+	public function testCheckUserLoginMultiplePoliciesFirstThrowException() {
+		$this->expectException(LoginException::class);
+
+		$user = $this->createMock(IUser::class);
+		$user->method('getUID')->willReturn('myuserid');
+
+		// policies will require different class names
+		$policy1 = $this->getMockBuilder(ILoginPolicy::class)
+			->setMockClassName('ILoginPolicy_Policy1')
+			->getMock();
+		$policy1->expects($this->once())
+			->method('checkPolicy')
+			->will($this->throwException(new LoginException('Policy1 failed')));
+
+		$policy2 = $this->getMockBuilder(ILoginPolicy::class)
+			->setMockClassName('ILoginPolicy_Policy2')
+			->getMock();
+		$policy2->expects($this->never())  // first policy fails, this won't be checked
+			->method('checkPolicy')
+			->willReturn(true);
+
+		$this->loginPolicyManager->registerPolicy($policy1);
+		$this->loginPolicyManager->registerPolicy($policy2);
+
+		$this->config->method('getSystemValue')
+			->with('loginPolicy.order', [])
+			->willReturn([\get_class($policy1), \get_class($policy2)]);
+
+		$this->loginPolicyManager->checkUserLogin('mycustomLogin', $user);
+	}
+
+	public function testCheckUserLoginMultiplePoliciesSecondFail() {
+		$this->expectException(LoginException::class);
+
+		$user = $this->createMock(IUser::class);
+		$user->method('getUID')->willReturn('myuserid');
+
+		// policies will require different class names
+		$policy1 = $this->getMockBuilder(ILoginPolicy::class)
+			->setMockClassName('ILoginPolicy_Policy1')
+			->getMock();
+		$policy1->expects($this->once())
+			->method('checkPolicy')
+			->willReturn(true);
+
+		$policy2 = $this->getMockBuilder(ILoginPolicy::class)
+			->setMockClassName('ILoginPolicy_Policy2')
+			->getMock();
+		$policy2->expects($this->once())
+			->method('checkPolicy')
+			->willReturn(false);
+
+		$this->loginPolicyManager->registerPolicy($policy1);
+		$this->loginPolicyManager->registerPolicy($policy2);
+
+		$this->config->method('getSystemValue')
+			->with('loginPolicy.order', [])
+			->willReturn([\get_class($policy1), \get_class($policy2)]);
+
+		$this->loginPolicyManager->checkUserLogin('mycustomLogin', $user);
+	}
+
+	public function testCheckUserLoginMultiplePoliciesSecondThrowException() {
+		$this->expectException(LoginException::class);
+
+		$user = $this->createMock(IUser::class);
+		$user->method('getUID')->willReturn('myuserid');
+
+		// policies will require different class names
+		$policy1 = $this->getMockBuilder(ILoginPolicy::class)
+			->setMockClassName('ILoginPolicy_Policy1')
+			->getMock();
+		$policy1->expects($this->once())
+			->method('checkPolicy')
+			->willReturn(true);
+
+		$policy2 = $this->getMockBuilder(ILoginPolicy::class)
+			->setMockClassName('ILoginPolicy_Policy2')
+			->getMock();
+		$policy2->expects($this->once())
+			->method('checkPolicy')
+			->will($this->throwException(new LoginException('Policy1 failed')));
+
+		$this->loginPolicyManager->registerPolicy($policy1);
+		$this->loginPolicyManager->registerPolicy($policy2);
+
+		$this->config->method('getSystemValue')
+			->with('loginPolicy.order', [])
+			->willReturn([\get_class($policy1), \get_class($policy2)]);
+
+		$this->loginPolicyManager->checkUserLogin('mycustomLogin', $user);
+	}
+
+	public function testCheckUserLoginMultiplePoliciesFirstInactive() {
+		$user = $this->createMock(IUser::class);
+		$user->method('getUID')->willReturn('myuserid');
+
+		// policies will require different class names
+		$policy1 = $this->getMockBuilder(ILoginPolicy::class)
+			->setMockClassName('ILoginPolicy_Policy1')
+			->getMock();
+		$policy1->expects($this->once())
+			->method('checkPolicy')
+			->willReturn(true);
+
+		$policy2 = $this->getMockBuilder(ILoginPolicy::class)
+			->setMockClassName('ILoginPolicy_Policy2')
+			->getMock();
+		$policy2->expects($this->never())  // inactive policy won't be called
+			->method('checkPolicy')
+			->will($this->throwException(new LoginException('Policy1 failed')));
+
+		$this->loginPolicyManager->registerPolicy($policy1);
+		$this->loginPolicyManager->registerPolicy($policy2);
+
+		$this->config->method('getSystemValue')
+			->with('loginPolicy.order', [])
+			->willReturn([\get_class($policy1)]);
+
+		$this->assertNull($this->loginPolicyManager->checkUserLogin('mycustomLogin', $user));
+	}
+}

--- a/tests/lib/User/SessionTest.php
+++ b/tests/lib/User/SessionTest.php
@@ -2004,7 +2004,9 @@ class SessionTest extends TestCase {
 		$iUser->expects($this->atLeastOnce())
 			->method('updateLastLoginTimestamp');
 
-		$result = $this->invokePrivate($userSession, 'loginUser', [$iUser, 'foo']);
+		// loginPolicyManager shouldn't have any policy active here, so it won't do anything
+
+		$result = $this->invokePrivate($userSession, 'loginUser', [$iUser, 'foo', 'authModuleClassname']);
 		$this->assertTrue($result);
 	}
 
@@ -2047,7 +2049,7 @@ class SessionTest extends TestCase {
 
 		$beforeEvent = new GenericEvent(
 			null,
-			['loginType' => null, 'login' => 'foo', 'uid' => 'foo',  // loginType == null because no authModule specified
+			['loginType' => 'authModuleClassname', 'login' => 'foo', 'uid' => 'foo',  // loginType == null because no authModule specified
 				'_uid' => 'deprecated: please use \'login\', the real uid is not yet known',
 				'password' => 'bar']
 		);
@@ -2055,6 +2057,6 @@ class SessionTest extends TestCase {
 			->method('dispatch')
 			->with($this->equalTo($beforeEvent), $this->equalTo('user.beforelogin'));
 
-		$this->invokePrivate($userSession, 'loginUser', [$iUser, 'bar']);
+		$this->invokePrivate($userSession, 'loginUser', [$iUser, 'bar', 'authModuleClassname']);
 	}
 }


### PR DESCRIPTION
A policy has been implemented so admins can allow or reject groups of users to access via specific login mechanisms

<!--
Thanks for submitting a change to ownCloud!

This is the bug tracker for the Server component. Find other components at https://github.com/owncloud/core/blob/master/.github/CONTRIBUTING.md#guidelines

For fixing potential security issues please see https://owncloud.com/security/

To make it possible for us to get your change reviewed and merged please carefully fill out the requested information below.

Please note that any kind of change needs first be submitted to the master branch which holds the next version of ownCloud.

Please set the following labels:

- Set label "3 - To review" for review or "2 - Development" if the PR still has open tasks
- Assignment: assign to self
- Milestone: set the same as the ticket this PR fixes, or "development" by default
- Reviewers: pick at least one
-->

## Description
Add support for login policies. An initial login policy has been implemented so admins can allow or reject groups to access ownCloud via specific login mechanism.
For example, only the groups "guests" and "admin" could access via username + password, while the rest of users must access through other mechanisms such as openidconnect.

Login policies will emit a "failed login" event if the user isn't allowed to login.

Some additional changes have been made in the token access (app password) so it isn't invalidated under some circumstances (login policies were causing the invalidation of the token if the policy rejected the user.)

## Related Issue
https://github.com/owncloud/enterprise/issues/5295

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
- test environment:
- test case 1:
- test case 2:
- ...

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Database schema changes (next release will require increase of minor version instead of patch)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [ ] Tests only (no source changes)

## Checklist:
<!-- Tick the checkboxes when done. -->
<!-- Raise documentation ticket in https://github.com/owncloud/documentation -->
- [x] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 
- [ ] Changelog item, see [TEMPLATE](https://github.com/owncloud/core/blob/master/changelog/TEMPLATE)

## TODO:
- [x] Unit tests.
- [x] Changes in config.sample.php

## Usage:

The `GroupLoginPolicy` is already pre-registered, so there is nothing to do in order to register this policy in the `LoginPolicyManager`

The `LoginPolicyManager` will use the `loginPolicy.order` key in the config.php file to activate and use the policies in the list in the specified order.
```
'loginPolicy.order' => ['OC\Authentication\LoginPolicies\GroupLoginPolicy'],
```
If no login policy is activated in the `loginPolicy.order` list, ownCloud will work normally. Only registered policies can be activated.

For now, only the `OC\Authentication\LoginPolicies\GroupLoginPolicy` is available.

## GroupLoginPolicy configuration.
The configuration of the `GroupLoginPolicy` is done through the config.php file.
```
loginChecker.groupLoginChecker.forbidMap => [
  'password' => [
    'allowOnly' => ['group1, group2'],
    'reject' => ['group3'],
  ],
  'token' => [
    'reject' => ['admin'],
  ],
  '' => [
    'allowOnly' => ['group2'],
  ],
]
```

Each key of the forbidMap is a known login type (**to be listed every known login type**), and the value is a map containing a list of groups that are allow to use that login type (rejecting everyone else), and a list of groups that are rejected from using that login type.

In the above example, users belonging to the admin group won't be able to access via token (app password), while the rest of the users can.
Only users from group1 and group2 are allowed to access through username + password, and users from group3 will be rejected. In case a users is member of an allowOnly group and a reject group, rejection will take priority. This means that even if user1 is member of group1 he won't be able to access if he's also member of group3.

In some weird cases the login type is unknown (there was an issue with openidconnect which should be solved in the master code of the branch). In this case, the login type might be the empty string `''`.