### PR TITLE
[tests-only][full-ci] Removed scenarios that are only for ocis/reva

### DIFF
--- a/tests/acceptance/features/apiAuth/webDavAuth.feature
+++ b/tests/acceptance/features/apiAuth/webDavAuth.feature
@@ -9,11 +9,6 @@ Feature: auth
     When a user requests "/remote.php/webdav" with "PROPFIND" and no authentication
     Then the HTTP status code should be "401"
 
-  @smokeTest @skipOnOcV10 @personalSpace
-  Scenario: using spaces WebDAV anonymously
-    When user "Alice" requests "/dav/spaces/%spaceid%" with "PROPFIND" and no authentication
-    Then the HTTP status code should be "401"
-
   @smokeTest
   Scenario Outline: using WebDAV with basic auth
     When user "Alice" requests "<dav_path>" with "PROPFIND" using basic auth

--- a/tests/acceptance/features/apiAuthWebDav/webDavCOPYAuth.feature
+++ b/tests/acceptance/features/apiAuthWebDav/webDavCOPYAuth.feature
@@ -26,15 +26,6 @@ Feature: COPY file/folder
       | /remote.php/dav/files/%username%/PARENT/parent.txt |
     Then the HTTP status code of responses on all endpoints should be "401"
 
-  @smokeTest @skipOnBruteForceProtection @issue-brute_force_protection-112 @skipOnOcV10 @personalSpace
-  Scenario: send COPY requests to webDav endpoints as normal user with wrong password using the spaces WebDAV API
-    When user "Alice" requests these endpoints with "COPY" using password "invalid" about user "Alice"
-      | endpoint                                           |
-      | /remote.php/dav/spaces/%spaceid%/textfile0.txt     |
-      | /remote.php/dav/spaces/%spaceid%/PARENT            |
-      | /remote.php/dav/spaces/%spaceid%/PARENT/parent.txt |
-    Then the HTTP status code of responses on all endpoints should be "401"
-
   @smokeTest @skipOnBruteForceProtection @issue-brute_force_protection-112
   Scenario: send COPY requests to webDav endpoints as normal user with no password
     When user "Alice" requests these endpoints with "COPY" using password "" about user "Alice"
@@ -46,15 +37,6 @@ Feature: COPY file/folder
       | /remote.php/dav/files/%username%/PARENT/parent.txt |
     Then the HTTP status code of responses on all endpoints should be "401"
 
-  @smokeTest @skipOnBruteForceProtection @issue-brute_force_protection-112 @skipOnOcV10 @personalSpace
-  Scenario: send COPY requests to webDav endpoints as normal user with no password using the spaces WebDAV API
-    When user "Alice" requests these endpoints with "COPY" using password "" about user "Alice"
-      | endpoint                                           |
-      | /remote.php/dav/spaces/%spaceid%/textfile0.txt     |
-      | /remote.php/dav/spaces/%spaceid%/PARENT            |
-      | /remote.php/dav/spaces/%spaceid%/PARENT/parent.txt |
-    Then the HTTP status code of responses on all endpoints should be "401"
-
   @issue-ocis-reva-14
   Scenario: send COPY requests to another user's webDav endpoints as normal user
     When user "Brian" requests these endpoints with "COPY" about user "Alice"
@@ -63,15 +45,6 @@ Feature: COPY file/folder
       | /remote.php/dav/files/%username%/PARENT            |
       | /remote.php/dav/files/%username%/PARENT/parent.txt |
     Then the HTTP status code of responses on all endpoints should be "403"
-
- @skipOnOcV10 @personalSpace @issue-ocis-reva-14
- Scenario: send COPY requests to another user's webDav endpoints as normal user using the spaces WebDAV API
-   When user "Brian" requests these endpoints with "COPY" about user "Alice"
-     | endpoint                                           |
-     | /remote.php/dav/spaces/%spaceid%/textfile0.txt     |
-     | /remote.php/dav/spaces/%spaceid%/PARENT            |
-     | /remote.php/dav/spaces/%spaceid%/PARENT/parent.txt |
-   Then the HTTP status code of responses on all endpoints should be "403"
 
 
   Scenario: send COPY requests to webDav endpoints using invalid username but correct password
@@ -82,15 +55,6 @@ Feature: COPY file/folder
       | /remote.php/webdav/PARENT                          |
       | /remote.php/dav/files/%username%/PARENT            |
       | /remote.php/dav/files/%username%/PARENT/parent.txt |
-    Then the HTTP status code of responses on all endpoints should be "401"
-
-  @skipOnOcV10 @personalSpace
-  Scenario: send COPY requests to webDav endpoints using invalid username but correct password using the spaces WebDAV API
-    When user "usero" requests these endpoints with "COPY" using the password of user "Alice"
-      | endpoint                                           |
-      | /remote.php/dav/spaces/%spaceid%/textfile0.txt     |
-      | /remote.php/dav/spaces/%spaceid%/PARENT            |
-      | /remote.php/dav/spaces/%spaceid%/PARENT/parent.txt |
     Then the HTTP status code of responses on all endpoints should be "401"
 
 
@@ -104,15 +68,6 @@ Feature: COPY file/folder
       | /remote.php/dav/files/%username%/PARENT/parent.txt |
     Then the HTTP status code of responses on all endpoints should be "401"
 
-  @skipOnOcV10 @personalSpace
-  Scenario: send COPY requests to webDav endpoints using valid password and username of different user using the spaces WebDAV API
-    When user "Brian" requests these endpoints with "COPY" using the password of user "Alice"
-      | endpoint                                           |
-      | /remote.php/dav/spaces/%spaceid%/textfile0.txt     |
-      | /remote.php/dav/spaces/%spaceid%/PARENT            |
-      | /remote.php/dav/spaces/%spaceid%/PARENT/parent.txt |
-    Then the HTTP status code of responses on all endpoints should be "401"
-
   @smokeTest @skipOnBruteForceProtection @issue-brute_force_protection-112
   Scenario: send COPY requests to webDav endpoints without any authentication
     When a user requests these endpoints with "COPY" with no authentication about user "Alice"
@@ -122,15 +77,6 @@ Feature: COPY file/folder
       | /remote.php/webdav/PARENT                          |
       | /remote.php/dav/files/%username%/PARENT            |
       | /remote.php/dav/files/%username%/PARENT/parent.txt |
-    Then the HTTP status code of responses on all endpoints should be "401"
-
-  @smokeTest @skipOnBruteForceProtection @issue-brute_force_protection-112 @skipOnOcV10 @personalSpace
-  Scenario: send COPY requests to webDav endpoints without any authentication using the spaces WebDAV API
-    When a user requests these endpoints with "COPY" with no authentication about user "Alice"
-      | endpoint                                           |
-      | /remote.php/dav/spaces/%spaceid%/textfile0.txt     |
-      | /remote.php/dav/spaces/%spaceid%/PARENT            |
-      | /remote.php/dav/spaces/%spaceid%/PARENT/parent.txt |
     Then the HTTP status code of responses on all endpoints should be "401"
 
   @notToImplementOnOCIS @issue-ocis-reva-37
@@ -172,13 +118,4 @@ Feature: COPY file/folder
       | /remote.php/dav/files/%username%/PARENT            |
       | /remote.php/webdav/PARENT/parent.txt               |
       | /remote.php/dav/files/%username%/PARENT/parent.txt |
-    Then the HTTP status code of responses on all endpoints should be "415"
-
- @skipOnOcV10 @personalSpace
-  Scenario: send COPY requests to webDav endpoints with body as normal user using the spaces WebDAV API
-    When user "Alice" requests these endpoints with "COPY" including body "doesnotmatter" about user "Alice"
-      | endpoint                                           |
-      | /remote.php/dav/spaces/%spaceid%/textfile0.txt     |
-      | /remote.php/dav/spaces/%spaceid%/PARENT            |
-      | /remote.php/dav/spaces/%spaceid%/PARENT/parent.txt |
     Then the HTTP status code of responses on all endpoints should be "415"

--- a/tests/acceptance/features/apiAuthWebDav/webDavDELETEAuth.feature
+++ b/tests/acceptance/features/apiAuthWebDav/webDavDELETEAuth.feature
@@ -24,14 +24,6 @@ Feature: delete file/folder
       | /remote.php/dav/files/%username%/PARENT/parent.txt |
     Then the HTTP status code of responses on all endpoints should be "401"
 
-  @smokeTest @skipOnBruteForceProtection @issue-brute_force_protection-112 @skipOnOcV10 @personalSpace
-  Scenario: send DELETE requests to webDav endpoints as normal user with wrong password using the spaces WebDAV API
-    When user "Alice" requests these endpoints with "DELETE" using password "invalid" about user "Alice"
-      | endpoint                                           |
-      | /remote.php/dav/spaces/%spaceid%/textfile0.txt     |
-      | /remote.php/dav/spaces/%spaceid%/PARENT            |
-      | /remote.php/dav/spaces/%spaceid%/PARENT/parent.txt |
-    Then the HTTP status code of responses on all endpoints should be "401"
 
   Scenario: send DELETE requests to webDav endpoints as normal user with no password
     When user "Alice" requests these endpoints with "DELETE" using password "" about user "Alice"
@@ -44,15 +36,6 @@ Feature: delete file/folder
       | /remote.php/dav/files/%username%/PARENT/parent.txt |
     Then the HTTP status code of responses on all endpoints should be "401"
 
-  @skipOnOcV10 @personalSpace
-  Scenario: send DELETE requests to webDav endpoints as normal user with no password using the spaces WebDAV API
-    When user "Alice" requests these endpoints with "DELETE" using password "" about user "Alice"
-      | endpoint                                           |
-      | /remote.php/dav/spaces/%spaceid%/textfile0.txt     |
-      | /remote.php/dav/spaces/%spaceid%/PARENT            |
-      | /remote.php/dav/spaces/%spaceid%/PARENT/parent.txt |
-    Then the HTTP status code of responses on all endpoints should be "401"
-
   @issue-ocis-reva-13
   Scenario: send DELETE requests to another user's webDav endpoints as normal user
     When user "Brian" requests these endpoints with "DELETE" about user "Alice"
@@ -60,15 +43,6 @@ Feature: delete file/folder
       | /remote.php/dav/files/%username%/textfile0.txt     |
       | /remote.php/dav/files/%username%/PARENT            |
       | /remote.php/dav/files/%username%/PARENT/parent.txt |
-    Then the HTTP status code of responses on all endpoints should be "404"
-
-  @issue-ocis-reva-13 @skipOnOcV10 @personalSpace
-  Scenario: send DELETE requests to another user's webDav endpoints as normal user using the spaces WebDAV API
-    When user "Brian" requests these endpoints with "DELETE" about user "Alice"
-      | endpoint                                           |
-      | /remote.php/dav/spaces/%spaceid%/textfile0.txt     |
-      | /remote.php/dav/spaces/%spaceid%/PARENT            |
-      | /remote.php/dav/spaces/%spaceid%/PARENT/parent.txt |
     Then the HTTP status code of responses on all endpoints should be "404"
 
   @smokeTest
@@ -82,15 +56,6 @@ Feature: delete file/folder
       | /remote.php/dav/files/%username%/PARENT/parent.txt |
     Then the HTTP status code of responses on all endpoints should be "401"
 
-  @smokeTest @skipOnOcV10 @personalSpace
-  Scenario: send DELETE requests to webDav endpoints using invalid username but correct password using the spaces WebDAV API
-    When user "usero" requests these endpoints with "DELETE" using the password of user "Alice"
-      | endpoint                                           |
-      | /remote.php/dav/spaces/%spaceid%/textfile0.txt     |
-      | /remote.php/dav/spaces/%spaceid%/PARENT            |
-      | /remote.php/dav/spaces/%spaceid%/PARENT/parent.txt |
-    Then the HTTP status code of responses on all endpoints should be "401"
-
 
   Scenario: send DELETE requests to webDav endpoints using valid password and username of different user
     When user "Brian" requests these endpoints with "DELETE" using the password of user "Alice"
@@ -102,15 +67,6 @@ Feature: delete file/folder
       | /remote.php/dav/files/%username%/PARENT/parent.txt |
     Then the HTTP status code of responses on all endpoints should be "401"
 
-  @skipOnOcV10 @personalSpace
-  Scenario: send DELETE requests to webDav endpoints using valid password and username of different user using the spaces WebDAV API
-    When user "Brian" requests these endpoints with "DELETE" using the password of user "Alice"
-      | endpoint                                           |
-      | /remote.php/dav/spaces/%spaceid%/textfile0.txt     |
-      | /remote.php/dav/spaces/%spaceid%/PARENT            |
-      | /remote.php/dav/spaces/%spaceid%/PARENT/parent.txt |
-    Then the HTTP status code of responses on all endpoints should be "401"
-
   @smokeTest @skipOnBruteForceProtection @issue-brute_force_protection-112
   Scenario: send DELETE requests to webDav endpoints without any authentication
     When a user requests these endpoints with "DELETE" with no authentication about user "Alice"
@@ -120,15 +76,6 @@ Feature: delete file/folder
       | /remote.php/webdav/PARENT                          |
       | /remote.php/dav/files/%username%/PARENT            |
       | /remote.php/dav/files/%username%/PARENT/parent.txt |
-    Then the HTTP status code of responses on all endpoints should be "401"
-
-  @smokeTest @skipOnBruteForceProtection @issue-brute_force_protection-112 @skipOnOcV10 @personalSpace
-  Scenario: send DELETE requests to webDav endpoints without any authentication using the spaces WebDAV API
-    When a user requests these endpoints with "DELETE" with no authentication about user "Alice"
-      | endpoint                                           |
-      | /remote.php/dav/spaces/%spaceid%/textfile0.txt     |
-      | /remote.php/dav/spaces/%spaceid%/PARENT            |
-      | /remote.php/dav/spaces/%spaceid%/PARENT/parent.txt |
     Then the HTTP status code of responses on all endpoints should be "401"
 
   @issue-ocis-reva-60
@@ -145,18 +92,6 @@ Feature: delete file/folder
       | /remote.php/dav/files/%username%/PARENT/parent.txt |
     Then the HTTP status code of responses on all endpoints should be "401"
 
