### PR TITLE
[full-ci] Fix event dispatch calls for Symfony

### DIFF
--- a/apps/comments/lib/Dav/RootCollection.php
+++ b/apps/comments/lib/Dav/RootCollection.php
@@ -97,7 +97,7 @@ class RootCollection implements ICollection {
 		}
 
 		$event = new CommentsEntityEvent(CommentsEntityEvent::EVENT_ENTITY);
-		$this->dispatcher->dispatch(CommentsEntityEvent::EVENT_ENTITY, $event);
+		$this->dispatcher->dispatch($event, CommentsEntityEvent::EVENT_ENTITY);
 
 		$this->entityTypeCollections = [];
 		foreach ($event->getEntityCollections() as $entity => $entityExistsFunction) {

--- a/apps/dav/appinfo/v1/webdav.php
+++ b/apps/dav/appinfo/v1/webdav.php
@@ -60,7 +60,7 @@ $server = $serverFactory->createServer($baseuri, $requestUri, $authBackend, func
 
 // allow setup of additional auth backends
 $event = new \OCP\SabrePluginEvent($server);
-\OC::$server->getEventDispatcher()->dispatch('OCA\DAV\Connector\Sabre::authInit', $event);
+\OC::$server->getEventDispatcher()->dispatch($event, 'OCA\DAV\Connector\Sabre::authInit');
 
 \Sabre\DAV\Server::$streamMultiStatus = true;
 // And off we go!

--- a/apps/dav/lib/CardDAV/CardDavBackend.php
+++ b/apps/dav/lib/CardDAV/CardDavBackend.php
@@ -552,11 +552,11 @@ class CardDavBackend implements BackendInterface, SyncSupport {
 
 		if ($this->dispatcher !== null) {
 			$this->dispatcher->dispatch(
-				'\OCA\DAV\CardDAV\CardDavBackend::createCard',
 				new GenericEvent(null, [
 					'addressBookId' => $addressBookId,
 					'cardUri' => $cardUri,
-					'cardData' => $cardData])
+					'cardData' => $cardData]),
+				'\OCA\DAV\CardDAV\CardDavBackend::createCard',
 			);
 		}
 
@@ -605,11 +605,11 @@ class CardDavBackend implements BackendInterface, SyncSupport {
 
 		if ($this->dispatcher !== null) {
 			$this->dispatcher->dispatch(
-				'\OCA\DAV\CardDAV\CardDavBackend::updateCard',
 				new GenericEvent(null, [
 					'addressBookId' => $addressBookId,
 					'cardUri' => $cardUri,
-					'cardData' => $cardData])
+					'cardData' => $cardData]),
+				'\OCA\DAV\CardDAV\CardDavBackend::updateCard'
 			);
 		}
 
@@ -639,10 +639,10 @@ class CardDavBackend implements BackendInterface, SyncSupport {
 
 		if ($this->dispatcher !== null) {
 			$this->dispatcher->dispatch(
-				'\OCA\DAV\CardDAV\CardDavBackend::deleteCard',
 				new GenericEvent(null, [
 					'addressBookId' => $addressBookId,
-					'cardUri' => $cardUri])
+					'cardUri' => $cardUri]),
+				'\OCA\DAV\CardDAV\CardDavBackend::deleteCard'
 			);
 		}
 

--- a/apps/dav/lib/Connector/Sabre/File.php
+++ b/apps/dav/lib/Connector/Sabre/File.php
@@ -161,10 +161,10 @@ class File extends Node implements IFile, IFileNode {
 		$path = $this->fileView->getAbsolutePath($this->path);
 		$beforeEvent = new GenericEvent(null, ['path' => $path]);
 		if (!$this->fileView->file_exists($this->path)) {
-			\OC::$server->getEventDispatcher()->dispatch('file.beforecreate', $beforeEvent);
+			\OC::$server->getEventDispatcher()->dispatch($beforeEvent, 'file.beforecreate');
 			$newFile = true;
 		} else {
-			\OC::$server->getEventDispatcher()->dispatch('file.beforeupdate', $beforeEvent);
+			\OC::$server->getEventDispatcher()->dispatch($beforeEvent, 'file.beforeupdate');
 		}
 
 		list($partStorage) = $this->fileView->resolvePath($this->path);
@@ -311,9 +311,9 @@ class File extends Node implements IFile, IFileNode {
 
 		$afterEvent = new GenericEvent(null, ['path' => $path]);
 		if ($newFile === true) {
-			\OC::$server->getEventDispatcher()->dispatch('file.aftercreate', $afterEvent);
+			\OC::$server->getEventDispatcher()->dispatch($afterEvent, 'file.aftercreate');
 		} else {
-			\OC::$server->getEventDispatcher()->dispatch('file.afterupdate', $afterEvent);
+			\OC::$server->getEventDispatcher()->dispatch($afterEvent, 'file.afterupdate');
 		}
 		return '"' . $this->info->getEtag() . '"';
 	}
@@ -365,7 +365,7 @@ class File extends Node implements IFile, IFileNode {
 			]);
 			if ($run) {
 				$event->setArgument('run', $run);
-				\OC::$server->getEventDispatcher()->dispatch('file.beforeCreate', $event);
+				\OC::$server->getEventDispatcher()->dispatch($event, 'file.beforeCreate');
 				$run = $event->getArgument('run');
 			}
 		} else {
@@ -375,7 +375,7 @@ class File extends Node implements IFile, IFileNode {
 			]);
 			if ($run) {
 				$event->setArgument('run', $run);
-				\OC::$server->getEventDispatcher()->dispatch('file.beforeUpdate', $event);
+				\OC::$server->getEventDispatcher()->dispatch($event, 'file.beforeUpdate');
 				$run = $event->getArgument('run');
 			}
 		}
