### PR TITLE
Make remote sharee search configurable - adjust

### DIFF
--- a/apps/files_sharing/lib/Controller/ShareesController.php
+++ b/apps/files_sharing/lib/Controller/ShareesController.php
@@ -43,7 +43,6 @@ use OCP\IUserSession;
 use OCP\Share;
 use OCA\Files_Sharing\SharingBlacklist;
 use OCP\Util\UserSearch;
-use OCA\ScienceMesh\Plugins\ScienceMeshSearchPlugin;
 
 class ShareesController extends OCSController {
 	/** @var IGroupManager */
@@ -382,9 +381,10 @@ class ShareesController extends OCSController {
 	 * @return void
 	 */
 	protected function getRemote($search) {
-		if (\OC::$server->getAppManager()->isEnabledForUser('sciencemesh')) {
+		$pluginClass = $this->config->getSystemValue('sharing.remoteShareesSearch');
+		if ($pluginClass !== '') {
 			$this->result['remotes'] = [];
-			$plugin = new ScienceMeshSearchPlugin($this->config, $this->userManager, $this->userSession);
+			$plugin = new $pluginClass($this->config, $this->userManager, $this->userSession);
 			$result = $plugin->search($search);
 			$this->result['exact']['remotes'] = $result;
 			$this->reachedEndFor[] = 'remotes';

--- a/apps/files_sharing/lib/Controller/ShareesController.php
+++ b/apps/files_sharing/lib/Controller/ShareesController.php
@@ -381,6 +381,14 @@ class ShareesController extends OCSController {
 	 * @return void
 	 */
 	protected function getRemote($search) {
+		if (\OC::$server->getAppManager()->isEnabledForUser('sciencemesh')) {
+			$this->result['remotes'] = [];
+			$plugin = new \OCA\ScienceMesh\Plugins\ScienceMeshSearchPlugin($this->config, $this->userManager, $this->userSession);
+			$result = $plugin->search($search, 100, 0);
+			$this->result['exact']['remotes'] = $result;
+			$this->reachedEndFor[] = 'remotes';
+			return;
+		}
 		$this->result['remotes'] = [];
 		// Fetch remote search properties from app config
 		/**

--- a/apps/files_sharing/lib/Controller/ShareesController.php
+++ b/apps/files_sharing/lib/Controller/ShareesController.php
@@ -43,6 +43,7 @@ use OCP\IUserSession;
 use OCP\Share;
 use OCA\Files_Sharing\SharingBlacklist;
 use OCP\Util\UserSearch;
+use OCA\ScienceMesh\Plugins\ScienceMeshSearchPlugin;
 
 class ShareesController extends OCSController {
 	/** @var IGroupManager */
@@ -383,7 +384,7 @@ class ShareesController extends OCSController {
 	protected function getRemote($search) {
 		if (\OC::$server->getAppManager()->isEnabledForUser('sciencemesh')) {
 			$this->result['remotes'] = [];
-			$plugin = new \OCA\ScienceMesh\Plugins\ScienceMeshSearchPlugin($this->config, $this->userManager, $this->userSession);
+			$plugin = new ScienceMeshSearchPlugin($this->config, $this->userManager, $this->userSession);
 			$result = $plugin->search($search);
 			$this->result['exact']['remotes'] = $result;
 			$this->reachedEndFor[] = 'remotes';

--- a/apps/files_sharing/lib/Controller/ShareesController.php
+++ b/apps/files_sharing/lib/Controller/ShareesController.php
@@ -381,8 +381,8 @@ class ShareesController extends OCSController {
 	 * @return void
 	 */
 	protected function getRemote($search) {
-		$pluginClass = $this->config->getSystemValue('sharing.remoteShareesSearch', null);
-		if ($pluginClass !== null) {
+		$pluginClass = $this->config->getSystemValue('sharing.remoteShareesSearch');
+		if ($pluginClass !== '') {
 			$this->result['remotes'] = [];
 			$plugin = new $pluginClass($this->config, $this->userManager, $this->userSession);
 			$result = $plugin->search($search);

--- a/apps/files_sharing/lib/Controller/ShareesController.php
+++ b/apps/files_sharing/lib/Controller/ShareesController.php
@@ -381,8 +381,8 @@ class ShareesController extends OCSController {
 	 * @return void
 	 */
 	protected function getRemote($search) {
-		$pluginClass = $this->config->getSystemValue('sharing.remoteShareesSearch', '');
-		if ($pluginClass !== '') {
+		$pluginClass = $this->config->getSystemValue('sharing.remoteShareesSearch', null);
+		if ($pluginClass !== null) {
 			$this->result['remotes'] = [];
 			$plugin = new $pluginClass($this->config, $this->userManager, $this->userSession);
 			$result = $plugin->search($search);

--- a/apps/files_sharing/lib/Controller/ShareesController.php
+++ b/apps/files_sharing/lib/Controller/ShareesController.php
@@ -381,7 +381,7 @@ class ShareesController extends OCSController {
 	 * @return void
 	 */
 	protected function getRemote($search) {
-		$pluginClass = $this->config->getSystemValue('sharing.remoteShareesSearch');
+		$pluginClass = $this->config->getSystemValue('sharing.remoteShareesSearch', '');
 		if ($pluginClass !== '') {
 			$this->result['remotes'] = [];
 			$plugin = new $pluginClass($this->config, $this->userManager, $this->userSession);

--- a/apps/files_sharing/lib/Controller/ShareesController.php
+++ b/apps/files_sharing/lib/Controller/ShareesController.php
@@ -384,7 +384,7 @@ class ShareesController extends OCSController {
 		if (\OC::$server->getAppManager()->isEnabledForUser('sciencemesh')) {
 			$this->result['remotes'] = [];
 			$plugin = new \OCA\ScienceMesh\Plugins\ScienceMeshSearchPlugin($this->config, $this->userManager, $this->userSession);
-			$result = $plugin->search($search, 100, 0);
+			$result = $plugin->search($search);
 			$this->result['exact']['remotes'] = $result;
 			$this->reachedEndFor[] = 'remotes';
 			return;

--- a/apps/files_sharing/tests/API/ShareesTest.php
+++ b/apps/files_sharing/tests/API/ShareesTest.php
@@ -1513,7 +1513,8 @@ class ShareesTest extends TestCase {
 
 		$configMap = [
 			['trusted_domains', [], ['trusted.domain.tld', 'trusted2.domain.tld']],
-			['accounts.enable_medial_search', true, true]
+			['accounts.enable_medial_search', true, true],
+			['sharing.remoteShareesSearch', '', '']
 		];
 
 		$this->config->expects($this->any())

--- a/changelog/unreleased/40577
+++ b/changelog/unreleased/40577
@@ -1,0 +1,10 @@
+Enhancement: Add support for OCM via ScienceMesh
+
+
+We've added an if-statement in the files_sharing ShareesController
+code that searches for remote sharees. When the 'sciencemesh' app
+is installed, use it instead of the federatedfilesharing app to
+find sharee matches for OCM sharing.
+
+https://github.com/owncloud/core/issues/40576
+https://github.com/pondersource/oc-sciencemesh/pull/39


### PR DESCRIPTION
This is the code of #40577 plus the last commit that adjusts the code of `getRemote` and the associated test.

https://github.com/owncloud/core/pull/40587/commits/431099872ab7ff090d5e6d0fc3c256a3318eacfc

We can call `getSystemValue` without having to specify a default - that all works fine. We just need to add to the mocks in `returnValueMap` in the related unit test.