-  @issue-ocis-reva-60 @skipOnOcV10 @personalSpace
-  Scenario: send DELETE requests to webDav endpoints using token authentication should not work using the spaces WebDAV API
-    Given token auth has been enforced
-    And a new browser session for "Alice" has been started
-    And the user has generated a new app password named "my-client"
-    When the user requests these endpoints with "DELETE" using the generated app password about user "Alice"
-      | endpoint                                           |
-      | /remote.php/dav/spaces/%spaceid%/textfile0.txt     |
-      | /remote.php/dav/spaces/%spaceid%/PARENT            |
-      | /remote.php/dav/spaces/%spaceid%/PARENT/parent.txt |
-    Then the HTTP status code of responses on all endpoints should be "401"
-
   @issue-ocis-reva-60
   Scenario: send DELETE requests to webDav endpoints using app password token as password
     Given token auth has been enforced
@@ -171,18 +106,6 @@ Feature: delete file/folder
       | /remote.php/dav/files/%username%/FOLDER            |
     Then the HTTP status code of responses on all endpoints should be "204"
 
-  @issue-ocis-reva-60 @skipOnOcV10 @personalSpace
-  Scenario: send DELETE requests to webDav endpoints using app password token as password using the spaces WebDAV API
-    Given token auth has been enforced
-    And a new browser session for "Alice" has been started
-    And the user has generated a new app password named "my-client"
-    When the user "Alice" requests these endpoints with "DELETE" using basic auth and generated app password about user "Alice"
-      | endpoint                                           |
-      | /remote.php/dav/spaces/%spaceid%/textfile0.txt     |
-      | /remote.php/dav/spaces/%spaceid%/PARENT            |
-      | /remote.php/dav/spaces/%spaceid%/PARENT/parent.txt |
-    Then the HTTP status code of responses on all endpoints should be "204"
-
   @skipOnOcV10
   Scenario: send DELETE requests to webDav endpoints with body as normal user
     When user "Alice" requests these endpoints with "DELETE" including body "doesnotmatter" about user "Alice"
@@ -192,13 +115,4 @@ Feature: delete file/folder
       | /remote.php/dav/files/%username%/PARENT/parent.txt |
       | /remote.php/webdav/PARENT                          |
       | /remote.php/dav/files/%username%/FOLDER            |
-    Then the HTTP status code of responses on all endpoints should be "415"
-
-  @skipOnOcV10 @personalSpace
-  Scenario: send DELETE requests to webDav endpoints with body as normal user using the spaces WebDAV API
-    When user "Alice" requests these endpoints with "DELETE" including body "doesnotmatter" about user "Alice"
-      | endpoint                                           |
-      | /remote.php/dav/spaces/%spaceid%/textfile0.txt     |
-      | /remote.php/dav/spaces/%spaceid%/PARENT/parent.txt |
-      | /remote.php/dav/spaces/%spaceid%/PARENT            |
     Then the HTTP status code of responses on all endpoints should be "415"

--- a/tests/acceptance/features/apiAuthWebDav/webDavLOCKAuth.feature
+++ b/tests/acceptance/features/apiAuthWebDav/webDavLOCKAuth.feature
@@ -23,15 +23,6 @@ Feature: LOCK file/folder
       | /remote.php/dav/files/%username%/PARENT/parent.txt |
     Then the HTTP status code of responses on all endpoints should be "401"
 
-  @smokeTest @skipOnBruteForceProtection @issue-brute_force_protection-112 @skipOnOcV10 @personalSpace
-  Scenario: send LOCK requests to webDav endpoints as normal user with wrong password using the spaces WebDAV API
-    When user "Alice" requests these endpoints with "LOCK" including body "doesnotmatter" using password "invalid" about user "Alice"
-      | endpoint                                           |
-      | /remote.php/dav/spaces/%spaceid%/textfile0.txt     |
-      | /remote.php/dav/spaces/%spaceid%/PARENT            |
-      | /remote.php/dav/spaces/%spaceid%/PARENT/parent.txt |
-    Then the HTTP status code of responses on all endpoints should be "401"
-
   @smokeTest @skipOnBruteForceProtection @issue-brute_force_protection-112
   Scenario: send LOCK requests to webDav endpoints as normal user with no password
     When user "Alice" requests these endpoints with "LOCK" including body "doesnotmatter" using password "" about user "Alice"
@@ -41,15 +32,6 @@ Feature: LOCK file/folder
       | /remote.php/webdav/PARENT                          |
       | /remote.php/dav/files/%username%/PARENT            |
       | /remote.php/dav/files/%username%/PARENT/parent.txt |
-    Then the HTTP status code of responses on all endpoints should be "401"
-
-  @smokeTest @skipOnBruteForceProtection @issue-brute_force_protection-112 @skipOnOcV10 @personalSpace
-  Scenario: send LOCK requests to webDav endpoints as normal user with no password using the spaces WebDAV API
-    When user "Alice" requests these endpoints with "LOCK" including body "doesnotmatter" using password "" about user "Alice"
-      | endpoint                                           |
-      | /remote.php/dav/spaces/%spaceid%/textfile0.txt     |
-      | /remote.php/dav/spaces/%spaceid%/PARENT            |
-      | /remote.php/dav/spaces/%spaceid%/PARENT/parent.txt |
     Then the HTTP status code of responses on all endpoints should be "401"
 
   @issue-ocis-reva-9
@@ -64,19 +46,6 @@ Feature: LOCK file/folder
       | /remote.php/dav/files/%username%/PARENT/parent.txt |
     Then the HTTP status code of responses on all endpoints should be "409"
 
-  @issue-ocis-reva-9 @skipOnOcV10 @personalSpace
-  Scenario: send LOCK requests to another user's webDav endpoints as normal user using the spaces WebDAV API
-    When user "Brian" requests these endpoints with "LOCK" to get property "d:shared" about user "Alice"
-      | endpoint                                       |
-      | /remote.php/dav/spaces/%spaceid%/textfile0.txt |
-      | /remote.php/dav/spaces/%spaceid%/PARENT        |
-    Then the HTTP status code of responses on all endpoints should be "403"
-    When user "Brian" requests these endpoints with "LOCK" to get property "d:shared" about user "Alice"
-      | endpoint                                           |
-      | /remote.php/dav/spaces/%spaceid%/PARENT/parent.txt |
-    Then the HTTP status code of responses on all endpoints should be "409"
-
-
   Scenario: send LOCK requests to webDav endpoints using invalid username but correct password
     When user "usero" requests these endpoints with "LOCK" including body "doesnotmatter" using the password of user "Alice"
       | endpoint                                           |
@@ -85,15 +54,6 @@ Feature: LOCK file/folder
       | /remote.php/webdav/PARENT                          |
       | /remote.php/dav/files/%username%/PARENT            |
       | /remote.php/dav/files/%username%/PARENT/parent.txt |
-    Then the HTTP status code of responses on all endpoints should be "401"
-
-  @skipOnOcV10 @personalSpace
-  Scenario: send LOCK requests to webDav endpoints using invalid username but correct password using the spaces WebDAV API
-    When user "usero" requests these endpoints with "LOCK" including body "doesnotmatter" using the password of user "Alice"
-      | endpoint                                           |
-      | /remote.php/dav/spaces/%spaceid%/textfile0.txt     |
-      | /remote.php/dav/spaces/%spaceid%/PARENT            |
-      | /remote.php/dav/spaces/%spaceid%/PARENT/parent.txt |
     Then the HTTP status code of responses on all endpoints should be "401"
 
 
@@ -107,15 +67,6 @@ Feature: LOCK file/folder
       | /remote.php/dav/files/%username%/PARENT/parent.txt |
     Then the HTTP status code of responses on all endpoints should be "401"
 
-  @skipOnOcV10 @personalSpace
-  Scenario: send LOCK requests to webDav endpoints using valid password and username of different user using the spaces WebDAV API
-    When user "Brian" requests these endpoints with "LOCK" including body "doesnotmatter" using the password of user "Alice"
-      | endpoint                                           |
-      | /remote.php/dav/spaces/%spaceid%/textfile0.txt     |
-      | /remote.php/dav/spaces/%spaceid%/PARENT            |
-      | /remote.php/dav/spaces/%spaceid%/PARENT/parent.txt |
-    Then the HTTP status code of responses on all endpoints should be "401"
-
   @smokeTest @skipOnBruteForceProtection @issue-brute_force_protection-112
   Scenario: send LOCK requests to webDav endpoints without any authentication
     When a user requests these endpoints with "LOCK" with body "doesnotmatter" and no authentication about user "Alice"
@@ -125,15 +76,6 @@ Feature: LOCK file/folder
       | /remote.php/webdav/PARENT                          |
       | /remote.php/dav/files/%username%/PARENT            |
       | /remote.php/dav/files/%username%/PARENT/parent.txt |
-    Then the HTTP status code of responses on all endpoints should be "401"
-
-  @smokeTest @skipOnBruteForceProtection @issue-brute_force_protection-112 @skipOnOcV10 @personalSpace
-  Scenario: send LOCK requests to webDav endpoints without any authentication using the spaces WebDAV API
-    When a user requests these endpoints with "LOCK" with body "doesnotmatter" and no authentication about user "Alice"
-      | endpoint                                           |
-      | /remote.php/dav/spaces/%spaceid%/textfile0.txt     |
-      | /remote.php/dav/spaces/%spaceid%/PARENT            |
-      | /remote.php/dav/spaces/%spaceid%/PARENT/parent.txt |
     Then the HTTP status code of responses on all endpoints should be "401"
 
   @notToImplementOnOCIS @issue-ocis-reva-37

--- a/tests/acceptance/features/apiAuthWebDav/webDavMKCOLAuth.feature
+++ b/tests/acceptance/features/apiAuthWebDav/webDavMKCOLAuth.feature
@@ -19,15 +19,6 @@ Feature: create folder using MKCOL
       | /remote.php/dav/files/%username%/PARENT/parent.txt |
     Then the HTTP status code of responses on all endpoints should be "401"
 
-  @smokeTest @skipOnBruteForceProtection @issue-brute_force_protection-112 @skipOnOcV10 @personalSpace
-  Scenario: send MKCOL requests to webDav endpoints as normal user with wrong password using the spaces WebDAV API
-    When user "Alice" requests these endpoints with "MKCOL" including body "doesnotmatter" using password "invalid" about user "Alice"
-      | endpoint                                           |
-      | /remote.php/dav/spaces/%spaceid%/textfile0.txt     |
-      | /remote.php/dav/spaces/%spaceid%/PARENT            |
-      | /remote.php/dav/spaces/%spaceid%/PARENT/parent.txt |
-    Then the HTTP status code of responses on all endpoints should be "401"
-
   @smokeTest @skipOnBruteForceProtection @issue-brute_force_protection-112
   Scenario: send MKCOL requests to webDav endpoints as normal user with no password
     When user "Alice" requests these endpoints with "MKCOL" including body "doesnotmatter" using password "" about user "Alice"
@@ -37,15 +28,6 @@ Feature: create folder using MKCOL
       | /remote.php/webdav/PARENT                          |
       | /remote.php/dav/files/%username%/PARENT            |
       | /remote.php/dav/files/%username%/PARENT/parent.txt |
-    Then the HTTP status code of responses on all endpoints should be "401"
-
-  @smokeTest @skipOnOcV10 @personalSpace @skipOnBruteForceProtection @issue-brute_force_protection-112
-  Scenario: send MKCOL requests to webDav endpoints as normal user with no password using the spaces WebDAV API
-    When user "Alice" requests these endpoints with "MKCOL" including body "doesnotmatter" using password "" about user "Alice"
-      | endpoint                                           |
-      | /remote.php/dav/spaces/%spaceid%/textfile0.txt     |
-      | /remote.php/dav/spaces/%spaceid%/PARENT            |
-      | /remote.php/dav/spaces/%spaceid%/PARENT/parent.txt |
     Then the HTTP status code of responses on all endpoints should be "401"
 
   @skipOnOcV10 @issue-ocis-5049 @issue-ocis-reva-9 @issue-ocis-reva-197
@@ -70,28 +52,6 @@ Feature: create folder using MKCOL
       | /remote.php/dav/files/non-existent-user/PARENT/parent.txt |
     Then the HTTP status code of responses on all endpoints should be "404"
 
-  @skipOnOcV10 @personalSpace @issue-ocis-reva-9 @issue-ocis-reva-197
-  Scenario: send MKCOL requests to another user's webDav endpoints as normal user using the spaces WebDAV API
-    Given user "Brian" has been created with default attributes and without skeleton files
-    When user "Brian" requests these endpoints with "MKCOL" including body "" about user "Alice"
-      | endpoint                                           |
-      | /remote.php/dav/spaces/%spaceid%/textfile0.txt     |
-      | /remote.php/dav/spaces/%spaceid%/PARENT            |
-      | /remote.php/dav/spaces/%spaceid%/does-not-exist    |
-      | /remote.php/dav/spaces/%spaceid%/PARENT/parent.txt |
-    Then the HTTP status code of responses on all endpoints should be "404"
-
-  @skipOnOcV10 @issue-ocis-5049 @personalSpace @issue-ocis-reva-9 @issue-ocis-reva-197
-  Scenario: send MKCOL requests to non-existent user's webDav endpoints as normal user using the spaces WebDAV API
-    Given user "Brian" has been created with default attributes and without skeleton files
-    When user "Brian" requests these endpoints with "MKCOL" including body "" about user "non-existent-user"
-      | endpoint                                           |
-      | /remote.php/dav/spaces/%spaceid%/textfile0.txt     |
-      | /remote.php/dav/spaces/%spaceid%/PARENT            |
-      | /remote.php/dav/spaces/%spaceid%/does-not-exist    |
-      | /remote.php/dav/spaces/%spaceid%/PARENT/parent.txt |
-    Then the HTTP status code of responses on all endpoints should be "404"
-
 
   Scenario: send MKCOL requests to webDav endpoints using invalid username but correct password
     When user "usero" requests these endpoints with "MKCOL" including body "doesnotmatter" using the password of user "Alice"
