### PR TITLE
[tests-only][full-ci] Remove scenario tag `skipOnOcis` from feature files

### DIFF
--- a/tests/acceptance/features/apiAuth/cors.feature
+++ b/tests/acceptance/features/apiAuth/cors.feature
@@ -1,4 +1,4 @@
-@api @issue-ocis-reva-26 @issue-ocis-reva-27 @skipOnOcis
+@api @issue-ocis-reva-26 @issue-ocis-reva-27
 Feature: CORS headers
 
   Background:

--- a/tests/acceptance/features/apiAuthWebDav/webDavCOPYAuthOC10Issue40144.feature
+++ b/tests/acceptance/features/apiAuthWebDav/webDavCOPYAuthOC10Issue40144.feature
@@ -1,4 +1,4 @@
-@api @skipOnOcis
+@api
 Feature: COPY file/folder
 
   As a user

--- a/tests/acceptance/features/apiAuthWebDav/webDavMCKOLAuthOC10Issue40485.feature
+++ b/tests/acceptance/features/apiAuthWebDav/webDavMCKOLAuthOC10Issue40485.feature
@@ -1,4 +1,4 @@
-@api @skipOnOcis
+@api
 Feature: create folder using MKCOL
 
   Background:

--- a/tests/acceptance/features/apiAuthWebDav/webDavPUTAuthOC10Issue39597.feature
+++ b/tests/acceptance/features/apiAuthWebDav/webDavPUTAuthOC10Issue39597.feature
@@ -1,4 +1,4 @@
-@api @issue-39597 @skipOnOcis
+@api @issue-39597
 Feature: get file info using PUT
 
   Background:

--- a/tests/acceptance/features/apiCapabilities/capabilities.feature
+++ b/tests/acceptance/features/apiCapabilities/capabilities.feature
@@ -4,35 +4,35 @@ Feature: capabilities
   Background:
     Given using OCS API version "1"
 
-  @smokeTest @skipOnOcis
+  @smokeTest
   Scenario: Check that the sharing API can be enabled
     Given parameter "shareapi_enabled" of app "core" has been set to "no"
     And the capabilities setting of "files_sharing" path "api_enabled" has been confirmed to be ""
     When the administrator sets parameter "shareapi_enabled" of app "core" to "yes"
     Then the capabilities setting of "files_sharing" path "api_enabled" should be "1"
 
-  @smokeTest @skipOnOcis
+  @smokeTest
   Scenario: Check that the sharing API can be disabled
     Given parameter "shareapi_enabled" of app "core" has been set to "yes"
     And the capabilities setting of "files_sharing" path "api_enabled" has been confirmed to be "1"
     When the administrator sets parameter "shareapi_enabled" of app "core" to "no"
     Then the capabilities setting of "files_sharing" path "api_enabled" should be ""
 
-  @skipOnOcis
+
   Scenario: Check that group sharing can be enabled
     Given parameter "shareapi_allow_group_sharing" of app "core" has been set to "no"
     And the capabilities setting of "files_sharing" path "group_sharing" has been confirmed to be ""
     When the administrator sets parameter "shareapi_allow_group_sharing" of app "core" to "yes"
     Then the capabilities setting of "files_sharing" path "group_sharing" should be "1"
 
-  @skipOnOcis
+
   Scenario: Check that group sharing can be disabled
     Given parameter "shareapi_allow_group_sharing" of app "core" has been set to "yes"
     And the capabilities setting of "files_sharing" path "group_sharing" has been confirmed to be "1"
     When the administrator sets parameter "shareapi_allow_group_sharing" of app "core" to "no"
     Then the capabilities setting of "files_sharing" path "group_sharing" should be ""
 
-  @smokeTest @skipOnOcis
+  @smokeTest
   Scenario: getting default capabilities with admin user
     When the administrator retrieves the capabilities using the capabilities API
     Then the OCS status code should be "100"
@@ -75,7 +75,7 @@ Feature: capabilities
       | files         | privateLinks                              | 1                 |
       | files         | privateLinksDetailsParam                  | 1                 |
 
-  @smokeTest @skipOnOcis
+  @smokeTest
   Scenario: getting default capabilities with admin user with new values
     When the administrator retrieves the capabilities using the capabilities API
     Then the OCS status code should be "100"
@@ -89,7 +89,7 @@ Feature: capabilities
       | files_sharing | providers_capabilities@@@ocinternal@@@link@@@element[0]  | shareExpiration   |
       | files_sharing | providers_capabilities@@@ocinternal@@@link@@@element[1]  | passwordProtected |
 
-  @smokeTest @skipOnOcis
+  @smokeTest
   Scenario: the default capabilities should include share expiration for all of user, group, link and remote (federated)
     When the administrator retrieves the capabilities using the capabilities API
     Then the OCS status code should be "100"
@@ -104,7 +104,7 @@ Feature: capabilities
       | files_sharing | providers_capabilities@@@ocinternal@@@link@@@element[0]           | shareExpiration |
       | files_sharing | providers_capabilities@@@ocFederatedSharing@@@remote@@@element[0] | shareExpiration |
 
