### PR TITLE
[tests-only][full-ci] Skip recently added file versions tests on s3 storage

### DIFF
--- a/tests/acceptance/features/apiVersions/fileVersions.feature
+++ b/tests/acceptance/features/apiVersions/fileVersions.feature
@@ -532,14 +532,14 @@ Feature: dav-versions
     Then the HTTP status code should be "204"
     And the content of file "/davtest.txt" for user "Alice" should be "Old Test Content."
 
-  @issue-ocis-5010
+  @issue-ocis-5010 @skip_on_objectstore
   Scenario: Upload the same file twice with the same mtime and a version is available
     Given user "Alice" has uploaded file "filesForUpload/textfile.txt" to "file.txt" with mtime "Thu, 08 Aug 2019 04:18:13 GMT" using the WebDAV API
     When user "Alice" uploads file "filesForUpload/textfile.txt" to "file.txt" with mtime "Thu, 08 Aug 2019 04:18:13 GMT" using the WebDAV API
     Then the HTTP status code should be "204"
     And the version folder of file "/file.txt" for user "Alice" should contain "1" element
 
-  @issue-ocis-5010
+  @issue-ocis-5010 @skip_on_objectstore
   Scenario: Upload the same file more than twice with the same mtime and only one version is available
     Given user "Alice" has uploaded file "filesForUpload/textfile.txt" to "file.txt" with mtime "Thu, 08 Aug 2019 04:18:13 GMT" using the WebDAV API
     And user "Alice" has uploaded file "filesForUpload/textfile.txt" to "file.txt" with mtime "Thu, 08 Aug 2019 04:18:13 GMT" using the WebDAV API
@@ -547,7 +547,7 @@ Feature: dav-versions
     Then the HTTP status code should be "204"
     And the version folder of file "/file.txt" for user "Alice" should contain "1" element
 
-  @issue-ocis-5010
+  @issue-ocis-5010 @skip_on_objectstore
   Scenario: Upload the same file twice with the same mtime and no version after restoring
     Given user "Alice" has uploaded file "filesForUpload/textfile.txt" to "file.txt" with mtime "Thu, 08 Aug 2019 04:18:13 GMT" using the WebDAV API
     And user "Alice" has uploaded file "filesForUpload/textfile.txt" to "file.txt" with mtime "Thu, 08 Aug 2019 04:18:13 GMT" using the WebDAV API


### PR DESCRIPTION
## Description
Skipping recently added versions tests (see https://github.com/owncloud/core/pull/40573) with `@skip_on_objectstore` for files_primary_s3 app
See:
https://github.com/owncloud/files_primary_s3/issues/647#issuecomment-1384907869
https://github.com/owncloud/files_primary_s3/issues/647#issuecomment-1384911242

## Related Issue
- Fixes https://github.com/owncloud/files_primary_s3/issues/647

## How Has This Been Tested?
- test environment:

## Screenshots (if appropriate):

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Database schema changes (next release will require increase of minor version instead of patch)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [x] Tests only (no source changes)

## Checklist:
- [ ] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 
- [ ] Changelog item, see [TEMPLATE](https://github.com/owncloud/core/blob/master/changelog/TEMPLATE)