@@ -101,15 +61,6 @@ Feature: create folder using MKCOL
       | /remote.php/webdav/PARENT                          |
       | /remote.php/dav/files/%username%/PARENT            |
       | /remote.php/dav/files/%username%/PARENT/parent.txt |
-    Then the HTTP status code of responses on all endpoints should be "401"
-
-  @skipOnOcV10 @personalSpace
-  Scenario: send MKCOL requests to webDav endpoints using invalid username but correct password using the spaces WebDAV API
-    When user "usero" requests these endpoints with "MKCOL" including body "doesnotmatter" using the password of user "Alice"
-      | endpoint                                           |
-      | /remote.php/dav/spaces/%spaceid%/textfile0.txt     |
-      | /remote.php/dav/spaces/%spaceid%/PARENT            |
-      | /remote.php/dav/spaces/%spaceid%/PARENT/parent.txt |
     Then the HTTP status code of responses on all endpoints should be "401"
 
 
@@ -124,16 +75,6 @@ Feature: create folder using MKCOL
       | /remote.php/dav/files/%username%/PARENT/parent.txt |
     Then the HTTP status code of responses on all endpoints should be "401"
 
-  @skipOnOcV10 @personalSpace
-  Scenario: send MKCOL requests to webDav endpoints using valid password and username of different user using the spaces WebDAV API
-    Given user "Brian" has been created with default attributes and without skeleton files
-    When user "Brian" requests these endpoints with "MKCOL" including body "doesnotmatter" using the password of user "Alice"
-      | endpoint                                           |
-      | /remote.php/dav/spaces/%spaceid%/textfile0.txt     |
-      | /remote.php/dav/spaces/%spaceid%/PARENT            |
-      | /remote.php/dav/spaces/%spaceid%/PARENT/parent.txt |
-    Then the HTTP status code of responses on all endpoints should be "401"
-
   @smokeTest @skipOnBruteForceProtection @issue-brute_force_protection-112
   Scenario: send MKCOL requests to webDav endpoints without any authentication
     When a user requests these endpoints with "MKCOL" with body "doesnotmatter" and no authentication about user "Alice"
@@ -143,15 +84,6 @@ Feature: create folder using MKCOL
       | /remote.php/webdav/PARENT                          |
       | /remote.php/dav/files/%username%/PARENT            |
       | /remote.php/dav/files/%username%/PARENT/parent.txt |
-    Then the HTTP status code of responses on all endpoints should be "401"
-
-  @smokeTest @skipOnBruteForceProtection @issue-brute_force_protection-112 @skipOnOcV10 @personalSpace
-  Scenario: send MKCOL requests to webDav endpoints without any authentication using the spaces WebDAV API
-    When a user requests these endpoints with "MKCOL" with body "doesnotmatter" and no authentication about user "Alice"
-      | endpoint                                           |
-      | /remote.php/dav/spaces/%spaceid%/textfile0.txt     |
-      | /remote.php/dav/spaces/%spaceid%/PARENT            |
-      | /remote.php/dav/spaces/%spaceid%/PARENT/parent.txt |
     Then the HTTP status code of responses on all endpoints should be "401"
 
   @notToImplementOnOCIS @issue-ocis-reva-37

--- a/tests/acceptance/features/apiAuthWebDav/webDavMOVEAuth.feature
+++ b/tests/acceptance/features/apiAuthWebDav/webDavMOVEAuth.feature
@@ -22,15 +22,6 @@ Feature: MOVE file/folder
       | /remote.php/dav/files/%username%/PARENT/parent.txt |
     Then the HTTP status code of responses on all endpoints should be "401"
 
-  @smokeTest @skipOnBruteForceProtection @issue-brute_force_protection-112 @skipOnOcV10 @personalSpace
-  Scenario: send MOVE requests to webDav endpoints as normal user with wrong password using the spaces WebDAV API
-    When user "Alice" requests these endpoints with "MOVE" using password "invalid" about user "Alice"
-      | endpoint                                           |
-      | /remote.php/dav/spaces/%spaceid%/textfile0.txt     |
-      | /remote.php/dav/spaces/%spaceid%/PARENT            |
-      | /remote.php/dav/spaces/%spaceid%/PARENT/parent.txt |
-    Then the HTTP status code of responses on all endpoints should be "401"
-
   @smokeTest @skipOnBruteForceProtection @issue-brute_force_protection-112
   Scenario: send MOVE requests to webDav endpoints as normal user with no password
     When user "Alice" requests these endpoints with "MOVE" using password "" about user "Alice"
@@ -42,15 +33,6 @@ Feature: MOVE file/folder
       | /remote.php/dav/files/%username%/PARENT/parent.txt |
     Then the HTTP status code of responses on all endpoints should be "401"
 
-  @smokeTest @skipOnBruteForceProtection @issue-brute_force_protection-112 @skipOnOcV10 @personalSpace
-  Scenario: send MOVE requests to webDav endpoints as normal user with no password using the spaces WebDAV API
-    When user "Alice" requests these endpoints with "MOVE" using password "" about user "Alice"
-      | endpoint                                           |
-      | /remote.php/dav/spaces/%spaceid%/textfile0.txt     |
-      | /remote.php/dav/spaces/%spaceid%/PARENT            |
-      | /remote.php/dav/spaces/%spaceid%/PARENT/parent.txt |
-    Then the HTTP status code of responses on all endpoints should be "401"
-
   @issue-ocis-reva-14
   Scenario: send MOVE requests to another user's webDav endpoints as normal user
     When user "Brian" requests these endpoints with "MOVE" about user "Alice"
@@ -58,15 +40,6 @@ Feature: MOVE file/folder
       | /remote.php/dav/files/%username%/textfile0.txt     |
       | /remote.php/dav/files/%username%/PARENT            |
       | /remote.php/dav/files/%username%/PARENT/parent.txt |
-    Then the HTTP status code of responses on all endpoints should be "403"
-
-  @skipOnOcV10 @personalSpace @issue-ocis-reva-14
-  Scenario: send MOVE requests to another user's webDav endpoints as normal user using the spaces WebDAV API
-    When user "Brian" requests these endpoints with "MOVE" about user "Alice"
-      | endpoint                                           |
-      | /remote.php/dav/spaces/%spaceid%/textfile0.txt     |
-      | /remote.php/dav/spaces/%spaceid%/PARENT            |
-      | /remote.php/dav/spaces/%spaceid%/PARENT/parent.txt |
     Then the HTTP status code of responses on all endpoints should be "403"
 
 
@@ -80,15 +53,6 @@ Feature: MOVE file/folder
       | /remote.php/dav/files/%username%/PARENT/parent.txt |
     Then the HTTP status code of responses on all endpoints should be "401"
 
-  @skipOnOcV10 @personalSpace
-  Scenario: send MOVE requests to webDav endpoints using invalid username but correct password using the spaces WebDAV API
-    When user "usero" requests these endpoints with "MOVE" using the password of user "Alice"
-      | endpoint                                           |
-      | /remote.php/dav/spaces/%spaceid%/textfile0.txt     |
-      | /remote.php/dav/spaces/%spaceid%/PARENT            |
-      | /remote.php/dav/spaces/%spaceid%/PARENT/parent.txt |
-    Then the HTTP status code of responses on all endpoints should be "401"
-
 
   Scenario: send MOVE requests to webDav endpoints using valid password and username of different user
     When user "Brian" requests these endpoints with "MOVE" using the password of user "Alice"
@@ -100,15 +64,6 @@ Feature: MOVE file/folder
       | /remote.php/dav/files/%username%/PARENT/parent.txt |
     Then the HTTP status code of responses on all endpoints should be "401"
 
-  @skipOnOcV10 @personalSpace
-  Scenario: send MOVE requests to webDav endpoints using valid password and username of different user using the spaces WebDAV API
-    When user "Brian" requests these endpoints with "MOVE" using the password of user "Alice"
-      | endpoint                                           |
-      | /remote.php/dav/spaces/%spaceid%/textfile0.txt     |
-      | /remote.php/dav/spaces/%spaceid%/PARENT            |
-      | /remote.php/dav/spaces/%spaceid%/PARENT/parent.txt |
-    Then the HTTP status code of responses on all endpoints should be "401"
-
   @smokeTest @skipOnBruteForceProtection @issue-brute_force_protection-112
   Scenario: send MOVE requests to webDav endpoints without any authentication
     When a user requests these endpoints with "MOVE" with no authentication about user "Alice"
@@ -118,15 +73,6 @@ Feature: MOVE file/folder
       | /remote.php/webdav/PARENT                          |
       | /remote.php/dav/files/%username%/PARENT            |
       | /remote.php/dav/files/%username%/PARENT/parent.txt |
-    Then the HTTP status code of responses on all endpoints should be "401"
-
-  @smokeTest @skipOnBruteForceProtection @issue-brute_force_protection-112 @skipOnOcV10 @personalSpace
-  Scenario: send MOVE requests to webDav endpoints without any authentication using the spaces WebDAV API
-    When a user requests these endpoints with "MOVE" with no authentication about user "Alice"
-      | endpoint                                           |
-      | /remote.php/dav/spaces/%spaceid%/textfile0.txt     |
-      | /remote.php/dav/spaces/%spaceid%/PARENT            |
-      | /remote.php/dav/spaces/%spaceid%/PARENT/parent.txt |
     Then the HTTP status code of responses on all endpoints should be "401"
 
   @notToImplementOnOCIS @issue-ocis-reva-37
@@ -168,13 +114,4 @@ Feature: MOVE file/folder
       | /remote.php/dav/files/%username%/PARENT            |
       | /remote.php/webdav/PARENT/parent.txt               |
       | /remote.php/dav/files/%username%/PARENT/parent.txt |
-    Then the HTTP status code of responses on all endpoints should be "415"
-
-  @skipOnOcV10 @personalSpace
-  Scenario: send MOVE requests to webDav endpoints with body as normal user using the spaces WebDAV API
-    When user "Alice" requests these endpoints with "MOVE" including body "doesnotmatter" about user "Alice"
-      | endpoint                                           |
-      | /remote.php/dav/spaces/%spaceid%/textfile0.txt     |
-      | /remote.php/dav/spaces/%spaceid%/PARENT            |
-      | /remote.php/dav/spaces/%spaceid%/PARENT/parent.txt |
     Then the HTTP status code of responses on all endpoints should be "415"

--- a/tests/acceptance/features/apiAuthWebDav/webDavPOSTAuth.feature
+++ b/tests/acceptance/features/apiAuthWebDav/webDavPOSTAuth.feature
@@ -23,15 +23,6 @@ Feature: get file info using POST
       | /remote.php/dav/files/%username%/PARENT/parent.txt |
     Then the HTTP status code of responses on all endpoints should be "401"
 
-  @smokeTest @skipOnBruteForceProtection @issue-brute_force_protection-112 @skipOnOcV10 @personalSpace
-  Scenario: send POST requests to webDav endpoints as normal user with wrong password using the spaces WebDAV API
-    When user "Alice" requests these endpoints with "POST" including body "doesnotmatter" using password "invalid" about user "Alice"
-      | endpoint                                           |
-      | /remote.php/dav/spaces/%spaceid%/textfile0.txt     |
-      | /remote.php/dav/spaces/%spaceid%/PARENT            |
-      | /remote.php/dav/spaces/%spaceid%/PARENT/parent.txt |
-    Then the HTTP status code of responses on all endpoints should be "401"
-
   @smokeTest @skipOnBruteForceProtection @issue-brute_force_protection-112
   Scenario: send POST requests to webDav endpoints as normal user with no password
     When user "Alice" requests these endpoints with "POST" including body "doesnotmatter" using password "" about user "Alice"
@@ -43,15 +34,6 @@ Feature: get file info using POST
       | /remote.php/dav/files/%username%/PARENT/parent.txt |
     Then the HTTP status code of responses on all endpoints should be "401"
 
-  @smokeTest @skipOnBruteForceProtection @issue-brute_force_protection-112 @skipOnOcV10 @personalSpace
-  Scenario: send POST requests to webDav endpoints as normal user with no password  using the spaces WebDAV API
-    When user "Alice" requests these endpoints with "POST" including body "doesnotmatter" using password "" about user "Alice"
-      | endpoint                                           |
-      | /remote.php/dav/spaces/%spaceid%/textfile0.txt     |
-      | /remote.php/dav/spaces/%spaceid%/PARENT            |
-      | /remote.php/dav/spaces/%spaceid%/PARENT/parent.txt |
-    Then the HTTP status code of responses on all endpoints should be "401"
-
   @issue-ocis-reva-179
   Scenario: send POST requests to another user's webDav endpoints as normal user
     When user "Brian" requests these endpoints with "POST" including body "doesnotmatter" about user "Alice"
@@ -59,15 +41,6 @@ Feature: get file info using POST
       | /remote.php/dav/files/%username%/textfile1.txt     |
       | /remote.php/dav/files/%username%/PARENT            |
       | /remote.php/dav/files/%username%/PARENT/parent.txt |
-    Then the HTTP status code of responses on all endpoints should be "404"
-
-  @skipOnOcV10 @personalSpace @issue-ocis-reva-179
-  Scenario: send POST requests to another user's webDav endpoints as normal user using the spaces WebDAV API
-    When user "Brian" requests these endpoints with "POST" including body "doesnotmatter" about user "Alice"
-      | endpoint                                           |
-      | /remote.php/dav/spaces/%spaceid%/textfile0.txt     |
-      | /remote.php/dav/spaces/%spaceid%/PARENT            |
-      | /remote.php/dav/spaces/%spaceid%/PARENT/parent.txt |
     Then the HTTP status code of responses on all endpoints should be "404"
 
 
@@ -81,15 +54,6 @@ Feature: get file info using POST
       | /remote.php/dav/files/%username%/PARENT/parent.txt |
     Then the HTTP status code of responses on all endpoints should be "401"
 