-  @smokeTest @skipOnOcis
+  @smokeTest
   Scenario: getting new default capabilities in versions after 10.5.0 with admin user
     When the administrator retrieves the capabilities using the capabilities API
     Then the OCS status code should be "100"
@@ -115,7 +115,7 @@ Feature: capabilities
       | files      | file_locking_support            | 1     |
       | files      | file_locking_enable_file_action | EMPTY |
 
-  @smokeTest @skipOnOcis
+  @smokeTest
   Scenario: lock file action can be enabled
     Given parameter "enable_lock_file_action" of app "files" has been set to "yes"
     When the administrator retrieves the capabilities using the capabilities API
@@ -126,7 +126,7 @@ Feature: capabilities
       | files      | file_locking_support            | 1     |
       | files      | file_locking_enable_file_action | 1     |
 
-  @smokeTest @skipOnOcis
+  @smokeTest
   Scenario: getting default capabilities with admin user
     When the administrator retrieves the capabilities using the capabilities API
     Then the OCS status code should be "100"
@@ -153,7 +153,7 @@ Feature: capabilities
       | capability | path_to_element | value |
       | files      | versioning      | 1     |
 
-  @skipOnOcis
+
   Scenario: getting default_permissions capability with admin user
     When the administrator retrieves the capabilities using the capabilities API
     Then the OCS status code should be "100"
@@ -162,7 +162,7 @@ Feature: capabilities
       | capability    | path_to_element     | value |
       | files_sharing | default_permissions | 31    |
 
-  @skipOnOcis
+
   Scenario: default_permissions capability can be changed
     Given parameter "shareapi_default_permissions" of app "core" has been set to "7"
     When the administrator retrieves the capabilities using the capabilities API
@@ -172,7 +172,7 @@ Feature: capabilities
       | capability    | path_to_element     | value |
       | files_sharing | default_permissions | 7     |
 
-  @skipOnOcis
+
   Scenario: .htaccess is reported as a blacklisted file by default
     When the administrator retrieves the capabilities using the capabilities API
     Then the OCS status code should be "100"
@@ -181,7 +181,7 @@ Feature: capabilities
       | capability | path_to_element                | value     |
       | files      | blacklisted_files@@@element[0] | .htaccess |
 
-  @skipOnOcis
+
   Scenario: multiple files can be reported as blacklisted
     Given the administrator has updated system config key "blacklisted_files" with value '["test.txt",".htaccess"]' and type "json"
     When the administrator retrieves the capabilities using the capabilities API
@@ -192,7 +192,7 @@ Feature: capabilities
       | files      | blacklisted_files@@@element[0] | test.txt  |
       | files      | blacklisted_files@@@element[1] | .htaccess |
 
-  @skipOnOcis
+
   Scenario: user expire date can be enabled
     Given parameter "shareapi_default_expire_date_user_share" of app "core" has been set to "yes"
     When the administrator retrieves the capabilities using the capabilities API
@@ -204,7 +204,7 @@ Feature: capabilities
       | files_sharing | user@@@expire_date@@@days     | 7     |
       | files_sharing | user@@@expire_date@@@enforced | EMPTY |
 
-  @skipOnOcis
+
   Scenario: user expire date can be enforced
     Given parameter "shareapi_default_expire_date_user_share" of app "core" has been set to "yes"
     And parameter "shareapi_enforce_expire_date_user_share" of app "core" has been set to "yes"
@@ -217,7 +217,7 @@ Feature: capabilities
       | files_sharing | user@@@expire_date@@@days     | 7     |
       | files_sharing | user@@@expire_date@@@enforced | 1     |
 
-  @skipOnOcis
+
   Scenario: user expire date days can be set
     Given parameter "shareapi_default_expire_date_user_share" of app "core" has been set to "yes"
     And parameter "shareapi_expire_after_n_days_user_share" of app "core" has been set to "14"
@@ -230,7 +230,7 @@ Feature: capabilities
       | files_sharing | user@@@expire_date@@@days     | 14    |
       | files_sharing | user@@@expire_date@@@enforced | EMPTY |
 
-  @skipOnOcis
+
   Scenario: group expire date can be enabled
     Given parameter "shareapi_default_expire_date_group_share" of app "core" has been set to "yes"
     When the administrator retrieves the capabilities using the capabilities API
@@ -242,7 +242,7 @@ Feature: capabilities
       | files_sharing | group@@@expire_date@@@days     | 7     |
       | files_sharing | group@@@expire_date@@@enforced | EMPTY |
 
-  @skipOnOcis
+
   Scenario: group expire date can be enforced
     Given parameter "shareapi_default_expire_date_group_share" of app "core" has been set to "yes"
     And parameter "shareapi_enforce_expire_date_group_share" of app "core" has been set to "yes"
@@ -255,7 +255,7 @@ Feature: capabilities
       | files_sharing | group@@@expire_date@@@days     | 7     |
       | files_sharing | group@@@expire_date@@@enforced | 1     |
 
-  @skipOnOcis
+
   Scenario: group expire date days can be set
     Given parameter "shareapi_default_expire_date_group_share" of app "core" has been set to "yes"
     And parameter "shareapi_expire_after_n_days_group_share" of app "core" has been set to "14"