@@ -385,7 +385,7 @@ class File extends Node implements IFile, IFileNode {
 		]);
 		if ($run) {
 			$event->setArgument('run', $run);
-			\OC::$server->getEventDispatcher()->dispatch('file.beforeWrite', $event);
+			\OC::$server->getEventDispatcher()->dispatch($event, 'file.beforeWrite');
 			$run = $event->getArgument('run');
 		}
 		return $run;
@@ -545,10 +545,10 @@ class File extends Node implements IFile, IFileNode {
 			$beforeEvent = new GenericEvent(null, ['path' => $absPath]);
 			$newFile = false;
 			if (!$this->fileView->file_exists($targetPath)) {
-				\OC::$server->getEventDispatcher()->dispatch('file.beforecreate', $beforeEvent);
+				\OC::$server->getEventDispatcher()->dispatch($beforeEvent, 'file.beforecreate');
 				$newFile = true;
 			} else {
-				\OC::$server->getEventDispatcher()->dispatch('file.beforeupdate', $beforeEvent);
+				\OC::$server->getEventDispatcher()->dispatch($beforeEvent, 'file.beforeupdate');
 			}
 
 			/** @var \OC\Files\Storage\Storage $targetStorage */
@@ -626,9 +626,9 @@ class File extends Node implements IFile, IFileNode {
 				if ($etag !== null) {
 					$afterEvent = new GenericEvent(null, ['path' => $absPath]);
 					if ($newFile === true) {
-						\OC::$server->getEventDispatcher()->dispatch('file.aftercreate', $afterEvent);
+						\OC::$server->getEventDispatcher()->dispatch($afterEvent, 'file.aftercreate');
 					} else {
-						\OC::$server->getEventDispatcher()->dispatch('file.afterupdate', $afterEvent);
+						\OC::$server->getEventDispatcher()->dispatch($afterEvent, 'file.afterupdate');
 					}
 				}
 				return $etag;

--- a/apps/dav/lib/Files/Sharing/PublicLinkEventsPlugin.php
+++ b/apps/dav/lib/Files/Sharing/PublicLinkEventsPlugin.php
@@ -87,7 +87,7 @@ class PublicLinkEventsPlugin extends ServerPlugin {
 		 * dav.public.delete.before
 		 */
 		$eventName = "dav.public.{$lowercaseMethod}.before";
-		$this->dispatcher->dispatch($eventName, $event);
+		$this->dispatcher->dispatch($event, $eventName);
 	}
 
 	/**
@@ -128,6 +128,6 @@ class PublicLinkEventsPlugin extends ServerPlugin {
 		 * dav.public.delete.after
 		 */
 		$eventName = "dav.public.{$lowercaseMethod}.after";
-		$this->dispatcher->dispatch($eventName, $event);
+		$this->dispatcher->dispatch($event, $eventName);
 	}
 }