-  @skipOnOcV10 @personalSpace
-  Scenario: send POST requests to webDav endpoints using invalid username but correct password using the spaces WebDAV API
-    When user "usero" requests these endpoints with "POST" including body "doesnotmatter" using the password of user "Alice"
-      | endpoint                                           |
-      | /remote.php/dav/spaces/%spaceid%/textfile0.txt     |
-      | /remote.php/dav/spaces/%spaceid%/PARENT            |
-      | /remote.php/dav/spaces/%spaceid%/PARENT/parent.txt |
-    Then the HTTP status code of responses on all endpoints should be "401"
-
 
   Scenario: send POST requests to webDav endpoints using valid password and username of different user
     When user "Brian" requests these endpoints with "POST" including body "doesnotmatter" using the password of user "Alice"
@@ -101,15 +65,6 @@ Feature: get file info using POST
       | /remote.php/dav/files/%username%/PARENT/parent.txt |
     Then the HTTP status code of responses on all endpoints should be "401"
 
-  @skipOnOcV10 @personalSpace
-  Scenario: send POST requests to webDav endpoints using valid password and username of different user using the spaces WebDAV API
-    When user "Brian" requests these endpoints with "POST" including body "doesnotmatter" using the password of user "Alice"
-      | endpoint                                           |
-      | /remote.php/dav/spaces/%spaceid%/textfile0.txt     |
-      | /remote.php/dav/spaces/%spaceid%/PARENT            |
-      | /remote.php/dav/spaces/%spaceid%/PARENT/parent.txt |
-    Then the HTTP status code of responses on all endpoints should be "401"
-
   @smokeTest @skipOnBruteForceProtection @issue-brute_force_protection-112
   Scenario: send POST requests to webDav endpoints without any authentication
     When a user requests these endpoints with "POST" with body "doesnotmatter" and no authentication about user "Alice"
@@ -119,15 +74,6 @@ Feature: get file info using POST
       | /remote.php/webdav/PARENT                          |
       | /remote.php/dav/files/%username%/PARENT            |
       | /remote.php/dav/files/%username%/PARENT/parent.txt |
-    Then the HTTP status code of responses on all endpoints should be "401"
-
-  @smokeTest @skipOnBruteForceProtection @issue-brute_force_protection-112 @skipOnOcV10 @personalSpace
-  Scenario: send POST requests to webDav endpoints without any authentication using the spaces WebDAV API
-    When a user requests these endpoints with "POST" with body "doesnotmatter" and no authentication about user "Alice"
-      | endpoint                                           |
-      | /remote.php/dav/spaces/%spaceid%/textfile0.txt     |
-      | /remote.php/dav/spaces/%spaceid%/PARENT            |
-      | /remote.php/dav/spaces/%spaceid%/PARENT/parent.txt |
     Then the HTTP status code of responses on all endpoints should be "401"
 
   @notToImplementOnOCIS @issue-ocis-reva-37

--- a/tests/acceptance/features/apiAuthWebDav/webDavPROPFINDAuth.feature
+++ b/tests/acceptance/features/apiAuthWebDav/webDavPROPFINDAuth.feature
@@ -22,15 +22,6 @@ Feature: get file info using PROPFIND
       | /remote.php/dav/files/%username%/PARENT/parent.txt |
     Then the HTTP status code of responses on all endpoints should be "401"
 
-  @smokeTest @skipOnBruteForceProtection @issue-brute_force_protection-112 @skipOnOcV10 @personalSpace
-  Scenario: send PROPFIND requests to webDav endpoints as normal user with wrong password using the spaces WebDAV API
-    When user "Alice" requests these endpoints with "PROPFIND" including body "doesnotmatter" using password "invalid" about user "Alice"
-      | endpoint                                           |
-      | /remote.php/dav/spaces/%spaceid%/textfile0.txt     |
-      | /remote.php/dav/spaces/%spaceid%/PARENT            |
-      | /remote.php/dav/spaces/%spaceid%/PARENT/parent.txt |
-    Then the HTTP status code of responses on all endpoints should be "401"
-
   @smokeTest @skipOnBruteForceProtection @issue-brute_force_protection-112
   Scenario: send PROPFIND requests to webDav endpoints as normal user with no password
     When user "Alice" requests these endpoints with "PROPFIND" including body "doesnotmatter" using password "" about user "Alice"
@@ -42,15 +33,6 @@ Feature: get file info using PROPFIND
       | /remote.php/dav/files/%username%/PARENT/parent.txt |
     Then the HTTP status code of responses on all endpoints should be "401"
 
-  @smokeTest @skipOnBruteForceProtection @issue-brute_force_protection-112 @skipOnOcV10 @personalSpace
-  Scenario: send PROPFIND requests to webDav endpoints as normal user with no password using the spaces WebDAV API
-    When user "Alice" requests these endpoints with "PROPFIND" including body "doesnotmatter" using password "" about user "Alice"
-      | endpoint                                           |
-      | /remote.php/dav/spaces/%spaceid%/textfile0.txt     |
-      | /remote.php/dav/spaces/%spaceid%/PARENT            |
-      | /remote.php/dav/spaces/%spaceid%/PARENT/parent.txt |
-    Then the HTTP status code of responses on all endpoints should be "401"
-
   @issue-ocis-reva-9
   Scenario: send PROPFIND requests to another user's webDav endpoints as normal user
     When user "Brian" requests these endpoints with "PROPFIND" to get property "d:getetag" about user "Alice"
@@ -58,15 +40,6 @@ Feature: get file info using PROPFIND
       | /remote.php/dav/files/%username%/textfile0.txt     |
       | /remote.php/dav/files/%username%/PARENT            |
       | /remote.php/dav/files/%username%/PARENT/parent.txt |
-    Then the HTTP status code of responses on all endpoints should be "404"
-
-  @skipOnOcV10 @personalSpace @issue-ocis-reva-9
-  Scenario: send PROPFIND requests to another user's webDav endpoints as normal user using the spaces WebDAV API
-    When user "Brian" requests these endpoints with "PROPFIND" to get property "d:getetag" about user "Alice"
-      | endpoint                                           |
-      | /remote.php/dav/spaces/%spaceid%/textfile0.txt     |
-      | /remote.php/dav/spaces/%spaceid%/PARENT            |
-      | /remote.php/dav/spaces/%spaceid%/PARENT/parent.txt |
     Then the HTTP status code of responses on all endpoints should be "404"
 
 
@@ -80,15 +53,6 @@ Feature: get file info using PROPFIND
       | /remote.php/dav/files/%username%/PARENT/parent.txt |
     Then the HTTP status code of responses on all endpoints should be "401"
 
-  @skipOnOcV10 @personalSpace
-  Scenario: send PROPFIND requests to webDav endpoints using invalid username but correct password using the spaces WebDAV API
-    When user "usero" requests these endpoints with "PROPFIND" including body "doesnotmatter" using the password of user "Alice"
-      | endpoint                                           |
-      | /remote.php/dav/spaces/%spaceid%/textfile0.txt     |
-      | /remote.php/dav/spaces/%spaceid%/PARENT            |
-      | /remote.php/dav/spaces/%spaceid%/PARENT/parent.txt |
-    Then the HTTP status code of responses on all endpoints should be "401"
-
 
   Scenario: send PROPFIND requests to webDav endpoints using valid password and username of different user
     When user "Brian" requests these endpoints with "PROPFIND" including body "doesnotmatter" using the password of user "Alice"
@@ -100,15 +64,6 @@ Feature: get file info using PROPFIND
       | /remote.php/dav/files/%username%/PARENT/parent.txt |
     Then the HTTP status code of responses on all endpoints should be "401"
 
-  @skipOnOcV10 @personalSpace
-  Scenario: send PROPFIND requests to webDav endpoints using valid password and username of different user using the spaces WebDAV API
-    When user "Brian" requests these endpoints with "PROPFIND" including body "doesnotmatter" using the password of user "Alice"
-      | endpoint                                           |
-      | /remote.php/dav/spaces/%spaceid%/textfile0.txt     |
-      | /remote.php/dav/spaces/%spaceid%/PARENT            |
-      | /remote.php/dav/spaces/%spaceid%/PARENT/parent.txt |
-    Then the HTTP status code of responses on all endpoints should be "401"
-
   @smokeTest @skipOnBruteForceProtection @issue-brute_force_protection-112
   Scenario: send PROPFIND requests to webDav endpoints without any authentication
     When a user requests these endpoints with "PROPFIND" with body "doesnotmatter" and no authentication about user "Alice"
@@ -118,15 +73,6 @@ Feature: get file info using PROPFIND
       | /remote.php/webdav/PARENT                          |
       | /remote.php/dav/files/%username%/PARENT            |
       | /remote.php/dav/files/%username%/PARENT/parent.txt |
-    Then the HTTP status code of responses on all endpoints should be "401"
-
-  @smokeTest @skipOnBruteForceProtection @issue-brute_force_protection-112 @skipOnOcV10 @personalSpace
-  Scenario: send PROPFIND requests to webDav endpoints without any authentication using the spaces WebDAV API
-    When a user requests these endpoints with "PROPFIND" with body "doesnotmatter" and no authentication about user "Alice"
-      | endpoint                                           |
-      | /remote.php/dav/spaces/%spaceid%/textfile0.txt     |
-      | /remote.php/dav/spaces/%spaceid%/PARENT            |
-      | /remote.php/dav/spaces/%spaceid%/PARENT/parent.txt |
     Then the HTTP status code of responses on all endpoints should be "401"
 
   @notToImplementOnOCIS @issue-ocis-reva-37

--- a/tests/acceptance/features/apiAuthWebDav/webDavPROPPATCHAuth.feature
+++ b/tests/acceptance/features/apiAuthWebDav/webDavPROPPATCHAuth.feature
@@ -23,15 +23,6 @@ Feature: PROPPATCH file/folder
       | /remote.php/dav/files/%username%/PARENT/parent.txt |
     Then the HTTP status code of responses on all endpoints should be "401"
 
-  @smokeTest @skipOnBruteForceProtection @issue-brute_force_protection-112 @skipOnOcV10 @personalSpace
-  Scenario: send PROPPATCH requests to webDav endpoints as normal user with wrong password using the spaces WebDAV API
-    When user "Alice" requests these endpoints with "PROPPATCH" including body "doesnotmatter" using password "invalid" about user "Alice"
-      | endpoint                                           |
-      | /remote.php/dav/spaces/%spaceid%/textfile0.txt     |
-      | /remote.php/dav/spaces/%spaceid%/PARENT            |
-      | /remote.php/dav/spaces/%spaceid%/PARENT/parent.txt |
-    Then the HTTP status code of responses on all endpoints should be "401"
-
   @smokeTest @skipOnBruteForceProtection @issue-brute_force_protection-112
   Scenario: send PROPPATCH requests to webDav endpoints as normal user with no password
     When user "Alice" requests these endpoints with "PROPPATCH" including body "doesnotmatter" using password "" about user "Alice"
@@ -43,15 +34,6 @@ Feature: PROPPATCH file/folder
       | /remote.php/dav/files/%username%/PARENT/parent.txt |
     Then the HTTP status code of responses on all endpoints should be "401"
 
-  @smokeTest @skipOnBruteForceProtection @issue-brute_force_protection-112 @skipOnOcV10 @personalSpace
-  Scenario: send PROPPATCH requests to webDav endpoints as normal user with no password using the spaces WebDAV API
-    When user "Alice" requests these endpoints with "PROPPATCH" including body "doesnotmatter" using password "" about user "Alice"
-      | endpoint                                           |
-      | /remote.php/dav/spaces/%spaceid%/textfile0.txt     |
-      | /remote.php/dav/spaces/%spaceid%/PARENT            |
-      | /remote.php/dav/spaces/%spaceid%/PARENT/parent.txt |
-    Then the HTTP status code of responses on all endpoints should be "401"
-
   @issue-ocis-reva-9 @issue-ocis-reva-197
   Scenario: send PROPPATCH requests to another user's webDav endpoints as normal user
     When user "Brian" requests these endpoints with "PROPPATCH" to set property "favorite" about user "Alice"
@@ -59,15 +41,6 @@ Feature: PROPPATCH file/folder
       | /remote.php/dav/files/%username%/textfile0.txt     |
       | /remote.php/dav/files/%username%/PARENT            |
       | /remote.php/dav/files/%username%/PARENT/parent.txt |
-    Then the HTTP status code of responses on all endpoints should be "404"
-
-  @issue-ocis-reva-9 @issue-ocis-reva-197 @skipOnOcV10 @personalSpace
-  Scenario: send PROPPATCH requests to another user's webDav endpoints as normal user using the spaces WebDAV API
-    When user "Brian" requests these endpoints with "PROPPATCH" to set property "favorite" about user "Alice"
-      | endpoint                                           |
-      | /remote.php/dav/spaces/%spaceid%/textfile0.txt     |
-      | /remote.php/dav/spaces/%spaceid%/PARENT            |
-      | /remote.php/dav/spaces/%spaceid%/PARENT/parent.txt |
     Then the HTTP status code of responses on all endpoints should be "404"
 
 
@@ -81,15 +54,6 @@ Feature: PROPPATCH file/folder
       | /remote.php/dav/files/%username%/PARENT/parent.txt |
     Then the HTTP status code of responses on all endpoints should be "401"
 
-  @skipOnOcV10 @personalSpace
-  Scenario: send PROPPATCH requests to webDav endpoints using invalid username but correct password using the spaces WebDAV API
-    When user "usero" requests these endpoints with "PROPPATCH" including body "doesnotmatter" using the password of user "Alice"
-      | endpoint                                           |
-      | /remote.php/dav/spaces/%spaceid%/textfile0.txt     |
-      | /remote.php/dav/spaces/%spaceid%/PARENT            |
-      | /remote.php/dav/spaces/%spaceid%/PARENT/parent.txt |
-    Then the HTTP status code of responses on all endpoints should be "401"
-
 
   Scenario: send PROPPATCH requests to webDav endpoints using valid password and username of different user
     When user "Brian" requests these endpoints with "PROPPATCH" including body "doesnotmatter" using the password of user "Alice"
@@ -101,15 +65,6 @@ Feature: PROPPATCH file/folder
       | /remote.php/dav/files/%username%/PARENT/parent.txt |
     Then the HTTP status code of responses on all endpoints should be "401"
 