@@ -269,7 +269,7 @@ Feature: capabilities
       | files_sharing | group@@@expire_date@@@enforced | EMPTY |
 
   #feature added in #31824 released in 10.0.10
-  @smokeTest @skipOnOcis
+  @smokeTest
   Scenario: getting capabilities with admin user
     When the administrator retrieves the capabilities using the capabilities API
     Then the OCS status code should be "100"
@@ -278,8 +278,8 @@ Feature: capabilities
       | capability    | path_to_element | value |
       | files_sharing | can_share       | 1     |
 
+
   #feature added in #32414 released in 10.0.10
-  @skipOnOcis
   Scenario: getting async capabilities when async operations are enabled
     Given the administrator has enabled async operations
     When the administrator retrieves the capabilities using the capabilities API
@@ -297,7 +297,7 @@ Feature: capabilities
       | capability | path_to_element | value |
       | async      |                 | EMPTY |
 
-  @skipOnOcis
+
   Scenario: Changing public upload
     Given parameter "shareapi_allow_public_upload" of app "core" has been set to "no"
     When the administrator retrieves the capabilities using the capabilities API
@@ -323,7 +323,7 @@ Feature: capabilities
       | files_sharing | user_enumeration@@@group_members_only | EMPTY             |
       | files         | bigfilechunking                       | 1                 |
 
-  @skipOnOcis
+
   Scenario: Disabling share api
     Given parameter "shareapi_enabled" of app "core" has been set to "no"
     When the administrator retrieves the capabilities using the capabilities API
@@ -343,7 +343,7 @@ Feature: capabilities
       | files_sharing | federation@@@incoming | 1                 |
       | files         | bigfilechunking       | 1                 |
 
-  @skipOnOcis
+
   Scenario: Disabling public links
     Given parameter "shareapi_allow_links" of app "core" has been set to "no"
     When the administrator retrieves the capabilities using the capabilities API
@@ -367,7 +367,7 @@ Feature: capabilities
       | files_sharing | user_enumeration@@@group_members_only | EMPTY             |
       | files         | bigfilechunking                       | 1                 |
 
-  @skipOnOcis
+
   Scenario: Changing resharing
     Given parameter "shareapi_allow_resharing" of app "core" has been set to "no"
     When the administrator retrieves the capabilities using the capabilities API
@@ -392,7 +392,7 @@ Feature: capabilities
       | files_sharing | user_enumeration@@@group_members_only | EMPTY             |
       | files         | bigfilechunking                       | 1                 |
 
-  @skipOnOcis
+
   Scenario: Changing federation outgoing
     Given parameter "outgoing_server2server_share_enabled" of app "files_sharing" has been set to "no"
     When the administrator retrieves the capabilities using the capabilities API
@@ -417,7 +417,7 @@ Feature: capabilities
       | files_sharing | user_enumeration@@@group_members_only | EMPTY             |
       | files         | bigfilechunking                       | 1                 |
 
-  @skipOnOcis
+
   Scenario: Changing federation incoming
     Given parameter "incoming_server2server_share_enabled" of app "files_sharing" has been set to "no"
     When the administrator retrieves the capabilities using the capabilities API
@@ -442,7 +442,7 @@ Feature: capabilities
       | files_sharing | user_enumeration@@@group_members_only | EMPTY             |
       | files         | bigfilechunking                       | 1                 |
 
-  @skipOnOcis
+
   Scenario: Changing "password enforced for read-only public link shares"
     Given parameter "shareapi_enforce_links_password_read_only" of app "core" has been set to "yes"
     When the administrator retrieves the capabilities using the capabilities API
@@ -470,7 +470,7 @@ Feature: capabilities
       | files_sharing | user_enumeration@@@group_members_only          | EMPTY             |
       | files         | bigfilechunking                                | 1                 |
 
-  @skipOnOcis
+
   Scenario: Changing "password enforced for read-write public link shares"
     Given parameter "shareapi_enforce_links_password_read_write" of app "core" has been set to "yes"
     When the administrator retrieves the capabilities using the capabilities API
@@ -498,7 +498,7 @@ Feature: capabilities
       | files_sharing | user_enumeration@@@group_members_only          | EMPTY             |
       | files         | bigfilechunking                                | 1                 |
 
-  @skipOnOcis
+
   Scenario: Changing "password enforced for write-only public link shares"
     Given parameter "shareapi_enforce_links_password_write_only" of app "core" has been set to "yes"
     When the administrator retrieves the capabilities using the capabilities API
@@ -526,7 +526,7 @@ Feature: capabilities
       | files_sharing | user_enumeration@@@group_members_only          | EMPTY             |
       | files         | bigfilechunking                                | 1                 |
 
-  @skipOnOcis
+
   Scenario: Changing public notifications
     Given parameter "shareapi_allow_public_notification" of app "core" has been set to "yes"
     When the administrator retrieves the capabilities using the capabilities API
@@ -551,7 +551,7 @@ Feature: capabilities
       | files_sharing | user_enumeration@@@group_members_only | EMPTY             |
       | files         | bigfilechunking                       | 1                 |
 