--- a/apps/dav/lib/Server.php
+++ b/apps/dav/lib/Server.php
@@ -145,7 +145,7 @@ class Server {
 
 		// allow setup of additional auth backends
 		$event = new SabrePluginEvent($this->server);
-		$dispatcher->dispatch('OCA\DAV\Connector\Sabre::authInit', $event);
+		$dispatcher->dispatch($event, 'OCA\DAV\Connector\Sabre::authInit');
 
 		// because we are throwing exceptions this plugin has to be the last one
 		$authPlugin->addBackend($authBackend);

--- a/apps/dav/tests/unit/Files/Sharing/PublicLinkEventsPluginTest.php
+++ b/apps/dav/tests/unit/Files/Sharing/PublicLinkEventsPluginTest.php
@@ -85,7 +85,7 @@ class PublicLinkEventsPluginTest extends TestCase {
 		$lowercaseMethod = \strtolower($method);
 		$this->dispatcher->expects($this->once())
 			->method('dispatch')
-			->with("dav.public.{$lowercaseMethod}.before", $this->anything());
+			->with($this->anything(), "dav.public.{$lowercaseMethod}.before");
 
 		$this->publicLinkEventsPlugin->initialize($this->server);  // required to include the server instance
 		$this->publicLinkEventsPlugin->beforeMethod($request, $response);
@@ -113,7 +113,7 @@ class PublicLinkEventsPluginTest extends TestCase {
 		$lowercaseMethod = \strtolower($method);
 		$this->dispatcher->expects($this->once())
 			->method('dispatch')
-			->with("dav.public.{$lowercaseMethod}.after", $this->anything());
+			->with($this->anything(), "dav.public.{$lowercaseMethod}.after");
 
 		$this->publicLinkEventsPlugin->initialize($this->server);  // required to include the server instance
 		$this->publicLinkEventsPlugin->afterMethod($request, $response);

--- a/apps/federatedfilesharing/lib/FedShareManager.php
+++ b/apps/federatedfilesharing/lib/FedShareManager.php
@@ -143,7 +143,6 @@ class FedShareManager {
 		);
 
 		$this->eventDispatcher->dispatch(
-			'\OCA\FederatedFileSharing::remote_shareReceived',
 			new GenericEvent(
 				null,
 				[
@@ -154,7 +153,8 @@ class FedShareManager {
 					'sharedby' => $sharedByAddress->getUserId(),
 					'remoteid' => $remoteId
 				]
-			)
+			),
+			'\OCA\FederatedFileSharing::remote_shareReceived'
 		);
 		$this->publishActivity(
 			$shareWith,

--- a/apps/federatedfilesharing/lib/FederatedShareProvider.php
+++ b/apps/federatedfilesharing/lib/FederatedShareProvider.php
@@ -554,7 +554,7 @@ class FederatedShareProvider implements IShareProvider {
 	 * a message that the file was unshared
 	 *
 	 * @param IShare $share
-	 * @param bool $isOwner the user can either be the owner or the user who re-sahred it
+	 * @param bool $isOwner the user can either be the owner or the user who re-shared it
 	 * @throws ShareNotFound
 	 * @throws \OC\HintException
 	 */
@@ -921,7 +921,7 @@ class FederatedShareProvider implements IShareProvider {
 	}
 
 	/**
-	 * Create a share object from an database row
+	 * Create a share object from a database row
 	 *
 	 * @param array $data
 	 * @return IShare
@@ -1153,8 +1153,8 @@ class FederatedShareProvider implements IShareProvider {
 	 */
 	public function getAccepted($remote, $shareWith) {
 		$event = $this->eventDispatcher->dispatch(
-			'remoteshare.received',
-			new GenericEvent('', ['remote' => $remote])
+			new GenericEvent('', ['remote' => $remote]),
+			'remoteshare.received'
 		);
 		'@phan-var GenericEvent $event';
 		if ($event->getArgument('autoAddServers')) {

--- a/apps/federatedfilesharing/tests/FederatedShareProviderTest.php
+++ b/apps/federatedfilesharing/tests/FederatedShareProviderTest.php
@@ -980,7 +980,7 @@ class FederatedShareProviderTest extends \Test\TestCase {
 			]
 		);
 		$this->eventDispatcher->method('dispatch')
-			->with('remoteshare.received', $this->anything())
+			->with($this->anything(), 'remoteshare.received')
 			->willReturn($event);
 
 		$shouldAutoAccept = $this->provider->getAccepted('remote', 'user@server.com');

--- a/apps/federation/lib/TrustedServers.php
+++ b/apps/federation/lib/TrustedServers.php
@@ -167,7 +167,7 @@ class TrustedServers {
 		$server = $this->dbHandler->getServerById($id);
 		$this->dbHandler->removeServer($id);
 		$event = new GenericEvent($server['url_hash']);
-		$this->dispatcher->dispatch('OCP\Federation\TrustedServerEvent::remove', $event);
+		$this->dispatcher->dispatch($event, 'OCP\Federation\TrustedServerEvent::remove');
 	}
 
 	/**

--- a/apps/federation/tests/TrustedServersTest.php
+++ b/apps/federation/tests/TrustedServersTest.php
@@ -207,7 +207,7 @@ class TrustedServersTest extends TestCase {
 			->willReturn($server);
 		$this->dispatcher->expects($this->once())->method('dispatch')
 			->willReturnCallback(
-				function ($eventId, $event) {
+				function ($event, $eventId) {
 					$this->assertSame($eventId, 'OCP\Federation\TrustedServerEvent::remove');
 					$this->assertInstanceOf('Symfony\Component\EventDispatcher\GenericEvent', $event);
 					/** @var \Symfony\Component\EventDispatcher\GenericEvent $event */

--- a/apps/files/download.php
+++ b/apps/files/download.php
@@ -41,7 +41,7 @@ if (!\OC\Files\Filesystem::file_exists($filename)) {
 
 //Dispatch an event to see if any apps have problem with download
 $event = new \Symfony\Component\EventDispatcher\GenericEvent(null, ['path' => $filename]);
-OC::$server->getEventDispatcher()->dispatch('file.beforeGetDirect', $event);
+OC::$server->getEventDispatcher()->dispatch($event, 'file.beforeGetDirect');
 if ($event->hasArgument('errorMessage')) {
 	\http_response_code(403);
 	$tmpl = new OCP\Template('', '403', 'guest');

--- a/apps/files/lib/Controller/ViewController.php
+++ b/apps/files/lib/Controller/ViewController.php
@@ -300,7 +300,7 @@ class ViewController extends Controller {
 				'resolvedWebLink' => null,
 				'resolvedDavLink' => null,
 			]);
-			$this->eventDispatcher->dispatch('files.resolvePrivateLink', $event);
+			$this->eventDispatcher->dispatch($event, 'files.resolvePrivateLink');
 
 			$webUrl = $event->getArgument('resolvedWebLink');
 			$webdavUrl = $event->getArgument('resolvedDavLink');

--- a/apps/files/tests/Controller/ViewControllerTest.php
+++ b/apps/files/tests/Controller/ViewControllerTest.php
@@ -38,6 +38,7 @@ use OCP\IUser;
 use OCP\IUserSession;
 use OCP\Template;
 use Symfony\Component\EventDispatcher\EventDispatcherInterface;
+use Symfony\Component\EventDispatcher\GenericEvent;
 use Test\TestCase;
 
 /**
@@ -487,10 +488,17 @@ class ViewControllerTest extends TestCase {
 			->with(123)
 			->will($this->returnValue([]));
 
+		$event = new GenericEvent(null, [
+			'fileid' => 123,
+			'uid' => $this->userSession->getUser()->getUID(),
+			'resolvedWebLink' => null,
+			'resolvedDavLink' => null,
+		]);
+
 		$this->eventDispatcher->expects($this->once())
 			->method('dispatch')
-			->with('files.resolvePrivateLink')
-			->will($this->returnCallback(function ($eventName, $event) {
+			->with($event, 'files.resolvePrivateLink')
+			->will($this->returnCallback(function ($event, $eventName) {
 				$event->setArgument('resolvedWebLink', '/owncloud/weblink/' . $event->getArgument('uid') . '/' . $event->getArgument('fileid'));
 				$event->setArgument('resolvedDavLink', '/owncloud/davlink/' . $event->getArgument('uid') . '/' . $event->getArgument('fileid'));
 			}));

--- a/apps/files_sharing/lib/Controller/Share20OcsController.php
+++ b/apps/files_sharing/lib/Controller/Share20OcsController.php
@@ -256,7 +256,7 @@ class Share20OcsController extends OCSController {
 			$result['share_with_displayname'] = $group !== null ? $group->getDisplayName() : $share->getSharedWith();
 		} elseif ($share->getShareType() === Share::SHARE_TYPE_LINK) {
 			if ($share->getPassword() !== null) {
-				// Misleading names ahead!: This fields are miss-used to
+				// Misleading names ahead!: These fields are miss-used to
 				// read/write public link password-hashes
 				$result['share_with'] = '***redacted***';
 				$result['share_with_displayname'] = '***redacted***';
@@ -307,7 +307,7 @@ class Share20OcsController extends OCSController {
 				$share = $this->formatShare($share);
 				return new Result([$share]);
 			} catch (NotFoundException $e) {
-				//Fall trough
+				//Fall through
 			} catch (StorageNotAvailableException $e) {
 				// could happen if the share node points to a storage which isn't available
 				// TODO: This should go through an injected logger instance
@@ -453,7 +453,7 @@ class Share20OcsController extends OCSController {
 				return new Result(null, 404, $this->l->t('Please specify a valid user'));
 			}
 
-			// Fetch the UID to match exactly with the user (case sensitive).
+			// Fetch the UID to match exactly with the user (case-sensitive).
 			$share->setSharedWith($user->getUID());
 			$share->setPermissions($permissions);
 			if ($userAutoAccept) {
@@ -1018,7 +1018,7 @@ class Share20OcsController extends OCSController {
 
 		try {
 			$share = $this->getShareById($id, $this->userSession->getUser()->getUID());
-			$this->eventDispatcher->dispatch('share.before' . $eventName, new GenericEvent(null, ['share' => $share]));
+			$this->eventDispatcher->dispatch(new GenericEvent(null, ['share' => $share]), 'share.before' . $eventName);
 		} catch (ShareNotFound $e) {
 			return new Result(null, 404, $this->l->t('Wrong share ID, share doesn\'t exist'));
 		}
@@ -1041,7 +1041,7 @@ class Share20OcsController extends OCSController {
 
 		if ($share->getState() === $state) {
 			if ($eventName !== '') {
-				$this->eventDispatcher->dispatch('share.after' . $eventName, new GenericEvent(null, ['share' => $share]));
+				$this->eventDispatcher->dispatch(new GenericEvent(null, ['share' => $share]), 'share.after' . $eventName);
 			}
 			// if there are no changes in the state, just return the share as if the change was successful
 			$node->unlock(ILockingProvider::LOCK_SHARED);
@@ -1084,7 +1084,7 @@ class Share20OcsController extends OCSController {
 		$this->notificationPublisher->discardNotificationForUser($share, $this->userSession->getUser()->getUID());
 
 		if ($eventName !== '') {
-			$this->eventDispatcher->dispatch('share.after' . $eventName, new GenericEvent(null, ['share' => $share]));
+			$this->eventDispatcher->dispatch(new GenericEvent(null, ['share' => $share]), 'share.after' . $eventName);
 		}
 		return new Result([$this->formatShare($share, true)]);
 	}

--- a/apps/files_sharing/lib/Controllers/ExternalSharesController.php
+++ b/apps/files_sharing/lib/Controllers/ExternalSharesController.php
@@ -105,7 +105,7 @@ class ExternalSharesController extends Controller {
 					'shareRecipient' => $shareInfo['user'],
 				]
 			);
-			$this->dispatcher->dispatch('remoteshare.accepted', $event);
+			$this->dispatcher->dispatch($event, 'remoteshare.accepted');
 			$this->externalManager->acceptShare($id);
 		}
 		return new JSONResponse();
@@ -130,7 +130,7 @@ class ExternalSharesController extends Controller {
 					'remoteUrl' => $shareInfo['remote']
 				]
 			);
-			$this->dispatcher->dispatch('remoteshare.declined', $event);
+			$this->dispatcher->dispatch($event, 'remoteshare.declined');
 			$this->externalManager->declineShare($id);
 		}
 		return new JSONResponse();

--- a/apps/files_sharing/lib/Controllers/ShareController.php
+++ b/apps/files_sharing/lib/Controllers/ShareController.php
@@ -192,7 +192,7 @@ class ShareController extends Controller {
 	 */
 	private function linkShareAuth(\OCP\Share\IShare $share, $password = null) {
 		$beforeEvent = new GenericEvent(null, ['shareObject' => $share]);
-		$this->eventDispatcher->dispatch('share.beforelinkauth', $beforeEvent);
+		$this->eventDispatcher->dispatch($beforeEvent, 'share.beforelinkauth');
 		if ($password !== null) {
 			if ($this->shareManager->checkPassword($share, $password)) {
 				$this->session->set('public_link_authenticated', (string)$share->getId());
@@ -208,7 +208,7 @@ class ShareController extends Controller {
 			}
 		}
 		$afterEvent = new GenericEvent(null, ['shareObject' => $share]);
-		$this->eventDispatcher->dispatch('share.afterlinkauth', $afterEvent);
+		$this->eventDispatcher->dispatch($afterEvent, 'share.afterlinkauth');
 		return true;
 	}
 
@@ -253,7 +253,7 @@ class ShareController extends Controller {
 				['shareObject' => $cloneShare, 'errorCode' => $errorCode,
 					'errorMessage' => $errorMessage]
 			);
-			$this->eventDispatcher->dispatch('share.linkaccess', $publicShareLinkAccessEvent);
+			$this->eventDispatcher->dispatch($publicShareLinkAccessEvent, 'share.linkaccess');
 		}
 
 		if ($exception !== null) {

--- a/apps/files_sharing/lib/External/Manager.php
+++ b/apps/files_sharing/lib/External/Manager.php
@@ -256,8 +256,8 @@ class Manager {
 			$fileId = $this->getShareFileId($share, $mountPoint);
 
 			$this->eventDispatcher->dispatch(
-				AcceptShare::class,
-				new AcceptShare($share)
+				new AcceptShare($share),
+				AcceptShare::class
 			);
 
 			$event = new GenericEvent(
@@ -271,7 +271,7 @@ class Manager {
 					'shareRecipient' => $this->uid,
 				]
 			);
-			$this->eventDispatcher->dispatch('remoteshare.accepted', $event);
+			$this->eventDispatcher->dispatch($event, 'remoteshare.accepted');
 			\OC_Hook::emit('OCP\Share', 'federated_share_added', ['server' => $share['remote']]);
 
 			$this->processNotification($id);
@@ -296,13 +296,13 @@ class Manager {
 			$removeShare->execute([$id, $this->uid]);
 
 			$this->eventDispatcher->dispatch(
-				DeclineShare::class,
-				new DeclineShare($share)
+				new DeclineShare($share),
+				DeclineShare::class
 			);
 
 			$event = new GenericEvent(null, ['sharedItem' => $share['name'], 'shareAcceptedFrom' => $share['owner'],
 				'remoteUrl' => $share['remote']]);
-			$this->eventDispatcher->dispatch('remoteshare.declined', $event);
+			$this->eventDispatcher->dispatch($event, 'remoteshare.declined');
 
 			$this->processNotification($id);
 			return true;
@@ -421,8 +421,8 @@ class Manager {
 			$share = $getShare->fetch();
 			if ($share !== false) {
 				$this->eventDispatcher->dispatch(
-					DeclineShare::class,
-					new DeclineShare($share)
+					new DeclineShare($share),
+					DeclineShare::class
 				);
 			}
 		}
@@ -438,7 +438,7 @@ class Manager {
 		if ($result) {
 			$this->removeReShares($id);
 			$event = new GenericEvent(null, ['user' => $this->uid, 'targetmount' => $mountPoint]);
-			$this->eventDispatcher->dispatch('\OCA\Files_Sharing::unshareEvent', $event);
+			$this->eventDispatcher->dispatch($event, '\OCA\Files_Sharing::unshareEvent');
 		}
 
 		return $result;
@@ -483,8 +483,8 @@ class Manager {
 			$shares = $getShare->fetchAll();
 			foreach ($shares as $share) {
 				$this->eventDispatcher->dispatch(
-					DeclineShare::class,
-					new DeclineShare($share)
+					new DeclineShare($share),
+					DeclineShare::class
 				);
 			}
 		}

--- a/apps/files_sharing/tests/Controller/Share20OcsControllerTest.php
+++ b/apps/files_sharing/tests/Controller/Share20OcsControllerTest.php
@@ -3386,8 +3386,8 @@ class Share20OcsControllerTest extends TestCase {
 			$this->eventDispatcher->expects($this->exactly(2))
 				->method('dispatch')
 				->withConsecutive(
-					[$this->equalTo('share.beforeaccept'), $this->equalTo(new GenericEvent(null, ['share' => $userShare]))],
-					[$this->equalTo('share.afteraccept'), $this->equalTo(new GenericEvent(null, ['share' => $userShare]))]
+					[$this->equalTo(new GenericEvent(null, ['share' => $userShare])), $this->equalTo('share.beforeaccept')],
+					[$this->equalTo(new GenericEvent(null, ['share' => $userShare])), $this->equalTo('share.afteraccept')]
 				);
 		} else {
 			$userFolder->expects($this->never())
@@ -3395,8 +3395,8 @@ class Share20OcsControllerTest extends TestCase {
 			$this->eventDispatcher->expects($this->exactly(2))
 				->method('dispatch')
 				->withConsecutive(
-					[$this->equalTo('share.beforereject'), $this->equalTo(new GenericEvent(null, ['share' => $userShare]))],
-					[$this->equalTo('share.afterreject'), $this->equalTo(new GenericEvent(null, ['share' => $userShare]))]
+					[$this->equalTo(new GenericEvent(null, ['share' => $userShare])), $this->equalTo('share.beforereject')],
+					[$this->equalTo(new GenericEvent(null, ['share' => $userShare])), $this->equalTo('share.afterreject')]
 				);
 		}
 
@@ -3441,16 +3441,16 @@ class Share20OcsControllerTest extends TestCase {
 			$this->eventDispatcher->expects($this->exactly(2))
 				->method('dispatch')
 				->withConsecutive(
-					[$this->equalTo('share.beforeaccept'), $this->equalTo(new GenericEvent(null, ['share' => $userShare]))],
-					[$this->equalTo('share.afteraccept'), $this->equalTo(new GenericEvent(null, ['share' => $userShare]))]
+					[$this->equalTo(new GenericEvent(null, ['share' => $userShare])), $this->equalTo('share.beforeaccept')],
+					[$this->equalTo(new GenericEvent(null, ['share' => $userShare])), $this->equalTo('share.afteraccept')]
 				);
 		} else {
 			$userShare->setState(\OCP\Share::STATE_REJECTED);
 			$this->eventDispatcher->expects($this->exactly(2))
 				->method('dispatch')
 				->withConsecutive(
-					[$this->equalTo('share.beforereject'), $this->equalTo(new GenericEvent(null, ['share' => $userShare]))],
-					[$this->equalTo('share.afterreject'), $this->equalTo(new GenericEvent(null, ['share' => $userShare]))]
+					[$this->equalTo(new GenericEvent(null, ['share' => $userShare])), $this->equalTo('share.beforereject')],
+					[$this->equalTo(new GenericEvent(null, ['share' => $userShare])), $this->equalTo('share.afterreject')]
 				);
 		}
 
@@ -3515,8 +3515,8 @@ class Share20OcsControllerTest extends TestCase {
 			$this->eventDispatcher->expects($this->exactly(2))
 				->method('dispatch')
 				->withConsecutive(
-					[$this->equalTo('share.beforeaccept'), $this->equalTo(new GenericEvent(null, ['share' => $userShare]))],
-					[$this->equalTo('share.afteraccept'), $this->equalTo(new GenericEvent(null, ['share' => $userShare]))]
+					[$this->equalTo(new GenericEvent(null, ['share' => $userShare])), $this->equalTo('share.beforeaccept')],
+					[$this->equalTo(new GenericEvent(null, ['share' => $userShare])), $this->equalTo('share.afteraccept')]
 				);
 		} else {
 			$userFolder->expects($this->never())
@@ -3524,8 +3524,8 @@ class Share20OcsControllerTest extends TestCase {
 			$this->eventDispatcher->expects($this->exactly(2))
 				->method('dispatch')
 				->withConsecutive(
-					[$this->equalTo('share.beforereject'), $this->equalTo(new GenericEvent(null, ['share' => $userShare]))],
-					[$this->equalTo('share.afterreject'), $this->equalTo(new GenericEvent(null, ['share' => $userShare]))]
+					[$this->equalTo(new GenericEvent(null, ['share' => $userShare])), $this->equalTo('share.beforereject')],
+					[$this->equalTo(new GenericEvent(null, ['share' => $userShare])), $this->equalTo('share.afterreject')]
 				);
 		}
 

--- a/apps/files_sharing/tests/External/ManagerTest.php
+++ b/apps/files_sharing/tests/External/ManagerTest.php
@@ -152,14 +152,14 @@ class ManagerTest extends TestCase {
 			->method('dispatch')
 			->withConsecutive(
 				[
-					AcceptShare::class,
 					$this->callback(
 						function ($event) use ($openShares) {
 							return $this->verifyShareEvent($event, $openShares[0], AcceptShare::class);
 						}
-					)
+					),
+					AcceptShare::class
 				],
-				['remoteshare.accepted', $event]
+				[$event, 'remoteshare.accepted']
 			);
 
 		// Accept the first share
@@ -206,14 +206,14 @@ class ManagerTest extends TestCase {
 			->method('dispatch')
 			->withConsecutive(
 				[
-					DeclineShare::class,
 					$this->callback(
 						function ($event) use ($openShares) {
 							return $this->verifyShareEvent($event, $openShares[1], DeclineShare::class);
 						}
-					)
+					),
+					DeclineShare::class
 				],
-				['remoteshare.declined', $event2]
+				[$event2, 'remoteshare.declined']
 			);
 
 		// Decline the third share
@@ -243,20 +243,20 @@ class ManagerTest extends TestCase {
 			->method('dispatch')
 			->withConsecutive(
 				[
-					DeclineShare::class,
 					$this->callback(
 						function ($event) use ($openShares) {
 							return $this->verifyShareEvent($event, $openShares[0], DeclineShare::class);
 						}
-					)
+					),
+					DeclineShare::class
 				],
 				[
-					DeclineShare::class,
 					$this->callback(
 						function ($event) use ($acceptedShares) {
 							return $this->verifyShareEvent($event, $acceptedShares[0], DeclineShare::class);
 						}
-					)
+					),
+					DeclineShare::class
 				],
 			);
 

--- a/changelog/unreleased/PHPdependencies20220920onwardSymfony
+++ b/changelog/unreleased/PHPdependencies20220920onwardSymfony
@@ -26,3 +26,4 @@ https://github.com/owncloud/core/pull/40517
 Code that has been deprecated in Symfony 4 has been refactored to be ready for Symfony 5.
 
 https://github.com/owncloud/core/pull/40521
+https://github.com/owncloud/core/pull/40575

--- a/lib/private/Share20/Manager.php
+++ b/lib/private/Share20/Manager.php
@@ -1596,15 +1596,15 @@ class Manager implements IManager {
 			return false;
 		}
 		$beforeEvent = new GenericEvent(null, ['shareObject' => $share]);
-		$this->eventDispatcher->dispatch('share.beforepasswordcheck', $beforeEvent);
+		$this->eventDispatcher->dispatch($beforeEvent, 'share.beforepasswordcheck');
 		$newHash = '';
 		if (!$this->hasher->verify($password, $share->getPassword(), $newHash)) {
 			$failEvent = new GenericEvent(null, ['shareObject' => $share]);
-			$this->eventDispatcher->dispatch('share.failedpasswordcheck', $failEvent);
+			$this->eventDispatcher->dispatch($failEvent, 'share.failedpasswordcheck');
 			return false;
 		}
 		$afterEvent = new GenericEvent(null, ['shareObject' => $share]);
-		$this->eventDispatcher->dispatch('share.afterpasswordcheck', $afterEvent);
+		$this->eventDispatcher->dispatch($afterEvent, 'share.afterpasswordcheck');
 		if (!empty($newHash)) {
 			$share->setPassword($newHash);
 			$provider = $this->factory->getProviderForType($share->getShareType());

--- a/lib/private/User/User.php
+++ b/lib/private/User/User.php
@@ -666,7 +666,7 @@ class User implements IUser {
 	 * are allowed to go up. The exceptions are not caught in this method.
 	 *
 	 *
-	 * @param bool $clearCache, set to true if user attributes should be created every time, else false is set to reuse the userExtendedAttributes cache.
+	 * @param bool $clearCache set to true if user attributes should be created every time, else false is set to reuse the userExtendedAttributes cache.
 	 * @return array
 	 * @throws NotPermittedActionException
 	 * @since 10.11.0
@@ -689,7 +689,7 @@ class User implements IUser {
 			 */
 			$this->allowUserAccountUpdate = false;
 			try {
-				$this->eventDispatcher->dispatch(UserExtendedAttributesEvent::USER_EXTENDED_ATTRIBUTES, $userExtendedAttributesEvent);
+				$this->eventDispatcher->dispatch($userExtendedAttributesEvent, UserExtendedAttributesEvent::USER_EXTENDED_ATTRIBUTES);
 			} finally {
 				//Reset the flag to true so that account table can now be allowed to update.
 				$this->allowUserAccountUpdate = true;

--- a/tests/lib/User/UserTest.php
+++ b/tests/lib/User/UserTest.php
@@ -600,7 +600,7 @@ class UserTest extends TestCase {
 
 		$this->eventDispatcher->expects($this->once())
 			->method('dispatch')
-			->with(UserExtendedAttributesEvent::USER_EXTENDED_ATTRIBUTES, $userExtendedAttributesEvent);
+			->with($userExtendedAttributesEvent, UserExtendedAttributesEvent::USER_EXTENDED_ATTRIBUTES);
 
 		$this->assertEquals($this->user->getExtendedAttributes($clearCache), []);
 	}
@@ -615,7 +615,7 @@ class UserTest extends TestCase {
 
 		$this->eventDispatcher->expects($this->once())
 			->method('dispatch')
-			->with(UserExtendedAttributesEvent::USER_EXTENDED_ATTRIBUTES, $userExtendedAttributesEvent)
+			->with($userExtendedAttributesEvent, UserExtendedAttributesEvent::USER_EXTENDED_ATTRIBUTES)
 			->willThrowException(new NotPermittedActionException());
 
 		$this->user->getExtendedAttributes();
@@ -631,7 +631,7 @@ class UserTest extends TestCase {
 		$userExtendedAttributesEvent = new UserExtendedAttributesEvent($this->user);
 		$this->eventDispatcher->expects($this->once())
 			->method('dispatch')
-			->with(UserExtendedAttributesEvent::USER_EXTENDED_ATTRIBUTES, $userExtendedAttributesEvent);
+			->with($userExtendedAttributesEvent, UserExtendedAttributesEvent::USER_EXTENDED_ATTRIBUTES);
 
 		$this->user->getExtendedAttributes();
 		$value = $this->invokePrivate($this->user, 'allowUserAccountUpdate');
@@ -646,7 +646,7 @@ class UserTest extends TestCase {
 		$userExtendedAttributesEvent = new UserExtendedAttributesEvent($this->user);
 		$this->eventDispatcher->expects($this->once())
 			->method('dispatch')
-			->with(UserExtendedAttributesEvent::USER_EXTENDED_ATTRIBUTES, $userExtendedAttributesEvent)
+			->with($userExtendedAttributesEvent, UserExtendedAttributesEvent::USER_EXTENDED_ATTRIBUTES)
 			->willThrowException(new NotPermittedActionException());
 
 		try {
@@ -665,7 +665,7 @@ class UserTest extends TestCase {
 		$userExtendedAttributesEvent = new UserExtendedAttributesEvent($this->user);
 		$this->eventDispatcher->expects($this->once())
 			->method('dispatch')
-			->with(UserExtendedAttributesEvent::USER_EXTENDED_ATTRIBUTES, $userExtendedAttributesEvent)
+			->with($userExtendedAttributesEvent, UserExtendedAttributesEvent::USER_EXTENDED_ATTRIBUTES)
 			->willThrowException(new \Exception());
 
 		try {
@@ -684,7 +684,7 @@ class UserTest extends TestCase {
 		$userExtendedAttributesEvent = new UserExtendedAttributesEvent($this->user);
 		$this->eventDispatcher->expects($this->once())
 			->method('dispatch')
-			->with(UserExtendedAttributesEvent::USER_EXTENDED_ATTRIBUTES, $userExtendedAttributesEvent)
+			->with($userExtendedAttributesEvent, UserExtendedAttributesEvent::USER_EXTENDED_ATTRIBUTES)
 			->will($this->returnCallback(function () {
 				$this->user->getExtendedAttributes();
 			}));


### PR DESCRIPTION
## Description
The order of parameters to the `dispatch` method changes in Symfony5. Symfony4 accepts the parameters in either order, so as to be backward-compatible and future-compatible.

This PR changes the order to the Symfony5 new order.

This gets closer to being able to use Symfony5 (trial PR #40518 ) Symfony4 has ended support, so there could be bugs and/or CVEs that only get addressed in Symfony5. If we can go to Symfony5 then it will be easy to keep up-to-date with any CVEs if they happen.

## How Has This Been Tested?
CI

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Database schema changes (next release will require increase of minor version instead of patch)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [ ] Tests only (no source changes)

## Checklist:
- [ ] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 
- [ ] Changelog item, see [TEMPLATE](https://github.com/owncloud/core/blob/master/changelog/TEMPLATE)