-  @skipOnOcV10 @personalSpace
-  Scenario: send PROPPATCH requests to webDav endpoints using valid password and username of different user using the spaces WebDAV API
-    When user "Brian" requests these endpoints with "PROPPATCH" including body "doesnotmatter" using the password of user "Alice"
-      | endpoint                                           |
-      | /remote.php/dav/spaces/%spaceid%/textfile0.txt     |
-      | /remote.php/dav/spaces/%spaceid%/PARENT            |
-      | /remote.php/dav/spaces/%spaceid%/PARENT/parent.txt |
-    Then the HTTP status code of responses on all endpoints should be "401"
-
   @smokeTest @skipOnBruteForceProtection @issue-brute_force_protection-112
   Scenario: send PROPPATCH requests to webDav endpoints without any authentication
     When a user requests these endpoints with "PROPPATCH" with body "doesnotmatter" and no authentication about user "Alice"
@@ -119,15 +74,6 @@ Feature: PROPPATCH file/folder
       | /remote.php/webdav/PARENT                          |
       | /remote.php/dav/files/%username%/PARENT            |
       | /remote.php/dav/files/%username%/PARENT/parent.txt |
-    Then the HTTP status code of responses on all endpoints should be "401"
-
-  @smokeTest @skipOnBruteForceProtection @issue-brute_force_protection-112 @skipOnOcV10 @personalSpace
-  Scenario: send PROPPATCH requests to webDav endpoints without any authentication using the spaces WebDAV API
-    When a user requests these endpoints with "PROPPATCH" with body "doesnotmatter" and no authentication about user "Alice"
-      | endpoint                                           |
-      | /remote.php/dav/spaces/%spaceid%/textfile0.txt     |
-      | /remote.php/dav/spaces/%spaceid%/PARENT            |
-      | /remote.php/dav/spaces/%spaceid%/PARENT/parent.txt |
     Then the HTTP status code of responses on all endpoints should be "401"
 
   @notToImplementOnOCIS @issue-ocis-reva-37

--- a/tests/acceptance/features/apiAuthWebDav/webDavPUTAuth.feature
+++ b/tests/acceptance/features/apiAuthWebDav/webDavPUTAuth.feature
@@ -23,15 +23,6 @@ Feature: get file info using PUT
       | /remote.php/dav/files/%username%/PARENT/parent.txt |
     Then the HTTP status code of responses on all endpoints should be "401"
 
-  @smokeTest @skipOnBruteForceProtection @issue-brute_force_protection-112 @skipOnOcV10 @personalSpace
-  Scenario: send PUT requests to webDav endpoints as normal user with wrong password using the spaces WebDAV API
-    When user "Alice" requests these endpoints with "PUT" including body "doesnotmatter" using password "invalid" about user "Alice"
-      | endpoint                                           |
-      | /remote.php/dav/spaces/%spaceid%/textfile0.txt     |
-      | /remote.php/dav/spaces/%spaceid%/PARENT            |
-      | /remote.php/dav/spaces/%spaceid%/PARENT/parent.txt |
-    Then the HTTP status code of responses on all endpoints should be "401"
-
   @smokeTest @skipOnBruteForceProtection @issue-brute_force_protection-112
   Scenario: send PUT requests to webDav endpoints as normal user with no password
     When user "Alice" requests these endpoints with "PUT" including body "doesnotmatter" using password "" about user "Alice"
@@ -41,15 +32,6 @@ Feature: get file info using PUT
       | /remote.php/webdav/PARENT                          |
       | /remote.php/dav/files/%username%/PARENT            |
       | /remote.php/dav/files/%username%/PARENT/parent.txt |
-    Then the HTTP status code of responses on all endpoints should be "401"
-
-  @smokeTest @skipOnBruteForceProtection @issue-brute_force_protection-112 @skipOnOcV10 @personalSpace
-  Scenario: send PUT requests to webDav endpoints as normal user with no password using the spaces WebDAV API
-    When user "Alice" requests these endpoints with "PUT" including body "doesnotmatter" using password "" about user "Alice"
-      | endpoint                                           |
-      | /remote.php/dav/spaces/%spaceid%/textfile0.txt     |
-      | /remote.php/dav/spaces/%spaceid%/PARENT            |
-      | /remote.php/dav/spaces/%spaceid%/PARENT/parent.txt |
     Then the HTTP status code of responses on all endpoints should be "401"
 
   @skipOnOcV10
@@ -64,18 +46,6 @@ Feature: get file info using PUT
       | /remote.php/dav/files/%username%/PARENT/parent.txt |
     Then the HTTP status code of responses on all endpoints should be "403"
 
-  @skipOnOcV10 @personalSpace
-  Scenario: send PUT requests to another user's webDav endpoints as normal user using the spaces WebDAV API
-    When user "Brian" requests these endpoints with "PUT" including body "doesnotmatter" about user "Alice"
-      | endpoint                                       |
-      | /remote.php/dav/spaces/%spaceid%/textfile0.txt |
-      | /remote.php/dav/spaces/%spaceid%/PARENT        |
-    Then the HTTP status code of responses on all endpoints should be "403"
-    When user "Brian" requests these endpoints with "PUT" including body "doesnotmatter" about user "Alice"
-      | endpoint                                           |
-      | /remote.php/dav/spaces/%spaceid%/PARENT/parent.txt |
-    Then the HTTP status code of responses on all endpoints should be "403"
-
 
   Scenario: send PUT requests to webDav endpoints using invalid username but correct password
     When user "usero" requests these endpoints with "PUT" including body "doesnotmatter" using the password of user "Alice"
@@ -85,15 +55,6 @@ Feature: get file info using PUT
       | /remote.php/webdav/PARENT                          |
       | /remote.php/dav/files/%username%/PARENT            |
       | /remote.php/dav/files/%username%/PARENT/parent.txt |
-    Then the HTTP status code of responses on all endpoints should be "401"
-
-  @skipOnOcV10 @personalSpace
-  Scenario: send PUT requests to webDav endpoints using invalid username but correct password using the spaces WebDAV API
-    When user "usero" requests these endpoints with "PUT" including body "doesnotmatter" using the password of user "Alice"
-      | endpoint                                           |
-      | /remote.php/dav/spaces/%spaceid%/textfile0.txt     |
-      | /remote.php/dav/spaces/%spaceid%/PARENT            |
-      | /remote.php/dav/spaces/%spaceid%/PARENT/parent.txt |
     Then the HTTP status code of responses on all endpoints should be "401"
 
 
@@ -107,15 +68,6 @@ Feature: get file info using PUT
       | /remote.php/dav/files/%username%/PARENT/parent.txt |
     Then the HTTP status code of responses on all endpoints should be "401"
 
-  @skipOnOcV10 @personalSpace
-  Scenario: send PUT requests to webDav endpoints using valid password and username of different user using the spaces WebDAV API
-    When user "Brian" requests these endpoints with "PUT" including body "doesnotmatter" using the password of user "Alice"
-      | endpoint                                           |
-      | /remote.php/dav/spaces/%spaceid%/textfile0.txt     |
-      | /remote.php/dav/spaces/%spaceid%/PARENT            |
-      | /remote.php/dav/spaces/%spaceid%/PARENT/parent.txt |
-    Then the HTTP status code of responses on all endpoints should be "401"
-
   @smokeTest @skipOnBruteForceProtection @issue-brute_force_protection-112
   Scenario: send PUT requests to webDav endpoints without any authentication
     When a user requests these endpoints with "PUT" with body "doesnotmatter" and no authentication about user "Alice"
@@ -125,15 +77,6 @@ Feature: get file info using PUT
       | /remote.php/webdav/PARENT                          |
       | /remote.php/dav/files/%username%/PARENT            |
       | /remote.php/dav/files/%username%/PARENT/parent.txt |
-    Then the HTTP status code of responses on all endpoints should be "401"
-
-  @smokeTest @skipOnBruteForceProtection @issue-brute_force_protection-112 @skipOnOcV10 @personalSpace
-  Scenario: send PUT requests to webDav endpoints without any authentication using the spaces WebDAV API
-    When a user requests these endpoints with "PUT" with body "doesnotmatter" and no authentication about user "Alice"
-      | endpoint                                           |
-      | /remote.php/dav/spaces/%spaceid%/textfile0.txt     |
-      | /remote.php/dav/spaces/%spaceid%/PARENT            |
-      | /remote.php/dav/spaces/%spaceid%/PARENT/parent.txt |
     Then the HTTP status code of responses on all endpoints should be "401"
 
   @notToImplementOnOCIS @issue-ocis-reva-37

--- a/tests/acceptance/features/apiAuthWebDav/webDavSpecialURLs.feature
+++ b/tests/acceptance/features/apiAuthWebDav/webDavSpecialURLs.feature
@@ -20,16 +20,6 @@ Feature: make webdav request with special urls
       | //remote.php/dav//files/%username%//FOLDER          |
     Then the HTTP status code of responses on all endpoints should be "204"
 
-  @skipOnOcV10 @personalSpace
-  Scenario: send DELETE requests to webDav endpoints with 2 slashes using the spaces WebDAV API
-    When user "Alice" requests these endpoints with "DELETE" using password "%regular%" about user "Alice"
-      | endpoint                                             |
-      | //remote.php/dav/spaces/%spaceid%/textfile0.txt      |
-      | //remote.php//dav/spaces/%spaceid%/PARENT/parent.txt |
-      | /remote.php//dav/spaces/%spaceid%/PARENT             |
-      | //remote.php/dav//spaces/%spaceid%//FOLDER           |
-    Then the HTTP status code of responses on all endpoints should be "204"
-
 
   Scenario: send GET requests to webDav endpoints with 2 slashes
     When user "Alice" requests these endpoints with "GET" using password "%regular%" about user "Alice"
@@ -41,16 +31,6 @@ Feature: make webdav request with special urls
       | //remote.php/dav//files/%username%//FOLDER          |
     Then the HTTP status code of responses on all endpoints should be "200"
 
-  @skipOnOcV10 @personalSpace
-  Scenario: send GET requests to webDav endpoints with 2 slashes using the spaces WebDAV API
-    When user "Alice" requests these endpoints with "GET" using password "%regular%" about user "Alice"
-      | endpoint                                             |
-      | //remote.php/dav/spaces/%spaceid%/textfile0.txt      |
-      | //remote.php//dav/spaces/%spaceid%/PARENT/parent.txt |
-      | /remote.php//dav/spaces/%spaceid%/PARENT             |
-      | //remote.php/dav//spaces/%spaceid%//FOLDER           |
-    Then the HTTP status code of responses on all endpoints should be "200"
-
 
   Scenario: send LOCK requests to webDav endpoints with 2 slashes
     When the user "Alice" requests these endpoints with "LOCK" to get property "d:shared" with password "%regular%" about user "Alice"
@@ -60,16 +40,6 @@ Feature: make webdav request with special urls
       | /remote.php//dav/files/%username%/PARENT/parent.txt |
       | /remote.php//webdav/PARENT                          |
       | //remote.php/dav//files/%username%//FOLDER          |
-    Then the HTTP status code of responses on all endpoints should be "200"
-
-  @skipOnOcV10 @personalSpace
-  Scenario: send LOCK requests to webDav endpoints with 2 slashes using the spaces WebDAV API
-    When the user "Alice" requests these endpoints with "LOCK" to get property "d:shared" with password "%regular%" about user "Alice"
-      | endpoint                                             |
-      | //remote.php/dav/spaces/%spaceid%/textfile0.txt      |
-      | //remote.php//dav/spaces/%spaceid%/PARENT/parent.txt |
-      | /remote.php//dav/spaces/%spaceid%/PARENT             |
-      | //remote.php/dav//spaces/%spaceid%//FOLDER           |
     Then the HTTP status code of responses on all endpoints should be "200"
 
 
@@ -84,18 +54,6 @@ Feature: make webdav request with special urls
       | /remote.php/dav//files/%username%/PARENT6  |
     Then the HTTP status code of responses on all endpoints should be "201"
 
-  @skipOnOcV10 @personalSpace
-  Scenario: send MKCOL requests to webDav endpoints with 2 slashes using the spaces WebDAV API
-    When user "Alice" requests these endpoints with "MKCOL" using password "%regular%" about user "Alice"
-      | endpoint                                   |
-      | //remote.php/dav/spaces/%spaceid%/PARENT1  |
-      | /remote.php//dav/spaces/%spaceid%/PARENT2  |
-      | //remote.php//dav/spaces/%spaceid%/PARENT3 |
-      | //remote.php/dav//spaces/%spaceid%/PARENT4 |
-      | /remote.php/dav/spaces/%spaceid%//PARENT5  |
-      | /remote.php/dav//spaces/%spaceid%/PARENT6  |
-    Then the HTTP status code of responses on all endpoints should be "201"
-
 
   Scenario: send MOVE requests to webDav endpoints with 2 slashes
     When user "Alice" requests these endpoints with "MOVE" using password "%regular%" about user "Alice"
@@ -105,16 +63,6 @@ Feature: make webdav request with special urls
       | /remote.php/webdav//PARENT                           | /remote.php/webdav/PARENT1                           |
       | //remote.php/dav/files/%username%//PARENT1           | /remote.php/dav/files/%username%/PARENT2             |
       | /remote.php/dav//files/%username%/PARENT2/parent.txt | /remote.php/dav/files/%username%/PARENT2/parent1.txt |
-    Then the HTTP status code of responses on all endpoints should be "201"
-
-  @skipOnOcV10 @personalSpace
-  Scenario: send MOVE requests to webDav endpoints with 2 slashes using the spaces WebDAV API
-    When user "Alice" requests these endpoints with "MOVE" using password "%regular%" about user "Alice"
-      | endpoint                                             | destination                                          |
-      | /remote.php//dav/spaces/%spaceid%/textfile1.txt      | /remote.php/dav/spaces/%spaceid%/textfileOne.txt     |
-      | /remote.php/dav//spaces/%spaceid%/PARENT             | /remote.php/dav/spaces/%spaceid%/PARENT1             |
-      | //remote.php/dav/spaces/%spaceid%//PARENT1           | /remote.php/dav/spaces/%spaceid%/PARENT2             |
-      | //remote.php/dav/spaces/%spaceid%/PARENT2/parent.txt | /remote.php/dav/spaces/%spaceid%/PARENT2/parent1.txt |
     Then the HTTP status code of responses on all endpoints should be "201"
 
 