-  @skipOnOcis
+
   Scenario: Changing public social share
     Given parameter "shareapi_allow_social_share" of app "core" has been set to "no"
     When the administrator retrieves the capabilities using the capabilities API
@@ -576,7 +576,7 @@ Feature: capabilities
       | files_sharing | user_enumeration@@@group_members_only | EMPTY             |
       | files         | bigfilechunking                       | 1                 |
 
-  @skipOnOcis
+
   Scenario: Changing expire date
     Given parameter "shareapi_default_expire_date" of app "core" has been set to "yes"
     When the administrator retrieves the capabilities using the capabilities API
@@ -602,7 +602,7 @@ Feature: capabilities
       | files_sharing | user_enumeration@@@group_members_only | EMPTY             |
       | files         | bigfilechunking                       | 1                 |
 
-  @skipOnOcis
+
   Scenario: Changing expire date enforcing
     Given parameter "shareapi_default_expire_date" of app "core" has been set to "yes"
     And parameter "shareapi_enforce_expire_date" of app "core" has been set to "yes"
@@ -630,7 +630,7 @@ Feature: capabilities
       | files_sharing | user_enumeration@@@group_members_only | EMPTY             |
       | files         | bigfilechunking                       | 1                 |
 
-  @skipOnOcis
+
   Scenario: Changing group sharing allowed
     Given parameter "shareapi_allow_group_sharing" of app "core" has been set to "no"
     When the administrator retrieves the capabilities using the capabilities API
@@ -655,7 +655,7 @@ Feature: capabilities
       | files_sharing | user_enumeration@@@group_members_only | EMPTY             |
       | files         | bigfilechunking                       | 1                 |
 
-  @skipOnOcis
+
   Scenario: Changing only share with group member
     Given parameter "shareapi_only_share_with_group_members" of app "core" has been set to "yes"
     When the administrator retrieves the capabilities using the capabilities API
@@ -680,7 +680,7 @@ Feature: capabilities
       | files_sharing | user_enumeration@@@group_members_only | EMPTY             |
       | files         | bigfilechunking                       | 1                 |
 
-  @skipOnOcis
+
   Scenario: Changing only share with membership groups
     Given parameter "shareapi_only_share_with_membership_groups" of app "core" has been set to "yes"
     When the administrator retrieves the capabilities using the capabilities API
@@ -706,7 +706,7 @@ Feature: capabilities
       | files_sharing | user_enumeration@@@group_members_only | EMPTY             |
       | files         | bigfilechunking                       | 1                 |
 
-  @skipOnOcis
+
   Scenario: Changing auto accept share
     Given parameter "shareapi_auto_accept_share" of app "core" has been set to "no"
     When the administrator retrieves the capabilities using the capabilities API
@@ -733,7 +733,7 @@ Feature: capabilities
       | files_sharing | user_enumeration@@@group_members_only | EMPTY             |
       | files         | bigfilechunking                       | 1                 |
 
-  @skipOnOcis
+
   Scenario: Changing allow share dialog user enumeration
     Given parameter "shareapi_allow_share_dialog_user_enumeration" of app "core" has been set to "no"
     When the administrator retrieves the capabilities using the capabilities API
@@ -757,7 +757,7 @@ Feature: capabilities
       | files_sharing | user_enumeration@@@enabled    | EMPTY             |
       | files         | bigfilechunking               | 1                 |
 
-  @skipOnOcis
+
   Scenario: Changing allow share dialog user enumeration for group members only
     Given parameter "shareapi_share_dialog_user_enumeration_group_members" of app "core" has been set to "yes"
     When the administrator retrieves the capabilities using the capabilities API
@@ -782,7 +782,7 @@ Feature: capabilities
       | files_sharing | user_enumeration@@@group_members_only | 1                 |
       | files         | bigfilechunking                       | 1                 |
 
-  @skipOnOcis
+
   Scenario: Changing allow mail notification
     Given parameter "shareapi_allow_mail_notification" of app "core" has been set to "yes"
     When the administrator retrieves the capabilities using the capabilities API
@@ -808,7 +808,7 @@ Feature: capabilities
       | files_sharing | user@@@send_mail                      | 1                 |
       | files         | bigfilechunking                       | 1                 |
 
-  @skipOnOcis
+
   Scenario: Changing exclude groups from sharing
     Given parameter "shareapi_exclude_groups" of app "core" has been set to "yes"
     And group "group1" has been created
@@ -837,7 +837,7 @@ Feature: capabilities
       | files_sharing | user_enumeration@@@group_members_only | EMPTY             |
       | files         | bigfilechunking                       | 1                 |
 
-  @skipOnOcis
+
   Scenario: When in a group that is excluded from sharing, can_share is off
     Given parameter "shareapi_exclude_groups" of app "core" has been set to "yes"
     And user "Alice" has been created with default attributes and without skeleton files
@@ -869,7 +869,7 @@ Feature: capabilities
       | files_sharing | user_enumeration@@@group_members_only | EMPTY             |
       | files         | bigfilechunking                       | 1                 |
 
-  @skipOnOcis
+
   Scenario: When not in any group that is excluded from sharing, can_share is on
     Given parameter "shareapi_exclude_groups" of app "core" has been set to "yes"
     And user "Alice" has been created with default attributes and without skeleton files
