### PR TITLE
Add a default Event to dispatch events with just a name

### DIFF
--- a/apps/files/lib/Controller/ViewController.php
+++ b/apps/files/lib/Controller/ViewController.php
@@ -43,6 +43,7 @@ use OCP\IUserSession;
 use Symfony\Component\EventDispatcher\EventDispatcherInterface;
 use OCP\AppFramework\Http;
 use Symfony\Component\EventDispatcher\GenericEvent;
+use Symfony\Contracts\EventDispatcher\Event;
 
 /**
  * Class ViewController
@@ -243,7 +244,7 @@ class ViewController extends Controller {
 			$contentItems[] = $contentItem;
 		}
 
-		$this->eventDispatcher->dispatch('OCA\Files::loadAdditionalScripts');
+		$this->eventDispatcher->dispatch(new Event(), 'OCA\Files::loadAdditionalScripts');
 
 		$params = [];
 		$params['usedSpacePercent'] = (int)$storageInfo['relative'];

--- a/apps/files_sharing/lib/Controllers/ShareController.php
+++ b/apps/files_sharing/lib/Controllers/ShareController.php
@@ -56,6 +56,7 @@ use OCP\Share\Exceptions\ShareNotFound;
 use OCP\Template;
 use Symfony\Component\EventDispatcher\EventDispatcher;
 use Symfony\Component\EventDispatcher\GenericEvent;
+use Symfony\Contracts\EventDispatcher\Event;
 
 /**
  * Class ShareController
@@ -394,7 +395,7 @@ class ShareController extends Controller {
 			$shareTmpl['previewImage'] = $this->urlGenerator->getAbsoluteURL($this->urlGenerator->imagePath('core', 'favicon-fb.png'));
 		}
 
-		$this->eventDispatcher->dispatch('OCA\Files_Sharing::loadAdditionalScripts');
+		$this->eventDispatcher->dispatch(new Event(), 'OCA\Files_Sharing::loadAdditionalScripts');
 
 		$csp = new OCP\AppFramework\Http\ContentSecurityPolicy();
 		$csp->addAllowedFrameDomain('\'self\'');

--- a/changelog/unreleased/PHPdependencies20220920onwardSymfony
+++ b/changelog/unreleased/PHPdependencies20220920onwardSymfony
@@ -27,3 +27,4 @@ Code that has been deprecated in Symfony 4 has been refactored to be ready for S
 
 https://github.com/owncloud/core/pull/40521
 https://github.com/owncloud/core/pull/40575
+https://github.com/owncloud/core/pull/40592

--- a/settings/users.php
+++ b/settings/users.php
@@ -34,6 +34,8 @@
  *
  */
 
+use Symfony\Contracts\EventDispatcher\Event;
+
 OC_Util::checkSubAdminUser();
 
 \OC::$server->getNavigationManager()->setActiveEntry('core_users');
@@ -104,7 +106,7 @@ $defaultQuota=$config->getAppValue('files', 'default_quota', 'none');
 $defaultQuotaIsUserDefined=\array_search($defaultQuota, $quotaPreset)===false
 	&& \array_search($defaultQuota, ['none', 'default'])===false;
 
-\OC::$server->getEventDispatcher()->dispatch('OC\Settings\Users::loadAdditionalScripts');
+\OC::$server->getEventDispatcher()->dispatch(new Event(), 'OC\Settings\Users::loadAdditionalScripts');
 
 $tmpl = new OC_Template("settings", "users/main", "user");
 $tmpl->assign('groups', $groups);


### PR DESCRIPTION
## Description
In Symfony 5, `eventDispatcher->dispatch` must be passed an Event as the first parameter\, followed by the event name.
In Symfony 4, an event can be dispatched with just a name (as the first parameter) or can have an Event and name (the Symfony 5 call interface)

This PR adjusts the remaining eventDispatcher->dispatch calls so that thet all pass an event as the first parameter.

## Related Issue

#39630 

## How Has This Been Tested?
CI

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Database schema changes (next release will require increase of minor version instead of patch)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [ ] Tests only (no source changes)

## Checklist:
- [ ] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 
- [ ] Changelog item, see [TEMPLATE](https://github.com/owncloud/core/blob/master/changelog/TEMPLATE)