@@ -128,16 +76,6 @@ Feature: make webdav request with special urls
       | //remote.php/dav//files/%username%//FOLDER          |
     Then the HTTP status code of responses on all endpoints should be "500" or "501"
 
-  @skipOnOcV10 @personalSpace
-  Scenario: send POST requests to webDav endpoints with 2 slashes using the spaces WebDAV API
-    When user "Alice" requests these endpoints with "POST" including body "doesnotmatter" using password "%regular%" about user "Alice"
-      | endpoint                                            |
-      | //remote.php//dav/spaces/%spaceid%/textfile1.txt    |
-      | /remote.php//dav/spaces/%spaceid%/PARENT/parent.txt |
-      | /remote.php//dav/spaces/%spaceid%/PARENT            |
-      | //remote.php/dav//spaces/%spaceid%//FOLDER          |
-    Then the HTTP status code of responses on all endpoints should be "500" or "501"
-
 
   Scenario: send PROPFIND requests to webDav endpoints with 2 slashes
     When the user "Alice" requests these endpoints with "PROPFIND" to get property "d:href" with password "%regular%" about user "Alice"
@@ -147,16 +85,6 @@ Feature: make webdav request with special urls
       | /remote.php//dav/files/%username%/PARENT/parent.txt |
       | /remote.php//webdav/PARENT                          |
       | //remote.php/dav//files/%username%//FOLDER           |
-    Then the HTTP status code of responses on all endpoints should be "207"
-
-  @skipOnOcV10 @personalSpace
-  Scenario: send PROPFIND requests to webDav endpoints with 2 slashes using the spaces WebDAV API
-    When the user "Alice" requests these endpoints with "PROPFIND" to get property "d:href" with password "%regular%" about user "Alice"
-      | endpoint                                            |
-      | //remote.php//dav/spaces/%spaceid%/textfile1.txt    |
-      | /remote.php//dav/spaces/%spaceid%/PARENT/parent.txt |
-      | /remote.php//dav/spaces/%spaceid%/PARENT            |
-      | //remote.php/dav//spaces/%spaceid%//FOLDER          |
     Then the HTTP status code of responses on all endpoints should be "207"
 
 
@@ -170,16 +98,6 @@ Feature: make webdav request with special urls
       | //remote.php/dav//files/%username%//FOLDER           |
     Then the HTTP status code of responses on all endpoints should be "207"
 
-  @skipOnOcV10 @personalSpace
-  Scenario: send PROPPATCH requests to webDav endpoints with 2 slashes using the spaces WebDAV API
-    When the user "Alice" requests these endpoints with "PROPPATCH" to set property "d:getlastmodified" with password "%regular%" about user "Alice"
-      | endpoint                                            |
-      | //remote.php//dav/spaces/%spaceid%/textfile1.txt    |
-      | /remote.php//dav/spaces/%spaceid%/PARENT/parent.txt |
-      | /remote.php//dav/spaces/%spaceid%/PARENT            |
-      | //remote.php/dav//spaces/%spaceid%//FOLDER          |
-    Then the HTTP status code of responses on all endpoints should be "207"
-
 
   Scenario: send PUT requests to webDav endpoints with 2 slashes
     When user "Alice" requests these endpoints with "PUT" including body "doesnotmatter" using password "%regular%" about user "Alice"
@@ -189,15 +107,4 @@ Feature: make webdav request with special urls
       | //remote.php//dav/files/%username%/textfile1.txt     |
       | /remote.php/dav/files/%username%/textfile7.txt       |
       | //remote.php/dav/files/%username%/PARENT//parent.txt |
-    Then the HTTP status code of responses on all endpoints should be "204" or "201"
-
-  @skipOnOcV10 @personalSpace
-  Scenario: send PUT requests to webDav endpoints with 2 slashes using the spaces WebDAV API
-    When user "Alice" requests these endpoints with "PUT" including body "doesnotmatter" using password "%regular%" about user "Alice"
-      | endpoint                                             |
-      | //remote.php/dav/spaces/%spaceid%/textfile0.txt      |
-      | /remote.php//dav/spaces/%spaceid%/textfile1.txt      |
-      | //remote.php//dav/spaces/%spaceid%/textfile1.txt     |
-      | /remote.php/dav/spaces/%spaceid%/textfile7.txt       |
-      | //remote.php/dav/spaces/%spaceid%/PARENT//parent.txt |
     Then the HTTP status code of responses on all endpoints should be "204" or "201"

--- a/tests/acceptance/features/apiProvisioning-v1/resetUserPassword.feature
+++ b/tests/acceptance/features/apiProvisioning-v1/resetUserPassword.feature
@@ -93,12 +93,6 @@ Feature: reset user password
       | ⌚️ 📱 📲 💻   | objects |
       | 🚴🏿‍♀️ 🚴‍♂️ | cycling |
 
-  @skipOnOcV10 @issue-37992
-  Scenario: admin tries to reset the password of a user that does not exist on ocis
-    When the administrator resets the password of user "nonexistentuser" to "%alt1%" using the provisioning API
-    Then the OCS status code should be "998"
-    And the HTTP status code should be "200"
-
   @skipOnEncryptionType:user-keys @encryption-issue-57
   Scenario: admin resets password of user with admin permissions
     Given these users have been created with small skeleton files:

--- a/tests/acceptance/features/apiProvisioning-v2/resetUserPassword.feature
+++ b/tests/acceptance/features/apiProvisioning-v2/resetUserPassword.feature
@@ -93,12 +93,6 @@ Feature: reset user password
       | ⌚️ 📱 📲 💻   | objects |
       | 🚴🏿‍♀️ 🚴‍♂️ | cycling |
 
-  @skipOnOcV10 @issue-37992
-  Scenario: admin tries to reset the password of a user that does not exist on OCIS
-    When the administrator resets the password of user "nonexistentuser" to "%alt1%" using the provisioning API
-    Then the OCS status code should be "998"
-    And the HTTP status code should be "404"
-
   @skipOnEncryptionType:user-keys @encryption-issue-57 @notToImplementOnOCIS
   Scenario: admin resets password of user with admin permissions
     Given these users have been created with small skeleton files:

--- a/tests/acceptance/features/apiProvisioningGroups-v1/getUserGroups.feature
+++ b/tests/acceptance/features/apiProvisioningGroups-v1/getUserGroups.feature
@@ -91,44 +91,6 @@ Feature: get user groups
     And the HTTP status code should be "200"
     And the list of groups returned by the API should be empty
 
-  @smokeTest @skipOnOcV10
-  Scenario: admin gets groups of an user on ocis
-    Given user "brand-new-user" has been created with default attributes and without skeleton files
-    And group "unused-group" has been created
-    And group "brand-new-group" has been created
-    And group "0" has been created
-    And group "Admin & Finance (NP)" has been created
-    And group "admin:Pokhara@Nepal" has been created
-    And group "नेपाली" has been created
-    And group "😅 😆" has been created
-    And user "brand-new-user" has been added to group "brand-new-group"
-    And user "brand-new-user" has been added to group "0"
-    And user "brand-new-user" has been added to group "Admin & Finance (NP)"
-    And user "brand-new-user" has been added to group "admin:Pokhara@Nepal"
-    And user "brand-new-user" has been added to group "नेपाली"
-    And user "brand-new-user" has been added to group "😅 😆"
-    When the administrator gets all the groups of user "brand-new-user" using the provisioning API
-    Then the OCS status code should be "100"
-    And the HTTP status code should be "200"
-    And the groups returned by the API should be
-      | brand-new-group      |
-      | 0                    |
-      | Admin & Finance (NP) |
-      | admin:Pokhara@Nepal  |
-      | नेपाली               |
-      | 😅 😆                |
-      | users                |
-
-  @skipOnOcV10
-  Scenario: admin gets groups of an user who is not in any groups on ocis
-    Given user "brand-new-user" has been created with default attributes and without skeleton files
-    And group "unused-group" has been created
-    When the administrator gets all the groups of user "brand-new-user" using the provisioning API
-    Then the OCS status code should be "100"
-    And the HTTP status code should be "200"
-    And the groups returned by the API should be
-      | users |
-
   @notToImplementOnOCIS
   Scenario: normal user gets his/her groups
     Given these users have been created with default attributes and without skeleton files:
@@ -144,20 +106,3 @@ Feature: get user groups
     And the groups returned by the API should be
       | group1 |
       | group2 |
-
-  @skipOnOcV10
-  Scenario: normal user gets his/her groups in ocis
-    Given these users have been created with default attributes and without skeleton files:
-      | username |
-      | Alice    |
-    And group "group1" has been created
-    And group "group2" has been created
-    And user "Alice" has been added to group "group1"
-    And user "Alice" has been added to group "group2"
-    When user "Alice" gets all the groups of user "Alice" using the provisioning API
-    Then the OCS status code should be "100"
-    And the HTTP status code should be "200"
-    And the groups returned by the API should be
-      | group1 |
-      | group2 |
-      | users  |

--- a/tests/acceptance/features/apiProvisioningGroups-v2/getUserGroups.feature
+++ b/tests/acceptance/features/apiProvisioningGroups-v2/getUserGroups.feature
@@ -91,44 +91,6 @@ Feature: get user groups
     And the HTTP status code should be "200"
     And the list of groups returned by the API should be empty
 
-  @smokeTest @skipOnOcV10
-  Scenario: admin gets groups of an user on ocis
-    Given user "brand-new-user" has been created with default attributes and without skeleton files
-    And group "unused-group" has been created
-    And group "brand-new-group" has been created
-    And group "0" has been created
-    And group "Admin & Finance (NP)" has been created
-    And group "admin:Pokhara@Nepal" has been created
-    And group "नेपाली" has been created
-    And group "😅 😆" has been created
-    And user "brand-new-user" has been added to group "brand-new-group"
-    And user "brand-new-user" has been added to group "0"
-    And user "brand-new-user" has been added to group "Admin & Finance (NP)"
-    And user "brand-new-user" has been added to group "admin:Pokhara@Nepal"
-    And user "brand-new-user" has been added to group "नेपाली"
-    And user "brand-new-user" has been added to group "😅 😆"
-    When the administrator gets all the groups of user "brand-new-user" using the provisioning API
-    Then the OCS status code should be "200"
-    And the HTTP status code should be "200"
-    And the groups returned by the API should be
-      | brand-new-group      |
-      | 0                    |
-      | Admin & Finance (NP) |
-      | admin:Pokhara@Nepal  |
-      | नेपाली               |
-      | 😅 😆                |
-      | users                |
-
-  @skipOnOcV10
-  Scenario: admin gets groups of an user who is not in any groups on ocis
-    Given user "brand-new-user" has been created with default attributes and without skeleton files
-    And group "unused-group" has been created
-    When the administrator gets all the groups of user "brand-new-user" using the provisioning API
-    Then the OCS status code should be "200"
-    And the HTTP status code should be "200"
-    And the groups returned by the API should be
-      | users |
-
   @notToImplementOnOCIS
   Scenario: normal user gets his/her groups
     Given these users have been created with default attributes and without skeleton files:
@@ -144,20 +106,3 @@ Feature: get user groups
     And the groups returned by the API should be
       | group1 |
       | group2 |
-
-  @skipOnOcV10
-  Scenario: normal user gets his/her groups in ocis
-    Given these users have been created with default attributes and without skeleton files:
-      | username |
-      | Alice    |
-    And group "group1" has been created
-    And group "group2" has been created
-    And user "Alice" has been added to group "group1"
-    And user "Alice" has been added to group "group2"
-    When user "Alice" gets all the groups of user "Alice" using the provisioning API
-    Then the OCS status code should be "200"
-    And the HTTP status code should be "200"
-    And the groups returned by the API should be
-      | group1 |
-      | group2 |
-      | users  |

--- a/tests/acceptance/features/apiShareManagementToShares/moveShareInsideAnotherShare.feature
+++ b/tests/acceptance/features/apiShareManagementToShares/moveShareInsideAnotherShare.feature
@@ -95,13 +95,3 @@ Feature: moving a share inside another share
     And as "Brian" folder "/Shares/folderA/localFolder/subFolder" should exist
     And as "Alice" file "/folderA/localFolder/localFile.txt" should exist
     And as "Brian" file "/Shares/folderA/localFolder/localFile.txt" should exist
-
-  @skipOnOcV10
-  Scenario: share receiver tries to move a whole share inside a local folder
-    Given user "Brian" has created folder "localFolder"
-    And user "Brian" has uploaded file with content "local text" to "/localFolder/localFile.txt"
-    # On oCIS you cannot move received shares out of the "Shares" folder
-    When user "Brian" moves folder "Shares/folderB" to "localFolder/folderB" using the WebDAV API
-    Then the HTTP status code should be "403"
-    And as "Alice" file "/folderB/fileB.txt" should exist
-    And as "Brian" file "/Shares/folderB/fileB.txt" should exist

--- a/tests/acceptance/features/apiSharePublicLink1/createPublicLinkShare.feature
+++ b/tests/acceptance/features/apiSharePublicLink1/createPublicLinkShare.feature
@@ -406,33 +406,6 @@ Feature: create a public link share
       | 1               | 403             | 200              |
       | 2               | 403             | 403              |
 