@@ -901,7 +901,7 @@ Feature: capabilities
       | files_sharing | user_enumeration@@@group_members_only | EMPTY             |
       | files         | bigfilechunking                       | 1                 |
 
-  @skipOnOcis
+
   Scenario: When in a group that is excluded from sharing and in another group, can_share is off
     Given parameter "shareapi_exclude_groups" of app "core" has been set to "yes"
     And user "Alice" has been created with default attributes and without skeleton files
@@ -934,7 +934,7 @@ Feature: capabilities
       | files_sharing | user_enumeration@@@group_members_only | EMPTY             |
       | files         | bigfilechunking                       | 1                 |
 
-  @skipOnOcis
+
   Scenario: blacklisted_files_regex is reported in capabilities
     When the administrator retrieves the capabilities using the capabilities API
     Then the OCS status code should be "100"

--- a/tests/acceptance/features/apiShareCreateSpecialToShares1/createShareUniqueReceivedNames.feature
+++ b/tests/acceptance/features/apiShareCreateSpecialToShares1/createShareUniqueReceivedNames.feature
@@ -24,7 +24,6 @@ Feature: resources shared with the same name are received with unique names
     And user "Carol" should see the following elements
       | Shares/foo/ |
       | <share>     |
-    @skipOnOcis
     Examples:
       | share            |
       | /Shares/foo (2)/ |

--- a/tests/acceptance/features/apiShareCreateSpecialToShares1/createShareWhenExcludedFromSharing.feature
+++ b/tests/acceptance/features/apiShareCreateSpecialToShares1/createShareWhenExcludedFromSharing.feature
@@ -1,4 +1,4 @@
-@api @files_sharing-app-required @issue-ocis-reva-41 @skipOnOcis
+@api @files_sharing-app-required @issue-ocis-reva-41
 Feature: cannot share resources when in a group that is excluded from sharing
 
   Background:

--- a/tests/acceptance/features/apiShareCreateSpecialToShares2/createShareReceivedInMultipleWays.feature
+++ b/tests/acceptance/features/apiShareCreateSpecialToShares2/createShareReceivedInMultipleWays.feature
@@ -33,7 +33,6 @@ Feature: share resources where the sharee receives the share in multiple ways
       | mimetype               | text/plain                |
       | storage_id             | ANY_VALUE                 |
       | share_type             | user                      |
-    @skipOnOcis
     Examples:
       | ocs_api_version | ocs_status_code | file_target               |
       | 1               | 100             | /Shares/textfile0 (2).txt |
@@ -123,7 +122,6 @@ Feature: share resources where the sharee receives the share in multiple ways
       | permissions | read,update     |
     And the content of file "/Shares/randomfile.txt" for user "Alice" should be "First data"
     And the content of file "/Shares/randomfile (2).txt" for user "Alice" should be "Second data"
-    @skipOnOcis
     Examples:
       | ocs_api_version | file_target_1          | file_target_2              |
       | 1               | /Shares/randomfile.txt | /Shares/randomfile (2).txt |
@@ -157,7 +155,6 @@ Feature: share resources where the sharee receives the share in multiple ways
       | permissions | read,share      |
     And as "Alice" folder "/Shares/zzzfolder/Brian" should exist
     And as "Alice" folder "/Shares/zzzfolder (2)/Carol" should exist
-    @skipOnOcis
     Examples:
       | ocs_api_version | file_target_1     | file_target_2         | ocs_status_code |
       | 1               | /Shares/zzzfolder | /Shares/zzzfolder (2) | 100             |

--- a/tests/acceptance/features/apiShareCreateSpecialToShares2/createShareWhenShareWithOnlyMembershipGroups.feature
+++ b/tests/acceptance/features/apiShareCreateSpecialToShares2/createShareWhenShareWithOnlyMembershipGroups.feature
@@ -6,7 +6,7 @@ Feature: cannot share resources outside the group when share with membership gro
     And auto-accept shares has been disabled
     And user "Alice" has been created with default attributes and without skeleton files
 
-  @issue-ocis-1328 @skipOnOcis
+  @issue-ocis-1328
   Scenario Outline: sharer should not be able to share a folder to a group which he/she is not member of when share with only member group is enabled
     Given using OCS API version "<ocs_api_version>"
     And parameter "shareapi_only_share_with_membership_groups" of app "core" has been set to "yes"
@@ -66,7 +66,7 @@ Feature: cannot share resources outside the group when share with membership gro
       | 1               | 100             |
       | 2               | 200             |
 
-  @issue-ocis-1328 @skipOnOcis
+  @issue-ocis-1328
   Scenario Outline: sharer should not be able to share a file to a group which he/she is not member of when share with only member group is enabled
     Given using OCS API version "<ocs_api_version>"
     And parameter "shareapi_only_share_with_membership_groups" of app "core" has been set to "yes"

--- a/tests/acceptance/features/apiShareManagementBasicToShares/createShareToSharesFolder.feature
+++ b/tests/acceptance/features/apiShareManagementBasicToShares/createShareToSharesFolder.feature
@@ -523,7 +523,6 @@ Feature: sharing
     And file "/textfile0.txt" should not be included as path in the response
     And as "Brian" file "/Shares/textfile0.txt" should not exist
     And as "Carol" file "/Shares/textfile0.txt" should not exist