-  @issue-ocis-reva-283 @skipOnOcV10
-  Scenario Outline: Allow public sharing of the root on OCIS when the default permission is read and access using the public WebDAV API
-    Given using OCS API version "<ocs_api_version>"
-    And user "Alice" has uploaded file with content "Random data" to "/randomfile.txt"
-    When user "Alice" creates a public link share using the sharing API with settings
-      | path | / |
-    Then the OCS status code should be "<ocs_status_code>"
-    And the HTTP status code should be "200"
-    And the fields of the last response to user "Alice" should include
-      | item_type              | folder               |
-      | mimetype               | httpd/unix-directory |
-      | file_target            | /                    |
-      | path                   | /                    |
-      | permissions            | read                 |
-      | share_type             | public_link          |
-      | displayname_file_owner | %displayname%        |
-      | displayname_owner      | %displayname%        |
-      | uid_file_owner         | %username%           |
-      | uid_owner              | %username%           |
-      | name                   |                      |
-    And the public should be able to download file "/randomfile.txt" from inside the last public link shared folder using the new public WebDAV API without password and the content should be "Random data"
-    And the public upload to the last publicly shared folder using the new public WebDAV API should fail with HTTP status code "403"
-    @issue-ocis-2079
-    Examples:
-      | ocs_api_version | ocs_status_code |
-      | 1               | 100             |
-      | 2               | 200             |
 
   Scenario Outline: user creates a public link share of a file with file name longer than 64 chars using the public WebDAV API
     Given using OCS API version "<ocs_api_version>"

--- a/tests/acceptance/features/apiSharePublicLink3/updatePublicLinkShare.feature
+++ b/tests/acceptance/features/apiSharePublicLink3/updatePublicLinkShare.feature
@@ -475,46 +475,6 @@ Feature: update a public link share
       | 1               | new                       |
       | 2               | new                       |
 
-  @skipOnOcV10
-  Scenario Outline: API responds with a full set of parameters when owner renames the folder with a public link in ocis
-    Given using OCS API version "<ocs_api_version>"
-    And using <dav-path> DAV path
-    And user "Alice" has created folder "FOLDER"
-    And user "Alice" has created a public link share with settings
-      | path | FOLDER |
-    And user "Alice" has moved folder "/FOLDER" to "/RENAMED_FOLDER"
-    When user "Alice" gets the info of the last public link share using the sharing API
-    Then the OCS status code should be "<ocs_status_code>"
-    And the HTTP status code should be "200"
-    And the fields of the last response to user "Alice" should include
-      | id                     | A_STRING             |
-      | share_type             | public_link          |
-      | uid_owner              | %username%           |
-      | displayname_owner      | %displayname%        |
-      | permissions            | read                 |
-      | stime                  | A_NUMBER             |
-      | parent                 |                      |
-      | expiration             |                      |
-      | token                  | A_STRING             |
-      | uid_file_owner         | %username%           |
-      | displayname_file_owner | %displayname%        |
-      | item_type              | folder               |
-      | item_source            | A_STRING             |
-      | path                   | /RENAMED_FOLDER      |
-      | mimetype               | httpd/unix-directory |
-      | storage_id             | A_STRING             |
-      | storage                | A_STRING             |
-      | file_source            | A_STRING             |
-      | file_target            | /RENAMED_FOLDER      |
-      | mail_send              | 0                    |
-      | name                   |                      |
-    Examples:
-      | dav-path | ocs_api_version | ocs_status_code |
-      | old      | 1               | 100             |
-      | old      | 2               | 200             |
-      | new      | 1               | 100             |
-      | new      | 2               | 200             |
-
   @notToImplementOnOCIS @issue-39820
   Scenario Outline: API responds with a full set of parameters when owner renames the file with a public link (bug demonstration)
     Given using OCS API version "<ocs_api_version>"
@@ -552,46 +512,6 @@ Feature: update a public link share
       | file_target                | /lorem.txt     |
       | mail_send                  | 0              |
       | name                       |                |
-    Examples:
-      | dav-path | ocs_api_version | ocs_status_code |
-      | old      | 1               | 100             |
-      | old      | 2               | 200             |
-      | new      | 1               | 100             |
-      | new      | 2               | 200             |
-
-  @skipOnOcV10
-  Scenario Outline: API responds with a full set of parameters when owner renames the file with a public link in ocis
-    Given using OCS API version "<ocs_api_version>"
-    And using <dav-path> DAV path
-    And user "Alice" has uploaded file with content "some content" to "/lorem.txt"
-    And user "Alice" has created a public link share with settings
-      | path | lorem.txt |
-    And user "Alice" has moved file "/lorem.txt" to "/new-lorem.txt"
-    When user "Alice" gets the info of the last public link share using the sharing API
-    Then the OCS status code should be "<ocs_status_code>"
-    And the HTTP status code should be "200"
-    And the fields of the last response to user "Alice" should include
-      | id                     | A_STRING       |
-      | share_type             | public_link    |
-      | uid_owner              | %username%     |
-      | displayname_owner      | %displayname%  |
-      | permissions            | read           |
-      | stime                  | A_NUMBER       |
-      | parent                 |                |
-      | expiration             |                |
-      | token                  | A_STRING       |
-      | uid_file_owner         | %username%     |
-      | displayname_file_owner | %displayname%  |
-      | item_type              | file           |
-      | item_source            | A_STRING       |
-      | path                   | /new-lorem.txt |
-      | mimetype               | text/plain     |
-      | storage_id             | A_STRING       |
-      | storage                | A_STRING       |
-      | file_source            | A_STRING       |
-      | file_target            | /new-lorem.txt |
-      | mail_send              | 0              |
-      | name                   |                |
     Examples:
       | dav-path | ocs_api_version | ocs_status_code |
       | old      | 1               | 100             |

--- a/tests/acceptance/features/apiShareReshareToShares2/reShareChain.feature
+++ b/tests/acceptance/features/apiShareReshareToShares2/reShareChain.feature
@@ -29,17 +29,3 @@ Feature: resharing can be done on a reshared resource
       | pending_share_path    |
       | /textfile0_shared.txt |
       | /textfile0_shared.txt |
-
-  @skipOnOcV10
-  Scenario: Reshared files can be still accessed if a user in the middle removes it.
-    Given user "Alice" has uploaded file with content "ownCloud test text file 0" to "/textfile0.txt"
-    And user "Alice" has shared file "textfile0.txt" with user "Brian"
-    And user "Brian" has accepted share "/textfile0.txt" offered by user "Alice"
-    And user "Brian" has shared file "/Shares/textfile0.txt" with user "Carol"
-    And user "Carol" has accepted share "/textfile0.txt" offered by user "Brian"
-    And user "Carol" has shared file "/Shares/textfile0.txt" with user "David"
-    And user "David" has accepted share "/textfile0.txt" offered by user "Carol"
-    When user "Brian" deletes file "/Shares/textfile0.txt" using the WebDAV API
-    Then the HTTP status code should be "204"
-    And the content of file "/Shares/textfile0.txt" for user "Carol" should be "ownCloud test text file 0"
-    And the content of file "/Shares/textfile0.txt" for user "David" should be "ownCloud test text file 0"

--- a/tests/acceptance/features/apiWebdavOperations/downloadFile.feature
+++ b/tests/acceptance/features/apiWebdavOperations/downloadFile.feature
@@ -241,27 +241,6 @@ Feature: download file
       | old         |
       | new         |
 
-  @smokeTest @skipOnOcV10
-  Scenario Outline: Downloading a file should serve security headers
-    Given using <dav_version> DAV path
-    When user "Alice" downloads file "/welcome.txt" using the WebDAV API
-    Then the HTTP status code should be "200"
-    And the following headers should be set
-      | header                            | value                                                            |
-      | Content-Disposition               | attachment; filename*=UTF-8''welcome.txt; filename="welcome.txt" |
-      | Content-Security-Policy           | default-src 'none';                                              |
-      | X-Content-Type-Options            | nosniff                                                          |
-      | X-Download-Options                | noopen                                                           |
-      | X-Frame-Options                   | SAMEORIGIN                                                       |
-      | X-Permitted-Cross-Domain-Policies | none                                                             |
-      | X-Robots-Tag                      | none                                                             |
-      | X-XSS-Protection                  | 1; mode=block                                                    |
-    And the downloaded content should start with "Welcome"
-    Examples:
-      | dav_version |
-      | old         |
-      | new         |
-
 
   Scenario: download a zero byte size file
     Given user "Alice" has uploaded file "filesForUpload/zerobyte.txt" to "/zerobyte.txt"

--- a/tests/acceptance/features/apiWebdavUploadTUS/checksums.feature
+++ b/tests/acceptance/features/apiWebdavUploadTUS/checksums.feature
@@ -21,12 +21,6 @@ Feature: checksums
       | old         | SHA1 8cb2237d0679ca88db6464eac60da96345513964 |
       | new         | SHA1 8cb2237d0679ca88db6464eac60da96345513964 |
 
-    @personalSpace
-    Examples:
-      | dav_version | checksum                                      |
-      | spaces      | MD5 827ccb0eea8a706c4c34a16891f84e7b          |
-      | spaces      | SHA1 8cb2237d0679ca88db6464eac60da96345513964 |
-
 
   Scenario Outline: Uploading a file with checksum should return the checksum in the propfind
     Given using <dav_version> DAV path
@@ -43,11 +37,6 @@ Feature: checksums
       | old         |
       | new         |
 
-    @personalSpace
-    Examples:
-      | dav_version |
-      | spaces      |
-
 
   Scenario Outline: Uploading a file with checksum should return the checksum in the download header
     Given using <dav_version> DAV path
@@ -63,11 +52,6 @@ Feature: checksums
       | dav_version |
       | old         |
       | new         |
-
-    @personalSpace
-    Examples:
-      | dav_version |
-      | spaces      |
 
 
   Scenario Outline: Uploading a file with incorrect checksum should not work
@@ -86,12 +70,6 @@ Feature: checksums
       | old         | SHA1 8cb2237d0679ca88db6464eac60da96345513963 |
       | new         | SHA1 8cb2237d0679ca88db6464eac60da96345513963 |
 
-    @personalSpace
-    Examples:
-      | dav_version | incorrect_checksum                            |
-      | spaces      | MD5 827ccb0eea8a706c4c34a16891f84e7a          |
-      | spaces      | SHA1 8cb2237d0679ca88db6464eac60da96345513963 |
-
 
   Scenario Outline: Uploading a chunked file with correct checksum should work
     Given using <dav_version> DAV path
@@ -107,11 +85,6 @@ Feature: checksums
       | dav_version |
       | old         |
       | new         |
-
-    @personalSpace
-    Examples:
-      | dav_version |
-      | spaces      |
 
 
   Scenario Outline: Uploading a chunked file with correct checksum should return the checksum in the propfind
@@ -130,11 +103,6 @@ Feature: checksums
       | old         |
       | new         |
 
-    @personalSpace
-    Examples:
-      | dav_version |
-      | spaces      |
-
 
   Scenario Outline: Uploading a chunked file with checksum should return the checksum in the download header
     Given using <dav_version> DAV path
@@ -152,11 +120,6 @@ Feature: checksums
       | old         |
       | new         |
 
-    @personalSpace
-    Examples:
-      | dav_version |
-      | spaces      |
-
 
   Scenario Outline: Uploading second chunk of file with incorrect checksum should not work
     Given using <dav_version> DAV path
@@ -172,11 +135,6 @@ Feature: checksums
       | dav_version |
       | old         |
       | new         |
-
-    @personalSpace
-    Examples:
-      | dav_version |
-      | spaces      |
 
 
   Scenario Outline: Uploading a file with correct checksum and overwriting an existing file should return the checksum for new data in the propfind
@@ -201,12 +159,6 @@ Feature: checksums
       | old         | SHA1 aaf4c61ddcc5e8a2dabede0f3b482cd9aea9434d |
       | new         | SHA1 aaf4c61ddcc5e8a2dabede0f3b482cd9aea9434d |
 
-    @personalSpace
-    Examples:
-      | dav_version | overwriteChecksum                             |
-      | spaces      | MD5 5d41402abc4b2a76b9719d911017c592          |
-      | spaces      | SHA1 aaf4c61ddcc5e8a2dabede0f3b482cd9aea9434d |
-
 
   Scenario Outline: Uploading a file with correct checksum and overwriting an existing file with invalid checksum should not work
     Given using <dav_version> DAV path
@@ -227,12 +179,6 @@ Feature: checksums
       | new         | MD5 5d41402abc4b2a76b9719d911017c593          |
       | old         | SHA1 aaf4c61ddcc5e8a2dabede0f3b482cd9aea9434a |
       | new         | SHA1 aaf4c61ddcc5e8a2dabede0f3b482cd9aea9434a |
-
-    @personalSpace
-    Examples:
-      | dav_version | overwriteInvalidChecksum                      |
-      | spaces      | MD5 5d41402abc4b2a76b9719d911017c593          |
-      | spaces      | SHA1 aaf4c61ddcc5e8a2dabede0f3b482cd9aea9434a |
 
 
   Scenario Outline: Overwriting an existing file with new data and checksum should return the checksum of new data in the propfind
@@ -257,12 +203,6 @@ Feature: checksums
       | old         | SHA1 aaf4c61ddcc5e8a2dabede0f3b482cd9aea9434d |
       | new         | SHA1 aaf4c61ddcc5e8a2dabede0f3b482cd9aea9434d |
 
-    @personalSpace
-    Examples:
-      | dav_version | overwriteChecksum                             |
-      | spaces      | MD5 5d41402abc4b2a76b9719d911017c592          |
-      | spaces      | SHA1 aaf4c61ddcc5e8a2dabede0f3b482cd9aea9434d |
-
 
   Scenario Outline: Overwriting an existing file with new data and invalid checksum should not work
     Given using <dav_version> DAV path
@@ -283,9 +223,3 @@ Feature: checksums
       | new         | MD5 5d41402abc4b2a76b9719d911017c593          |
       | old         | SHA1 aaf4c61ddcc5e8a2dabede0f3b482cd9aea9434a |
       | new         | SHA1 aaf4c61ddcc5e8a2dabede0f3b482cd9aea9434a |
-
-    @personalSpace
-    Examples:
-      | dav_version | overwriteChecksum                             |
-      | spaces      | MD5 5d41402abc4b2a76b9719d911017c593          |
-      | spaces      | SHA1 aaf4c61ddcc5e8a2dabede0f3b482cd9aea9434a |

--- a/tests/acceptance/features/apiWebdavUploadTUS/creationWithUploadExtension.feature
+++ b/tests/acceptance/features/apiWebdavUploadTUS/creationWithUploadExtension.feature
@@ -25,11 +25,6 @@ Feature: tests of the creation extension see https://tus.io/protocols/resumable-
       | old         |
       | new         |
 
-    @personalSpace
-    Examples:
-      | dav_version |
-      | spaces      |
-
 
   Scenario Outline: creating a new resource and upload data in multiple bytes using creation with upload extension
     Given using <dav_version> DAV path
@@ -39,8 +34,3 @@ Feature: tests of the creation extension see https://tus.io/protocols/resumable-
       | dav_version |
       | old         |
       | new         |
-
-    @personalSpace
-    Examples:
-      | dav_version |
-      | spaces      |

--- a/tests/acceptance/features/apiWebdavUploadTUS/lowLevelCreationExtension.feature
+++ b/tests/acceptance/features/apiWebdavUploadTUS/lowLevelCreationExtension.feature
@@ -21,11 +21,6 @@ Feature: low level tests of the creation extension see https://tus.io/protocols/
       | old         |
       | new         |
 
-    @personalSpace
-    Examples:
-      | dav_version |
-      | spaces      |
-
 
   Scenario Outline: creating a new upload resource without upload length
     Given using <dav_version> DAV path
@@ -41,8 +36,3 @@ Feature: low level tests of the creation extension see https://tus.io/protocols/
       | dav_version |
       | old         |
       | new         |
-
-    @personalSpace
-    Examples:
-      | dav_version |
-      | spaces      |

--- a/tests/acceptance/features/apiWebdavUploadTUS/lowLevelUpload.feature
+++ b/tests/acceptance/features/apiWebdavUploadTUS/lowLevelUpload.feature
@@ -20,11 +20,6 @@ Feature: low level tests for upload of chunks
       | old         |
       | new         |
 
-    @personalSpace
-    Examples:
-      | dav_version |
-      | spaces      |
-
 
   Scenario Outline: finalize file upload after uploading a chunk twice
     Given using <dav_version> DAV path
@@ -41,11 +36,6 @@ Feature: low level tests for upload of chunks
       | dav_version |
       | old         |
       | new         |
-
-    @personalSpace
-    Examples:
-      | dav_version |
-      | spaces      |
 
 
   Scenario Outline: send last chunk twice
@@ -64,11 +54,6 @@ Feature: low level tests for upload of chunks
       | old         |
       | new         |
 
-    @personalSpace
-    Examples:
-      | dav_version |
-      | spaces      |
-
 
   Scenario Outline: start with uploading not at the beginning of the file
     Given using <dav_version> DAV path
@@ -83,8 +68,3 @@ Feature: low level tests for upload of chunks
       | dav_version |
       | old         |
       | new         |
-
-    @personalSpace
-    Examples:
-      | dav_version |
-      | spaces      |

--- a/tests/acceptance/features/apiWebdavUploadTUS/optionsRequest.feature
+++ b/tests/acceptance/features/apiWebdavUploadTUS/optionsRequest.feature
@@ -18,38 +18,12 @@ Feature: OPTIONS request
       | Tus-Extension          | creation,creation-with-upload,checksum,expiration |
       | Tus-Checksum-Algorithm | md5,sha1,adler32                                  |
 
-  @personalSpace
-  Scenario: send OPTIONS request to spaces webDav endpoint using the TUS protocol with valid password and username
-    When user "Alice" requests these endpoints with "OPTIONS" including body "doesnotmatter" using the password of user "Alice"
-      | endpoint                          |
-      | /remote.php/dav/spaces/%spaceid%/ |
-    Then the HTTP status code should be "204"
-    And the following headers should be set
-      | header                 | value                                             |
-      | Tus-Resumable          | 1.0.0                                             |
-      | Tus-Version            | 1.0.0                                             |
-      | Tus-Extension          | creation,creation-with-upload,checksum,expiration |
-      | Tus-Checksum-Algorithm | md5,sha1,adler32                                  |
-
 
   Scenario: send OPTIONS request to webDav endpoints using the TUS protocol without any authentication
     When a user requests these endpoints with "OPTIONS" with body "doesnotmatter" and no authentication about user "Alice"
       | endpoint                          |
       | /remote.php/webdav/               |
       | /remote.php/dav/files/%username%/ |
-    Then the HTTP status code should be "204"
-    And the following headers should be set
-      | header                 | value                                             |
-      | Tus-Resumable          | 1.0.0                                             |
-      | Tus-Version            | 1.0.0                                             |
-      | Tus-Extension          | creation,creation-with-upload,checksum,expiration |
-      | Tus-Checksum-Algorithm | md5,sha1,adler32                                  |
-
-  @personalSpace
-  Scenario: send OPTIONS request to spaces webDav endpoint using the TUS protocol without any authentication
-    When a user requests these endpoints with "OPTIONS" with body "doesnotmatter" and no authentication about user "Alice"
-      | endpoint                          |
-      | /remote.php/dav/spaces/%spaceid%/ |
     Then the HTTP status code should be "204"
     And the following headers should be set
       | header                 | value                                             |
@@ -72,19 +46,6 @@ Feature: OPTIONS request
       | Tus-Extension          | creation,creation-with-upload,checksum,expiration |
       | Tus-Checksum-Algorithm | md5,sha1,adler32                                  |
 
-  @personalSpace
-  Scenario: send OPTIONS request to spaces webDav endpoint using the TUS protocol with valid username and wrong password
-    When user "Alice" requests these endpoints with "OPTIONS" including body "doesnotmatter" using password "invalid" about user "Alice"
-      | endpoint                          |
-      | /remote.php/dav/spaces/%spaceid%/ |
-    Then the HTTP status code should be "401"
-    And the following headers should be set
-      | header                 | value                                             |
-      | Tus-Resumable          | 1.0.0                                             |
-      | Tus-Version            | 1.0.0                                             |
-      | Tus-Extension          | creation,creation-with-upload,checksum,expiration |
-      | Tus-Checksum-Algorithm | md5,sha1,adler32                                  |
-
 
   Scenario: send OPTIONS requests to webDav endpoints using valid password and username of different user
     Given user "Brian" has been created with default attributes and without skeleton files
@@ -92,20 +53,6 @@ Feature: OPTIONS request
       | endpoint                          |
       | /remote.php/webdav/               |
       | /remote.php/dav/files/%username%/ |
-    Then the HTTP status code should be "401"
-    And the following headers should be set
-      | header                 | value                                             |
-      | Tus-Resumable          | 1.0.0                                             |
-      | Tus-Version            | 1.0.0                                             |
-      | Tus-Extension          | creation,creation-with-upload,checksum,expiration |
-      | Tus-Checksum-Algorithm | md5,sha1,adler32                                  |
-
-  @personalSpace
-  Scenario: send OPTIONS requests to spaces webDav endpoints using valid password and username of different user
-    Given user "Brian" has been created with default attributes and without skeleton files
-    When user "Brian" requests these endpoints with "OPTIONS" including body "doesnotmatter" using the password of user "Alice"
-      | endpoint                          |
-      | /remote.php/dav/spaces/%spaceid%/ |
     Then the HTTP status code should be "401"
     And the following headers should be set
       | header                 | value                                             |

--- a/tests/acceptance/features/apiWebdavUploadTUS/uploadFile.feature
+++ b/tests/acceptance/features/apiWebdavUploadTUS/uploadFile.feature
@@ -29,17 +29,6 @@ Feature: upload file
       | new         | /?fi=le&%#2 . txt |
       | new         | /# %ab ab?=ed     |
 
-    @personalSpace
-    Examples:
-      | dav_version | file_name         |
-      | spaces      | /upload.txt       |
-      | spaces      | /strängé file.txt |
-      | spaces      | /नेपाली.txt       |
-      | spaces      | /s,a,m,p,l,e.txt  |
-      | spaces      | /C++ file.cpp     |
-      | spaces      | /?fi=le&%#2 . txt |
-      | spaces      | /# %ab ab?=ed     |
-
 
   Scenario Outline: upload a file into a folder and check download content
     Given using <dav_version> DAV path
@@ -63,17 +52,6 @@ Feature: upload file
       | new         | /folder ?2.txt                   | file ?2.txt                   |
       | new         | /?fi=le&%#2 . txt                | # %ab ab?=ed                  |
 
-    @personalSpace
-    Examples:
-      | dav_version | folder_name                      | file_name                     |
-      | spaces      | /upload                          | abc.txt                       |
-      | spaces      | /strängé folder (duplicate #2 &) | strängé file (duplicate #2 &) |
-      | spaces      | /C++ folder                      | C++ file.cpp                  |
-      | spaces      | /नेपाली                          | नेपाली                        |
-      | spaces      | /folder #2.txt                   | file #2.txt                   |
-      | spaces      | /folder ?2.txt                   | file ?2.txt                   |
-      | spaces      | /?fi=le&%#2 . txt                | # %ab ab?=ed                  |
-
 
   Scenario Outline: Upload chunked file with TUS
     Given using <dav_version> DAV path
@@ -84,11 +62,6 @@ Feature: upload file
       | old         |
       | new         |
 
-    @personalSpace
-    Examples:
-      | dav_version |
-      | spaces      |
-
 
   Scenario Outline: Upload 1 byte chunks with TUS
     Given using <dav_version> DAV path
@@ -98,11 +71,6 @@ Feature: upload file
       | dav_version |
       | old         |
       | new         |
-
-    @personalSpace
-    Examples:
-      | dav_version |
-      | spaces      |
 
 
   Scenario Outline: Upload to overwriting a file
@@ -115,11 +83,6 @@ Feature: upload file
       | old         |
       | new         |
 
-    @personalSpace
-    Examples:
-      | dav_version |
-      | spaces      |
-
 
   Scenario Outline: upload a file and no version is available
     Given using <dav_version> DAV path
@@ -129,11 +92,6 @@ Feature: upload file
       | dav_version |
       | old         |
       | new         |
-
-    @personalSpace
-    Examples:
-      | dav_version |
-      | spaces      |
 
 
   Scenario Outline: upload a file twice and versions are available
@@ -146,11 +104,6 @@ Feature: upload file
       | dav_version |
       | old         |
       | new         |
-
-    @personalSpace
-    Examples:
-      | dav_version |
-      | spaces      |
 
 
   Scenario Outline: upload a file in chunks with TUS and no version is available
@@ -174,11 +127,6 @@ Feature: upload file
       | old         |
       | new         |
 
-    @personalSpace
-    Examples:
-      | dav_version |
-      | spaces      |
-
 
   Scenario Outline: upload a file with invalid-name
     Given using <dav_version> DAV path
@@ -201,11 +149,3 @@ Feature: upload file
       | new         | "filewithLF-and-CR\r\n" | ZmlsZXdpdGhMRi1hbmQtQ1INCgo= |
       | new         | "folder/file"           | Zm9sZGVyL2ZpbGU=             |
       | new         | "my\\file"              | bXkMaWxl                     |
-
-  @personalSpace
-  Examples:
-    | dav_version | file_name               | metadata                     |
-    | spaces      | " "                     | IA==                         |
-    | spaces      | "filewithLF-and-CR\r\n" | ZmlsZXdpdGhMRi1hbmQtQ1INCgo= |
-    | spaces      | "folder/file"           | Zm9sZGVyL2ZpbGU=             |
-    | spaces      | "my\\file"              | bXkMaWxl                     |

--- a/tests/acceptance/features/apiWebdavUploadTUS/uploadFileMtime.feature
+++ b/tests/acceptance/features/apiWebdavUploadTUS/uploadFileMtime.feature
@@ -17,11 +17,6 @@ Feature: upload file
       | old         |
       | new         |
 
-    @personalSpace
-    Examples:
-      | dav_version |
-      | spaces      |
-
 
   Scenario Outline: upload file with future mtime
     Given using <dav_version> DAV path
@@ -31,11 +26,6 @@ Feature: upload file
       | dav_version |
       | old         |
       | new         |
-
-    @personalSpace
-    Examples:
-      | dav_version |
-      | spaces      |
 
 
   Scenario Outline: upload a file with mtime in a folder
@@ -48,11 +38,6 @@ Feature: upload file
       | old         |
       | new         |
 
-    @personalSpace
-    Examples:
-      | dav_version |
-      | spaces      |
-
 
   Scenario Outline: overwriting a file changes its mtime
     Given using <dav_version> DAV path
@@ -63,8 +48,3 @@ Feature: upload file
       | dav_version |
       | old         |
       | new         |
-
-    @personalSpace
-    Examples:
-      | dav_version |
-      | spaces      |

--- a/tests/acceptance/features/apiWebdavUploadTUS/uploadToMoveFolder.feature
+++ b/tests/acceptance/features/apiWebdavUploadTUS/uploadToMoveFolder.feature
@@ -20,9 +20,3 @@ Feature: move folders
       | dav_version |
       | old         |
       | new         |
-
-    @personalSpace
-    Examples:
-      | dav_version |
-      | spaces      |
-

--- a/tests/acceptance/features/apiWebdavUploadTUS/uploadToNonExistingFolder.feature
+++ b/tests/acceptance/features/apiWebdavUploadTUS/uploadToNonExistingFolder.feature
@@ -31,11 +31,6 @@ Feature: upload file
       | old         |
       | new         |
 
-    @personalSpace
-    Examples:
-      | dav_version |
-      | spaces      |
-
 
   Scenario Outline: attempt to upload a file into a nonexistent folder within correctly received share
     Given using <dav_version> DAV path


### PR DESCRIPTION

## Description
This PR removes scenarios and feature files that are only for ocis/reva.

## Related Issue
Part of issue 
- https://github.com/owncloud/core/issues/40572

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
- CI

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Database schema changes (next release will require increase of minor version instead of patch)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [x] Tests only (no source changes)

## Checklist:
<!-- Tick the checkboxes when done. -->
<!-- Raise documentation ticket in https://github.com/owncloud/documentation -->
- [ ] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 
- [ ] Changelog item, see [TEMPLATE](https://github.com/owncloud/core/blob/master/changelog/TEMPLATE)