-    @skipOnOcis
     Examples:
       | ocs_api_version | ocs_status_code | path                  |
       | 1               | 100             | /Shares/textfile0.txt |

--- a/tests/acceptance/features/apiShareManagementBasicToShares/excludeGroupFromReceivingSharesToSharesFolder.feature
+++ b/tests/acceptance/features/apiShareManagementBasicToShares/excludeGroupFromReceivingSharesToSharesFolder.feature
@@ -18,7 +18,7 @@ Feature: Exclude groups from receiving shares
     And user "Brian" has been added to group "grp1"
     And user "David" has been added to group "grp2"
 
-  @skipOnOcis
+
   Scenario Outline: user cannot share with a group that is excluded from receiving shares but can share with other groups
     Given using OCS API version "<ocs_api_version>"
     And user "Alice" has created folder "PARENT"
@@ -45,7 +45,7 @@ Feature: Exclude groups from receiving shares
       | 1               | 200              |
       | 2               | 403              |
 
-  @skipOnOcis
+
   Scenario Outline: exclude multiple groups from receiving shares stops the user to share with any of them
     Given using OCS API version "<ocs_api_version>"
     And group "grp3" has been created
@@ -77,7 +77,7 @@ Feature: Exclude groups from receiving shares
       | 1               | 200              |
       | 2               | 403              |
 
-  @skipOnOcis
+
   Scenario Outline: user cannot reshare a received share with a group that is excluded from receiving shares but can share with other groups
     Given using OCS API version "<ocs_api_version>"
     And user "Carol" has created folder "PARENT"

--- a/tests/acceptance/features/apiShareManagementToShares/mergeShare.feature
+++ b/tests/acceptance/features/apiShareManagementToShares/mergeShare.feature
@@ -108,7 +108,6 @@ Feature: sharing
     And as user "Brian" folder "/merge-test-inside-twogroups-perms" should contain a property "oc:permissions" with value "<expected_permission_1>" or with value "<expected_permission_2>"
     And as "Brian" folder "/Shares/merge-test-inside-twogroups-perms" should not exist
     And as "Brian" folder "/Shares/merge-test-inside-twogroups-perms (2)" should not exist
-    @skipOnOcis
     Examples:
       | expected_permission_1 | expected_permission_2 |
       | RDNVCK                | RMDNVCK               |

--- a/tests/acceptance/features/apiSharePublicLink1/createPublicLinkShare.feature
+++ b/tests/acceptance/features/apiSharePublicLink1/createPublicLinkShare.feature
@@ -333,7 +333,7 @@ Feature: create a public link share
       | 1               | 403             |
       | 2               | 403             |
 
-  @issue-ocis-reva-41 @skipOnOcis
+  @issue-ocis-reva-41
   Scenario Outline: Creating a link share with update permissions defaults to read permissions when public upload disabled globally
     Given using OCS API version "<ocs_api_version>"
     And parameter "shareapi_allow_public_upload" of app "core" has been set to "no"

--- a/tests/acceptance/features/apiShareReshareToShares2/reShareDisabled.feature
+++ b/tests/acceptance/features/apiShareReshareToShares2/reShareDisabled.feature
@@ -10,7 +10,7 @@ Feature: resharing can be disabled
       | Brian    |
     And user "Alice" has uploaded file "filesForUpload/textfile.txt" to "/textfile0.txt"
 
-  @smokeTest @skipOnOcis
+  @smokeTest
   Scenario Outline: resharing a file is not allowed when allow resharing has been disabled
     Given using OCS API version "<ocs_api_version>"
     And user "Carol" has been created with default attributes and without skeleton files

--- a/tests/acceptance/features/apiShareReshareToShares2/reShareWhenShareWithOnlyMembershipGroups.feature
+++ b/tests/acceptance/features/apiShareReshareToShares2/reShareWhenShareWithOnlyMembershipGroups.feature
@@ -1,4 +1,4 @@
-@api @files_sharing-app-required @issue-ocis-1289 @issue-ocis-reva-194 @issue-ocis-1328 @skipOnOcis
+@api @files_sharing-app-required @issue-ocis-1289 @issue-ocis-reva-194 @issue-ocis-1328
 Feature: resharing a resource with an expiration date
 
   Background:

--- a/tests/acceptance/features/apiShareUpdateToShares/updateShare.feature
+++ b/tests/acceptance/features/apiShareUpdateToShares/updateShare.feature
@@ -224,7 +224,6 @@ Feature: sharing
       | mimetype          | httpd/unix-directory |
     And as "Alice" folder "/Alice-folder/folder2" should not exist
     And as "Carol" folder "/Carol-folder/folder2" should exist
-    @skipOnOcis
     Examples:
       | path                 |
       | /Shares/Carol-folder |
@@ -299,7 +298,7 @@ Feature: sharing
       | 1               | 100             |
       | 2               | 200             |
 
-  @issue-ocis-1328 @skipOnOcis
+  @issue-ocis-1328
   Scenario Outline: Forbid sharing with groups
     Given using OCS API version "<ocs_api_version>"
     And group "grp1" has been created
@@ -313,7 +312,7 @@ Feature: sharing
       | 1               | 200              |
       | 2               | 404              |
 
-  @issue-ocis-1328 @skipOnOcis
+  @issue-ocis-1328
   Scenario Outline: Editing share permission of existing share is forbidden when sharing with groups is forbidden
     Given using OCS API version "<ocs_api_version>"
     And group "grp1" has been created
@@ -338,7 +337,7 @@ Feature: sharing
       | 1               | 200              |
       | 2               | 400              |
 
-  @issue-ocis-1328 @skipOnOcis
+  @issue-ocis-1328
   Scenario Outline: Deleting group share is allowed when sharing with groups is forbidden
     Given using OCS API version "<ocs_api_version>"
     And group "grp1" has been created
@@ -357,7 +356,7 @@ Feature: sharing
       | 1               | 100             | 200              |
       | 2               | 200             | 404              |
 
-  @issue-ocis-1328 @skipOnOcis
+  @issue-ocis-1328
   Scenario Outline: user can update the role in an existing share after the system maximum expiry date has been reduced
     Given using OCS API version "<ocs_api_version>"
     And parameter "shareapi_default_expire_date_user_share" of app "core" has been set to "yes"
@@ -384,7 +383,7 @@ Feature: sharing
       | 1               | 100             |
       | 2               | 200             |
 
-  @issue-ocis-1328 @skipOnOcis
+  @issue-ocis-1328
   Scenario Outline: user cannot concurrently update the role and date in an existing share after the system maximum expiry date has been reduced
     Given using OCS API version "<ocs_api_version>"
     And parameter "shareapi_default_expire_date_user_share" of app "core" has been set to "yes"

--- a/tests/acceptance/features/apiTranslation/translation.feature
+++ b/tests/acceptance/features/apiTranslation/translation.feature
@@ -1,4 +1,4 @@
-@api @skipOnLDAP @skipOnOcis
+@api @skipOnLDAP
 Feature: translate messages in api response to preferred language
   As a user
   I want response messages to be translated in preferred language

--- a/tests/acceptance/features/apiTrashbin/trashbinDelete.feature
+++ b/tests/acceptance/features/apiTrashbin/trashbinDelete.feature
@@ -82,7 +82,6 @@ Feature: files and folders can be deleted from the trashbin
     And as "Alice" the file with original path "/textfile0.txt" should exist in the trashbin
     And as "Alice" the file with original path "/PARENT/parent.txt" should exist in the trashbin
     And as "Alice" the file with original path "/PARENT/CHILD/child.txt" should exist in the trashbin
-    @skipOnOcis
     Examples:
       | dav-path | status-code |
       | new      | 401         |

--- a/tests/acceptance/features/apiTrashbin/trashbinFilesFolders.feature
+++ b/tests/acceptance/features/apiTrashbin/trashbinFilesFolders.feature
@@ -148,7 +148,6 @@ Feature: files and folders exist in the trashbin after being deleted
     And the last webdav response should not contain the following elements
       | path          | user            |
       | textfile1.txt | testtrashbin100 |
-    @skipOnOcis
     Examples:
       | dav-path | status-code |
       | new      | 401         |
@@ -168,7 +167,6 @@ Feature: files and folders exist in the trashbin after being deleted
       | path          | user            |
       | textfile0.txt | testtrashbin101 |
       | textfile2.txt | testtrashbin101 |
-    @skipOnOcis
     Examples:
       | dav-path | status-code |
       | new      | 401         |
@@ -193,7 +191,6 @@ Feature: files and folders exist in the trashbin after being deleted
       | textfile0.txt | testtrashbin102 |
       | textfile2.txt | testtrashbin102 |
       | textfile3.txt | testtrashbin102 |
-    @skipOnOcis
     Examples:
       | dav-path | status-code |
       | new      | 401         |
@@ -205,7 +202,6 @@ Feature: files and folders exist in the trashbin after being deleted
     And user "testtrashbinempty" has uploaded file "filesForUpload/textfile.txt" to "/textfile1.txt"
     When user "Alice" tries to list the trashbin content for user "testtrashbinempty"
     Then the HTTP status code should be "<status-code>"
-    @skipOnOcis
     Examples:
       | dav-path | status-code |
       | new      | 401         |

--- a/tests/acceptance/features/apiTrashbinRestore/trashbinRestore.feature
+++ b/tests/acceptance/features/apiTrashbinRestore/trashbinRestore.feature
@@ -193,7 +193,6 @@ Feature: Restore deleted files/folders
     And as "Alice" the folder with original path "/textfile0.txt" should exist in the trashbin
     And user "Alice" should not see the following elements
       | /textfile0.txt |
-    @skipOnOcis
     Examples:
       | dav-path | status-code |
       | old      | 401         |

--- a/tests/acceptance/features/apiWebdavMove1/moveFolder.feature
+++ b/tests/acceptance/features/apiWebdavMove1/moveFolder.feature
@@ -113,7 +113,7 @@ Feature: move (rename) folder
       | old         |
       | new         |
 
-  @files_sharing-app-required @skipOnOcis
+  @files_sharing-app-required
   Scenario Outline: Moving a folder out of a shared folder as the sharee and as the sharer
     Given using <dav_version> DAV path
     And user "Brian" has been created with default attributes and without skeleton files
@@ -137,7 +137,7 @@ Feature: move (rename) folder
       | new         | Alice |
       | new         | Brian |
 
-  @files_sharing-app-required @skipOnOcis
+  @files_sharing-app-required
   Scenario Outline: Moving a folder into a shared folder as the sharee and as the sharer
     Given using <dav_version> DAV path
     And user "Brian" has been created with default attributes and without skeleton files

--- a/tests/acceptance/features/apiWebdavMove2/moveFile.feature
+++ b/tests/acceptance/features/apiWebdavMove2/moveFile.feature
@@ -80,7 +80,7 @@ Feature: move (rename) file
       | old         |
       | new         |
 
-  @files_sharing-app-required @skipOnOcis
+  @files_sharing-app-required
   Scenario Outline: Moving a file into a shared folder as the sharee and as the sharer
     Given using <dav_version> DAV path
     And user "Brian" has been created with default attributes and without skeleton files
@@ -103,7 +103,7 @@ Feature: move (rename) file
       | old         | Brian |
       | new         | Brian |
 
-  @files_sharing-app-required @skipOnOcis
+  @files_sharing-app-required
   Scenario Outline: Moving a file out of a shared folder as the sharee and as the sharer
     Given using <dav_version> DAV path
     And user "Brian" has been created with default attributes and without skeleton files
@@ -126,7 +126,7 @@ Feature: move (rename) file
       | old         | Brian |
       | new         | Brian |
 
-  @files_sharing-app-required @skipOnOcis
+  @files_sharing-app-required
   Scenario Outline: Moving a file to a shared folder with no permissions
     Given using <dav_version> DAV path
     And user "Alice" has uploaded file "filesForUpload/textfile.txt" to "textfile0.txt"
@@ -145,7 +145,7 @@ Feature: move (rename) file
       | old         |
       | new         |
 
-  @files_sharing-app-required @skipOnOcis
+  @files_sharing-app-required
   Scenario Outline: Moving a file to overwrite a file in a shared folder with no permissions
     Given using <dav_version> DAV path
     And user "Alice" has uploaded file with content "ownCloud test text file 0" to "textfile0.txt"
@@ -204,7 +204,7 @@ Feature: move (rename) file
       | old         |
       | new         |
 
-  @files_sharing-app-required @skipOnOcis
+  @files_sharing-app-required
   Scenario Outline: Checking file id after a move between received shares
     Given using <dav_version> DAV path
     And user "Brian" has been created with default attributes and without skeleton files

--- a/tests/acceptance/features/apiWebdavPreviews/previewsExactSizing.feature
+++ b/tests/acceptance/features/apiWebdavPreviews/previewsExactSizing.feature
@@ -10,7 +10,7 @@ Feature: sizing of previews of files downloaded through the webdav API
   Background:
     Given user "Alice" has been created with default attributes and without skeleton files
 
-  @skipOnOcis
+
   Scenario Outline: download different sizes of previews of file
     Given user "Alice" has uploaded file "filesForUpload/lorem.txt" to "/parent.txt"
     When user "Alice" downloads the preview of "/parent.txt" with width <width> and height <height> using the WebDAV API

--- a/tests/acceptance/features/apiWebdavProperties2/getFileProperties.feature
+++ b/tests/acceptance/features/apiWebdavProperties2/getFileProperties.feature
@@ -246,8 +246,6 @@ Feature: get file properties
     Then the HTTP status code should be "404"
     And the value of the item "/d:error/s:message" in the response about user "Alice" should be "<message1>" or "<message2>"
     And the value of the item "/d:error/s:exception" in the response about user "Alice" should be "Sabre\DAV\Exception\NotFound"
-
-    @skipOnOcis
     Examples:
       | url                                  | message1                                     | message2 |
       | /remote.php/dav/files/does-not-exist | Principal with name does-not-exist not found |          |

--- a/tests/acceptance/features/cliMain/configKey.feature
+++ b/tests/acceptance/features/cliMain/configKey.feature
@@ -95,7 +95,7 @@ Feature: add and delete app configs using occ command
     Then the command should have been successful
     And the system config key "installed" from the last command output should match value "true" of type "boolean"
 
-  @skipOnOcis
+
   Scenario: Check that search_min_length can be changed
     Given using OCS API version "1"
     When the administrator updates system config key "user.search_min_length" with value "4" using the occ command


### PR DESCRIPTION
## Description
This PR removes scenario tag `skipOnOcis`  from the feature files.
## Related Issue
Part of issue 
- https://github.com/owncloud/core/issues/40572

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
- CI

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Database schema changes (next release will require increase of minor version instead of patch)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [x] Tests only (no source changes)

## Checklist:
<!-- Tick the checkboxes when done. -->
<!-- Raise documentation ticket in https://github.com/owncloud/documentation -->
- [ ] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 
- [ ] Changelog item, see [TEMPLATE](https://github.com/owncloud/core/blob/master/changelog/TEMPLATE)
