### PR TITLE
[tests-only][full-ci] Remove scenario tag @notToImplementOnOcis from feature files

### DIFF
--- a/tests/acceptance/features/apiAuth/cors.feature
+++ b/tests/acceptance/features/apiAuth/cors.feature
@@ -32,7 +32,7 @@ Feature: CORS headers
       | 1               | /config                                          | 100      | 200       |
       | 2               | /config                                          | 200      | 200       |
 
-    @files_external-app-required @notToImplementOnOCIS
+    @files_external-app-required
     Examples:
       | ocs_api_version | endpoint                                         | ocs-code | http-code |
       | 1               | /apps/files_external/api/v1/mounts               | 100      | 200       |
@@ -100,7 +100,7 @@ Feature: CORS headers
       | 1               | /cloud/users                                     | 997      | 401       |
       | 2               | /cloud/users                                     | 997      | 401       |
 
-    @files_external-app-required @notToImplementOnOCIS
+    @files_external-app-required
     Examples:
       | ocs_api_version | endpoint                                         | ocs-code | http-code |
       | 1               | /apps/files_external/api/v1/mounts               | 100      | 200       |
@@ -166,7 +166,7 @@ Feature: CORS headers
       | 1               | /cloud/users                                     | 997      | 401       |
       | 2               | /cloud/users                                     | 997      | 401       |
 
-    @files_external-app-required @notToImplementOnOCIS
+    @files_external-app-required
     Examples:
       | ocs_api_version | endpoint                                         | ocs-code | http-code |
       | 1               | /apps/files_external/api/v1/mounts               | 997      | 401       |

--- a/tests/acceptance/features/apiAuth/corsOc10Issue34679.feature
+++ b/tests/acceptance/features/apiAuth/corsOc10Issue34679.feature
@@ -1,4 +1,4 @@
-@api @notToImplementOnOCIS
+@api
 Feature: CORS headers current oC10 behavior for issue-34679
 
   Background:
@@ -36,7 +36,7 @@ Feature: CORS headers current oC10 behavior for issue-34679
       | 1               | /cloud/users                                     | 997      | 401       |
       | 2               | /cloud/users                                     | 997      | 401       |
 
-    @files_external-app-required @notToImplementOnOCIS
+    @files_external-app-required
     Examples:
       | ocs_api_version | endpoint                                         | ocs-code | http-code |
       | 1               | /apps/files_external/api/v1/mounts               | 997      | 401       |

--- a/tests/acceptance/features/apiAuth/filesAppAuth.feature
+++ b/tests/acceptance/features/apiAuth/filesAppAuth.feature
@@ -1,4 +1,4 @@
-@api @notToImplementOnOCIS @issue-ocis-reva-28
+@api @issue-ocis-reva-28
 Feature: auth
 
   Background:

--- a/tests/acceptance/features/apiAuth/tokenAuth.feature
+++ b/tests/acceptance/features/apiAuth/tokenAuth.feature
@@ -1,4 +1,4 @@
-@api @notToImplementOnOCIS @issue-ocis-reva-28 @issue-ocis-reva-37
+@api @issue-ocis-reva-28 @issue-ocis-reva-37
 Feature: tokenAuth
 
   Background:

--- a/tests/acceptance/features/apiAuth/webDavAuth.feature
+++ b/tests/acceptance/features/apiAuth/webDavAuth.feature
@@ -17,13 +17,13 @@ Feature: auth
       | dav_path           |
       | /remote.php/webdav |
 
-  @smokeTest @notToImplementOnOCIS @issue-ocis-reva-28
+  @smokeTest @issue-ocis-reva-28
   Scenario: using WebDAV with token auth
     Given a new client token for "Alice" has been generated
     When user "Alice" requests "/remote.php/webdav" with "PROPFIND" using basic token auth
     Then the HTTP status code should be "207"
 
-  @smokeTest  @notToImplementOnOCIS
+  @smokeTest
   Scenario: using WebDAV with browser session
     Given a new browser session for "Alice" has been started
     When the user requests "/remote.php/webdav" with "PROPFIND" using the browser session

--- a/tests/acceptance/features/apiAuthOcs/ocsDELETEAuthOc10Issue32068.feature
+++ b/tests/acceptance/features/apiAuthOcs/ocsDELETEAuthOc10Issue32068.feature
@@ -1,4 +1,4 @@
-@api @files_sharing-app-required @notToImplementOnOCIS
+@api @files_sharing-app-required
 Feature: current oC10 behavior for issue-32068
 
   @smokeTest @issue-32068 @issue-ocis-reva-30 @issue-ocis-reva-65 @skipOnBruteForceProtection @issue-brute_force_protection-112

--- a/tests/acceptance/features/apiAuthOcs/ocsGETAuth.feature
+++ b/tests/acceptance/features/apiAuthOcs/ocsGETAuth.feature
@@ -150,7 +150,7 @@ Feature: auth
     Then the HTTP status code of responses on all endpoints should be "200"
     And the OCS status code of responses on all endpoints should be "200"
 
-  @notToImplementOnOCIS @issue-ocis-reva-30 @issue-ocis-reva-28
+  @issue-ocis-reva-30 @issue-ocis-reva-28
   Scenario: using OCS with token auth of a normal user
     Given a new client token for "Alice" has been generated
     When user "Alice" requests these endpoints with "GET" using basic token auth
@@ -182,7 +182,7 @@ Feature: auth
     Then the HTTP status code of responses on all endpoints should be "401"
     And the OCS status code of responses on all endpoints should be "997"
 
-  @notToImplementOnOCIS
+
   Scenario: using OCS with browser session of normal user
     Given a new browser session for "Alice" has been started
     When the user requests these endpoints with "GET" using a new browser session
@@ -214,7 +214,7 @@ Feature: auth
     Then the HTTP status code of responses on all endpoints should be "401"
     And the OCS status code of responses on all endpoints should be "997"
 
-  @notToImplementOnOCIS
+
   Scenario: using OCS with an app password of a normal user
     Given a new browser session for "Alice" has been started
     And the user has generated a new app password named "my-client"

--- a/tests/acceptance/features/apiAuthOcs/ocsGETAuthFilesExternal.feature
+++ b/tests/acceptance/features/apiAuthOcs/ocsGETAuthFilesExternal.feature
@@ -1,4 +1,4 @@
-@api @files_external-app-required @notToImplementOnOCIS
+@api @files_external-app-required
 Feature: auth
 
   Background:

--- a/tests/acceptance/features/apiAuthOcs/ocsGETAuthFilesExternalOc10Issue32068.feature
+++ b/tests/acceptance/features/apiAuthOcs/ocsGETAuthFilesExternalOc10Issue32068.feature
@@ -1,4 +1,4 @@
-@api @notToImplementOnOCIS @files_external-app-required @issue-32068
+@api @files_external-app-required @issue-32068
 Feature: current oC10 behavior for issue-32068
 
   Background:

--- a/tests/acceptance/features/apiAuthOcs/ocsGETAuthOc10Issue32068.feature
+++ b/tests/acceptance/features/apiAuthOcs/ocsGETAuthOc10Issue32068.feature
@@ -1,4 +1,4 @@
-@api @notToImplementOnOCIS @files_sharing-app-required @issue-32068
+@api @files_sharing-app-required @issue-32068
 Feature: current oC10 behavior for issue-32068
 
   Background:

--- a/tests/acceptance/features/apiAuthOcs/ocsPUTAuthOc10Issue38423.feature
+++ b/tests/acceptance/features/apiAuthOcs/ocsPUTAuthOc10Issue38423.feature
@@ -1,4 +1,4 @@
-@api @files_sharing-app-required @notToImplementOnOCIS
+@api @files_sharing-app-required
 #When this issue is fixed, please delete this file and use the one from ocsPUTAuth.feature
 Feature: current oC10 behavior for issue-38423
 

--- a/tests/acceptance/features/apiAuthWebDav/webDavCOPYAuth.feature
+++ b/tests/acceptance/features/apiAuthWebDav/webDavCOPYAuth.feature
@@ -79,7 +79,7 @@ Feature: COPY file/folder
       | /remote.php/dav/files/%username%/PARENT/parent.txt |
     Then the HTTP status code of responses on all endpoints should be "401"
 
-	@issue-ocis-reva-37
+  @issue-ocis-reva-37
   Scenario: send COPY requests to webDav endpoints using token authentication should not work
     Given token auth has been enforced
     And a new browser session for "Alice" has been started
@@ -93,7 +93,7 @@ Feature: COPY file/folder
       | /remote.php/dav/files/%username%/PARENT/parent.txt |
     Then the HTTP status code of responses on all endpoints should be "401"
 
-	@issue-ocis-reva-37
+  @issue-ocis-reva-37
   Scenario: send COPY requests to webDav endpoints using app password token as password
     Given token auth has been enforced
     And a new browser session for "Alice" has been started

--- a/tests/acceptance/features/apiAuthWebDav/webDavCOPYAuth.feature
+++ b/tests/acceptance/features/apiAuthWebDav/webDavCOPYAuth.feature
@@ -79,7 +79,7 @@ Feature: COPY file/folder
       | /remote.php/dav/files/%username%/PARENT/parent.txt |
     Then the HTTP status code of responses on all endpoints should be "401"
 
-  @notToImplementOnOCIS @issue-ocis-reva-37
+	@issue-ocis-reva-37
   Scenario: send COPY requests to webDav endpoints using token authentication should not work
     Given token auth has been enforced
     And a new browser session for "Alice" has been started
@@ -93,7 +93,7 @@ Feature: COPY file/folder
       | /remote.php/dav/files/%username%/PARENT/parent.txt |
     Then the HTTP status code of responses on all endpoints should be "401"
 
-  @notToImplementOnOCIS @issue-ocis-reva-37
+	@issue-ocis-reva-37
   Scenario: send COPY requests to webDav endpoints using app password token as password
     Given token auth has been enforced
     And a new browser session for "Alice" has been started

--- a/tests/acceptance/features/apiAuthWebDav/webDavCaseInsensitiveAuth.feature
+++ b/tests/acceptance/features/apiAuthWebDav/webDavCaseInsensitiveAuth.feature
@@ -1,4 +1,4 @@
-@api @notToImplementOnOCIS
+@api
 Feature: usernames are case-insensitive in webDAV requests with app passwords
 
   Background:

--- a/tests/acceptance/features/apiAuthWebDav/webDavDELETEAuthOC10Issue40144.feature
+++ b/tests/acceptance/features/apiAuthWebDav/webDavDELETEAuthOC10Issue40144.feature
@@ -1,4 +1,4 @@
-@api @notToImplementOnOCIS
+@api
 Feature: delete file/folder
 
   Background:

--- a/tests/acceptance/features/apiAuthWebDav/webDavLOCKAuth.feature
+++ b/tests/acceptance/features/apiAuthWebDav/webDavLOCKAuth.feature
@@ -78,7 +78,7 @@ Feature: LOCK file/folder
       | /remote.php/dav/files/%username%/PARENT/parent.txt |
     Then the HTTP status code of responses on all endpoints should be "401"
 
-	@issue-ocis-reva-37
+  @issue-ocis-reva-37
   Scenario: send LOCK requests to webDav endpoints using token authentication should not work
     Given token auth has been enforced
     And a new browser session for "Alice" has been started
@@ -92,7 +92,7 @@ Feature: LOCK file/folder
       | /remote.php/dav/files/%username%/PARENT/parent.txt |
     Then the HTTP status code of responses on all endpoints should be "401"
 
-	@issue-ocis-reva-37
+  @issue-ocis-reva-37
   Scenario: send LOCK requests to webDav endpoints using app password token as password
     Given token auth has been enforced
     And a new browser session for "Alice" has been started

--- a/tests/acceptance/features/apiAuthWebDav/webDavLOCKAuth.feature
+++ b/tests/acceptance/features/apiAuthWebDav/webDavLOCKAuth.feature
@@ -78,7 +78,7 @@ Feature: LOCK file/folder
       | /remote.php/dav/files/%username%/PARENT/parent.txt |
     Then the HTTP status code of responses on all endpoints should be "401"
 
-  @notToImplementOnOCIS @issue-ocis-reva-37
+	@issue-ocis-reva-37
   Scenario: send LOCK requests to webDav endpoints using token authentication should not work
     Given token auth has been enforced
     And a new browser session for "Alice" has been started
@@ -92,7 +92,7 @@ Feature: LOCK file/folder
       | /remote.php/dav/files/%username%/PARENT/parent.txt |
     Then the HTTP status code of responses on all endpoints should be "401"
 
-  @notToImplementOnOCIS @issue-ocis-reva-37
+	@issue-ocis-reva-37
   Scenario: send LOCK requests to webDav endpoints using app password token as password
     Given token auth has been enforced
     And a new browser session for "Alice" has been started

--- a/tests/acceptance/features/apiAuthWebDav/webDavMKCOLAuth.feature
+++ b/tests/acceptance/features/apiAuthWebDav/webDavMKCOLAuth.feature
@@ -86,7 +86,7 @@ Feature: create folder using MKCOL
       | /remote.php/dav/files/%username%/PARENT/parent.txt |
     Then the HTTP status code of responses on all endpoints should be "401"
 
-	@issue-ocis-reva-37
+  @issue-ocis-reva-37
   Scenario: send MKCOL requests to webDav endpoints using token authentication should not work
     Given token auth has been enforced
     And a new browser session for "Alice" has been started
@@ -100,7 +100,7 @@ Feature: create folder using MKCOL
       | /remote.php/dav/files/%username%/PARENT/parent.txt |
     Then the HTTP status code of responses on all endpoints should be "401"
 
-	@issue-ocis-reva-37
+  @issue-ocis-reva-37
   Scenario: send MKCOL requests to webDav endpoints using app password token as password
     Given token auth has been enforced
     And a new browser session for "Alice" has been started

--- a/tests/acceptance/features/apiAuthWebDav/webDavMKCOLAuth.feature
+++ b/tests/acceptance/features/apiAuthWebDav/webDavMKCOLAuth.feature
@@ -86,7 +86,7 @@ Feature: create folder using MKCOL
       | /remote.php/dav/files/%username%/PARENT/parent.txt |
     Then the HTTP status code of responses on all endpoints should be "401"
 
-  @notToImplementOnOCIS @issue-ocis-reva-37
+	@issue-ocis-reva-37
   Scenario: send MKCOL requests to webDav endpoints using token authentication should not work
     Given token auth has been enforced
     And a new browser session for "Alice" has been started
@@ -100,7 +100,7 @@ Feature: create folder using MKCOL
       | /remote.php/dav/files/%username%/PARENT/parent.txt |
     Then the HTTP status code of responses on all endpoints should be "401"
 
-  @notToImplementOnOCIS @issue-ocis-reva-37
+	@issue-ocis-reva-37
   Scenario: send MKCOL requests to webDav endpoints using app password token as password
     Given token auth has been enforced
     And a new browser session for "Alice" has been started

--- a/tests/acceptance/features/apiAuthWebDav/webDavMOVEAuth.feature
+++ b/tests/acceptance/features/apiAuthWebDav/webDavMOVEAuth.feature
@@ -75,7 +75,7 @@ Feature: MOVE file/folder
       | /remote.php/dav/files/%username%/PARENT/parent.txt |
     Then the HTTP status code of responses on all endpoints should be "401"
 
-  @notToImplementOnOCIS @issue-ocis-reva-37
+	@issue-ocis-reva-37
   Scenario: send MOVE requests to webDav endpoints using token authentication should not work
     Given token auth has been enforced
     And a new browser session for "Alice" has been started
@@ -89,7 +89,7 @@ Feature: MOVE file/folder
       | /remote.php/dav/files/%username%/PARENT/parent.txt |
     Then the HTTP status code of responses on all endpoints should be "401"
 
-  @notToImplementOnOCIS @issue-ocis-reva-37
+	@issue-ocis-reva-37
   Scenario: send MOVE requests to webDav endpoints using app password token as password
     Given token auth has been enforced
     And a new browser session for "Alice" has been started

--- a/tests/acceptance/features/apiAuthWebDav/webDavMOVEAuth.feature
+++ b/tests/acceptance/features/apiAuthWebDav/webDavMOVEAuth.feature
@@ -75,7 +75,7 @@ Feature: MOVE file/folder
       | /remote.php/dav/files/%username%/PARENT/parent.txt |
     Then the HTTP status code of responses on all endpoints should be "401"
 
-	@issue-ocis-reva-37
+  @issue-ocis-reva-37
   Scenario: send MOVE requests to webDav endpoints using token authentication should not work
     Given token auth has been enforced
     And a new browser session for "Alice" has been started
@@ -89,7 +89,7 @@ Feature: MOVE file/folder
       | /remote.php/dav/files/%username%/PARENT/parent.txt |
     Then the HTTP status code of responses on all endpoints should be "401"
 
-	@issue-ocis-reva-37
+  @issue-ocis-reva-37
   Scenario: send MOVE requests to webDav endpoints using app password token as password
     Given token auth has been enforced
     And a new browser session for "Alice" has been started

--- a/tests/acceptance/features/apiAuthWebDav/webDavMOVEAuthOC10Issue40144.feature
+++ b/tests/acceptance/features/apiAuthWebDav/webDavMOVEAuthOC10Issue40144.feature
@@ -1,4 +1,4 @@
-@api @notToImplementOnOCIS
+@api
 Feature: MOVE file/folder
 
   Background:

--- a/tests/acceptance/features/apiAuthWebDav/webDavPOSTAuth.feature
+++ b/tests/acceptance/features/apiAuthWebDav/webDavPOSTAuth.feature
@@ -76,7 +76,7 @@ Feature: get file info using POST
       | /remote.php/dav/files/%username%/PARENT/parent.txt |
     Then the HTTP status code of responses on all endpoints should be "401"
 
-	@issue-ocis-reva-37
+  @issue-ocis-reva-37
   Scenario: send POST requests to webDav endpoints using token authentication should not work
     Given token auth has been enforced
     And a new browser session for "Alice" has been started
@@ -90,7 +90,7 @@ Feature: get file info using POST
       | /remote.php/dav/files/%username%/PARENT/parent.txt |
     Then the HTTP status code of responses on all endpoints should be "401"
 
-	@issue-ocis-reva-37
+  @issue-ocis-reva-37
   Scenario: send POST requests to webDav endpoints using app password token as password
     Given token auth has been enforced
     And a new browser session for "Alice" has been started

--- a/tests/acceptance/features/apiAuthWebDav/webDavPOSTAuth.feature
+++ b/tests/acceptance/features/apiAuthWebDav/webDavPOSTAuth.feature
@@ -76,7 +76,7 @@ Feature: get file info using POST
       | /remote.php/dav/files/%username%/PARENT/parent.txt |
     Then the HTTP status code of responses on all endpoints should be "401"
 
-  @notToImplementOnOCIS @issue-ocis-reva-37
+	@issue-ocis-reva-37
   Scenario: send POST requests to webDav endpoints using token authentication should not work
     Given token auth has been enforced
     And a new browser session for "Alice" has been started
@@ -90,7 +90,7 @@ Feature: get file info using POST
       | /remote.php/dav/files/%username%/PARENT/parent.txt |
     Then the HTTP status code of responses on all endpoints should be "401"
 
-  @notToImplementOnOCIS @issue-ocis-reva-37
+	@issue-ocis-reva-37
   Scenario: send POST requests to webDav endpoints using app password token as password
     Given token auth has been enforced
     And a new browser session for "Alice" has been started

--- a/tests/acceptance/features/apiAuthWebDav/webDavPROPFINDAuth.feature
+++ b/tests/acceptance/features/apiAuthWebDav/webDavPROPFINDAuth.feature
@@ -75,7 +75,7 @@ Feature: get file info using PROPFIND
       | /remote.php/dav/files/%username%/PARENT/parent.txt |
     Then the HTTP status code of responses on all endpoints should be "401"
 
-  @notToImplementOnOCIS @issue-ocis-reva-37
+	@issue-ocis-reva-37
   Scenario: send PROPFIND requests to webDav endpoints using token authentication should not work
     Given token auth has been enforced
     And a new browser session for "Alice" has been started
@@ -89,7 +89,7 @@ Feature: get file info using PROPFIND
       | /remote.php/dav/files/%username%/PARENT/parent.txt |
     Then the HTTP status code of responses on all endpoints should be "401"
 
-  @notToImplementOnOCIS @issue-ocis-reva-37
+	@issue-ocis-reva-37
   Scenario: send PROPFIND requests to webDav endpoints using app password token as password
     Given token auth has been enforced
     And a new browser session for "Alice" has been started

--- a/tests/acceptance/features/apiAuthWebDav/webDavPROPFINDAuth.feature
+++ b/tests/acceptance/features/apiAuthWebDav/webDavPROPFINDAuth.feature
@@ -75,7 +75,7 @@ Feature: get file info using PROPFIND
       | /remote.php/dav/files/%username%/PARENT/parent.txt |
     Then the HTTP status code of responses on all endpoints should be "401"
 
-	@issue-ocis-reva-37
+  @issue-ocis-reva-37
   Scenario: send PROPFIND requests to webDav endpoints using token authentication should not work
     Given token auth has been enforced
     And a new browser session for "Alice" has been started
@@ -89,7 +89,7 @@ Feature: get file info using PROPFIND
       | /remote.php/dav/files/%username%/PARENT/parent.txt |
     Then the HTTP status code of responses on all endpoints should be "401"
 
-	@issue-ocis-reva-37
+  @issue-ocis-reva-37
   Scenario: send PROPFIND requests to webDav endpoints using app password token as password
     Given token auth has been enforced
     And a new browser session for "Alice" has been started

--- a/tests/acceptance/features/apiAuthWebDav/webDavPROPPATCHAuth.feature
+++ b/tests/acceptance/features/apiAuthWebDav/webDavPROPPATCHAuth.feature
@@ -76,7 +76,7 @@ Feature: PROPPATCH file/folder
       | /remote.php/dav/files/%username%/PARENT/parent.txt |
     Then the HTTP status code of responses on all endpoints should be "401"
 
-  @notToImplementOnOCIS @issue-ocis-reva-37
+	@issue-ocis-reva-37
   Scenario: send PROPPATCH requests to webDav endpoints using token authentication should not work
     Given token auth has been enforced
     And a new browser session for "Alice" has been started
@@ -90,7 +90,7 @@ Feature: PROPPATCH file/folder
       | /remote.php/dav/files/%username%/PARENT/parent.txt |
     Then the HTTP status code of responses on all endpoints should be "401"
 
-  @notToImplementOnOCIS @issue-ocis-reva-37
+	@issue-ocis-reva-37
   Scenario: send PROPPATCH requests to webDav endpoints using app password token as password
     Given token auth has been enforced
     And a new browser session for "Alice" has been started

--- a/tests/acceptance/features/apiAuthWebDav/webDavPROPPATCHAuth.feature
+++ b/tests/acceptance/features/apiAuthWebDav/webDavPROPPATCHAuth.feature
@@ -76,7 +76,7 @@ Feature: PROPPATCH file/folder
       | /remote.php/dav/files/%username%/PARENT/parent.txt |
     Then the HTTP status code of responses on all endpoints should be "401"
 
-	@issue-ocis-reva-37
+  @issue-ocis-reva-37
   Scenario: send PROPPATCH requests to webDav endpoints using token authentication should not work
     Given token auth has been enforced
     And a new browser session for "Alice" has been started
@@ -90,7 +90,7 @@ Feature: PROPPATCH file/folder
       | /remote.php/dav/files/%username%/PARENT/parent.txt |
     Then the HTTP status code of responses on all endpoints should be "401"
 
-	@issue-ocis-reva-37
+  @issue-ocis-reva-37
   Scenario: send PROPPATCH requests to webDav endpoints using app password token as password
     Given token auth has been enforced
     And a new browser session for "Alice" has been started

--- a/tests/acceptance/features/apiAuthWebDav/webDavPUTAuth.feature
+++ b/tests/acceptance/features/apiAuthWebDav/webDavPUTAuth.feature
@@ -79,7 +79,7 @@ Feature: get file info using PUT
       | /remote.php/dav/files/%username%/PARENT/parent.txt |
     Then the HTTP status code of responses on all endpoints should be "401"
 
-  @notToImplementOnOCIS @issue-ocis-reva-37
+	@issue-ocis-reva-37
   Scenario: send PUT requests to webDav endpoints using token authentication should not work
     Given token auth has been enforced
     And a new browser session for "Alice" has been started
@@ -93,7 +93,7 @@ Feature: get file info using PUT
       | /remote.php/dav/files/%username%/PARENT/parent.txt |
     Then the HTTP status code of responses on all endpoints should be "401"
 
-  @notToImplementOnOCIS @issue-ocis-reva-37
+	@issue-ocis-reva-37
   Scenario: send PUT requests to webDav endpoints using app password token as password
     Given token auth has been enforced
     And a new browser session for "Alice" has been started

--- a/tests/acceptance/features/apiAuthWebDav/webDavPUTAuth.feature
+++ b/tests/acceptance/features/apiAuthWebDav/webDavPUTAuth.feature
@@ -79,7 +79,7 @@ Feature: get file info using PUT
       | /remote.php/dav/files/%username%/PARENT/parent.txt |
     Then the HTTP status code of responses on all endpoints should be "401"
 
-	@issue-ocis-reva-37
+  @issue-ocis-reva-37
   Scenario: send PUT requests to webDav endpoints using token authentication should not work
     Given token auth has been enforced
     And a new browser session for "Alice" has been started
@@ -93,7 +93,7 @@ Feature: get file info using PUT
       | /remote.php/dav/files/%username%/PARENT/parent.txt |
     Then the HTTP status code of responses on all endpoints should be "401"
 
-	@issue-ocis-reva-37
+  @issue-ocis-reva-37
   Scenario: send PUT requests to webDav endpoints using app password token as password
     Given token auth has been enforced
     And a new browser session for "Alice" has been started

--- a/tests/acceptance/features/apiFavorites/favorites.feature
+++ b/tests/acceptance/features/apiFavorites/favorites.feature
@@ -117,7 +117,7 @@ Feature: favorite
       | old         |
       | new         |
 
-  @files_sharing-app-required @notToImplementOnOCIS
+  @files_sharing-app-required
   Scenario Outline: moving a favorite file out of a share keeps favorite state
     Given using <dav_version> DAV path
     And user "Brian" has been created with default attributes and without skeleton files
@@ -181,7 +181,7 @@ Feature: favorite
       | old         |
       | new         |
 
-  @files_sharing-app-required @notToImplementOnOCIS
+  @files_sharing-app-required
   Scenario Outline: sharer file favorite state should not change the favorite state of sharee
     Given using <dav_version> DAV path
     And user "Brian" has been created with default attributes and without skeleton files
@@ -196,7 +196,7 @@ Feature: favorite
       | old         |
       | new         |
 
-  @files_sharing-app-required @notToImplementOnOCIS
+  @files_sharing-app-required
   Scenario Outline: sharee file favorite state should not change the favorite state of sharer
     Given using <dav_version> DAV path
     And user "Brian" has been created with default attributes and without skeleton files
@@ -224,7 +224,7 @@ Feature: favorite
       | old         |
       | new         |
 
-  @files_sharing-app-required @notToImplementOnOCIS
+  @files_sharing-app-required
   Scenario Outline: favorite a file inside of a received share
     Given using <dav_version> DAV path
     And user "Brian" has been created with default attributes and without skeleton files
@@ -236,7 +236,7 @@ Feature: favorite
       | old         |
       | new         |
 
-  @files_sharing-app-required @notToImplementOnOCIS
+  @files_sharing-app-required
   Scenario Outline: favorite a folder inside of a received share
     Given using <dav_version> DAV path
     And user "Brian" has been created with default attributes and without skeleton files
@@ -249,7 +249,7 @@ Feature: favorite
       | old         |
       | new         |
 
-  @files_sharing-app-required @notToImplementOnOCIS
+  @files_sharing-app-required
   Scenario Outline: favorite a received share itself
     Given using <dav_version> DAV path
     And user "Brian" has been created with default attributes and without skeleton files

--- a/tests/acceptance/features/apiFavorites/favoritesOc10Issue33840.feature
+++ b/tests/acceptance/features/apiFavorites/favoritesOc10Issue33840.feature
@@ -1,4 +1,4 @@
-@api @notToImplementOnOCIS
+@api
 Feature: current oC10 behavior for issue-33840
 
   Background:

--- a/tests/acceptance/features/apiFederationToRoot1/etagPropagation.feature
+++ b/tests/acceptance/features/apiFederationToRoot1/etagPropagation.feature
@@ -1,4 +1,4 @@
-@api @federation-app-required @files_sharing-app-required @notToImplementOnOCIS
+@api @federation-app-required @files_sharing-app-required
 Feature: propagation of etags between federated and local server
 
   Background:

--- a/tests/acceptance/features/apiFederationToRoot1/federated.feature
+++ b/tests/acceptance/features/apiFederationToRoot1/federated.feature
@@ -1,4 +1,4 @@
-@api @federation-app-required @files_sharing-app-required @notToImplementOnOCIS
+@api @federation-app-required @files_sharing-app-required
 Feature: federated
 
   Background:

--- a/tests/acceptance/features/apiFederationToRoot1/federatedOc10Issue31276.feature
+++ b/tests/acceptance/features/apiFederationToRoot1/federatedOc10Issue31276.feature
@@ -1,4 +1,4 @@
-@api @federation-app-required @files_sharing-app-required @notToImplementOnOCIS
+@api @federation-app-required @files_sharing-app-required
 Feature: current oC10 behavior for issue-31276
 
   Background:

--- a/tests/acceptance/features/apiFederationToRoot1/savePublicShare.feature
+++ b/tests/acceptance/features/apiFederationToRoot1/savePublicShare.feature
@@ -1,4 +1,4 @@
-@api @federation-app-required @files_sharing-app-required @notToImplementOnOCIS
+@api @federation-app-required @files_sharing-app-required
 Feature: Save public shares created by oC users
 
   Background:

--- a/tests/acceptance/features/apiFederationToRoot2/federated.feature
+++ b/tests/acceptance/features/apiFederationToRoot2/federated.feature
@@ -1,4 +1,4 @@
-@api @federation-app-required @files_sharing-app-required @notToImplementOnOCIS
+@api @federation-app-required @files_sharing-app-required
 Feature: federated
 
   Background:

--- a/tests/acceptance/features/apiFederationToRoot2/federatedOc10Issue35839.feature
+++ b/tests/acceptance/features/apiFederationToRoot2/federatedOc10Issue35839.feature
@@ -1,4 +1,4 @@
-@api @federation-app-required @files_sharing-app-required @notToImplementOnOCIS
+@api @federation-app-required @files_sharing-app-required
 Feature: current oC10 behavior for issue-35839
 
   Background:

--- a/tests/acceptance/features/apiFederationToShares1/savePublicShare.feature
+++ b/tests/acceptance/features/apiFederationToShares1/savePublicShare.feature
@@ -1,4 +1,4 @@
-@api @federation-app-required @files_sharing-app-required @notToImplementOnOCIS
+@api @federation-app-required @files_sharing-app-required
 Feature: Save public shares created by oC users
 
   Background:

--- a/tests/acceptance/features/apiMain/appManagement.feature
+++ b/tests/acceptance/features/apiMain/appManagement.feature
@@ -1,4 +1,4 @@
-@api @skipOnLDAP @notToImplementOnOCIS
+@api @skipOnLDAP
 Feature: AppManagement
 
   Scenario: Update of patch version of an app

--- a/tests/acceptance/features/apiMain/checksums-TestOc10Issue38835.feature
+++ b/tests/acceptance/features/apiMain/checksums-TestOc10Issue38835.feature
@@ -1,4 +1,4 @@
-@api @notToImplementOnOCIS
+@api
 Feature: checksums
 
   Background:

--- a/tests/acceptance/features/apiMain/checksums.feature
+++ b/tests/acceptance/features/apiMain/checksums.feature
@@ -87,7 +87,7 @@ Feature: checksums
       | dav_version |
       | old         |
 
-  @local_storage @files_external-app-required @notToImplementOnOCIS
+  @local_storage @files_external-app-required
   Scenario Outline: Downloading a file from local storage has correct checksum
     Given using <dav_version> DAV path
     # Create the file directly in local storage, bypassing ownCloud
@@ -170,7 +170,7 @@ Feature: checksums
       | dav_version | checksum                                                                                            |
       | new         | SHA1:ce5582148c6f0c1282335b87df5ed4be4b781399 MD5:56e57920c3c8c727bfe7a5288cdf61c4 ADLER32:1048035a |
 
-  @issue-ocis-reva-56 @notToImplementOnOCIS @newChunking @issue-ocis-1321
+  @issue-ocis-reva-56 @newChunking @issue-ocis-1321
   Scenario: Upload new DAV chunked file where checksum matches
     Given using new DAV path
     And user "Alice" has created a new chunking upload with id "chunking-42"
@@ -179,7 +179,7 @@ Feature: checksums
     And user "Alice" moves new chunk file with id "chunking-42" to "/myChunkedFile.txt" with checksum "SHA1:5d84d61b03fdacf813640f5242d309721e0629b1" using the WebDAV API
     Then the HTTP status code of responses on all endpoints should be "201"
 
-  @issue-ocis-reva-56 @notToImplementOnOCIS @newChunking @issue-ocis-1321
+  @issue-ocis-reva-56 @newChunking @issue-ocis-1321
   Scenario: Upload new DAV chunked file where checksum does not match
     Given using new DAV path
     And user "Alice" has created a new chunking upload with id "chunking-42"
@@ -190,7 +190,7 @@ Feature: checksums
     And user "Alice" should not see the following elements
       | /myChunkedFile.txt |
 
-  @issue-ocis-reva-56 @notToImplementOnOCIS @newChunking @issue-ocis-1321
+  @issue-ocis-reva-56 @newChunking @issue-ocis-1321
   Scenario: Upload new DAV chunked file using async MOVE where checksum matches
     Given using new DAV path
     And the administrator has enabled async operations
@@ -206,7 +206,7 @@ Feature: checksums
       | fileId | /^[0-9a-z]{20,}$/ |
     And the content of file "/myChunkedFile.txt" for user "Alice" should be "BBBBBCCCCC"
 
-  @issue-ocis-reva-56 @notToImplementOnOCIS @newChunking @issue-ocis-1321
+  @issue-ocis-reva-56 @newChunking @issue-ocis-1321
   Scenario: Upload new DAV chunked file using async MOVE where checksum does not match
     Given using new DAV path
     And the administrator has enabled async operations
@@ -224,7 +224,7 @@ Feature: checksums
     And user "Alice" should not see the following elements
       | /myChunkedFile.txt |
 
-  @issue-ocis-reva-56 @notToImplementOnOCIS @newChunking @issue-ocis-1321
+  @issue-ocis-reva-56 @newChunking @issue-ocis-1321
   Scenario: Upload new DAV chunked file using async MOVE where checksum does not match - retry with correct checksum
     Given using new DAV path
     And the administrator has enabled async operations
@@ -277,7 +277,7 @@ Feature: checksums
       | old         |
       | new         |
 
-  @local_storage @files_external-app-required @notToImplementOnOCIS @skipOnEncryptionType:user-keys @encryption-issue-42
+  @local_storage @files_external-app-required @skipOnEncryptionType:user-keys @encryption-issue-42
   Scenario Outline: Uploaded file to external storage should have the same checksum when downloaded
     Given using <dav_version> DAV path
     And user "Alice" has uploaded file with checksum "SHA1:ce5582148c6f0c1282335b87df5ed4be4b781399" and content "Some Text" to "/local_storage/chksumtst.txt"
@@ -353,7 +353,7 @@ Feature: checksums
       | old         |
       | new         |
 
-  @issue-ocis-reva-56 @notToImplementOnOCIS @newChunking @issue-ocis-1321
+  @issue-ocis-reva-56 @newChunking @issue-ocis-1321
   Scenario: Upload overwriting a file with new chunking and correct checksum
     Given using new DAV path
     And user "Alice" has uploaded file with content "ownCloud test text file 0" to "/textfile0.txt"
@@ -364,7 +364,7 @@ Feature: checksums
     Then the HTTP status code of responses on each endpoint should be "201, 201, 204" respectively
     And the content of file "/textfile0.txt" for user "Alice" should be "BBBBBCCCCC"
 
-  @skipOnStorage:ceph @skipOnStorage:scality @files_primary_s3-issue-224 @issue-ocis-reva-56 @notToImplementOnOCIS @newChunking @issue-ocis-1321
+  @skipOnStorage:ceph @skipOnStorage:scality @files_primary_s3-issue-224 @issue-ocis-reva-56 @newChunking @issue-ocis-1321
   Scenario: Upload overwriting a file with new chunking and invalid checksum
     Given using new DAV path
     And user "Alice" has uploaded file with content "ownCloud test text file 0" to "/textfile0.txt"

--- a/tests/acceptance/features/apiMain/external-storage.feature
+++ b/tests/acceptance/features/apiMain/external-storage.feature
@@ -1,4 +1,4 @@
-@api @local_storage @files_external-app-required @notToImplementOnOCIS
+@api @local_storage @files_external-app-required
 Feature: external-storage
 
   Background:

--- a/tests/acceptance/features/apiMain/quota.feature
+++ b/tests/acceptance/features/apiMain/quota.feature
@@ -12,7 +12,7 @@ Feature: quota
     When user "Alice" uploads file "filesForUpload/textfile.txt" to filenames based on "/testquota.txt" with all mechanisms except new chunking using the WebDAV API
     Then the HTTP status code of all upload responses should be "201"
 
-  @notToImplementOnOCIS @newChunking @issue-ocis-1321
+	@newChunking @issue-ocis-1321
   Scenario: Uploading a file as owner having enough quota (new chunking)
     Given the quota of user "Alice" has been set to "10 MB"
     And using new DAV path
@@ -26,7 +26,7 @@ Feature: quota
     Then the HTTP status code of all upload responses should be "507"
     And as "Alice" the files uploaded to "/testquota.txt" with all mechanisms except new chunking should not exist
 
-  @smokeTest @notToImplementOnOCIS @newChunking @issue-ocis-1321
+  @smokeTest @newChunking @issue-ocis-1321
   Scenario: Uploading a file as owner having insufficient quota (new chunking)
     Given the quota of user "Alice" has been set to "10 B"
     And using new DAV path
@@ -41,7 +41,7 @@ Feature: quota
     When user "Alice" overwrites from file "filesForUpload/textfile.txt" to file "/testquota.txt" with all mechanisms except new chunking using the WebDAV API
     Then the HTTP status code of all upload responses should be between "201" and "204"
 
-  @notToImplementOnOCIS @newChunking @issue-ocis-1321
+	@newChunking @issue-ocis-1321
   Scenario: Overwriting a file as owner having enough quota (new chunking)
     Given user "Alice" has uploaded file with content "test" to "/testquota.txt"
     And the quota of user "Alice" has been set to "10 MB"
@@ -57,7 +57,7 @@ Feature: quota
     Then the HTTP status code of all upload responses should be "507"
     And the content of file "/testquota.txt" for user "Alice" should be "test"
 
-  @notToImplementOnOCIS @newChunking @issue-ocis-1321
+	@newChunking @issue-ocis-1321
   Scenario: Overwriting a file as owner having insufficient quota (new chunking)
     Given user "Alice" has uploaded file with content "test" to "/testquota.txt"
     And the quota of user "Alice" has been set to "10 B"
@@ -78,7 +78,7 @@ Feature: quota
     When user "Brian" uploads file "filesForUpload/textfile.txt" to filenames based on "/testquota/testquota.txt" with all mechanisms except new chunking using the WebDAV API
     Then the HTTP status code of all upload responses should be "201"
 
-  @files_sharing-app-required @notToImplementOnOCIS @newChunking @issue-ocis-1321
+  @files_sharing-app-required @newChunking @issue-ocis-1321
   Scenario: Uploading a file in received folder having enough quota (new chunking)
     Given user "Brian" has been created with default attributes and without skeleton files
     And user "Alice" has created folder "/testquota"
@@ -100,7 +100,7 @@ Feature: quota
     Then the HTTP status code of all upload responses should be "507"
     And as "Brian" the files uploaded to "/testquota/testquota.txt" with all mechanisms except new chunking should not exist
 
-  @files_sharing-app-required @notToImplementOnOCIS @newChunking @issue-ocis-1321
+  @files_sharing-app-required @newChunking @issue-ocis-1321
   Scenario: Uploading a file in a received folder having insufficient quota (new chunking)
     Given user "Brian" has been created with default attributes and without skeleton files
     And user "Alice" has created folder "/testquota"
@@ -123,7 +123,7 @@ Feature: quota
     When user "Brian" overwrites from file "filesForUpload/textfile.txt" to file "/testquota/testquota.txt" with all mechanisms except new chunking using the WebDAV API
     Then the HTTP status code of all upload responses should be between "201" and "204"
 
-  @files_sharing-app-required @notToImplementOnOCIS @newChunking @issue-ocis-1321
+  @files_sharing-app-required @newChunking @issue-ocis-1321
   Scenario: Overwriting a file in received folder having enough quota (new chunking)
     Given user "Brian" has been created with default attributes and without skeleton files
     And user "Alice" has created folder "/testquota"
@@ -147,7 +147,7 @@ Feature: quota
     Then the HTTP status code of all upload responses should be "507"
     And the content of file "/testquota/testquota.txt" for user "Alice" should be "test"
 
-  @files_sharing-app-required @notToImplementOnOCIS @newChunking @issue-ocis-1321
+  @files_sharing-app-required @newChunking @issue-ocis-1321
   Scenario: Overwriting a file in received folder having insufficient quota (new chunking)
     Given user "Brian" has been created with default attributes and without skeleton files
     And user "Alice" has created folder "/testquota"
@@ -172,7 +172,7 @@ Feature: quota
     When user "Brian" overwrites from file "filesForUpload/textfile.txt" to file "/testquota.txt" with all mechanisms except new chunking using the WebDAV API
     Then the HTTP status code of all upload responses should be between "201" and "204"
 
-  @files_sharing-app-required @notToImplementOnOCIS @newChunking @issue-ocis-1321
+  @files_sharing-app-required @newChunking @issue-ocis-1321
   Scenario: Overwriting a received file having enough quota (new chunking)
     Given user "Brian" has been created with default attributes and without skeleton files
     And user "Alice" has uploaded file with content "test" to "/testquota.txt"
@@ -194,7 +194,7 @@ Feature: quota
     Then the HTTP status code of all upload responses should be "507"
     And the content of file "/testquota.txt" for user "Alice" should be "test"
 
-  @files_sharing-app-required @notToImplementOnOCIS @newChunking @issue-ocis-1321
+  @files_sharing-app-required @newChunking @issue-ocis-1321
   Scenario: Overwriting a received file having insufficient quota (new chunking)
     Given user "Brian" has been created with default attributes and without skeleton files
     And user "Alice" has uploaded file with content "test" to "/testquota.txt"

--- a/tests/acceptance/features/apiMain/quota.feature
+++ b/tests/acceptance/features/apiMain/quota.feature
@@ -12,7 +12,7 @@ Feature: quota
     When user "Alice" uploads file "filesForUpload/textfile.txt" to filenames based on "/testquota.txt" with all mechanisms except new chunking using the WebDAV API
     Then the HTTP status code of all upload responses should be "201"
 
-	@newChunking @issue-ocis-1321
+  @newChunking @issue-ocis-1321
   Scenario: Uploading a file as owner having enough quota (new chunking)
     Given the quota of user "Alice" has been set to "10 MB"
     And using new DAV path
@@ -41,7 +41,7 @@ Feature: quota
     When user "Alice" overwrites from file "filesForUpload/textfile.txt" to file "/testquota.txt" with all mechanisms except new chunking using the WebDAV API
     Then the HTTP status code of all upload responses should be between "201" and "204"
 
-	@newChunking @issue-ocis-1321
+  @newChunking @issue-ocis-1321
   Scenario: Overwriting a file as owner having enough quota (new chunking)
     Given user "Alice" has uploaded file with content "test" to "/testquota.txt"
     And the quota of user "Alice" has been set to "10 MB"
@@ -57,7 +57,7 @@ Feature: quota
     Then the HTTP status code of all upload responses should be "507"
     And the content of file "/testquota.txt" for user "Alice" should be "test"
 
-	@newChunking @issue-ocis-1321
+  @newChunking @issue-ocis-1321
   Scenario: Overwriting a file as owner having insufficient quota (new chunking)
     Given user "Alice" has uploaded file with content "test" to "/testquota.txt"
     And the quota of user "Alice" has been set to "10 B"

--- a/tests/acceptance/features/apiMain/userSync.feature
+++ b/tests/acceptance/features/apiMain/userSync.feature
@@ -1,4 +1,4 @@
-@api @notToImplementOnOCIS @issue-ocis-1241
+@api @issue-ocis-1241
 Feature: Users sync
 
   Background:

--- a/tests/acceptance/features/apiProvisioning-v1/addUser.feature
+++ b/tests/acceptance/features/apiProvisioning-v1/addUser.feature
@@ -54,7 +54,7 @@ Feature: add user
     And the HTTP status code should be "200"
     And the API should not return any data
 
-  @notToImplementOnOCIS
+
   Scenario: Admin creates a new user and adds him directly to a group
     Given group "brand-new-group" has been created
     When the administrator sends a user creation request for user "brand-new-user" password "%alt1%" group "brand-new-group" using the provisioning API
@@ -164,7 +164,7 @@ Feature: add user
       | -123     |
       | 0.0      |
 
-  @notToImplementOnOCIS
+
   Scenario: subadmin should not be able to create a new user
     Given user "brand-new-user" has been deleted
     And user "subadmin" has been created with default attributes and without skeleton files
@@ -185,7 +185,7 @@ Feature: add user
     And the HTTP status code should be "401"
     And user "brand-new-user" should not exist
 
-  @notToImplementOnOCIS
+
   Scenario: subadmin should be able to create a new user into their group
     Given user "brand-new-user" has been deleted
     And user "subadmin" has been created with default attributes and without skeleton files
@@ -197,7 +197,7 @@ Feature: add user
     And the HTTP status code should be "200"
     And user "brand-new-user" should exist
 
-  @notToImplementOnOCIS
+
   Scenario: subadmin should not be able to create a new user into other group
     Given user "brand-new-user" has been deleted
     And user "subadmin" has been created with default attributes and without skeleton files

--- a/tests/acceptance/features/apiProvisioning-v1/apiProvisioningUsingAppPassword.feature
+++ b/tests/acceptance/features/apiProvisioning-v1/apiProvisioningUsingAppPassword.feature
@@ -7,7 +7,7 @@ Feature: access user provisioning API using app password
   Background:
     Given using OCS API version "1"
 
-  @smokeTest @notToImplementOnOCIS
+  @smokeTest
   Scenario: admin deletes the user
     Given user "brand-new-user" has been created with default attributes and without skeleton files
     And group "brand-new-group" has been created
@@ -18,7 +18,7 @@ Feature: access user provisioning API using app password
     Then the HTTP status code should be "200"
     And user "brand-new-user" should not exist
 
-  @notToImplementOnOCIS
+
   Scenario: subadmin gets users in their group
     Given these users have been created with default attributes and without skeleton files:
       | username         |
@@ -47,7 +47,7 @@ Feature: access user provisioning API using app password
     Then the HTTP status code should be "200"
     And the display name returned by the API should be "New User"
 
-  @notToImplementOnOCIS
+
   Scenario: subadmin tries to get users of other group
     Given these users have been created with default attributes and without skeleton files:
       | username         |

--- a/tests/acceptance/features/apiProvisioning-v1/createSubAdmin.feature
+++ b/tests/acceptance/features/apiProvisioning-v1/createSubAdmin.feature
@@ -1,4 +1,4 @@
-@api @provisioning_api-app-required @skipOnLDAP @notToImplementOnOCIS @skipOnGraph
+@api @provisioning_api-app-required @skipOnLDAP @skipOnGraph
 Feature: create a subadmin
   As an admin
   I want to be able to make a user the subadmin of a group

--- a/tests/acceptance/features/apiProvisioning-v1/deleteUser.feature
+++ b/tests/acceptance/features/apiProvisioning-v1/deleteUser.feature
@@ -40,7 +40,7 @@ Feature: delete users
     And the HTTP status code should be "200"
     And user "brand-new-user" should not exist
 
-  @smokeTest @notToImplementOnOCIS
+  @smokeTest
   Scenario: subadmin deletes a user in their group
     Given these users have been created with default attributes and without skeleton files:
       | username       |
@@ -76,7 +76,7 @@ Feature: delete users
     And the HTTP status code should be "200"
     And user "another-admin" should not exist
 
-  @notToImplementOnOCIS
+
   Scenario: subadmin deletes a user with subadmin permissions in their group
     Given these users have been created with default attributes and without skeleton files:
       | username         |
@@ -91,7 +91,7 @@ Feature: delete users
     And the HTTP status code should be "200"
     And user "another-subadmin" should not exist
 
-  @notToImplementOnOCIS
+
   Scenario: subadmin should not be able to delete another subadmin of same group
     Given these users have been created with default attributes and without skeleton files:
       | username         |
@@ -105,7 +105,7 @@ Feature: delete users
     And the HTTP status code should be "401"
     And user "another-subadmin" should exist
 
-  @notToImplementOnOCIS
+
   Scenario: subadmin should not be able to delete a user with admin permissions in their group
     Given these users have been created with default attributes and without skeleton files:
       | username      |
@@ -120,7 +120,7 @@ Feature: delete users
     And the HTTP status code should be "401"
     And user "another-admin" should exist
 
-  @notToImplementOnOCIS
+
   Scenario: subadmin should not be able to delete a user not in their group
     Given these users have been created with default attributes and without skeleton files:
       | username       |

--- a/tests/acceptance/features/apiProvisioning-v1/disableApp.feature
+++ b/tests/acceptance/features/apiProvisioning-v1/disableApp.feature
@@ -1,4 +1,4 @@
-@api @provisioning_api-app-required @comments-app-required @skipOnLDAP @notToImplementOnOCIS @skipOnGraph
+@api @provisioning_api-app-required @comments-app-required @skipOnLDAP @skipOnGraph
 Feature: disable an app
   As an admin
   I want to be able to disable an enabled app

--- a/tests/acceptance/features/apiProvisioning-v1/disableUser.feature
+++ b/tests/acceptance/features/apiProvisioning-v1/disableUser.feature
@@ -32,7 +32,7 @@ Feature: disable user
       | a@-+_.b  |
       | a space  |
 
-  @smokeTest @notToImplementOnOCIS
+  @smokeTest
   Scenario: Subadmin should be able to disable an user in their group
     Given these users have been created with default attributes and without skeleton files:
       | username |
@@ -47,7 +47,7 @@ Feature: disable user
     And the HTTP status code should be "200"
     And user "Alice" should be disabled
 
-  @notToImplementOnOCIS
+
   Scenario: Subadmin should not be able to disable an user not in their group
     Given these users have been created with default attributes and without skeleton files:
       | username |
@@ -63,7 +63,7 @@ Feature: disable user
     And the HTTP status code should be "401"
     And user "Alice" should be enabled
 
-  @notToImplementOnOCIS
+
   Scenario: Subadmins should not be able to disable users that have admin permissions in their group
     Given these users have been created with default attributes and without skeleton files:
       | username      |
@@ -88,7 +88,7 @@ Feature: disable user
     And the HTTP status code should be "200"
     And user "another-admin" should be disabled
 
-  @notToImplementOnOCIS
+
   Scenario: Admin can disable subadmins in the same group
     Given user "subadmin" has been created with default attributes and without skeleton files
     And group "brand-new-group" has been created
@@ -120,7 +120,7 @@ Feature: disable user
     And the HTTP status code should be "401"
     And user "Brian" should be enabled
 
-  @notToImplementOnOCIS
+
   Scenario: Subadmin should not be able to disable himself
     Given user "subadmin" has been created with default attributes and without skeleton files
     And group "brand-new-group" has been created
@@ -204,7 +204,7 @@ Feature: disable user
     And as "Brian" file "/Shares/textfile0.txt" should exist
     And the content of file "/Shares/textfile0.txt" for user "Brian" should be "ownCloud test text file 0" plus end-of-line
 
-  @notToImplementOnOCIS
+
   Scenario: getting shares shared by disabled user (to root)
     Given user "Alice" has been created with default attributes and small skeleton files
     And user "Brian" has been created with default attributes and without skeleton files
@@ -233,7 +233,7 @@ Feature: disable user
     And as "Brian" folder "/Shares/PARENT" should exist
     And the content of file "/Shares/PARENT/parent.txt" for user "Brian" should be "ownCloud test text file parent" plus end-of-line
 
-  @notToImplementOnOCIS
+
   Scenario: getting shares shared by disabled user in a group (to root)
     Given user "Alice" has been created with default attributes and small skeleton files
     And user "Brian" has been created with default attributes and without skeleton files
@@ -271,7 +271,7 @@ Feature: disable user
       | old         |
       | new         |
 
-  @notToImplementOnOCIS
+
   Scenario: Subadmin should be able to disable user with subadmin permissions in their group
     Given these users have been created with default attributes and without skeleton files:
       | username         |
@@ -286,7 +286,7 @@ Feature: disable user
     And the HTTP status code should be "200"
     And user "another-subadmin" should be disabled
 
-  @notToImplementOnOCIS
+
   Scenario: Subadmin should not be able to disable another subadmin of same group
     Given these users have been created with default attributes and without skeleton files:
       | username         |

--- a/tests/acceptance/features/apiProvisioning-v1/editUser.feature
+++ b/tests/acceptance/features/apiProvisioning-v1/editUser.feature
@@ -80,7 +80,7 @@ Feature: edit users
     And the HTTP status code should be "200"
     And the email address of user "brand-new-user" should be ""
 
-  @smokeTest @notToImplementOnOCIS
+  @smokeTest
   Scenario: a subadmin should be able to edit the user information in their group
     Given these users have been created with default attributes and without skeleton files:
       | username       |
@@ -136,7 +136,7 @@ Feature: edit users
       | quota definition | default |
     And the quota definition of user "brand-new-user" should be "default"
 
-  @notToImplementOnOCIS
+
   Scenario: the administrator can edit user information with admin permissions
     Given these users have been created with default attributes and without skeleton files:
       | username      |
@@ -155,7 +155,7 @@ Feature: edit users
     And the HTTP status code should be "200"
     And the display name of user "another-admin" should be "Anne Brown"
 
-  @notToImplementOnOCIS
+
   Scenario: a subadmin should be able to edit user information with subadmin permissions in their group
     Given these users have been created with default attributes and without skeleton files:
       | username         |
@@ -178,7 +178,7 @@ Feature: edit users
     And the HTTP status code should be "200"
     And the display name of user "another-subadmin" should be "Anne Brown"
 
-  @notToImplementOnOCIS
+
   Scenario: a subadmin should not be able to edit user information of another subadmin of same group
     Given these users have been created with default attributes and without skeleton files:
       | username         |
@@ -226,7 +226,7 @@ Feature: edit users
       | email | alice@gmail.com |
     And the email address of user "Alice" should be "alice@gmail.com"
 
-  @notToImplementOnOCIS
+
   Scenario: Admin does not give access to users to change their email address
     Given user "Alice" has been created with default attributes and without skeleton files
     And the administrator has updated system config key "allow_user_to_change_mail_address" with value "false" and type "boolean"
@@ -237,7 +237,7 @@ Feature: edit users
       | email | alice@example.org |
     And the email address of user "Alice" should not have changed
 
-  @notToImplementOnOCIS
+
   Scenario: Admin does not give access to users to change their email address, admin can still change the email address
     Given user "Alice" has been created with default attributes and without skeleton files
     And the administrator has updated system config key "allow_user_to_change_mail_address" with value "false" and type "boolean"
@@ -248,7 +248,7 @@ Feature: edit users
       | email | alice@gmail.com |
     And the email address of user "Alice" should be "alice@gmail.com"
 
-  @notToImplementOnOCIS
+
   Scenario: Admin does not give access to users to change their email address, admin can still change their own email address
     Given the administrator has updated system config key "allow_user_to_change_mail_address" with value "false" and type "boolean"
     When the administrator changes the email of user "admin" to "something@example.com" using the provisioning API
@@ -258,7 +258,7 @@ Feature: edit users
       | email | something@example.com |
     And the email address of user "admin" should be "something@example.com"
 
-  @notToImplementOnOCIS
+
   Scenario: Admin does not give access to users to change their email address, subadmin can still change the email address of a user they are subadmin of
     Given these users have been created with default attributes and without skeleton files:
       | username |
@@ -275,7 +275,7 @@ Feature: edit users
       | email | alice@gmail.com |
     And the email address of user "Alice" should be "alice@gmail.com"
 
-  @notToImplementOnOCIS
+
   Scenario: Admin does not give access to users to change their email address, subadmin cannot change the email address of a user they are not subadmin of
     Given these users have been created with default attributes and without skeleton files:
       | username |
@@ -303,7 +303,7 @@ Feature: edit users
       | displayname | Alice Wonderland |
     And the display name of user "Alice" should be "Alice Wonderland"
 
-  @notToImplementOnOCIS
+
   Scenario: Admin does not give access to users to change their display name
     Given user "Alice" has been created with default attributes and without skeleton files
     And the administrator has updated system config key "allow_user_to_change_display_name" with value "false" and type "boolean"
@@ -314,7 +314,7 @@ Feature: edit users
       | displayname | Alice Hansen |
     And the display name of user "Alice" should not have changed
 
-  @notToImplementOnOCIS
+
   Scenario: Admin does not give access to users to change their display name, admin can still change display name
     Given user "Alice" has been created with default attributes and without skeleton files
     And the administrator has updated system config key "allow_user_to_change_display_name" with value "false" and type "boolean"
@@ -325,7 +325,7 @@ Feature: edit users
       | displayname | Alice Wonderland |
     And the display name of user "Alice" should be "Alice Wonderland"
 
-  @notToImplementOnOCIS
+
   Scenario: Admin does not give access to users to change their display name, admin can still change their own display name
     Given the administrator has updated system config key "allow_user_to_change_display_name" with value "false" and type "boolean"
     When the administrator changes the display name of user "admin" to "The Administrator" using the provisioning API
@@ -335,7 +335,7 @@ Feature: edit users
       | displayname | The Administrator |
     And the display name of user "admin" should be "The Administrator"
 
-  @notToImplementOnOCIS
+
   Scenario: Admin does not give access to users to change their display name, subadmin can still change the display name of a user they are subadmin of
     Given these users have been created with default attributes and without skeleton files:
       | username |
@@ -351,7 +351,7 @@ Feature: edit users
       | displayname | Alice Wonderland |
     And the display name of user "Alice" should be "Alice Wonderland"
 
-  @notToImplementOnOCIS
+
   Scenario: Admin does not give access to users to change their display name, subadmin cannot change the display name of a user they are not subadmin of
     Given these users have been created with default attributes and without skeleton files:
       | username |

--- a/tests/acceptance/features/apiProvisioning-v1/enableApp.feature
+++ b/tests/acceptance/features/apiProvisioning-v1/enableApp.feature
@@ -1,4 +1,4 @@
-@api @provisioning_api-app-required @comments-app-required @skipOnLDAP @notToImplementOnOCIS @skipOnGraph
+@api @provisioning_api-app-required @comments-app-required @skipOnLDAP @skipOnGraph
 Feature: enable an app
   As an admin
   I want to be able to enable a disabled app

--- a/tests/acceptance/features/apiProvisioning-v1/enableUser.feature
+++ b/tests/acceptance/features/apiProvisioning-v1/enableUser.feature
@@ -47,7 +47,7 @@ Feature: enable user
     And the HTTP status code should be "200"
     And user "another-admin" should be enabled
 
-  @notToImplementOnOCIS
+
   Scenario: admin enables subadmins in the same group
     Given user "subadmin" has been created with default attributes and without skeleton files
     And group "brand-new-group" has been created
@@ -82,7 +82,7 @@ Feature: enable user
     And the HTTP status code should be "401"
     And user "Brian" should be disabled
 
-  @notToImplementOnOCIS
+
   Scenario: subadmin tries to enable himself
     Given user "subadmin" has been created with default attributes and without skeleton files
     And group "brand-new-group" has been created
@@ -94,7 +94,7 @@ Feature: enable user
     And the HTTP status code should be "401"
     And user "subadmin" should be disabled
 
-  @notToImplementOnOCIS
+
   Scenario: Making a web request with an enabled user
     Given user "Alice" has been created with default attributes and without skeleton files
     When user "Alice" sends HTTP method "GET" to URL "/index.php/apps/files"

--- a/tests/acceptance/features/apiProvisioning-v1/getAppInfo.feature
+++ b/tests/acceptance/features/apiProvisioning-v1/getAppInfo.feature
@@ -1,4 +1,4 @@
-@api @provisioning_api-app-required @skipOnLDAP @notToImplementOnOCIS @skipOnGraph
+@api @provisioning_api-app-required @skipOnLDAP @skipOnGraph
 Feature: get app info
   As an admin
   I want to be able to get app info

--- a/tests/acceptance/features/apiProvisioning-v1/getApps.feature
+++ b/tests/acceptance/features/apiProvisioning-v1/getApps.feature
@@ -1,4 +1,4 @@
-@api @provisioning_api-app-required @files_sharing-app-required @skipOnLDAP @notToImplementOnOCIS @skipOnGraph
+@api @provisioning_api-app-required @files_sharing-app-required @skipOnLDAP @skipOnGraph
 Feature: get apps
   As an admin
   I want to be able to get the list of apps on my ownCloud

--- a/tests/acceptance/features/apiProvisioning-v1/getSubAdmins.feature
+++ b/tests/acceptance/features/apiProvisioning-v1/getSubAdmins.feature
@@ -1,4 +1,4 @@
-@api @provisioning_api-app-required @skipOnLDAP @notToImplementOnOCIS @skipOnGraph
+@api @provisioning_api-app-required @skipOnLDAP @skipOnGraph
 Feature: get subadmins
   As an admin
   I want to be able to get the list of subadmins of a group

--- a/tests/acceptance/features/apiProvisioning-v1/getUser.feature
+++ b/tests/acceptance/features/apiProvisioning-v1/getUser.feature
@@ -58,7 +58,7 @@ Feature: get user
     And the HTTP status code should be "200"
     And the API should not return any data
 
-  @smokeTest @notToImplementOnOCIS
+  @smokeTest
   Scenario: a subadmin gets information of a user in their group
     Given these users have been created with default attributes and without skeleton files:
       | username       | displayname |
@@ -75,7 +75,7 @@ Feature: get user
     And the free, used, total and relative quota returned by the API should exist and be valid numbers
     And the last login returned by the API should be a current Unix timestamp
 
-  @notToImplementOnOCIS
+
   Scenario: a subadmin tries to get information of a user not in their group
     Given these users have been created with default attributes and without skeleton files:
       | username       |
@@ -160,7 +160,7 @@ Feature: get user
     And the free, used, total and relative quota returned by the API should exist and be valid numbers
     And the last login returned by the API should be a current Unix timestamp
 
-  @notToImplementOnOCIS
+
   Scenario: a subadmin should be able to get information of a user with subadmin permissions in their group
     Given these users have been created with default attributes and without skeleton files:
       | username         |
@@ -178,7 +178,7 @@ Feature: get user
     And the free, used, total and relative quota returned by the API should exist and be valid numbers
     And the last login returned by the API should be a current Unix timestamp
 
-  @notToImplementOnOCIS
+
   Scenario: a subadmin should not be able to get information of another subadmin of same group
     Given these users have been created with default attributes and without skeleton files:
       | username         |

--- a/tests/acceptance/features/apiProvisioning-v1/getUsers.feature
+++ b/tests/acceptance/features/apiProvisioning-v1/getUsers.feature
@@ -7,7 +7,7 @@ Feature: get users
   Background:
     Given using OCS API version "1"
 
-  @smokeTest @notToImplementOnOCIS
+  @smokeTest
   Scenario: admin gets all users and checks for all the users including the admin user
     Given user "brand-new-user" has been created with default attributes and without skeleton files
     When the administrator gets the list of all users using the provisioning API
@@ -26,7 +26,7 @@ Feature: get users
     And the users returned by the API should include
       | brand-new-user |
 
-  @smokeTest @notToImplementOnOCIS
+  @smokeTest
   Scenario: subadmin gets the users in their group
     Given these users have been created with default attributes and without skeleton files:
       | username         |

--- a/tests/acceptance/features/apiProvisioning-v1/removeSubAdmin.feature
+++ b/tests/acceptance/features/apiProvisioning-v1/removeSubAdmin.feature
@@ -1,4 +1,4 @@
-@api @provisioning_api-app-required @skipOnLDAP @notToImplementOnOCIS @skipOnGraph
+@api @provisioning_api-app-required @skipOnLDAP @skipOnGraph
 Feature: remove subadmin
   As an admin
   I want to be able to remove subadmin rights to a user from a group

--- a/tests/acceptance/features/apiProvisioning-v1/resetUserPassword.feature
+++ b/tests/acceptance/features/apiProvisioning-v1/resetUserPassword.feature
@@ -18,13 +18,13 @@ Feature: reset user password
     And the content of file "textfile0.txt" for user "brand-new-user" using password "%alt1%" should be "ownCloud test text file 0" plus end-of-line
     But user "brand-new-user" using password "%regular%" should not be able to download file "textfile0.txt"
 
-  @issue-37992 @notToImplementOnOCIS
+  @issue-37992
   Scenario: admin tries to reset the password of a user that does not exist
     When the administrator resets the password of user "nonexistentuser" to "%alt1%" using the provisioning API
     Then the OCS status code should be "997"
     And the HTTP status code should be "401"
 
-  @smokeTest @skipOnEncryptionType:user-keys @encryption-issue-57 @notToImplementOnOCIS
+  @smokeTest @skipOnEncryptionType:user-keys @encryption-issue-57
   Scenario: subadmin should be able to reset the password of a user in their group
     Given these users have been created with small skeleton files:
       | username       | password   | displayname | email                    |
@@ -39,7 +39,7 @@ Feature: reset user password
     And the content of file "textfile0.txt" for user "brand-new-user" using password "%alt1%" should be "ownCloud test text file 0" plus end-of-line
     But user "brand-new-user" using password "%regular%" should not be able to download file "textfile0.txt"
 
-  @notToImplementOnOCIS
+
   Scenario: subadmin should not be able to reset the password of a user not in their group
     Given these users have been created with small skeleton files:
       | username       | password   | displayname | email                    |
@@ -105,7 +105,7 @@ Feature: reset user password
     And the content of file "textfile0.txt" for user "Alice" using password "%alt1%" should be "ownCloud test text file 0" plus end-of-line
     But user "Alice" using password "%regular%" should not be able to download file "textfile0.txt"
 
-  @skipOnEncryptionType:user-keys @encryption-issue-57 @notToImplementOnOCIS
+  @skipOnEncryptionType:user-keys @encryption-issue-57
   Scenario: subadmin should be able to reset the password of a user with subadmin permissions in their group
     Given these users have been created with small skeleton files:
       | username       | password   | displayname | email                    |
@@ -121,7 +121,7 @@ Feature: reset user password
     And the content of file "textfile0.txt" for user "brand-new-user" using password "%alt1%" should be "ownCloud test text file 0" plus end-of-line
     But user "brand-new-user" using password "%regular%" should not be able to download file "textfile0.txt"
 
-  @notToImplementOnOCIS
+
   Scenario: subadmin should not be able to reset the password of another subadmin of same group
     Given these users have been created with small skeleton files:
       | username         | password   | displayname | email                      |
@@ -136,7 +136,7 @@ Feature: reset user password
     And the content of file "textfile0.txt" for user "another-subadmin" using password "%regular%" should be "ownCloud test text file 0" plus end-of-line
     But user "another-subadmin" using password "%alt1%" should not be able to download file "textfile0.txt"
 
-  @notToImplementOnOCIS
+
   Scenario: apps password is preserved when resetting login password
     Given these users have been created with small skeleton files:
       | username       | password  | displayname | email                    |

--- a/tests/acceptance/features/apiProvisioning-v2/addUser.feature
+++ b/tests/acceptance/features/apiProvisioning-v2/addUser.feature
@@ -54,7 +54,7 @@ Feature: add user
     And the HTTP status code should be "400"
     And the API should not return any data
 
-  @notToImplementOnOCIS
+
   Scenario: Admin creates a new user and adds him directly to a group
     Given group "brand-new-group" has been created
     When the administrator sends a user creation request for user "brand-new-user" password "%alt1%" group "brand-new-group" using the provisioning API
@@ -164,7 +164,7 @@ Feature: add user
       | -123     |
       | 0.0      |
 
-  @notToImplementOnOCIS
+
   Scenario: subadmin should not be able to create a user
     Given user "brand-new-user" has been deleted
     And user "subadmin" has been created with default attributes and without skeleton files
@@ -185,7 +185,7 @@ Feature: add user
     And the HTTP status code should be "401"
     And user "brand-new-user" should not exist
 
-  @notToImplementOnOCIS
+
   Scenario: subadmin should be able to create a new user into their group
     Given user "brand-new-user" has been deleted
     And user "subadmin" has been created with default attributes and without skeleton files
@@ -197,7 +197,7 @@ Feature: add user
     And the HTTP status code should be "200"
     And user "brand-new-user" should exist
 
-  @notToImplementOnOCIS
+
   Scenario: subadmin should not be able to create a new user into other group
     Given user "brand-new-user" has been deleted
     And user "subadmin" has been created with default attributes and without skeleton files

--- a/tests/acceptance/features/apiProvisioning-v2/apiProvisioningUsingAppPassword.feature
+++ b/tests/acceptance/features/apiProvisioning-v2/apiProvisioningUsingAppPassword.feature
@@ -7,7 +7,7 @@ Feature: access user provisioning API using app password
   Background:
     Given using OCS API version "2"
 
-  @smokeTest @notToImplementOnOCIS
+  @smokeTest
   Scenario: admin deletes the user
     Given user "brand-new-user" has been created with default attributes and without skeleton files
     And group "brand-new-group" has been created
@@ -18,7 +18,7 @@ Feature: access user provisioning API using app password
     Then the HTTP status code should be "200"
     And user "brand-new-user" should not exist
 
-  @notToImplementOnOCIS
+
   Scenario: subadmin gets users in their group
     Given these users have been created with default attributes and without skeleton files:
       | username         |
@@ -47,7 +47,7 @@ Feature: access user provisioning API using app password
     Then the HTTP status code should be "200"
     And the display name returned by the API should be "New User"
 
-  @notToImplementOnOCIS
+
   Scenario: subadmin tries to get users of other group
     Given these users have been created with default attributes and without skeleton files:
       | username         |
@@ -77,7 +77,7 @@ Feature: access user provisioning API using app password
     Then the HTTP status code should be "401"
     And the API should not return any data
 
-  @notToImplementOnOCIS
+
   Scenario: normal user gets his own resources using the app password
     Given these users have been created with small skeleton files:
       | username       | password  | displayname | email                    |

--- a/tests/acceptance/features/apiProvisioning-v2/createSubAdmin.feature
+++ b/tests/acceptance/features/apiProvisioning-v2/createSubAdmin.feature
@@ -1,4 +1,4 @@
-@api @provisioning_api-app-required @skipOnLDAP @notToImplementOnOCIS @skipOnGraph
+@api @provisioning_api-app-required @skipOnLDAP @skipOnGraph
 Feature: create a subadmin
   As an admin
   I want to be able to make a user the subadmin of a group

--- a/tests/acceptance/features/apiProvisioning-v2/createSubAdminOc10Issue31276.feature
+++ b/tests/acceptance/features/apiProvisioning-v2/createSubAdminOc10Issue31276.feature
@@ -1,4 +1,4 @@
-@api @provisioning_api-app-required @skipOnLDAP @notToImplementOnOCIS @skipOnGraph
+@api @provisioning_api-app-required @skipOnLDAP @skipOnGraph
 Feature: current oC10 behavior for issue-31276
   As an admin
   I want to be able to make a user the subadmin of a group

--- a/tests/acceptance/features/apiProvisioning-v2/deleteUser.feature
+++ b/tests/acceptance/features/apiProvisioning-v2/deleteUser.feature
@@ -40,7 +40,7 @@ Feature: delete users
     And the HTTP status code should be "200"
     And user "brand-new-user" should not exist
 
-  @smokeTest @notToImplementOnOCIS
+  @smokeTest
   Scenario: subadmin deletes a user in their group
     Given these users have been created with default attributes and without skeleton files:
       | username       |
@@ -65,7 +65,7 @@ Feature: delete users
     And the HTTP status code should be "401"
     And user "Brian" should exist
 
-  @notToImplementOnOCIS
+
   Scenario: administrator deletes another admin user
     Given these users have been created with default attributes and without skeleton files:
       | username       |
@@ -76,7 +76,7 @@ Feature: delete users
     And the HTTP status code should be "200"
     And user "another-admin" should not exist
 
-  @notToImplementOnOCIS
+
   Scenario: subadmin deletes a user with subadmin permissions in their group
     Given these users have been created with default attributes and without skeleton files:
       | username         |
@@ -91,7 +91,7 @@ Feature: delete users
     And the HTTP status code should be "200"
     And user "another-subadmin" should not exist
 
-  @notToImplementOnOCIS
+
   Scenario: subadmin should not be able to delete another subadmin of same group
     Given these users have been created with default attributes and without skeleton files:
       | username         |
@@ -105,7 +105,7 @@ Feature: delete users
     And the HTTP status code should be "401"
     And user "another-subadmin" should exist
 
-  @notToImplementOnOCIS
+
   Scenario: subadmin should not be able to delete a user with admin permissions in their group
     Given these users have been created with default attributes and without skeleton files:
       | username       |
@@ -120,7 +120,7 @@ Feature: delete users
     And the HTTP status code should be "401"
     And user "another-admin" should exist
 
-  @notToImplementOnOCIS
+
   Scenario: subadmin should not be able to delete a user not in their group
     Given these users have been created with default attributes and without skeleton files:
       | username       |

--- a/tests/acceptance/features/apiProvisioning-v2/deleteUserOc10Issue31276.feature
+++ b/tests/acceptance/features/apiProvisioning-v2/deleteUserOc10Issue31276.feature
@@ -1,4 +1,4 @@
-@api @provisioning_api-app-required @skipOnLDAP @notToImplementOnOCIS @skipOnGraph
+@api @provisioning_api-app-required @skipOnLDAP @skipOnGraph
 Feature: current oC10 behavior for issue-31276
   As an admin
   I want to be able to delete users

--- a/tests/acceptance/features/apiProvisioning-v2/disableApp.feature
+++ b/tests/acceptance/features/apiProvisioning-v2/disableApp.feature
@@ -1,4 +1,4 @@
-@api @provisioning_api-app-required @comments-app-required @skipOnLDAP @notToImplementOnOCIS @skipOnGraph
+@api @provisioning_api-app-required @comments-app-required @skipOnLDAP @skipOnGraph
 Feature: disable an app
   As an admin
   I want to be able to disable an enabled app

--- a/tests/acceptance/features/apiProvisioning-v2/disableAppOc10Issue31276.feature
+++ b/tests/acceptance/features/apiProvisioning-v2/disableAppOc10Issue31276.feature
@@ -1,4 +1,4 @@
-@api @provisioning_api-app-required @comments-app-required @skipOnLDAP @notToImplementOnOCIS @skipOnGraph
+@api @provisioning_api-app-required @comments-app-required @skipOnLDAP @skipOnGraph
 Feature: current oC10 behavior for issue-31276
   As an admin
   I want to be able to disable an enabled app

--- a/tests/acceptance/features/apiProvisioning-v2/disableUser.feature
+++ b/tests/acceptance/features/apiProvisioning-v2/disableUser.feature
@@ -32,7 +32,7 @@ Feature: disable user
       | a@-+_.b  |
       | a space  |
 
-  @smokeTest @notToImplementOnOCIS
+  @smokeTest
   Scenario: Subadmin should be able to disable an user in their group
     Given these users have been created with default attributes and without skeleton files:
       | username |
@@ -47,7 +47,7 @@ Feature: disable user
     And the HTTP status code should be "200"
     And user "Alice" should be disabled
 
-  @issue-31276 @skipOnOcV10 @notToImplementOnOCIS
+  @issue-31276 @skipOnOcV10
   Scenario: Subadmin should not be able to disable an user not in their group
     Given these users have been created with default attributes and without skeleton files:
       | username |
@@ -63,7 +63,7 @@ Feature: disable user
     And the HTTP status code should be "401"
     And user "Alice" should be enabled
 
-  @issue-31276 @skipOnOcV10 @notToImplementOnOCIS
+  @issue-31276 @skipOnOcV10
   Scenario: Subadmins should not be able to disable users that have admin permissions in their group
     Given these users have been created with default attributes and without skeleton files:
       | username      |
@@ -88,7 +88,7 @@ Feature: disable user
     And the HTTP status code should be "200"
     And user "another-admin" should be disabled
 
-  @notToImplementOnOCIS
+
   Scenario: Admin can disable subadmins in the same group
     Given user "subadmin" has been created with default attributes and without skeleton files
     And group "brand-new-group" has been created
@@ -120,7 +120,7 @@ Feature: disable user
     And the HTTP status code should be "401"
     And user "Brian" should be enabled
 
-  @notToImplementOnOCIS
+
   Scenario: Subadmin should not be able to disable himself
     Given user "subadmin" has been created with default attributes and without skeleton files
     And group "brand-new-group" has been created
@@ -204,7 +204,7 @@ Feature: disable user
     And as "Brian" file "/Shares/textfile0.txt" should exist
     And the content of file "/Shares/textfile0.txt" for user "Brian" should be "ownCloud test text file 0" plus end-of-line
 
-  @notToImplementOnOCIS
+
   Scenario: getting shares shared by disabled user (to root)
     Given user "Alice" has been created with default attributes and small skeleton files
     And user "Brian" has been created with default attributes and without skeleton files
@@ -233,7 +233,7 @@ Feature: disable user
     And as "Brian" folder "/Shares/PARENT" should exist
     And the content of file "/Shares/PARENT/parent.txt" for user "Brian" should be "ownCloud test text file parent" plus end-of-line
 
-  @notToImplementOnOCIS
+
   Scenario: getting shares shared by disabled user in a group (to root)
     Given user "Alice" has been created with default attributes and small skeleton files
     And user "Brian" has been created with default attributes and without skeleton files
@@ -271,7 +271,7 @@ Feature: disable user
       | old         |
       | new         |
 
-  @notToImplementOnOCIS
+
   Scenario: Subadmin should be able to disable user with subadmin permissions in their group
     Given these users have been created with default attributes and without skeleton files:
       | username         |
@@ -286,7 +286,7 @@ Feature: disable user
     And the HTTP status code should be "200"
     And user "another-subadmin" should be disabled
 
-  @notToImplementOnOCIS
+
   Scenario: Subadmin should not be able to disable another subadmin of same group
     Given these users have been created with default attributes and without skeleton files:
       | username         |

--- a/tests/acceptance/features/apiProvisioning-v2/disableUserOc10Issue31276.feature
+++ b/tests/acceptance/features/apiProvisioning-v2/disableUserOc10Issue31276.feature
@@ -1,4 +1,4 @@
-@api @provisioning_api-app-required @skipOnLDAP @notToImplementOnOCIS @skipOnGraph
+@api @provisioning_api-app-required @skipOnLDAP @skipOnGraph
 Feature: current oC10 behavior for issue-31276
   As an admin
   I want to be able to disable a user

--- a/tests/acceptance/features/apiProvisioning-v2/editUser.feature
+++ b/tests/acceptance/features/apiProvisioning-v2/editUser.feature
@@ -84,7 +84,7 @@ Feature: edit users
     And the HTTP status code should be "200"
     And the email address of user "brand-new-user" should be ""
 
-  @smokeTest @notToImplementOnOCIS
+  @smokeTest
   Scenario: a subadmin should be able to edit the user information in their group
     Given these users have been created with default attributes and without skeleton files:
       | username       |
@@ -136,7 +136,7 @@ Feature: edit users
       | quota definition | default |
     And the quota definition of user "brand-new-user" should be "default"
 
-  @notToImplementOnOCIS
+
   Scenario: the administrator can edit user information with admin permissions
     Given these users have been created with default attributes and without skeleton files:
       | username      |
@@ -151,7 +151,7 @@ Feature: edit users
     And the email address of user "another-admin" should be "another-admin@example.com"
     And the quota definition of user "another-admin" should be "12 MB"
 
-  @notToImplementOnOCIS
+
   Scenario: a subadmin should be able to edit user information with subadmin permissions in their group
     Given these users have been created with default attributes and without skeleton files:
       | username         |
@@ -170,7 +170,7 @@ Feature: edit users
     And the email address of user "another-subadmin" should be "brand-new-user@example.com"
     And the quota definition of user "another-subadmin" should be "12 MB"
 
-  @notToImplementOnOCIS
+
   Scenario: a subadmin should not be able to edit user information of another subadmin of same group
     Given these users have been created with default attributes and without skeleton files:
       | username         |
@@ -212,7 +212,7 @@ Feature: edit users
       | email | alice@gmail.com |
     And the email address of user "Alice" should be "alice@gmail.com"
 
-  @notToImplementOnOCIS
+
   Scenario: Admin does not give access to users to change their email address
     Given user "Alice" has been created with default attributes and without skeleton files
     And the administrator has updated system config key "allow_user_to_change_mail_address" with value "false" and type "boolean"
@@ -223,7 +223,7 @@ Feature: edit users
       | email | alice@example.org |
     And the email address of user "Alice" should not have changed
 
-  @notToImplementOnOCIS
+
   Scenario: Admin does not give access to users to change their email address, admin can still change the email address
     Given user "Alice" has been created with default attributes and without skeleton files
     When the administrator updates system config key "allow_user_to_change_mail_address" with value "false" and type "boolean" using the occ command
@@ -234,7 +234,7 @@ Feature: edit users
       | email | alice@gmail.com |
     And the email address of user "Alice" should be "alice@gmail.com"
 
-  @notToImplementOnOCIS
+
   Scenario: Admin does not give access to users to change their email address, admin can still change their own email address
     When the administrator updates system config key "allow_user_to_change_mail_address" with value "false" and type "boolean" using the occ command
     And the administrator changes the email of user "admin" to "something@example.com" using the provisioning API
@@ -244,7 +244,7 @@ Feature: edit users
       | email | something@example.com |
     And the email address of user "admin" should be "something@example.com"
 
-  @notToImplementOnOCIS
+
   Scenario: Admin does not give access to users to change their email address, subadmin can still change the email address of a user they are subadmin of
     Given these users have been created with default attributes and without skeleton files:
       | username |
@@ -261,7 +261,7 @@ Feature: edit users
       | email | alice@gmail.com |
     And the email address of user "Alice" should be "alice@gmail.com"
 
-  @notToImplementOnOCIS
+
   Scenario: Admin does not give access to users to change their email address, subadmin cannot change the email address of a user they are not subadmin of
     Given these users have been created with default attributes and without skeleton files:
       | username |
@@ -289,7 +289,7 @@ Feature: edit users
       | displayname | Alice Wonderland |
     And the display name of user "Alice" should be "Alice Wonderland"
 
-  @notToImplementOnOCIS
+
   Scenario: Admin does not give access to users to change their display name
     Given user "Alice" has been created with default attributes and without skeleton files
     And the administrator has updated system config key "allow_user_to_change_display_name" with value "false" and type "boolean"
@@ -300,7 +300,7 @@ Feature: edit users
       | displayname | Alice Hansen |
     And the display name of user "Alice" should not have changed
 
-  @notToImplementOnOCIS
+
   Scenario: Admin does not give access to users to change their display name, admin can still change display name
     Given user "Alice" has been created with default attributes and without skeleton files
     When the administrator updates system config key "allow_user_to_change_display_name" with value "false" and type "boolean" using the occ command
@@ -311,7 +311,7 @@ Feature: edit users
       | displayname | Alice Wonderland |
     And the display name of user "Alice" should be "Alice Wonderland"
 
-  @notToImplementOnOCIS
+
   Scenario: Admin does not give access to users to change their display name, admin can still change their own display name
     When the administrator updates system config key "allow_user_to_change_display_name" with value "false" and type "boolean" using the occ command
     And the administrator changes the display name of user "admin" to "The Administrator" using the provisioning API
@@ -321,7 +321,7 @@ Feature: edit users
       | displayname | The Administrator |
     And the display name of user "admin" should be "The Administrator"
 
-  @notToImplementOnOCIS
+
   Scenario: Admin does not give access to users to change their display name, subadmin can still change the display name of a user they are subadmin of
     Given these users have been created with default attributes and without skeleton files:
       | username |
@@ -337,7 +337,7 @@ Feature: edit users
       | displayname | Alice Wonderland |
     And the display name of user "Alice" should be "Alice Wonderland"
 
-  @notToImplementOnOCIS
+
   Scenario: Admin does not give access to users to change their display name, subadmin cannot change the display name of a user they are not subadmin of
     Given these users have been created with default attributes and without skeleton files:
       | username |

--- a/tests/acceptance/features/apiProvisioning-v2/enableApp.feature
+++ b/tests/acceptance/features/apiProvisioning-v2/enableApp.feature
@@ -1,4 +1,4 @@
-@api @provisioning_api-app-required @comments-app-required @skipOnLDAP @notToImplementOnOCIS @skipOnGraph
+@api @provisioning_api-app-required @comments-app-required @skipOnLDAP @skipOnGraph
 Feature: enable an app
   As an admin
   I want to be able to enable a disabled app

--- a/tests/acceptance/features/apiProvisioning-v2/enableAppOc10Issue31276.feature
+++ b/tests/acceptance/features/apiProvisioning-v2/enableAppOc10Issue31276.feature
@@ -1,4 +1,4 @@
-@api @provisioning_api-app-required @comments-app-required @skipOnLDAP @notToImplementOnOCIS @skipOnGraph
+@api @provisioning_api-app-required @comments-app-required @skipOnLDAP @skipOnGraph
 Feature: enable an app - current oC10 behavior for issue-31276
   As an admin
   I want to be able to enable a disabled app

--- a/tests/acceptance/features/apiProvisioning-v2/enableUser.feature
+++ b/tests/acceptance/features/apiProvisioning-v2/enableUser.feature
@@ -47,7 +47,7 @@ Feature: enable user
     And the HTTP status code should be "200"
     And user "another-admin" should be enabled
 
-  @notToImplementOnOCIS
+
   Scenario: admin enables subadmins in the same group
     Given user "subadmin" has been created with default attributes and without skeleton files
     And group "brand-new-group" has been created
@@ -82,7 +82,7 @@ Feature: enable user
     And the HTTP status code should be "401"
     And user "Brian" should be disabled
 
-  @notToImplementOnOCIS
+
   Scenario: subadmin tries to enable himself
     Given user "subadmin" has been created with default attributes and without skeleton files
     And group "brand-new-group" has been created
@@ -94,13 +94,13 @@ Feature: enable user
     And the HTTP status code should be "401"
     And user "subadmin" should be disabled
 
-  @notToImplementOnOCIS
+
   Scenario: Making a web request with an enabled user
     Given user "Alice" has been created with default attributes and without skeleton files
     When user "Alice" sends HTTP method "GET" to URL "/index.php/apps/files"
     Then the HTTP status code should be "200"
 
-  @notToImplementOnOCIS
+
   Scenario: normal user should not be able to enable himself
     Given these users have been created with default attributes and without skeleton files:
       | username |
@@ -111,7 +111,7 @@ Feature: enable user
     And the HTTP status code should be "401"
     And user "Alice" should be disabled
 
-  @notToImplementOnOCIS
+
   Scenario: subadmin should be able to enable user in their group
     Given these users have been created with default attributes and without skeleton files:
       | username    |
@@ -126,7 +126,7 @@ Feature: enable user
     And the HTTP status code should be "200"
     And user "Alice" should be enabled
 
-  @notToImplementOnOCIS
+
   Scenario: subadmin should not be able to enable user not in their group
     Given these users have been created with default attributes and without skeleton files:
       | username    |
@@ -140,7 +140,7 @@ Feature: enable user
     And the HTTP status code should be "401"
     And user "Alice" should be disabled
 
-  @notToImplementOnOCIS
+
   Scenario: subadmin should be able to enable user with subadmin permissions in their group
     Given these users have been created with default attributes and without skeleton files:
       | username    |
@@ -156,7 +156,7 @@ Feature: enable user
     And the HTTP status code should be "200"
     And user "Alice" should be enabled
 
-  @notToImplementOnOCIS
+
   Scenario: subadmin should not be able to enable another subadmin of same group
     Given these users have been created with default attributes and without skeleton files:
       | username            |

--- a/tests/acceptance/features/apiProvisioning-v2/enableUserOc10Issue31276.feature
+++ b/tests/acceptance/features/apiProvisioning-v2/enableUserOc10Issue31276.feature
@@ -1,4 +1,4 @@
-@api @provisioning_api-app-required @skipOnLDAP @notToImplementOnOCIS @skipOnGraph
+@api @provisioning_api-app-required @skipOnLDAP @skipOnGraph
 Feature: enable user - current oC10 behavior for issue-31276
   As an admin
   I want to be able to enable a user

--- a/tests/acceptance/features/apiProvisioning-v2/getAppInfo.feature
+++ b/tests/acceptance/features/apiProvisioning-v2/getAppInfo.feature
@@ -1,4 +1,4 @@
-@api @provisioning_api-app-required @skipOnLDAP @notToImplementOnOCIS @skipOnGraph
+@api @provisioning_api-app-required @skipOnLDAP @skipOnGraph
 Feature: get app info
   As an admin
   I want to be able to get app info

--- a/tests/acceptance/features/apiProvisioning-v2/getApps.feature
+++ b/tests/acceptance/features/apiProvisioning-v2/getApps.feature
@@ -1,4 +1,4 @@
-@api @provisioning_api-app-required @files_sharing-app-required @skipOnLDAP @notToImplementOnOCIS @skipOnGraph
+@api @provisioning_api-app-required @files_sharing-app-required @skipOnLDAP @skipOnGraph
 Feature: get apps
   As an admin
   I want to be able to get the list of apps on my ownCloud

--- a/tests/acceptance/features/apiProvisioning-v2/getSubAdmins.feature
+++ b/tests/acceptance/features/apiProvisioning-v2/getSubAdmins.feature
@@ -1,4 +1,4 @@
-@api @provisioning_api-app-required @skipOnLDAP @notToImplementOnOCIS @skipOnGraph
+@api @provisioning_api-app-required @skipOnLDAP @skipOnGraph
 Feature: get subadmins
   As an admin
   I want to be able to get the list of subadmins of a group

--- a/tests/acceptance/features/apiProvisioning-v2/getSubAdminsOc10Issue31276.feature
+++ b/tests/acceptance/features/apiProvisioning-v2/getSubAdminsOc10Issue31276.feature
@@ -1,4 +1,4 @@
-@api @provisioning_api-app-required @skipOnLDAP @notToImplementOnOCIS @skipOnGraph
+@api @provisioning_api-app-required @skipOnLDAP @skipOnGraph
 Feature: get subadmins - current oC10 behavior for issue-31276
   As an admin
   I want to be able to get the list of subadmins of a group

--- a/tests/acceptance/features/apiProvisioning-v2/getUser.feature
+++ b/tests/acceptance/features/apiProvisioning-v2/getUser.feature
@@ -58,7 +58,7 @@ Feature: get user
     And the HTTP status code should be "404"
     And the API should not return any data
 
-  @smokeTest @notToImplementOnOCIS
+  @smokeTest
   Scenario: a subadmin gets information of a user in their group
     Given these users have been created with default attributes and without skeleton files:
       | username       | displayname |
@@ -75,7 +75,7 @@ Feature: get user
     And the free, used, total and relative quota returned by the API should exist and be valid numbers
     And the last login returned by the API should be a current Unix timestamp
 
-  @notToImplementOnOCIS
+
   Scenario: a subadmin tries to get information of a user not in their group
     Given these users have been created with default attributes and without skeleton files:
       | username       |
@@ -164,7 +164,7 @@ Feature: get user
     And the free, used, total and relative quota returned by the API should exist and be valid numbers
     And the last login returned by the API should be a current Unix timestamp
 
-  @notToImplementOnOCIS
+
   Scenario: admin gets information of a user with admin permissions
     Given these users have been created with default attributes and without skeleton files:
       | username       | displayname    |
@@ -178,7 +178,7 @@ Feature: get user
     And the free, used, total and relative quota returned by the API should exist and be valid numbers
     And the last login returned by the API should be a current Unix timestamp
 
-  @notToImplementOnOCIS
+
   Scenario: a subadmin should be able to get information of a user with subadmin permissions in their group
     Given these users have been created with default attributes and without skeleton files:
       | username         |
@@ -196,7 +196,7 @@ Feature: get user
     And the free, used, total and relative quota returned by the API should exist and be valid numbers
     And the last login returned by the API should be a current Unix timestamp
 
-  @notToImplementOnOCIS
+
   Scenario: a subadmin should not be able to get information of another subadmin of same group
     Given these users have been created with default attributes and without skeleton files:
       | username         |

--- a/tests/acceptance/features/apiProvisioning-v2/getUserOc10Issue31276.feature
+++ b/tests/acceptance/features/apiProvisioning-v2/getUserOc10Issue31276.feature
@@ -1,4 +1,4 @@
-@api @provisioning_api-app-required @skipOnLDAP @notToImplementOnOCIS @skipOnGraph
+@api @provisioning_api-app-required @skipOnLDAP @skipOnGraph
 Feature: get user - current oC10 behavior for issue-31276
   As an admin, subadmin or as myself
   I want to be able to retrieve user information

--- a/tests/acceptance/features/apiProvisioning-v2/getUsers.feature
+++ b/tests/acceptance/features/apiProvisioning-v2/getUsers.feature
@@ -7,7 +7,7 @@ Feature: get users
   Background:
     Given using OCS API version "2"
 
-  @smokeTest @notToImplementOnOCIS
+  @smokeTest
   Scenario: admin gets all users where default admin user exists
     Given user "brand-new-user" has been created with default attributes and without skeleton files
     When the administrator gets the list of all users using the provisioning API
@@ -26,7 +26,7 @@ Feature: get users
     And the users returned by the API should include
       | brand-new-user |
 
-  @smokeTest @notToImplementOnOCIS
+  @smokeTest
   Scenario: subadmin gets the users in their group
     Given these users have been created with default attributes and without skeleton files:
       | username         |

--- a/tests/acceptance/features/apiProvisioning-v2/getUsersOc10Issue31276.feature
+++ b/tests/acceptance/features/apiProvisioning-v2/getUsersOc10Issue31276.feature
@@ -1,4 +1,4 @@
-@api @provisioning_api-app-required @skipOnLDAP @notToImplementOnOCIS @skipOnGraph
+@api @provisioning_api-app-required @skipOnLDAP @skipOnGraph
 Feature: get users - current oC10 behavior for issue-31276
   As an admin, subadmin or as myself
   I want to be able to retrieve user information

--- a/tests/acceptance/features/apiProvisioning-v2/removeSubAdmin.feature
+++ b/tests/acceptance/features/apiProvisioning-v2/removeSubAdmin.feature
@@ -1,4 +1,4 @@
-@api @provisioning_api-app-required @skipOnLDAP @notToImplementOnOCIS @skipOnGraph
+@api @provisioning_api-app-required @skipOnLDAP @skipOnGraph
 Feature: remove subadmin
   As an admin
   I want to be able to remove subadmin rights to a user from a group

--- a/tests/acceptance/features/apiProvisioning-v2/removeSubAdminOc10Issue31276.feature
+++ b/tests/acceptance/features/apiProvisioning-v2/removeSubAdminOc10Issue31276.feature
@@ -1,4 +1,4 @@
-@api @provisioning_api-app-required @skipOnLDAP @notToImplementOnOCIS @skipOnGraph
+@api @provisioning_api-app-required @skipOnLDAP @skipOnGraph
 Feature: remove subadmin - current oC10 behavior for issue-31276
   As an admin
   I want to be able to remove subadmin rights to a user from a group

--- a/tests/acceptance/features/apiProvisioning-v2/resetUserPassword.feature
+++ b/tests/acceptance/features/apiProvisioning-v2/resetUserPassword.feature
@@ -18,7 +18,7 @@ Feature: reset user password
     And the content of file "textfile0.txt" for user "brand-new-user" using password "%alt1%" should be "ownCloud test text file 0" plus end-of-line
     But user "brand-new-user" using password "%regular%" should not be able to download file "textfile0.txt"
 
-	@issue-37992
+  @issue-37992
   Scenario: admin tries to reset the password of a user that does not exist
     When the administrator resets the password of user "nonexistentuser" to "%alt1%" using the provisioning API
     Then the OCS status code should be "997"

--- a/tests/acceptance/features/apiProvisioning-v2/resetUserPassword.feature
+++ b/tests/acceptance/features/apiProvisioning-v2/resetUserPassword.feature
@@ -18,13 +18,13 @@ Feature: reset user password
     And the content of file "textfile0.txt" for user "brand-new-user" using password "%alt1%" should be "ownCloud test text file 0" plus end-of-line
     But user "brand-new-user" using password "%regular%" should not be able to download file "textfile0.txt"
 
-  @notToImplementOnOCIS @issue-37992
+	@issue-37992
   Scenario: admin tries to reset the password of a user that does not exist
     When the administrator resets the password of user "nonexistentuser" to "%alt1%" using the provisioning API
     Then the OCS status code should be "997"
     And the HTTP status code should be "401"
 
-  @smokeTest @skipOnEncryptionType:user-keys @encryption-issue-57 @notToImplementOnOCIS
+  @smokeTest @skipOnEncryptionType:user-keys @encryption-issue-57
   Scenario: subadmin should be able to reset the password of a user in their group
     Given these users have been created with small skeleton files:
       | username       | password   | displayname | email                    |
@@ -39,7 +39,7 @@ Feature: reset user password
     And the content of file "textfile0.txt" for user "brand-new-user" using password "%alt1%" should be "ownCloud test text file 0" plus end-of-line
     But user "brand-new-user" using password "%regular%" should not be able to download file "textfile0.txt"
 
-  @notToImplementOnOCIS
+
   Scenario: subadmin should not be able to reset the password of a user not in their group
     Given these users have been created with small skeleton files:
       | username       | password   | displayname | email                    |
@@ -93,7 +93,7 @@ Feature: reset user password
       | ⌚️ 📱 📲 💻   | objects |
       | 🚴🏿‍♀️ 🚴‍♂️ | cycling |
 
-  @skipOnEncryptionType:user-keys @encryption-issue-57 @notToImplementOnOCIS
+  @skipOnEncryptionType:user-keys @encryption-issue-57
   Scenario: admin resets password of user with admin permissions
     Given these users have been created with small skeleton files:
       | username | password  | displayname | email           |
@@ -105,7 +105,7 @@ Feature: reset user password
     And the content of file "textfile0.txt" for user "Alice" using password "%alt1%" should be "ownCloud test text file 0" plus end-of-line
     But user "Alice" using password "%regular%" should not be able to download file "textfile0.txt"
 
-  @skipOnEncryptionType:user-keys @encryption-issue-57 @notToImplementOnOCIS
+  @skipOnEncryptionType:user-keys @encryption-issue-57
   Scenario: subadmin should be able to reset the password of a user with subadmin permissions in their group
     Given these users have been created with small skeleton files:
       | username       | password   | displayname | email                    |
@@ -121,7 +121,7 @@ Feature: reset user password
     And the content of file "textfile0.txt" for user "brand-new-user" using password "%alt1%" should be "ownCloud test text file 0" plus end-of-line
     But user "brand-new-user" using password "%regular%" should not be able to download file "textfile0.txt"
 
-  @notToImplementOnOCIS
+
   Scenario: subadmin should not be able to reset the password of another subadmin of same group
     Given these users have been created with small skeleton files:
       | username         | password   | displayname | email                      |
@@ -136,7 +136,7 @@ Feature: reset user password
     And the content of file "textfile0.txt" for user "another-subadmin" using password "%regular%" should be "ownCloud test text file 0" plus end-of-line
     But user "another-subadmin" using password "%alt1%" should not be able to download file "textfile0.txt"
 
-  @notToImplementOnOCIS
+
   Scenario: apps password is preserved when resetting login password
     Given these users have been created with small skeleton files:
       | username       | password  | displayname | email                    |

--- a/tests/acceptance/features/apiProvisioningGroups-v1/addGroup.feature
+++ b/tests/acceptance/features/apiProvisioningGroups-v1/addGroup.feature
@@ -123,7 +123,7 @@ Feature: add groups
 
   # A group name must not end in "/subadmins" because that would create ambiguity
   # with the endpoint for getting the subadmins of a group
-  @issue-31015 @skipOnOcV10 @notToImplementOnOCIS
+  @issue-31015 @skipOnOcV10
   Scenario: admin tries to create a group with name ending in "/subadmins"
     Given group "brand-new-group" has been created
     When the administrator tries to send a group creation request for group "priv/subadmins" using the provisioning API
@@ -147,7 +147,7 @@ Feature: add groups
     And the HTTP status code should be "401"
     And group "brand-new-group" should not exist
 
-  @notToImplementOnOCIS
+
   Scenario: subadmin tries to create a group
     Given user "subadmin" has been created with default attributes and without skeleton files
     And group "brand-new-group" has been created

--- a/tests/acceptance/features/apiProvisioningGroups-v1/addGroupOc10Issue31015.feature
+++ b/tests/acceptance/features/apiProvisioningGroups-v1/addGroupOc10Issue31015.feature
@@ -1,4 +1,4 @@
-@api @provisioning_api-app-required @skipOnLDAP @notToImplementOnOCIS @skipOnGraph
+@api @provisioning_api-app-required @skipOnLDAP @skipOnGraph
 Feature: add groups
   As an admin
   I want to be able to add groups

--- a/tests/acceptance/features/apiProvisioningGroups-v1/addToGroup.feature
+++ b/tests/acceptance/features/apiProvisioningGroups-v1/addToGroup.feature
@@ -172,7 +172,7 @@ Feature: add users to group
     And the HTTP status code should be "200"
     And the API should not return any data
 
-  @skipOnLDAP @notToImplementOnOCIS
+  @skipOnLDAP
   Scenario: a subadmin cannot add users to groups the subadmin is responsible for
     Given these users have been created with default attributes and without skeleton files:
       | username       |
@@ -185,7 +185,7 @@ Feature: add users to group
     And the HTTP status code should be "200"
     And user "brand-new-user" should not belong to group "brand-new-group"
 
-  @skipOnLDAP @notToImplementOnOCIS
+  @skipOnLDAP
   Scenario: a subadmin cannot add users to groups the subadmin is not responsible for
     Given these users have been created with default attributes and without skeleton files:
       | username         |
@@ -199,7 +199,7 @@ Feature: add users to group
     And the HTTP status code should be "200"
     And user "brand-new-user" should not belong to group "brand-new-group"
 
-  @skipOnLDAP @notToImplementOnOCIS
+  @skipOnLDAP
   Scenario: a subadmin can add users to other groups the subadmin is responsible for
     Given these users have been created with default attributes and without skeleton files:
       | username         |

--- a/tests/acceptance/features/apiProvisioningGroups-v1/deleteGroup.feature
+++ b/tests/acceptance/features/apiProvisioningGroups-v1/deleteGroup.feature
@@ -97,7 +97,7 @@ Feature: delete groups
     And the HTTP status code should be "401"
     And group "brand-new-group" should exist
 
-  @notToImplementOnOCIS
+
   Scenario: subadmin of the group tries to delete the group
     Given user "subadmin" has been created with default attributes and without skeleton files
     And group "brand-new-group" has been created

--- a/tests/acceptance/features/apiProvisioningGroups-v1/deleteGroupOc10Issue31015.feature
+++ b/tests/acceptance/features/apiProvisioningGroups-v1/deleteGroupOc10Issue31015.feature
@@ -1,4 +1,4 @@
-@api @provisioning_api-app-required @skipOnLDAP @notToImplementOnOCIS @skipOnGraph
+@api @provisioning_api-app-required @skipOnLDAP @skipOnGraph
 Feature: delete groups
   As an admin
   I want to be able to delete groups

--- a/tests/acceptance/features/apiProvisioningGroups-v1/getGroup.feature
+++ b/tests/acceptance/features/apiProvisioningGroups-v1/getGroup.feature
@@ -53,7 +53,7 @@ Feature: get group
       | CASE-SENSITIVE-GROUP | Case-Sensitive-Group |
       | CASE-SENSITIVE-GROUP | case-sensitive-group |
 
-  @smokeTest @notToImplementOnOCIS
+  @smokeTest
   Scenario: subadmin gets users in a group they are responsible for
     Given these users have been created with default attributes and without skeleton files:
       | username |
@@ -71,7 +71,7 @@ Feature: get group
       | Alice |
       | Brian |
 
-  @notToImplementOnOCIS
+
   Scenario: subadmin tries to get users in a group they are not responsible for
     Given user "subadmin" has been created with default attributes and without skeleton files
     And group "brand-new-group" has been created

--- a/tests/acceptance/features/apiProvisioningGroups-v1/getGroups.feature
+++ b/tests/acceptance/features/apiProvisioningGroups-v1/getGroups.feature
@@ -29,7 +29,7 @@ Feature: get groups
       | Case-Sensitive-Group |
       | CASE-SENSITIVE-GROUP |
 
-  @notToImplementOnOCIS
+
   Scenario: subadmin gets all the groups
     Given user "subadmin" has been created with default attributes and without skeleton files
     And group "brand-new-group" has been created

--- a/tests/acceptance/features/apiProvisioningGroups-v1/getSubAdminGroups.feature
+++ b/tests/acceptance/features/apiProvisioningGroups-v1/getSubAdminGroups.feature
@@ -1,4 +1,4 @@
-@api @provisioning_api-app-required @skipOnLDAP @notToImplementOnOCIS @skipOnGraph
+@api @provisioning_api-app-required @skipOnLDAP @skipOnGraph
 Feature: get subadmin groups
   As an admin
   I want to be able to get the groups in which the user is subadmin

--- a/tests/acceptance/features/apiProvisioningGroups-v1/getUserGroups.feature
+++ b/tests/acceptance/features/apiProvisioningGroups-v1/getUserGroups.feature
@@ -7,7 +7,7 @@ Feature: get user groups
   Background:
     Given using OCS API version "1"
 
-  @smokeTest @notToImplementOnOCIS
+  @smokeTest
   Scenario: admin gets groups of an user
     Given user "brand-new-user" has been created with default attributes and without skeleton files
     And group "unused-group" has been created
@@ -52,7 +52,7 @@ Feature: get user groups
       | var/../etc       |
       | priv/subadmins/1 |
 
-  @smokeTest @notToImplementOnOCIS
+  @smokeTest
   Scenario: subadmin tries to get other groups of a user in their group
     Given these users have been created with default attributes and without skeleton files:
       | username       |
@@ -82,7 +82,7 @@ Feature: get user groups
     And the HTTP status code should be "401"
     And the API should not return any data
 
-  @notToImplementOnOCIS
+
   Scenario: admin gets groups of an user who is not in any groups
     Given user "brand-new-user" has been created with default attributes and without skeleton files
     And group "unused-group" has been created
@@ -91,7 +91,7 @@ Feature: get user groups
     And the HTTP status code should be "200"
     And the list of groups returned by the API should be empty
 
-  @notToImplementOnOCIS
+
   Scenario: normal user gets his/her groups
     Given these users have been created with default attributes and without skeleton files:
       | username |

--- a/tests/acceptance/features/apiProvisioningGroups-v1/getUserGroupsOc10Issue31015.feature
+++ b/tests/acceptance/features/apiProvisioningGroups-v1/getUserGroupsOc10Issue31015.feature
@@ -1,4 +1,4 @@
-@api @provisioning_api-app-required @skipOnLDAP @notToImplementOnOCIS @skipOnGraph
+@api @provisioning_api-app-required @skipOnLDAP @skipOnGraph
 Feature: get user groups
   As an admin
   I want to be able to get groups

--- a/tests/acceptance/features/apiProvisioningGroups-v1/removeFromGroup.feature
+++ b/tests/acceptance/features/apiProvisioningGroups-v1/removeFromGroup.feature
@@ -185,7 +185,7 @@ Feature: remove a user from a group
     And the HTTP status code should be "200"
     And the API should not return any data
 
-  @smokeTest @notToImplementOnOCIS
+  @smokeTest
   Scenario: a subadmin can remove users from groups the subadmin is responsible for
     Given these users have been created with default attributes and without skeleton files:
       | username       |
@@ -199,7 +199,7 @@ Feature: remove a user from a group
     And the HTTP status code should be "200"
     And user "brand-new-user" should not belong to group "brand-new-group"
 
-  @notToImplementOnOCIS
+
   Scenario: a subadmin cannot remove users from groups the subadmin is not responsible for
     Given these users have been created with default attributes and without skeleton files:
       | username         |

--- a/tests/acceptance/features/apiProvisioningGroups-v1/removeFromGroupOc10Issue31015.feature
+++ b/tests/acceptance/features/apiProvisioningGroups-v1/removeFromGroupOc10Issue31015.feature
@@ -1,4 +1,4 @@
-@api @provisioning_api-app-required @skipOnLDAP @notToImplementOnOCIS @skipOnGraph
+@api @provisioning_api-app-required @skipOnLDAP @skipOnGraph
 Feature: remove a user from a group
   As an admin
   I want to be able to remove a user from a group

--- a/tests/acceptance/features/apiProvisioningGroups-v2/addGroup.feature
+++ b/tests/acceptance/features/apiProvisioningGroups-v2/addGroup.feature
@@ -119,7 +119,7 @@ Feature: add groups
 
   # A group name must not end in "/subadmins" because that would create ambiguity
   # with the endpoint for getting the subadmins of a group
-  @issue-31015 @skipOnOcV10 @notToImplementOnOCIS
+  @issue-31015 @skipOnOcV10
   Scenario: admin tries to create a group with name ending in "/subadmins"
     Given group "brand-new-group" has been created
     When the administrator tries to send a group creation request for group "priv/subadmins" using the provisioning API
@@ -143,7 +143,7 @@ Feature: add groups
     And the HTTP status code should be "401"
     And group "brand-new-group" should not exist
 
-  @notToImplementOnOCIS
+
   Scenario: subadmin tries to create a group
     Given user "subadmin" has been created with default attributes and without skeleton files
     And group "brand-new-group" has been created

--- a/tests/acceptance/features/apiProvisioningGroups-v2/addGroupOc10Issue31015.feature
+++ b/tests/acceptance/features/apiProvisioningGroups-v2/addGroupOc10Issue31015.feature
@@ -1,4 +1,4 @@
-@api @provisioning_api-app-required @skipOnLDAP @notToImplementOnOCIS @skipOnGraph
+@api @provisioning_api-app-required @skipOnLDAP @skipOnGraph
 Feature: add groups
   As an admin
   I want to be able to add groups

--- a/tests/acceptance/features/apiProvisioningGroups-v2/addGroupOc10Issue31276.feature
+++ b/tests/acceptance/features/apiProvisioningGroups-v2/addGroupOc10Issue31276.feature
@@ -1,4 +1,4 @@
-@api @provisioning_api-app-required @skipOnLDAP @notToImplementOnOCIS @skipOnGraph
+@api @provisioning_api-app-required @skipOnLDAP @skipOnGraph
 Feature: add groups
   As an admin
   I want to be able to add groups

--- a/tests/acceptance/features/apiProvisioningGroups-v2/addToGroup.feature
+++ b/tests/acceptance/features/apiProvisioningGroups-v2/addToGroup.feature
@@ -163,7 +163,7 @@ Feature: add users to group
     And the HTTP status code should be "400"
     And the API should not return any data
 
-  @skipOnLDAP @notToImplementOnOCIS
+  @skipOnLDAP
   Scenario: subadmin adds users to groups the subadmin is responsible for
     Given these users have been created with default attributes and without skeleton files:
       | username       |
@@ -176,7 +176,7 @@ Feature: add users to group
     And the HTTP status code should be "403"
     And user "brand-new-user" should not belong to group "brand-new-group"
 
-  @skipOnLDAP @notToImplementOnOCIS
+  @skipOnLDAP
   Scenario: subadmin tries to add user to groups the subadmin is not responsible for
     Given these users have been created with default attributes and without skeleton files:
       | username         |
@@ -190,7 +190,7 @@ Feature: add users to group
     And the HTTP status code should be "403"
     And user "brand-new-user" should not belong to group "brand-new-group"
 
-  @skipOnLDAP @notToImplementOnOCIS
+  @skipOnLDAP
   Scenario: a subadmin can add users to other groups the subadmin is responsible for
     Given these users have been created with default attributes and without skeleton files:
       | username         |

--- a/tests/acceptance/features/apiProvisioningGroups-v2/addToGroupOc10Issue31015.feature
+++ b/tests/acceptance/features/apiProvisioningGroups-v2/addToGroupOc10Issue31015.feature
@@ -1,4 +1,4 @@
-@api @provisioning_api-app-required @skipOnLDAP @notToImplementOnOCIS @skipOnGraph
+@api @provisioning_api-app-required @skipOnLDAP @skipOnGraph
 Feature: add users to group
   As a admin
   I want to be able to add users to a group

--- a/tests/acceptance/features/apiProvisioningGroups-v2/addToGroupOc10Issue31276.feature
+++ b/tests/acceptance/features/apiProvisioningGroups-v2/addToGroupOc10Issue31276.feature
@@ -1,4 +1,4 @@
-@api @provisioning_api-app-required @skipOnLDAP @notToImplementOnOCIS @skipOnGraph
+@api @provisioning_api-app-required @skipOnLDAP @skipOnGraph
 Feature: add users to group
   As a admin
   I want to be able to add users to a group

--- a/tests/acceptance/features/apiProvisioningGroups-v2/deleteGroup.feature
+++ b/tests/acceptance/features/apiProvisioningGroups-v2/deleteGroup.feature
@@ -97,7 +97,7 @@ Feature: delete groups
     And the HTTP status code should be "401"
     And group "brand-new-group" should exist
 
-  @issue-31276 @skipOnOcV10 @notToImplementOnOCIS
+  @issue-31276 @skipOnOcV10
   Scenario: subadmin of the group tries to delete the group
     Given user "subadmin" has been created with default attributes and without skeleton files
     And group "brand-new-group" has been created

--- a/tests/acceptance/features/apiProvisioningGroups-v2/deleteGroupOc10Issue31015.feature
+++ b/tests/acceptance/features/apiProvisioningGroups-v2/deleteGroupOc10Issue31015.feature
@@ -1,4 +1,4 @@
-@api @provisioning_api-app-required @skipOnLDAP @notToImplementOnOCIS @skipOnGraph
+@api @provisioning_api-app-required @skipOnLDAP @skipOnGraph
 Feature: delete groups
   As an admin
   I want to be able to delete groups

--- a/tests/acceptance/features/apiProvisioningGroups-v2/deleteGroupOc10Issue31276.feature
+++ b/tests/acceptance/features/apiProvisioningGroups-v2/deleteGroupOc10Issue31276.feature
@@ -1,4 +1,4 @@
-@api @provisioning_api-app-required @skipOnLDAP @notToImplementOnOCIS @skipOnGraph
+@api @provisioning_api-app-required @skipOnLDAP @skipOnGraph
 Feature: delete groups
   As an admin
   I want to be able to delete groups

--- a/tests/acceptance/features/apiProvisioningGroups-v2/getGroup.feature
+++ b/tests/acceptance/features/apiProvisioningGroups-v2/getGroup.feature
@@ -53,7 +53,7 @@ Feature: get group
       | CASE-SENSITIVE-GROUP | Case-Sensitive-Group |
       | CASE-SENSITIVE-GROUP | case-sensitive-group |
 
-  @smokeTest @notToImplementOnOCIS
+  @smokeTest
   Scenario: subadmin gets users in a group they are responsible for
     Given these users have been created with default attributes and without skeleton files:
       | username |
@@ -71,7 +71,7 @@ Feature: get group
       | Alice |
       | Brian |
 
-  @issue-31276 @skipOnOcV10 @notToImplementOnOCIS
+  @issue-31276 @skipOnOcV10
   Scenario: subadmin tries to get users in a group they are not responsible for
     Given user "subadmin" has been created with default attributes and without skeleton files
     And group "brand-new-group" has been created

--- a/tests/acceptance/features/apiProvisioningGroups-v2/getGroupOc10Issue31276.feature
+++ b/tests/acceptance/features/apiProvisioningGroups-v2/getGroupOc10Issue31276.feature
@@ -1,4 +1,4 @@
-@api @provisioning_api-app-required @skipOnLDAP @notToImplementOnOCIS @skipOnGraph
+@api @provisioning_api-app-required @skipOnLDAP @skipOnGraph
 Feature: get group
   As an admin
   I want to be able to get group details

--- a/tests/acceptance/features/apiProvisioningGroups-v2/getGroups.feature
+++ b/tests/acceptance/features/apiProvisioningGroups-v2/getGroups.feature
@@ -33,7 +33,7 @@ Feature: get groups
       | Case-Sensitive-Group |
       | CASE-SENSITIVE-GROUP |
 
-  @notToImplementOnOCIS
+
   Scenario: subadmin gets all the groups
     Given user "subadmin" has been created with default attributes and without skeleton files
     And group "brand-new-group" has been created

--- a/tests/acceptance/features/apiProvisioningGroups-v2/getSubAdminGroups.feature
+++ b/tests/acceptance/features/apiProvisioningGroups-v2/getSubAdminGroups.feature
@@ -1,4 +1,4 @@
-@api @provisioning_api-app-required @skipOnLDAP @notToImplementOnOCIS @skipOnGraph
+@api @provisioning_api-app-required @skipOnLDAP @skipOnGraph
 Feature: get subadmin groups
   As an admin
   I want to be able to get the groups in which the user is subadmin

--- a/tests/acceptance/features/apiProvisioningGroups-v2/getUserGroups.feature
+++ b/tests/acceptance/features/apiProvisioningGroups-v2/getUserGroups.feature
@@ -7,7 +7,7 @@ Feature: get user groups
   Background:
     Given using OCS API version "2"
 
-  @smokeTest @notToImplementOnOCIS
+  @smokeTest
   Scenario: admin gets groups of an user
     Given user "brand-new-user" has been created with default attributes and without skeleton files
     And group "unused-group" has been created
@@ -52,7 +52,7 @@ Feature: get user groups
     And the OCS status code should be "200"
     And the HTTP status code should be "200"
 
-  @smokeTest @notToImplementOnOCIS
+  @smokeTest
   Scenario: subadmin tries to get other groups of a user in their group
     Given these users have been created with default attributes and without skeleton files:
       | username       |
@@ -82,7 +82,7 @@ Feature: get user groups
     And the HTTP status code should be "401"
     And the API should not return any data
 
-  @notToImplementOnOCIS
+
   Scenario: admin gets groups of an user who is not in any groups
     Given user "brand-new-user" has been created with default attributes and without skeleton files
     And group "unused-group" has been created
@@ -91,7 +91,7 @@ Feature: get user groups
     And the HTTP status code should be "200"
     And the list of groups returned by the API should be empty
 
-  @notToImplementOnOCIS
+
   Scenario: normal user gets his/her groups
     Given these users have been created with default attributes and without skeleton files:
       | username |

--- a/tests/acceptance/features/apiProvisioningGroups-v2/getUserGroupsOc10Issue31015.feature
+++ b/tests/acceptance/features/apiProvisioningGroups-v2/getUserGroupsOc10Issue31015.feature
@@ -1,4 +1,4 @@
-@api @provisioning_api-app-required @skipOnLDAP @notToImplementOnOCIS @skipOnGraph
+@api @provisioning_api-app-required @skipOnLDAP @skipOnGraph
 Feature: get user groups
   As an admin
   I want to be able to get groups

--- a/tests/acceptance/features/apiProvisioningGroups-v2/getUserGroupsOc10Issue31276.feature
+++ b/tests/acceptance/features/apiProvisioningGroups-v2/getUserGroupsOc10Issue31276.feature
@@ -1,4 +1,4 @@
-@api @provisioning_api-app-required @skipOnLDAP @notToImplementOnOCIS @skipOnGraph
+@api @provisioning_api-app-required @skipOnLDAP @skipOnGraph
 Feature: get user groups
   As an admin
   I want to be able to get groups

--- a/tests/acceptance/features/apiProvisioningGroups-v2/removeFromGroup.feature
+++ b/tests/acceptance/features/apiProvisioningGroups-v2/removeFromGroup.feature
@@ -185,7 +185,7 @@ Feature: remove a user from a group
     And the HTTP status code should be "400"
     And the API should not return any data
 
-  @smokeTest @notToImplementOnOCIS
+  @smokeTest
   Scenario: a subadmin can remove users from groups the subadmin is responsible for
     Given these users have been created with default attributes and without skeleton files:
       | username       |
@@ -199,7 +199,7 @@ Feature: remove a user from a group
     And the HTTP status code should be "200"
     And user "brand-new-user" should not belong to group "brand-new-group"
 
-  @notToImplementOnOCIS
+
   Scenario: a subadmin cannot remove users from groups the subadmin is not responsible for
     Given these users have been created with default attributes and without skeleton files:
       | username         |

--- a/tests/acceptance/features/apiProvisioningGroups-v2/removeFromGroupOc10Issue31015.feature
+++ b/tests/acceptance/features/apiProvisioningGroups-v2/removeFromGroupOc10Issue31015.feature
@@ -1,4 +1,4 @@
-@api @provisioning_api-app-required @skipOnLDAP @notToImplementOnOCIS @skipOnGraph
+@api @provisioning_api-app-required @skipOnLDAP @skipOnGraph
 Feature: remove a user from a group
   As an admin
   I want to be able to remove a user from a group

--- a/tests/acceptance/features/apiProvisioningGroups-v2/removeFromGroupOc10Issue31276.feature
+++ b/tests/acceptance/features/apiProvisioningGroups-v2/removeFromGroupOc10Issue31276.feature
@@ -1,4 +1,4 @@
-@api @provisioning_api-app-required @skipOnLDAP @notToImplementOnOCIS @skipOnGraph
+@api @provisioning_api-app-required @skipOnLDAP @skipOnGraph
 Feature: remove a user from a group
   As an admin
   I want to be able to remove a user from a group

--- a/tests/acceptance/features/apiShareCreateSpecialToRoot1/createShareExpirationDate.feature
+++ b/tests/acceptance/features/apiShareCreateSpecialToRoot1/createShareExpirationDate.feature
@@ -1,4 +1,4 @@
-@api @files_sharing-app-required @notToImplementOnOCIS
+@api @files_sharing-app-required
 Feature: a default expiration date can be specified for shares with users or groups
 
   Background:

--- a/tests/acceptance/features/apiShareCreateSpecialToRoot1/createShareReceivedInMultipleWays.feature
+++ b/tests/acceptance/features/apiShareCreateSpecialToRoot1/createShareReceivedInMultipleWays.feature
@@ -1,4 +1,4 @@
-@api @files_sharing-app-required @notToImplementOnOCIS
+@api @files_sharing-app-required
 Feature: share resources where the sharee receives the share in multiple ways
 
   Background:

--- a/tests/acceptance/features/apiShareCreateSpecialToRoot1/createShareResourceCaseSensitiveName.feature
+++ b/tests/acceptance/features/apiShareCreateSpecialToRoot1/createShareResourceCaseSensitiveName.feature
@@ -1,4 +1,4 @@
-@api @files_sharing-app-required @notToImplementOnOCIS
+@api @files_sharing-app-required
 Feature: Sharing resources with different case names with the sharee and checking the coexistence of resources on sharee/receivers side
 
   Background:

--- a/tests/acceptance/features/apiShareCreateSpecialToRoot1/createShareUniqueReceivedNames.feature
+++ b/tests/acceptance/features/apiShareCreateSpecialToRoot1/createShareUniqueReceivedNames.feature
@@ -1,4 +1,4 @@
-@api @files_sharing-app-required @notToImplementOnOCIS
+@api @files_sharing-app-required
 Feature: resources shared with the same name are received with unique names
 
   Background:

--- a/tests/acceptance/features/apiShareCreateSpecialToRoot1/createShareWhenExcludedFromSharing.feature
+++ b/tests/acceptance/features/apiShareCreateSpecialToRoot1/createShareWhenExcludedFromSharing.feature
@@ -1,4 +1,4 @@
-@api @files_sharing-app-required @notToImplementOnOCIS
+@api @files_sharing-app-required
 Feature: cannot share resources when in a group that is excluded from sharing
 
   Background:

--- a/tests/acceptance/features/apiShareCreateSpecialToRoot2/createShareDefaultFolderForReceivedShares.feature
+++ b/tests/acceptance/features/apiShareCreateSpecialToRoot2/createShareDefaultFolderForReceivedShares.feature
@@ -1,4 +1,4 @@
-@api @files_sharing-app-required @notToImplementOnOCIS
+@api @files_sharing-app-required
 Feature: shares are received in the default folder for received shares
 
   Background:

--- a/tests/acceptance/features/apiShareCreateSpecialToRoot2/createShareGroupAndUserWithSameName.feature
+++ b/tests/acceptance/features/apiShareCreateSpecialToRoot2/createShareGroupAndUserWithSameName.feature
@@ -1,4 +1,4 @@
-@api @files_sharing-app-required @notToImplementOnOCIS
+@api @files_sharing-app-required
 Feature: sharing works when a username and group name are the same
 
   Background:

--- a/tests/acceptance/features/apiShareCreateSpecialToRoot2/createShareGroupCaseSensitive.feature
+++ b/tests/acceptance/features/apiShareCreateSpecialToRoot2/createShareGroupCaseSensitive.feature
@@ -1,4 +1,4 @@
-@api @files_sharing-app-required @notToImplementOnOCIS
+@api @files_sharing-app-required
 Feature: share with groups, group names are case-sensitive
 
   Background:

--- a/tests/acceptance/features/apiShareCreateSpecialToRoot2/createShareWhenShareWithOnlyMembershipGroups.feature
+++ b/tests/acceptance/features/apiShareCreateSpecialToRoot2/createShareWhenShareWithOnlyMembershipGroups.feature
@@ -1,4 +1,4 @@
-@api @files_sharing-app-required @notToImplementOnOCIS
+@api @files_sharing-app-required
 Feature: cannot share resources outside the group when share with membership groups is enabled
 
   Background:

--- a/tests/acceptance/features/apiShareCreateSpecialToRoot2/createShareWithDisabledUser.feature
+++ b/tests/acceptance/features/apiShareCreateSpecialToRoot2/createShareWithDisabledUser.feature
@@ -1,4 +1,4 @@
-@api @files_sharing-app-required @notToImplementOnOCIS
+@api @files_sharing-app-required
 Feature: share resources with a disabled user
 
   Background:

--- a/tests/acceptance/features/apiShareCreateSpecialToRoot2/createShareWithDisabledUserOc10Issue32068.feature
+++ b/tests/acceptance/features/apiShareCreateSpecialToRoot2/createShareWithDisabledUserOc10Issue32068.feature
@@ -1,4 +1,4 @@
-@api @files_sharing-app-required @notToImplementOnOCIS
+@api @files_sharing-app-required
 Feature: share resources with a disabled user - current oC10 behavior for issue-32068
 
   Background:

--- a/tests/acceptance/features/apiShareCreateSpecialToRoot2/createShareWithInvalidPermissions.feature
+++ b/tests/acceptance/features/apiShareCreateSpecialToRoot2/createShareWithInvalidPermissions.feature
@@ -1,4 +1,4 @@
-@api @files_sharing-app-required @notToImplementOnOCIS
+@api @files_sharing-app-required
 Feature: cannot share resources with invalid permissions
 
   Background:

--- a/tests/acceptance/features/apiShareCreateSpecialToShares2/createShareGroupCaseSensitive.feature
+++ b/tests/acceptance/features/apiShareCreateSpecialToShares2/createShareGroupCaseSensitive.feature
@@ -1,4 +1,4 @@
-@api @files_sharing-app-required @notToImplementOnOCIS
+@api @files_sharing-app-required
 Feature: share with groups, group names are case-sensitive
 
   Background:

--- a/tests/acceptance/features/apiShareCreateSpecialToShares2/createShareReceivedMultipleWaysIssue39347.feature
+++ b/tests/acceptance/features/apiShareCreateSpecialToShares2/createShareReceivedMultipleWaysIssue39347.feature
@@ -1,4 +1,4 @@
-@api @files_sharing-app-required @notToImplementOnOCIS
+@api @files_sharing-app-required
 Feature: share resources where the sharee receives the share in multiple ways
 
   # These are the bug demonstration scenarios for https://github.com/owncloud/core/issues/39347

--- a/tests/acceptance/features/apiShareManagementBasicToRoot/createShareFromLocalStorageToRootFolder.feature
+++ b/tests/acceptance/features/apiShareManagementBasicToRoot/createShareFromLocalStorageToRootFolder.feature
@@ -1,4 +1,4 @@
-@api @local_storage @files_external-app-required @files_sharing-app-required @notToImplementOnOCIS
+@api @local_storage @files_external-app-required @files_sharing-app-required
 Feature: local-storage
 
   Background:

--- a/tests/acceptance/features/apiShareManagementBasicToRoot/createShareToRootFolder.feature
+++ b/tests/acceptance/features/apiShareManagementBasicToRoot/createShareToRootFolder.feature
@@ -1,4 +1,4 @@
-@api @files_sharing-app-required @notToImplementOnOCIS
+@api @files_sharing-app-required
 Feature: sharing
 
   Background:

--- a/tests/acceptance/features/apiShareManagementBasicToRoot/deleteShareFromRoot.feature
+++ b/tests/acceptance/features/apiShareManagementBasicToRoot/deleteShareFromRoot.feature
@@ -1,4 +1,4 @@
-@api @files_sharing-app-required @notToImplementOnOCIS
+@api @files_sharing-app-required
 Feature: sharing
 
   Background:

--- a/tests/acceptance/features/apiShareManagementBasicToRoot/excludeGroupFromReceivingShares.feature
+++ b/tests/acceptance/features/apiShareManagementBasicToRoot/excludeGroupFromReceivingShares.feature
@@ -1,4 +1,4 @@
-@api @files_sharing-app-required @notToImplementOnOCIS
+@api @files_sharing-app-required
 Feature: Exclude groups from receiving shares
   As an admin
   I want to exclude groups from receiving shares

--- a/tests/acceptance/features/apiShareManagementBasicToShares/createShareFromLocalStorageToSharesFolder.feature
+++ b/tests/acceptance/features/apiShareManagementBasicToShares/createShareFromLocalStorageToSharesFolder.feature
@@ -1,4 +1,4 @@
-@api @local_storage @files_external-app-required @notToImplementOnOCIS @files_sharing-app-required
+@api @local_storage @files_external-app-required @files_sharing-app-required
 Feature: local-storage
 
   Background:

--- a/tests/acceptance/features/apiShareManagementToRoot/acceptShares.feature
+++ b/tests/acceptance/features/apiShareManagementToRoot/acceptShares.feature
@@ -1,4 +1,4 @@
-@api @files_sharing-app-required @notToImplementOnOCIS
+@api @files_sharing-app-required
 Feature: accept/decline shares coming from internal users
   As a user
   I want to have control of which received shares I accept

--- a/tests/acceptance/features/apiShareManagementToRoot/disableSharing.feature
+++ b/tests/acceptance/features/apiShareManagementToRoot/disableSharing.feature
@@ -1,4 +1,4 @@
-@api @files_sharing-app-required @notToImplementOnOCIS
+@api @files_sharing-app-required
 Feature: sharing
   As an admin
   I want to be able to disable sharing functionality

--- a/tests/acceptance/features/apiShareManagementToRoot/mergeShare.feature
+++ b/tests/acceptance/features/apiShareManagementToRoot/mergeShare.feature
@@ -1,4 +1,4 @@
-@api @files_sharing-app-required @notToImplementOnOCIS
+@api @files_sharing-app-required
 Feature: sharing
 
   Background:

--- a/tests/acceptance/features/apiShareManagementToRoot/moveReceivedShare.feature
+++ b/tests/acceptance/features/apiShareManagementToRoot/moveReceivedShare.feature
@@ -1,4 +1,4 @@
-@api @files_sharing-app-required @notToImplementOnOCIS
+@api @files_sharing-app-required
 Feature: sharing
 
   Background:

--- a/tests/acceptance/features/apiShareManagementToRoot/moveReceivedShareFromLocalStorage.feature
+++ b/tests/acceptance/features/apiShareManagementToRoot/moveReceivedShareFromLocalStorage.feature
@@ -1,4 +1,4 @@
-@api @local_storage @files_external-app-required @notToImplementOnOCIS
+@api @local_storage @files_external-app-required
 Feature: local-storage
 
   Background:

--- a/tests/acceptance/features/apiShareManagementToRoot/moveShareInsideAnotherShare.feature
+++ b/tests/acceptance/features/apiShareManagementToRoot/moveShareInsideAnotherShare.feature
@@ -1,4 +1,4 @@
-@api @files_sharing-app-required @notToImplementOnOCIS
+@api @files_sharing-app-required
 Feature: moving a share inside another share
   As a user
   I want to move a shared resource inside another shared resource

--- a/tests/acceptance/features/apiShareManagementToShares/acceptShares.feature
+++ b/tests/acceptance/features/apiShareManagementToShares/acceptShares.feature
@@ -127,7 +127,7 @@ Feature: accept/decline shares coming from internal users
       | /Shares/PARENT        |
       | /Shares/textfile0.txt |
 
-  @notToImplementOnOCIS
+
   Scenario Outline: accept a pending share when there is a default folder for received shares
     Given the administrator has set the default folder for received shares to "<share_folder>"
     And user "Alice" has shared folder "/PARENT" with user "Brian"

--- a/tests/acceptance/features/apiShareManagementToShares/moveReceivedShare.feature
+++ b/tests/acceptance/features/apiShareManagementToShares/moveReceivedShare.feature
@@ -11,7 +11,7 @@ Feature: sharing
       | Brian    |
       | Carol    |
 
-  @issue-ocis-2141 @notToImplementOnOCIS
+  @issue-ocis-2141
   Scenario: Keep usergroup shares (#22143)
     Given group "grp1" has been created
     And user "Brian" has been added to group "grp1"
@@ -44,7 +44,7 @@ Feature: sharing
     And user "Brian" should see the following elements
       | /Shares/new/|
 
-  @issue-ocis-2141 @notToImplementOnOCIS
+  @issue-ocis-2141
   Scenario: keep user shared file name same after one of recipient has renamed the file
     Given user "Alice" has uploaded file with content "foo" to "/sharefile.txt"
     And user "Alice" has shared file "/sharefile.txt" with user "Brian"
@@ -70,7 +70,7 @@ Feature: sharing
     And as "Alice" file "/sharefile.txt" should exist
     And as "Brian" file "/Shares/sharefile.txt" should exist
 
-  @issue-ocis-2141 @notToImplementOnOCIS
+  @issue-ocis-2141
   Scenario: keep user shared file directory same in respect to respective user if one of the recipient has moved the file
     Given user "Alice" has uploaded file with content "foo" to "/sharefile.txt"
     And user "Alice" has shared file "/sharefile.txt" with user "Brian"
@@ -84,7 +84,7 @@ Feature: sharing
     And as "Alice" file "/sharefile.txt" should exist
     And as "Brian" file "/Shares/sharefile.txt" should exist
 
-  @issue-ocis-2146 @notToImplementOnOCIS
+  @issue-ocis-2146
   Scenario Outline: move folder inside received folder with special characters
     Given group "grp1" has been created
     And user "Carol" has been added to group "grp1"
@@ -109,7 +109,7 @@ Feature: sharing
       | ?abc=oc #     | ?abc=oc g%rp#   | # oc?test=oc&a  |
       | @a#8a=b?c=d   | @a#8a=b?c=d grp | ?a#8 a=b?c=d    |
 
-  @issue-ocis-2141 @notToImplementOnOCIS
+  @issue-ocis-2141
   Scenario: receiver renames a received share with share, read, change permissions
     Given user "Alice" has created folder "folderToShare"
     And user "Alice" has uploaded file with content "thisIsAFileInsideTheSharedFolder" to "/folderToShare/fileInside"
@@ -141,7 +141,7 @@ Feature: sharing
     And as "Alice" file "/folderToShare/renamedFile" should exist
     But as "Alice" file "/folderToShare/fileInside" should not exist
 
-  @issue-ocis-2141 @notToImplementOnOCIS
+  @issue-ocis-2141
   Scenario: receiver tries to rename a received share with share, read permissions
     Given user "Alice" has created folder "folderToShare"
     And user "Alice" has uploaded file with content "thisIsAFileInsideTheSharedFolder" to "/folderToShare/fileInside"
@@ -215,7 +215,7 @@ Feature: sharing
     And as "Brian" folder "/Shares/myFolder" should exist
     But as "Alice" folder "myFolder" should not exist
 
-  @issue-ocis-2141 @notToImplementOnOCIS
+  @issue-ocis-2141
   Scenario: receiver renames a received file share with read,update,share permissions in group sharing
     Given group "grp1" has been created
     And user "Brian" has been added to group "grp1"
@@ -239,7 +239,7 @@ Feature: sharing
     And as "Brian" file "/Shares/newFile.txt" should exist
     But as "Alice" file "/Shares/newFile.txt" should not exist
 
-  @issue-ocis-2141 @notToImplementOnOCIS
+  @issue-ocis-2141
   Scenario: receiver renames a received folder share with share, read, change permissions in group sharing
     Given group "grp1" has been created
     And user "Alice" has created folder "PARENT"
@@ -263,7 +263,7 @@ Feature: sharing
     And as "Brian" folder "/Shares/myFolder" should exist
     But as "Alice" folder "/Shares/myFolder" should not exist
 
-  @issue-ocis-2141 @notToImplementOnOCIS
+  @issue-ocis-2141
   Scenario: receiver renames a received file share with share, read permissions in group sharing
     Given group "grp1" has been created
     And user "Brian" has been added to group "grp1"
@@ -287,7 +287,7 @@ Feature: sharing
     And as "Brian" file "/Shares/newFile.txt" should exist
     But as "Alice" file "/Shares/newFile.txt" should not exist
 
-  @issue-ocis-2141 @notToImplementOnOCIS
+  @issue-ocis-2141
   Scenario: receiver renames a received folder share with share, read permissions in group sharing
     Given group "grp1" has been created
     And user "Alice" has created folder "PARENT"
@@ -359,7 +359,7 @@ Feature: sharing
       | ?abc=oc #     | ?abc=oc g%rp#   | # oc?test=oc&a |
       | @a#8a=b?c=d   | @a#8a=b?c=d grp | ?a#8 a=b?c=d   |
 
-  @issue-ocis-2141 @notToImplementOnOCIS
+  @issue-ocis-2141
   Scenario: receiver moves file within a received folder to new folder
     Given user "Alice" has created folder "folderToShare"
     And user "Brian" has created folder "FOLDER"

--- a/tests/acceptance/features/apiShareManagementToShares/moveReceivedShareFromLocalStorage.feature
+++ b/tests/acceptance/features/apiShareManagementToShares/moveReceivedShareFromLocalStorage.feature
@@ -1,4 +1,4 @@
-@api @local_storage @files_external-app-required @notToImplementOnOCIS
+@api @local_storage @files_external-app-required
 Feature: local-storage
 
   Background:

--- a/tests/acceptance/features/apiShareManagementToShares/moveShareInsideAnotherShare.feature
+++ b/tests/acceptance/features/apiShareManagementToShares/moveShareInsideAnotherShare.feature
@@ -41,7 +41,7 @@ Feature: moving a share inside another share
     And as "Brian" file "/Shares/folderA/folderB/fileB.txt" should exist
     And as "Brian" file "/Shares/folderB/fileB.txt" should exist
 
-  @notToImplementOnOCIS
+
   Scenario: share receiver moves a whole share inside a local folder
     Given user "Brian" has created folder "localFolder"
     And user "Brian" has uploaded file with content "local text" to "/localFolder/localFile.txt"
@@ -52,7 +52,7 @@ Feature: moving a share inside another share
     And as "Brian" file "/localFolder/localFile.txt" should exist
     But as "Brian" file "/Shares/folderB/fileB.txt" should not exist
 
-  @notToImplementOnOCIS
+
   Scenario: share receiver moves a whole share inside a local folder then moves the local folder inside a received share
     Given user "Brian" has created folder "localFolder"
     And user "Brian" has uploaded file with content "local text" to "/localFolder/localFile.txt"
@@ -69,7 +69,7 @@ Feature: moving a share inside another share
     But as "Alice" folder "/folderA/localFolder/folderB" should not exist
     And as "Brian" folder "/Shares/folderA/localFolder/folderB" should not exist
 
-  @notToImplementOnOCIS
+
   Scenario: share receiver moves a whole share inside a local folder then tries to move the share inside a received share
     Given user "Brian" has created folder "localFolder"
     And user "Brian" has uploaded file with content "local text" to "/localFolder/localFile.txt"

--- a/tests/acceptance/features/apiShareOperationsToRoot1/accessToShare.feature
+++ b/tests/acceptance/features/apiShareOperationsToRoot1/accessToShare.feature
@@ -1,4 +1,4 @@
-@api @files_sharing-app-required @notToImplementOnOCIS
+@api @files_sharing-app-required
 Feature: sharing
 
   Background:

--- a/tests/acceptance/features/apiShareOperationsToRoot1/changingFilesShare.feature
+++ b/tests/acceptance/features/apiShareOperationsToRoot1/changingFilesShare.feature
@@ -1,4 +1,4 @@
-@api @files_sharing-app-required @notToImplementOnOCIS
+@api @files_sharing-app-required
 Feature: sharing
 
   Background:

--- a/tests/acceptance/features/apiShareOperationsToRoot1/gettingShares.feature
+++ b/tests/acceptance/features/apiShareOperationsToRoot1/gettingShares.feature
@@ -1,4 +1,4 @@
-@api @files_sharing-app-required @notToImplementOnOCIS
+@api @files_sharing-app-required
 Feature: sharing
 
   Background:

--- a/tests/acceptance/features/apiShareOperationsToRoot1/gettingSharesReceivedFiltered.feature
+++ b/tests/acceptance/features/apiShareOperationsToRoot1/gettingSharesReceivedFiltered.feature
@@ -1,4 +1,4 @@
-@api @files_sharing-app-required @notToImplementOnOCIS
+@api @files_sharing-app-required
 Feature: get the received shares filtered by type (user, group etc)
   As a user
   I want to be able to know the shares that I have received of a particular type (user, group etc)

--- a/tests/acceptance/features/apiShareOperationsToRoot1/gettingSharesReceivedFilteredEmpty.feature
+++ b/tests/acceptance/features/apiShareOperationsToRoot1/gettingSharesReceivedFilteredEmpty.feature
@@ -1,4 +1,4 @@
-@api @files_sharing-app-required @notToImplementOnOCIS
+@api @files_sharing-app-required
 Feature: get the received shares filtered by type (user, group etc)
   As a user
   I want to be able to know the shares that I have received of a particular type (user, group etc)

--- a/tests/acceptance/features/apiShareOperationsToRoot1/gettingSharesSharedFiltered.feature
+++ b/tests/acceptance/features/apiShareOperationsToRoot1/gettingSharesSharedFiltered.feature
@@ -1,4 +1,4 @@
-@api @files_sharing-app-required @notToImplementOnOCIS
+@api @files_sharing-app-required
 Feature: get shares filtered by type (user, group etc)
   As a user
   I want to be able to know the shares that I have made of a particular type (user, group etc)

--- a/tests/acceptance/features/apiShareOperationsToRoot1/gettingSharesSharedFilteredEmpty.feature
+++ b/tests/acceptance/features/apiShareOperationsToRoot1/gettingSharesSharedFilteredEmpty.feature
@@ -1,4 +1,4 @@
-@api @files_sharing-app-required @notToImplementOnOCIS
+@api @files_sharing-app-required
 Feature: get shares filtered by type (user, group etc)
   As a user
   I want to be able to know the shares that I have made of a particular type (user, group etc)

--- a/tests/acceptance/features/apiShareOperationsToRoot2/getWebDAVSharePermissions.feature
+++ b/tests/acceptance/features/apiShareOperationsToRoot2/getWebDAVSharePermissions.feature
@@ -1,4 +1,4 @@
-@api @files_sharing-app-required @notToImplementOnOCIS
+@api @files_sharing-app-required
 Feature: sharing
 
   Background:

--- a/tests/acceptance/features/apiShareOperationsToRoot2/shareAccessByID.feature
+++ b/tests/acceptance/features/apiShareOperationsToRoot2/shareAccessByID.feature
@@ -1,4 +1,4 @@
-@api @files_sharing-app-required @notToImplementOnOCIS
+@api @files_sharing-app-required
 Feature: share access by ID
 
   Background:

--- a/tests/acceptance/features/apiShareOperationsToRoot2/uploadToShare.feature
+++ b/tests/acceptance/features/apiShareOperationsToRoot2/uploadToShare.feature
@@ -1,4 +1,4 @@
-@api @files_sharing-app-required @notToImplementOnOCIS
+@api @files_sharing-app-required
 Feature: sharing
 
   Background:

--- a/tests/acceptance/features/apiShareOperationsToShares1/accessToSharesFolder.feature
+++ b/tests/acceptance/features/apiShareOperationsToShares1/accessToSharesFolder.feature
@@ -1,4 +1,4 @@
-@api @files_sharing-app-required @notToImplementOnOCIS
+@api @files_sharing-app-required
 Feature: write directly into the folder for received shares
   On ownCloud10 with the folder for received shares set, for example, to "Shares"
   A user should see a "Shares" folder when they have received a share.

--- a/tests/acceptance/features/apiShareOperationsToShares1/changingFilesShare.feature
+++ b/tests/acceptance/features/apiShareOperationsToShares1/changingFilesShare.feature
@@ -25,7 +25,7 @@ Feature: sharing
       | old         |
       | new         |
 
-  @smokeTest @files_trashbin-app-required @notToImplementOnOCIS
+  @smokeTest @files_trashbin-app-required
   Scenario Outline: moving a file out of a share as recipient creates a backup for the owner
     Given using <dav_version> DAV path
     And user "Alice" has created folder "/shared"
@@ -44,7 +44,7 @@ Feature: sharing
       | old         |
       | new         |
 
-  @files_trashbin-app-required @notToImplementOnOCIS
+  @files_trashbin-app-required
   Scenario Outline: moving a folder out of a share as recipient creates a backup for the owner
     Given using <dav_version> DAV path
     And user "Alice" has created folder "/shared"

--- a/tests/acceptance/features/apiShareOperationsToShares2/uploadToShare.feature
+++ b/tests/acceptance/features/apiShareOperationsToShares2/uploadToShare.feature
@@ -252,7 +252,7 @@ Feature: sharing
       | old      |
       | new      |
 
-	@newChunking @issue-ocis-1321
+  @newChunking @issue-ocis-1321
   Scenario: Uploading a file in to a shared folder without edit permissions
     Given using new DAV path
     And user "Brian" has been created with default attributes and without skeleton files

--- a/tests/acceptance/features/apiShareOperationsToShares2/uploadToShare.feature
+++ b/tests/acceptance/features/apiShareOperationsToShares2/uploadToShare.feature
@@ -252,7 +252,7 @@ Feature: sharing
       | old      |
       | new      |
 
-  @notToImplementOnOCIS @newChunking @issue-ocis-1321
+	@newChunking @issue-ocis-1321
   Scenario: Uploading a file in to a shared folder without edit permissions
     Given using new DAV path
     And user "Brian" has been created with default attributes and without skeleton files

--- a/tests/acceptance/features/apiSharePublicLink1/changingPublicLinkShare.feature
+++ b/tests/acceptance/features/apiSharePublicLink1/changingPublicLinkShare.feature
@@ -18,7 +18,7 @@ Feature: changing a public link share
     Then the HTTP status code should be "<http-status-code>"
     And as "Alice" file "PARENT/parent.txt" <should-or-not> exist
 
-    @notToImplementOnOCIS @issue-ocis-2079
+    @issue-ocis-2079
     Examples:
       | permissions               | http-status-code | should-or-not | public-webdav-api-version |
       | read,update,create        | 403              | should        | old                       |
@@ -40,7 +40,7 @@ Feature: changing a public link share
     And as "Alice" file "/PARENT/parent.txt" should exist
     And as "Alice" file "/PARENT/newparent.txt" should not exist
 
-    @notToImplementOnOCIS @issue-ocis-2079
+    @issue-ocis-2079
     Examples:
       | public-webdav-api-version |
       | old                       |
@@ -60,14 +60,10 @@ Feature: changing a public link share
     And as "Alice" file "/PARENT/parent.txt" should not exist
     And as "Alice" file "/PARENT/newparent.txt" should exist
 
-    @notToImplementOnOCIS @issue-ocis-2079
+    @issue-ocis-2079
     Examples:
       | public-webdav-api-version |
       | old                       |
-
-
-    Examples:
-      | public-webdav-api-version |
       | new                       |
 
 
@@ -79,7 +75,7 @@ Feature: changing a public link share
     Then the HTTP status code should be "403"
     And as "Alice" file "/PARENT/lorem.txt" should not exist
 
-    @notToImplementOnOCIS @issue-ocis-2079
+    @issue-ocis-2079
     Examples:
       | public-webdav-api-version |
       | old                       |
@@ -98,7 +94,7 @@ Feature: changing a public link share
     Then the HTTP status code should be "201"
     And the content of file "PARENT/lorem.txt" for user "Alice" should be "test"
 
-    @notToImplementOnOCIS @issue-ocis-2079
+    @issue-ocis-2079
     Examples:
       | public-webdav-api-version |
       | old                       |
@@ -118,14 +114,10 @@ Feature: changing a public link share
     Then the HTTP status code should be "401"
     And as "Alice" file "PARENT/parent.txt" should exist
 
-    @notToImplementOnOCIS @issue-ocis-2079
+    @issue-ocis-2079
     Examples:
       | public-webdav-api-version |
       | old                       |
-
-
-    Examples:
-      | public-webdav-api-version |
       | new                       |
 
 
@@ -138,7 +130,7 @@ Feature: changing a public link share
     Then the HTTP status code should be "204"
     And as "Alice" file "PARENT/parent.txt" should not exist
 
-    @notToImplementOnOCIS @issue-ocis-2079
+    @issue-ocis-2079
     Examples:
       | public-webdav-api-version |
       | old                       |
@@ -159,14 +151,10 @@ Feature: changing a public link share
     And as "Alice" file "/PARENT/newparent.txt" should not exist
     And as "Alice" file "/PARENT/parent.txt" should exist
 
-    @notToImplementOnOCIS @issue-ocis-2079
+    @issue-ocis-2079
     Examples:
       | public-webdav-api-version |
       | old                       |
-
-
-    Examples:
-      | public-webdav-api-version |
       | new                       |
 
   @skipOnRansomwareProtection @issue-ransomware-208
@@ -180,14 +168,10 @@ Feature: changing a public link share
     And as "Alice" file "/PARENT/newparent.txt" should exist
     And as "Alice" file "/PARENT/parent.txt" should not exist
 
-    @notToImplementOnOCIS @issue-ocis-2079
+    @issue-ocis-2079
     Examples:
       | public-webdav-api-version |
       | old                       |
-
-
-    Examples:
-      | public-webdav-api-version |
       | new                       |
 
 
@@ -200,14 +184,10 @@ Feature: changing a public link share
     Then the HTTP status code should be "401"
     And as "Alice" file "/PARENT/lorem.txt" should not exist
 
-    @notToImplementOnOCIS @issue-ocis-2079
+    @issue-ocis-2079
     Examples:
       | public-webdav-api-version |
       | old                       |
-
-
-    Examples:
-      | public-webdav-api-version |
       | new                       |
 
 
@@ -220,14 +200,10 @@ Feature: changing a public link share
     Then the HTTP status code should be "201"
     And as "Alice" file "/PARENT/lorem.txt" should exist
 
-    @notToImplementOnOCIS @issue-ocis-2079
+    @issue-ocis-2079
     Examples:
       | public-webdav-api-version |
       | old                       |
-
-
-    Examples:
-      | public-webdav-api-version |
       | new                       |
 
 
@@ -240,7 +216,7 @@ Feature: changing a public link share
     And as "Alice" file "/PARENT/parent.txt" should exist
     And as "Alice" file "/PARENT/newparent.txt" should not exist
 
-    @notToImplementOnOCIS @issue-ocis-2079
+    @issue-ocis-2079
     Examples:
       | public-webdav-api-version |
       | old                       |
@@ -259,7 +235,7 @@ Feature: changing a public link share
     Then the HTTP status code should be "403"
     And as "Alice" file "PARENT/parent.txt" should exist
 
-    @notToImplementOnOCIS @issue-ocis-2079
+    @issue-ocis-2079
     Examples:
       | public-webdav-api-version |
       | old                       |

--- a/tests/acceptance/features/apiSharePublicLink1/createPublicLinkShare.feature
+++ b/tests/acceptance/features/apiSharePublicLink1/createPublicLinkShare.feature
@@ -36,7 +36,7 @@ Feature: create a public link share
       | 1               | 100             |
       | 2               | 200             |
 
-  @smokeTest @notToImplementOnOCIS @issue-ocis-2079
+  @smokeTest @issue-ocis-2079
   Scenario Outline: Creating a new public link share of a file with password using the old public WebDAV API
     Given using OCS API version "<ocs_api_version>"
     And user "Alice" has uploaded file with content "Random data" to "/randomfile.txt"
@@ -277,7 +277,7 @@ Feature: create a public link share
       | permissions | read,create |
     Then the OCS status code should be "<ocs_status_code>"
 
-    @notToImplementOnOCIS @issue-ocis-2079
+    @issue-ocis-2079
     Examples:
       | ocs_api_version | ocs_status_code |
       | 1               | 403             |
@@ -293,7 +293,7 @@ Feature: create a public link share
       | permissions | create   |
     Then the OCS status code should be "<ocs_status_code>"
 
-    @notToImplementOnOCIS @issue-ocis-2079 @issue-ocis-reva-41
+    @issue-ocis-2079 @issue-ocis-reva-41
     Examples:
       | ocs_api_version | ocs_status_code |
       | 1               | 403             |
@@ -311,7 +311,7 @@ Feature: create a public link share
       | permissions | read,create |
     Then the OCS status code should be "<ocs_status_code>"
 
-    @notToImplementOnOCIS @issue-ocis-2079 @issue-ocis-reva-41
+    @issue-ocis-2079 @issue-ocis-reva-41
     Examples:
       | ocs_api_version | ocs_status_code |
       | 1               | 403             |
@@ -327,7 +327,7 @@ Feature: create a public link share
       | permissions | read,update,create |
     Then the OCS status code should be "<ocs_status_code>"
 
-    @notToImplementOnOCIS @issue-ocis-2079
+    @issue-ocis-2079
     Examples:
       | ocs_api_version | ocs_status_code |
       | 1               | 403             |
@@ -394,7 +394,7 @@ Feature: create a public link share
       | 2               | 200             |
 
 
-  @issue-ocis-reva-283 @notToImplementOnOCIS
+  @issue-ocis-reva-283
   Scenario Outline: Do not allow public sharing of the root on ownCloud10
     Given using OCS API version "<ocs_api_version>"
     When user "Alice" creates a public link share using the sharing API with settings
@@ -474,7 +474,7 @@ Feature: create a public link share
     And the public should be able to download the last publicly shared file using the old public WebDAV API without a password and the content should be "Random data"
     And the public should be able to download the last publicly shared file using the new public WebDAV API without a password and the content should be "Random data"
 
-    @notToImplementOnOCIS @issue-ocis-2079
+    @issue-ocis-2079
     Examples:
       | ocs_api_version | ocs_status_code | http_status_code |
       | 1               | 100             | 200              |
@@ -490,7 +490,7 @@ Feature: create a public link share
     When user "Alice" deletes folder "PARENT" using the WebDAV API
     And the public download of file "/parent.txt" from inside the last public link shared folder using the <public-webdav-api-version> public WebDAV API should fail with HTTP status code "404"
 
-    @notToImplementOnOCIS @issue-ocis-2079
+    @issue-ocis-2079
     Examples:
       | public-webdav-api-version |
       | old                       |
@@ -511,7 +511,7 @@ Feature: create a public link share
     Then the value of the item "//s:message" in the response should be "<response>"
     And the HTTP status code should be "404"
 
-    @notToImplementOnOCIS @issue-ocis-2079
+    @issue-ocis-2079
     Examples:
       | public-webdav-api-version | response |
       | old                       |          |
@@ -585,7 +585,7 @@ Feature: create a public link share
     And as "Alice" the mtime of the file "testFolder/file.txt" should be "Thu, 08 Aug 2019 04:18:13 GMT"
     And the mtime of file "file.txt" in the last shared public link using the WebDAV API should be "Thu, 08 Aug 2019 04:18:13 GMT"
 
-  @notToImplementOnOCIS
+
   Scenario Outline: Set multiple expiration dates, the expired date shouldn't affect the future expiration date
     Given using OCS API version "<ocs_api_version>"
     And parameter "shareapi_enforce_expire_date" of app "core" has been set to "yes"

--- a/tests/acceptance/features/apiSharePublicLink1/createPublicLinkShareOc10Issue37605.feature
+++ b/tests/acceptance/features/apiSharePublicLink1/createPublicLinkShareOc10Issue37605.feature
@@ -1,4 +1,4 @@
-@api @files_sharing-app-required @public_link_share-feature-required @notToImplementOnOCIS
+@api @files_sharing-app-required @public_link_share-feature-required
 
 Feature: create a public link share
 

--- a/tests/acceptance/features/apiSharePublicLink2/copyFromPublicLinkOc10Issue37683.feature
+++ b/tests/acceptance/features/apiSharePublicLink2/copyFromPublicLinkOc10Issue37683.feature
@@ -1,4 +1,4 @@
-@api @files_sharing-app-required @public_link_share-feature-required @issue-ocis-reva-310 @notToImplementOnOCIS
+@api @files_sharing-app-required @public_link_share-feature-required @issue-ocis-reva-310
 Feature: copying from public link share
 
   Background:

--- a/tests/acceptance/features/apiSharePublicLink2/reShareAsPublicLinkToRoot.feature
+++ b/tests/acceptance/features/apiSharePublicLink2/reShareAsPublicLinkToRoot.feature
@@ -1,4 +1,4 @@
-@api @files_sharing-app-required @public_link_share-feature-required @notToImplementOnOCIS
+@api @files_sharing-app-required @public_link_share-feature-required
 Feature: reshare as public link
   As a user
   I want to create public link shares from files/folders shared with me

--- a/tests/acceptance/features/apiSharePublicLink2/reShareAsPublicLinkToSharesOldDav.feature
+++ b/tests/acceptance/features/apiSharePublicLink2/reShareAsPublicLinkToSharesOldDav.feature
@@ -1,4 +1,4 @@
-@api @files_sharing-app-required @public_link_share-feature-required @notToImplementOnOCIS @issue-ocis-2079
+@api @files_sharing-app-required @public_link_share-feature-required @issue-ocis-2079
 Feature: reshare as public link
   As a user
   I want to create public link shares from files/folders shared with me

--- a/tests/acceptance/features/apiSharePublicLink3/allowGroupToCreatePublicLinks.feature
+++ b/tests/acceptance/features/apiSharePublicLink3/allowGroupToCreatePublicLinks.feature
@@ -1,4 +1,4 @@
-@api @files_sharing-app-required @notToImplementOnOcis
+@api @files_sharing-app-required
 Feature: public share sharers groups setting
   As an admin
   I should be able to allow only certain groups to create public links

--- a/tests/acceptance/features/apiSharePublicLink3/updatePublicLinkShare.feature
+++ b/tests/acceptance/features/apiSharePublicLink3/updatePublicLinkShare.feature
@@ -78,7 +78,7 @@ Feature: update a public link share
       | 1               | 100             |
       | 2               | 200             |
 
-	@issue-39820
+  @issue-39820
   Scenario Outline: API responds with a full set of parameters when owner renames the folder with a public link (bug demonstration)
     Given using OCS API version "<ocs_api_version>"
     And using <dav-path> DAV path
@@ -471,7 +471,7 @@ Feature: update a public link share
       | 1               | new                       |
       | 2               | new                       |
 
-	@issue-39820
+  @issue-39820
   Scenario Outline: API responds with a full set of parameters when owner renames the file with a public link (bug demonstration)
     Given using OCS API version "<ocs_api_version>"
     And using <dav-path> DAV path

--- a/tests/acceptance/features/apiSharePublicLink3/updatePublicLinkShare.feature
+++ b/tests/acceptance/features/apiSharePublicLink3/updatePublicLinkShare.feature
@@ -78,7 +78,7 @@ Feature: update a public link share
       | 1               | 100             |
       | 2               | 200             |
 
-  @notToImplementOnOCIS @issue-39820
+	@issue-39820
   Scenario Outline: API responds with a full set of parameters when owner renames the folder with a public link (bug demonstration)
     Given using OCS API version "<ocs_api_version>"
     And using <dav-path> DAV path
@@ -463,19 +463,15 @@ Feature: update a public link share
     And as "Alice" file "PARENT/CHILD/child.txt" should not exist
     And as "Alice" file "PARENT/parent.txt" should not exist
 
-    @notToImplementOnOCIS @issue-ocis-2079
+    @issue-ocis-2079
     Examples:
       | ocs_api_version | public-webdav-api-version |
       | 1               | old                       |
       | 2               | old                       |
-
-
-    Examples:
-      | ocs_api_version | public-webdav-api-version |
       | 1               | new                       |
       | 2               | new                       |
 
-  @notToImplementOnOCIS @issue-39820
+	@issue-39820
   Scenario Outline: API responds with a full set of parameters when owner renames the file with a public link (bug demonstration)
     Given using OCS API version "<ocs_api_version>"
     And using <dav-path> DAV path

--- a/tests/acceptance/features/apiSharePublicLink3/updatePublicLinkShareOc10Issue37653.feature
+++ b/tests/acceptance/features/apiSharePublicLink3/updatePublicLinkShareOc10Issue37653.feature
@@ -1,4 +1,4 @@
-@api @files_sharing-app-required @public_link_share-feature-required @notToImplementOnOCIS
+@api @files_sharing-app-required @public_link_share-feature-required
 Feature: update a public link share
 
   Background:

--- a/tests/acceptance/features/apiSharePublicLink3/uploadToPublicLinkShare.feature
+++ b/tests/acceptance/features/apiSharePublicLink3/uploadToPublicLinkShare.feature
@@ -6,7 +6,7 @@ Feature: upload to a public link share
     Given user "Alice" has been created with default attributes and without skeleton files
     And user "Alice" has created folder "FOLDER"
 
-  @smokeTest @notToImplementOnOCIS @issue-ocis-2079
+  @smokeTest @issue-ocis-2079
   Scenario: Uploading same file to a public upload-only share multiple times via old API
     # The old API needs to have the header OC-Autorename: 1 set to do the autorename
     Given user "Alice" has created a public link share with settings
@@ -44,7 +44,7 @@ Feature: upload to a public link share
     When the public uploads file "test.txt" with content "test" using the <public-webdav-api-version> public WebDAV API
     And the HTTP status code should be "404"
 
-    @notToImplementOnOCIS @issue-ocis-2079
+    @issue-ocis-2079
     Examples:
       | dav-path | public-webdav-api-version |
       | old      | old                       |
@@ -64,7 +64,7 @@ Feature: upload to a public link share
     When the public uploads file "test.txt" with content "test" using the <public-webdav-api-version> public WebDAV API
     And the HTTP status code should be "403"
 
-    @notToImplementOnOCIS @issue-ocis-2079
+    @issue-ocis-2079
     Examples:
       | public-webdav-api-version |
       | old                       |
@@ -85,14 +85,10 @@ Feature: upload to a public link share
     And the following headers should match these regular expressions
       | ETag | /^"[a-f0-9:\.]{1,32}"$/ |
 
-    @notToImplementOnOCIS @issue-ocis-2079
+    @issue-ocis-2079
     Examples:
       | public-webdav-api-version |
       | old                       |
-
-
-    Examples:
-      | public-webdav-api-version |
       | new                       |
 
 
@@ -105,14 +101,10 @@ Feature: upload to a public link share
     Then the HTTP status code should be "201"
     And the content of file "/FOLDER/test.txt" for user "Alice" should be "test-file"
 
-    @notToImplementOnOCIS @issue-ocis-2079
+    @issue-ocis-2079
     Examples:
       | public-webdav-api-version |
       | old                       |
-
-
-    Examples:
-      | public-webdav-api-version |
       | new                       |
 
 
@@ -125,14 +117,10 @@ Feature: upload to a public link share
     Then the HTTP status code should be "201"
     And the content of file "/FOLDER/test.txt" for user "Alice" should be "test-file"
 
-    @notToImplementOnOCIS @issue-ocis-2079
+    @issue-ocis-2079
     Examples:
       | public-webdav-api-version |
       | old                       |
-
-
-    Examples:
-      | public-webdav-api-version |
       | new                       |
 
 
@@ -144,7 +132,7 @@ Feature: upload to a public link share
     When the public uploads file "test.txt" with content "test-file" using the <public-webdav-api-version> public WebDAV API
     Then the HTTP status code should be "507"
 
-    @notToImplementOnOCIS @issue-ocis-2079
+    @issue-ocis-2079
     Examples:
       | public-webdav-api-version |
       | old                       |
@@ -163,7 +151,7 @@ Feature: upload to a public link share
     When the public uploads file "test.txt" with content "test-file" using the <public-webdav-api-version> public WebDAV API
     Then the HTTP status code should be "507"
 
-    @notToImplementOnOCIS @issue-ocis-2079
+    @issue-ocis-2079
     Examples:
       | public-webdav-api-version |
       | old                       |
@@ -182,7 +170,7 @@ Feature: upload to a public link share
     When the public uploads file "test.txt" with content "test-file" using the <public-webdav-api-version> public WebDAV API
     Then the HTTP status code should be "403"
 
-    @notToImplementOnOCIS @issue-ocis-2079
+    @issue-ocis-2079
     Examples:
       | public-webdav-api-version |
       | old                       |
@@ -197,7 +185,7 @@ Feature: upload to a public link share
     When the public uploads file "test.txt" with content "test-file" using the <public-webdav-api-version> public WebDAV API
     And the HTTP status code should be "403"
 
-    @notToImplementOnOCIS @issue-ocis-2079
+    @issue-ocis-2079
     Examples:
       | public-webdav-api-version |
       | old                       |
@@ -218,7 +206,7 @@ Feature: upload to a public link share
     Then the HTTP status code should be "201"
     And the content of file "/FOLDER/test.txt" for user "Alice" should be "test-file"
 
-    @notToImplementOnOCIS @issue-ocis-2079
+    @issue-ocis-2079
     Examples:
       | public-webdav-api-version |
       | old                       |
@@ -237,17 +225,13 @@ Feature: upload to a public link share
     Then the HTTP status code should be "201"
     And the content of file "/FOLDER/test.txt" for user "Alice" should be "test-file"
 
-    @notToImplementOnOCIS @issue-ocis-2079
+    @issue-ocis-2079
     Examples:
       | public-webdav-api-version |
       | old                       |
-
-
-    Examples:
-      | public-webdav-api-version |
       | new                       |
 
-  @smokeTest @notToImplementOnOCIS @issue-ocis-2079
+  @smokeTest @issue-ocis-2079
   Scenario: Uploading same file to a public upload-write and no edit and no overwrite share multiple times with old public API
     Given user "Alice" has created a public link share with settings
       | path        | FOLDER          |

--- a/tests/acceptance/features/apiShareReshareToRoot1/reShare.feature
+++ b/tests/acceptance/features/apiShareReshareToRoot1/reShare.feature
@@ -1,4 +1,4 @@
-@api @files_sharing-app-required @notToImplementOnOCIS
+@api @files_sharing-app-required
 Feature: sharing
 
   Background:

--- a/tests/acceptance/features/apiShareReshareToRoot2/reShareChain.feature
+++ b/tests/acceptance/features/apiShareReshareToRoot2/reShareChain.feature
@@ -1,4 +1,4 @@
-@api @files_sharing-app-required @notToImplementOnOCIS
+@api @files_sharing-app-required
 Feature: resharing can be done on a reshared resource
 
   Background:

--- a/tests/acceptance/features/apiShareReshareToRoot2/reShareDisabled.feature
+++ b/tests/acceptance/features/apiShareReshareToRoot2/reShareDisabled.feature
@@ -1,4 +1,4 @@
-@api @files_sharing-app-required @notToImplementOnOCIS
+@api @files_sharing-app-required
 Feature: resharing can be disabled
 
   Background:

--- a/tests/acceptance/features/apiShareReshareToRoot2/reShareSubfolder.feature
+++ b/tests/acceptance/features/apiShareReshareToRoot2/reShareSubfolder.feature
@@ -1,4 +1,4 @@
-@api @files_sharing-app-required @notToImplementOnOCIS
+@api @files_sharing-app-required
 Feature: a subfolder of a received share can be reshared
 
   Background:

--- a/tests/acceptance/features/apiShareReshareToRoot2/reShareWhenShareWithOnlyMembershipGroups.feature
+++ b/tests/acceptance/features/apiShareReshareToRoot2/reShareWhenShareWithOnlyMembershipGroups.feature
@@ -1,4 +1,4 @@
-@api @files_sharing-app-required @notToImplementOnOCIS
+@api @files_sharing-app-required
 Feature: resharing a resource with an expiration date
 
   Background:

--- a/tests/acceptance/features/apiShareReshareToRoot3/reShareUpdate.feature
+++ b/tests/acceptance/features/apiShareReshareToRoot3/reShareUpdate.feature
@@ -1,4 +1,4 @@
-@api @files_sharing-app-required @notToImplementOnOCIS
+@api @files_sharing-app-required
 Feature: sharing
 
   Background:

--- a/tests/acceptance/features/apiShareReshareToRoot3/reShareWithExpiryDate.feature
+++ b/tests/acceptance/features/apiShareReshareToRoot3/reShareWithExpiryDate.feature
@@ -1,4 +1,4 @@
-@api @files_sharing-app-required @notToImplementOnOCIS
+@api @files_sharing-app-required
 Feature: resharing a resource with an expiration date
 
   Background:

--- a/tests/acceptance/features/apiShareReshareToShares2/reShareChain.feature
+++ b/tests/acceptance/features/apiShareReshareToShares2/reShareChain.feature
@@ -11,7 +11,7 @@ Feature: resharing can be done on a reshared resource
       | Carol    |
       | David    |
 
-  @notToImplementOnOCIS
+
   Scenario Outline: Reshared files can be still accessed if a user in the middle removes it.
     Given user "Alice" has uploaded file with content "ownCloud test text file 0" to "/textfile0.txt"
     And user "Alice" has shared file "textfile0.txt" with user "Brian"

--- a/tests/acceptance/features/apiShareReshareToShares3/reShareWithExpiryDateOc10Issue37013.feature
+++ b/tests/acceptance/features/apiShareReshareToShares3/reShareWithExpiryDateOc10Issue37013.feature
@@ -1,4 +1,4 @@
-@api @files_sharing-app-required @issue-ocis-1250 @notToImplementOnOCIS
+@api @files_sharing-app-required @issue-ocis-1250
 Feature: resharing a resource with an expiration date
 
   Background:

--- a/tests/acceptance/features/apiShareUpdateToRoot/updateShare.feature
+++ b/tests/acceptance/features/apiShareUpdateToRoot/updateShare.feature
@@ -1,4 +1,4 @@
-@api @files_sharing-app-required @notToImplementOnOCIS
+@api @files_sharing-app-required
 Feature: sharing
 
   Background:

--- a/tests/acceptance/features/apiShareUpdateToRoot/updateShareGroupAndUserWithSameName.feature
+++ b/tests/acceptance/features/apiShareUpdateToRoot/updateShareGroupAndUserWithSameName.feature
@@ -1,4 +1,4 @@
-@api @files_sharing-app-required @notToImplementOnOCIS
+@api @files_sharing-app-required
 Feature: updating shares to users and groups that have the same name
 
   Background:

--- a/tests/acceptance/features/apiShareUpdateToShares/updateShare.feature
+++ b/tests/acceptance/features/apiShareUpdateToShares/updateShare.feature
@@ -30,7 +30,7 @@ Feature: sharing
       | 1               | 100             |
       | 2               | 200             |
 
-  @issue-ocis-1289 @notToImplementOnOCIS
+  @issue-ocis-1289
   Scenario Outline: keep group permissions in sync when the share is moved to another folder by the receiver and then the sharer updates the permissions
     Given using OCS API version "<ocs_api_version>"
     And user "Brian" has been created with default attributes and without skeleton files

--- a/tests/acceptance/features/apiSharees/sharees.feature
+++ b/tests/acceptance/features/apiSharees/sharees.feature
@@ -54,7 +54,7 @@ Feature: sharees
       | 1               | 100        | 200         |
       | 2               | 200        | 200         |
 
-  @notToImplementOnOCIS @issue-ocis-1317 @issue-ocis-1328
+	@issue-ocis-1317 @issue-ocis-1328
   Scenario Outline: Search only with group members - denied
     Given using OCS API version "<ocs-api-version>"
     And parameter "shareapi_only_share_with_group_members" of app "core" has been set to "yes"
@@ -100,7 +100,7 @@ Feature: sharees
       | 1               | 100        | 200         |
       | 2               | 200        | 200         |
 
-  @notToImplementOnOCIS @issue-ocis-1317 @issue-ocis-1328
+	@issue-ocis-1317 @issue-ocis-1328
   Scenario Outline: Search only with group members - no group as non-member
     Given using OCS API version "<ocs-api-version>"
     And parameter "shareapi_only_share_with_group_members" of app "core" has been set to "yes"
@@ -121,7 +121,7 @@ Feature: sharees
       | 1               | 100        | 200         |
       | 2               | 200        | 200         |
 
-  @notToImplementOnOCIS @issue-ocis-1317 @issue-ocis-1328
+	@issue-ocis-1317 @issue-ocis-1328
   Scenario Outline: Search only with membership groups - denied
     Given using OCS API version "<ocs-api-version>"
     And parameter "shareapi_only_share_with_membership_groups" of app "core" has been set to "yes"
@@ -141,7 +141,7 @@ Feature: sharees
       | 1               | 100        | 200         |
       | 2               | 200        | 200         |
 
-  @notToImplementOnOCIS @issue-ocis-1317 @issue-ocis-1328
+	@issue-ocis-1317 @issue-ocis-1328
   Scenario Outline: Search only with membership groups - denied but users match
     Given using OCS API version "<ocs-api-version>"
     And parameter "shareapi_only_share_with_membership_groups" of app "core" has been set to "yes"
@@ -162,7 +162,7 @@ Feature: sharees
       | 1               | 100        | 200         |
       | 2               | 200        | 200         |
 
-  @notToImplementOnOCIS @issue-ocis-1317 @issue-ocis-1328
+	@issue-ocis-1317 @issue-ocis-1328
   Scenario Outline: Search only with membership groups - allowed
     Given using OCS API version "<ocs-api-version>"
     And parameter "shareapi_only_share_with_membership_groups" of app "core" has been set to "yes"
@@ -183,7 +183,7 @@ Feature: sharees
       | 1               | 100        | 200         |
       | 2               | 200        | 200         |
 
-  @notToImplementOnOCIS @issue-ocis-1317 @issue-ocis-1328
+	@issue-ocis-1317 @issue-ocis-1328
   Scenario Outline: Search only with membership groups - allowed including users
     Given using OCS API version "<ocs-api-version>"
     And parameter "shareapi_only_share_with_membership_groups" of app "core" has been set to "yes"
@@ -205,7 +205,7 @@ Feature: sharees
       | 1               | 100        | 200         |
       | 2               | 200        | 200         |
 
-  @notToImplementOnOCIS @issue-ocis-1317 @issue-ocis-1328
+	@issue-ocis-1317 @issue-ocis-1328
   Scenario Outline: Search without exact match no iteration allowed
     Given using OCS API version "<ocs-api-version>"
     And parameter "shareapi_allow_share_dialog_user_enumeration" of app "core" has been set to "no"
@@ -225,7 +225,7 @@ Feature: sharees
       | 1               | 100        | 200         |
       | 2               | 200        | 200         |
 
-  @notToImplementOnOCIS @issue-ocis-1317 @issue-ocis-1328
+	@issue-ocis-1317 @issue-ocis-1328
   Scenario Outline: Search with exact match no iteration allowed
     Given using OCS API version "<ocs-api-version>"
     And parameter "shareapi_allow_share_dialog_user_enumeration" of app "core" has been set to "no"
@@ -246,7 +246,7 @@ Feature: sharees
       | 1               | 100        | 200         |
       | 2               | 200        | 200         |
 
-  @notToImplementOnOCIS @issue-ocis-1317 @issue-ocis-1328
+	@issue-ocis-1317 @issue-ocis-1328
   Scenario Outline: Search with exact match group no iteration allowed
     Given using OCS API version "<ocs-api-version>"
     And parameter "shareapi_allow_share_dialog_user_enumeration" of app "core" has been set to "no"
@@ -267,7 +267,7 @@ Feature: sharees
       | 1               | 100        | 200         |
       | 2               | 200        | 200         |
 
-  @notToImplementOnOCIS @issue-ocis-1317 @issue-ocis-1328
+	@issue-ocis-1317 @issue-ocis-1328
   Scenario Outline: Try to search for users and groups when in a group that is excluded from sharing (could match both users and groups)
     Given using OCS API version "<ocs-api-version>"
     And parameter "shareapi_exclude_groups" of app "core" has been set to "yes"
@@ -288,7 +288,7 @@ Feature: sharees
       | 1               | 100        | 200         |
       | 2               | 200        | 200         |
 
-  @notToImplementOnOCIS @issue-ocis-1317 @issue-ocis-1328
+	@issue-ocis-1317 @issue-ocis-1328
   Scenario Outline: Try to search for users and groups when in a group that is excluded from sharing (exact match to a user)
     Given using OCS API version "<ocs-api-version>"
     And parameter "shareapi_exclude_groups" of app "core" has been set to "yes"
@@ -309,7 +309,7 @@ Feature: sharees
       | 1               | 100        | 200         |
       | 2               | 200        | 200         |
 
-  @notToImplementOnOCIS @issue-ocis-1317 @issue-ocis-1328
+	@issue-ocis-1317 @issue-ocis-1328
   Scenario Outline: Try to search for users and groups when in a group that is excluded from sharing (exact match to a group)
     Given using OCS API version "<ocs-api-version>"
     And parameter "shareapi_exclude_groups" of app "core" has been set to "yes"
@@ -449,7 +449,7 @@ Feature: sharees
       | 1               | 100        | 200         |
       | 2               | 200        | 200         |
 
-  @notToImplementOnOCIS @issue-ocis-1317 @issue-ocis-1328
+	@issue-ocis-1317 @issue-ocis-1328
   Scenario Outline: Group sharees not returned when group sharing is disabled
     Given using OCS API version "<ocs-api-version>"
     And parameter "shareapi_allow_group_sharing" of app "core" has been set to "no"
@@ -495,7 +495,7 @@ Feature: sharees
       | 1               | 100        | 200         |
       | 2               | 200        | 200         |
 
-  @notToImplementOnOCIS @issue-ocis-1317 @issue-ocis-1328
+	@issue-ocis-1317 @issue-ocis-1328
   Scenario Outline: Enumerate only group members - accept exact match from non-member groups
     Given using OCS API version "<ocs-api-version>"
     And parameter "shareapi_share_dialog_user_enumeration_group_members" of app "core" has been set to "yes"
@@ -516,7 +516,7 @@ Feature: sharees
       | 1               | 100        | 200         |
       | 2               | 200        | 200         |
 
-  @notToImplementOnOCIS @issue-ocis-1317 @issue-ocis-1328
+	@issue-ocis-1317 @issue-ocis-1328
   Scenario Outline: Enumerate only group members - only show partial results from member groups
     Given using OCS API version "<ocs-api-version>"
     And parameter "shareapi_share_dialog_user_enumeration_group_members" of app "core" has been set to "yes"
@@ -537,7 +537,7 @@ Feature: sharees
       | 1               | 100        | 200         |
       | 2               | 200        | 200         |
 
-  @skipOnLDAP @notToImplementOnOCIS @issue-ocis-1317 @issue-ocis-1328
+  @skipOnLDAP @issue-ocis-1317 @issue-ocis-1328
   Scenario Outline: Enumerate only group members - only accept exact group match from non-memberships
     Given using OCS API version "<ocs-api-version>"
     And group "ShareeGroupNonMember" has been created
@@ -583,7 +583,7 @@ Feature: sharees
       | 1               | 100        | 200         |
       | 2               | 200        | 200         |
 
-  @notToImplementOnOCIS @issue-ocis-1317 @issue-ocis-1328
+	@issue-ocis-1317 @issue-ocis-1328
   Scenario Outline: empty search for sharees when search min length is set to 0
     Given the administrator has updated system config key "user.search_min_length" with value "0"
     And user "sharee2" has been created with default attributes and without skeleton files
@@ -609,7 +609,7 @@ Feature: sharees
       | 1               | 100        | 200         |
       | 2               | 200        | 200         |
 
-  @notToImplementOnOCIS @issue-ocis-1317 @issue-ocis-1328
+	@issue-ocis-1317 @issue-ocis-1328
   Scenario Outline: empty search for sharees when search min length is set to 2
     Given the administrator has updated system config key "user.search_min_length" with value "2"
     And user "sharee2" has been created with default attributes and without skeleton files
@@ -680,7 +680,7 @@ Feature: sharees
       | 1               | 100        | 200         |
       | 2               | 200        | 200         |
 
-  @notToImplementOnOCIS @issue-ocis-1317 @issue-ocis-1328
+	@issue-ocis-1317 @issue-ocis-1328
   Scenario Outline: search for sharees without search when min length is set to 0
     Given the administrator has updated system config key "user.search_min_length" with value "0"
     And user "sharee2" has been created with default attributes and without skeleton files
@@ -705,7 +705,7 @@ Feature: sharees
       | 1               | 100        | 200         |
       | 2               | 200        | 200         |
 
-  @notToImplementOnOCIS @issue-ocis-1317 @issue-ocis-1328
+	@issue-ocis-1317 @issue-ocis-1328
   Scenario Outline: search for sharees without search when min length is set to 2
     Given the administrator has updated system config key "user.search_min_length" with value "2"
     And user "sharee2" has been created with default attributes and without skeleton files

--- a/tests/acceptance/features/apiSharees/sharees.feature
+++ b/tests/acceptance/features/apiSharees/sharees.feature
@@ -54,7 +54,7 @@ Feature: sharees
       | 1               | 100        | 200         |
       | 2               | 200        | 200         |
 
-	@issue-ocis-1317 @issue-ocis-1328
+  @issue-ocis-1317 @issue-ocis-1328
   Scenario Outline: Search only with group members - denied
     Given using OCS API version "<ocs-api-version>"
     And parameter "shareapi_only_share_with_group_members" of app "core" has been set to "yes"
@@ -100,7 +100,7 @@ Feature: sharees
       | 1               | 100        | 200         |
       | 2               | 200        | 200         |
 
-	@issue-ocis-1317 @issue-ocis-1328
+  @issue-ocis-1317 @issue-ocis-1328
   Scenario Outline: Search only with group members - no group as non-member
     Given using OCS API version "<ocs-api-version>"
     And parameter "shareapi_only_share_with_group_members" of app "core" has been set to "yes"
@@ -121,7 +121,7 @@ Feature: sharees
       | 1               | 100        | 200         |
       | 2               | 200        | 200         |
 
-	@issue-ocis-1317 @issue-ocis-1328
+  @issue-ocis-1317 @issue-ocis-1328
   Scenario Outline: Search only with membership groups - denied
     Given using OCS API version "<ocs-api-version>"
     And parameter "shareapi_only_share_with_membership_groups" of app "core" has been set to "yes"
@@ -141,7 +141,7 @@ Feature: sharees
       | 1               | 100        | 200         |
       | 2               | 200        | 200         |
 
-	@issue-ocis-1317 @issue-ocis-1328
+  @issue-ocis-1317 @issue-ocis-1328
   Scenario Outline: Search only with membership groups - denied but users match
     Given using OCS API version "<ocs-api-version>"
     And parameter "shareapi_only_share_with_membership_groups" of app "core" has been set to "yes"
@@ -162,7 +162,7 @@ Feature: sharees
       | 1               | 100        | 200         |
       | 2               | 200        | 200         |
 
-	@issue-ocis-1317 @issue-ocis-1328
+  @issue-ocis-1317 @issue-ocis-1328
   Scenario Outline: Search only with membership groups - allowed
     Given using OCS API version "<ocs-api-version>"
     And parameter "shareapi_only_share_with_membership_groups" of app "core" has been set to "yes"
@@ -183,7 +183,7 @@ Feature: sharees
       | 1               | 100        | 200         |
       | 2               | 200        | 200         |
 
-	@issue-ocis-1317 @issue-ocis-1328
+  @issue-ocis-1317 @issue-ocis-1328
   Scenario Outline: Search only with membership groups - allowed including users
     Given using OCS API version "<ocs-api-version>"
     And parameter "shareapi_only_share_with_membership_groups" of app "core" has been set to "yes"
@@ -205,7 +205,7 @@ Feature: sharees
       | 1               | 100        | 200         |
       | 2               | 200        | 200         |
 
-	@issue-ocis-1317 @issue-ocis-1328
+  @issue-ocis-1317 @issue-ocis-1328
   Scenario Outline: Search without exact match no iteration allowed
     Given using OCS API version "<ocs-api-version>"
     And parameter "shareapi_allow_share_dialog_user_enumeration" of app "core" has been set to "no"
@@ -225,7 +225,7 @@ Feature: sharees
       | 1               | 100        | 200         |
       | 2               | 200        | 200         |
 
-	@issue-ocis-1317 @issue-ocis-1328
+  @issue-ocis-1317 @issue-ocis-1328
   Scenario Outline: Search with exact match no iteration allowed
     Given using OCS API version "<ocs-api-version>"
     And parameter "shareapi_allow_share_dialog_user_enumeration" of app "core" has been set to "no"
@@ -246,7 +246,7 @@ Feature: sharees
       | 1               | 100        | 200         |
       | 2               | 200        | 200         |
 
-	@issue-ocis-1317 @issue-ocis-1328
+  @issue-ocis-1317 @issue-ocis-1328
   Scenario Outline: Search with exact match group no iteration allowed
     Given using OCS API version "<ocs-api-version>"
     And parameter "shareapi_allow_share_dialog_user_enumeration" of app "core" has been set to "no"
@@ -267,7 +267,7 @@ Feature: sharees
       | 1               | 100        | 200         |
       | 2               | 200        | 200         |
 
-	@issue-ocis-1317 @issue-ocis-1328
+  @issue-ocis-1317 @issue-ocis-1328
   Scenario Outline: Try to search for users and groups when in a group that is excluded from sharing (could match both users and groups)
     Given using OCS API version "<ocs-api-version>"
     And parameter "shareapi_exclude_groups" of app "core" has been set to "yes"
@@ -288,7 +288,7 @@ Feature: sharees
       | 1               | 100        | 200         |
       | 2               | 200        | 200         |
 
-	@issue-ocis-1317 @issue-ocis-1328
+  @issue-ocis-1317 @issue-ocis-1328
   Scenario Outline: Try to search for users and groups when in a group that is excluded from sharing (exact match to a user)
     Given using OCS API version "<ocs-api-version>"
     And parameter "shareapi_exclude_groups" of app "core" has been set to "yes"
@@ -309,7 +309,7 @@ Feature: sharees
       | 1               | 100        | 200         |
       | 2               | 200        | 200         |
 
-	@issue-ocis-1317 @issue-ocis-1328
+  @issue-ocis-1317 @issue-ocis-1328
   Scenario Outline: Try to search for users and groups when in a group that is excluded from sharing (exact match to a group)
     Given using OCS API version "<ocs-api-version>"
     And parameter "shareapi_exclude_groups" of app "core" has been set to "yes"
@@ -449,7 +449,7 @@ Feature: sharees
       | 1               | 100        | 200         |
       | 2               | 200        | 200         |
 
-	@issue-ocis-1317 @issue-ocis-1328
+  @issue-ocis-1317 @issue-ocis-1328
   Scenario Outline: Group sharees not returned when group sharing is disabled
     Given using OCS API version "<ocs-api-version>"
     And parameter "shareapi_allow_group_sharing" of app "core" has been set to "no"
@@ -495,7 +495,7 @@ Feature: sharees
       | 1               | 100        | 200         |
       | 2               | 200        | 200         |
 
-	@issue-ocis-1317 @issue-ocis-1328
+  @issue-ocis-1317 @issue-ocis-1328
   Scenario Outline: Enumerate only group members - accept exact match from non-member groups
     Given using OCS API version "<ocs-api-version>"
     And parameter "shareapi_share_dialog_user_enumeration_group_members" of app "core" has been set to "yes"
@@ -516,7 +516,7 @@ Feature: sharees
       | 1               | 100        | 200         |
       | 2               | 200        | 200         |
 
-	@issue-ocis-1317 @issue-ocis-1328
+  @issue-ocis-1317 @issue-ocis-1328
   Scenario Outline: Enumerate only group members - only show partial results from member groups
     Given using OCS API version "<ocs-api-version>"
     And parameter "shareapi_share_dialog_user_enumeration_group_members" of app "core" has been set to "yes"
@@ -583,7 +583,7 @@ Feature: sharees
       | 1               | 100        | 200         |
       | 2               | 200        | 200         |
 
-	@issue-ocis-1317 @issue-ocis-1328
+  @issue-ocis-1317 @issue-ocis-1328
   Scenario Outline: empty search for sharees when search min length is set to 0
     Given the administrator has updated system config key "user.search_min_length" with value "0"
     And user "sharee2" has been created with default attributes and without skeleton files
@@ -609,7 +609,7 @@ Feature: sharees
       | 1               | 100        | 200         |
       | 2               | 200        | 200         |
 
-	@issue-ocis-1317 @issue-ocis-1328
+  @issue-ocis-1317 @issue-ocis-1328
   Scenario Outline: empty search for sharees when search min length is set to 2
     Given the administrator has updated system config key "user.search_min_length" with value "2"
     And user "sharee2" has been created with default attributes and without skeleton files
@@ -680,7 +680,7 @@ Feature: sharees
       | 1               | 100        | 200         |
       | 2               | 200        | 200         |
 
-	@issue-ocis-1317 @issue-ocis-1328
+  @issue-ocis-1317 @issue-ocis-1328
   Scenario Outline: search for sharees without search when min length is set to 0
     Given the administrator has updated system config key "user.search_min_length" with value "0"
     And user "sharee2" has been created with default attributes and without skeleton files
@@ -705,7 +705,7 @@ Feature: sharees
       | 1               | 100        | 200         |
       | 2               | 200        | 200         |
 
-	@issue-ocis-1317 @issue-ocis-1328
+  @issue-ocis-1317 @issue-ocis-1328
   Scenario Outline: search for sharees without search when min length is set to 2
     Given the administrator has updated system config key "user.search_min_length" with value "2"
     And user "sharee2" has been created with default attributes and without skeleton files

--- a/tests/acceptance/features/apiSharingNotificationsToRoot/sharingNotifications.feature
+++ b/tests/acceptance/features/apiSharingNotificationsToRoot/sharingNotifications.feature
@@ -1,4 +1,4 @@
-@api @app-required @notifications-app-required @files_sharing-app-required @notToImplementOnOCIS
+@api @app-required @notifications-app-required @files_sharing-app-required
 Feature: Display notifications when receiving a share
   As a user
   I want to see notifications about shares that have been offered to me

--- a/tests/acceptance/features/apiTrashbin/trashbinFilesFoldersOc10Issue23151.feature
+++ b/tests/acceptance/features/apiTrashbin/trashbinFilesFoldersOc10Issue23151.feature
@@ -1,4 +1,4 @@
-@api @files_trashbin-app-required @issue-ocis-reva-52 @notToImplementOnOCIS
+@api @files_trashbin-app-required @issue-ocis-reva-52
 Feature: files and folders exist in the trashbin after being deleted
   As a user
   I want deleted files and folders to be available in the trashbin

--- a/tests/acceptance/features/apiTrashbin/trashbinSharingToRoot.feature
+++ b/tests/acceptance/features/apiTrashbin/trashbinSharingToRoot.feature
@@ -1,4 +1,4 @@
-@api @files_trashbin-app-required @files_sharing-app-required @notToImplementOnOCIS
+@api @files_trashbin-app-required @files_sharing-app-required
 Feature: using trashbin together with sharing
 
   Background:

--- a/tests/acceptance/features/apiTrashbin/trashbinSkip.feature
+++ b/tests/acceptance/features/apiTrashbin/trashbinSkip.feature
@@ -1,4 +1,4 @@
-@api @files_trashbin-app-required @notToImplementOnOCIS
+@api @files_trashbin-app-required
 Feature: files and folders can be deleted completely skipping the trashbin
   As an admin
   I want to configure some files to be deleted without the trashbin

--- a/tests/acceptance/features/apiTrashbinRestore/trashbinRestore.feature
+++ b/tests/acceptance/features/apiTrashbinRestore/trashbinRestore.feature
@@ -167,7 +167,7 @@ Feature: Restore deleted files/folders
     And as "Alice" the folder with original path "/local_storage/tmp/textfile0.txt" should not exist in the trashbin
     And the content of file "/local_storage/tmp/textfile0.txt" for user "Alice" should be "AA"
 
-  @local_storage @files_external-app-required @skipOnEncryptionType:user-keys @encryption-issue-42 @skip_on_objectstore @notToImplementOnOCIS @newChunking @issue-ocis-1321
+  @local_storage @files_external-app-required @skipOnEncryptionType:user-keys @encryption-issue-42 @skip_on_objectstore @newChunking @issue-ocis-1321
   Scenario: Deleting an updated file into external storage moves it to the trashbin and can be restored with new chunking
     Given using new DAV path
     And the administrator has invoked occ command "files:scan --all"

--- a/tests/acceptance/features/apiTrashbinRestore/trashbinRestoreOc10Issue35974.feature
+++ b/tests/acceptance/features/apiTrashbinRestore/trashbinRestoreOc10Issue35974.feature
@@ -1,4 +1,4 @@
-@api @files_trashbin-app-required @issue-ocis-reva-52 @notToImplementOnOCIS
+@api @files_trashbin-app-required @issue-ocis-reva-52
 Feature: Restore deleted files/folders
   As a user
   I would like to restore files/folders

--- a/tests/acceptance/features/apiVersions/fileVersions.feature
+++ b/tests/acceptance/features/apiVersions/fileVersions.feature
@@ -21,13 +21,13 @@ Feature: dav-versions
     And the version folder of file "/davtest.txt-newdav-regular" for user "Alice" should contain "0" elements
     And the version folder of file "/davtest.txt-olddav-oldchunking" for user "Alice" should contain "0" elements
 
-  @issue-ocis-reva-17 @issue-ocis-reva-56 @notToImplementOnOCIS @newChunking @issue-ocis-1321
+  @issue-ocis-reva-17 @issue-ocis-reva-56 @newChunking @issue-ocis-1321
   Scenario: Upload file and no version is available using new chunking
     When user "Alice" uploads file "filesForUpload/davtest.txt" to "/davtest.txt" in 2 chunks with new chunking and using the WebDAV API
     Then the HTTP status code should be "201"
     And the version folder of file "/davtest.txt" for user "Alice" should contain "0" elements
 
-  @issue-ocis-reva-56 @notToImplementOnOCIS @newChunking @issue-ocis-1321
+  @issue-ocis-reva-56 @newChunking @issue-ocis-1321
   Scenario: Upload file and no version is available using async upload
     Given the administrator has enabled async operations
     When user "Alice" uploads file "filesForUpload/davtest.txt" asynchronously to "/davtest.txt" in 3 chunks with new chunking and using the WebDAV API
@@ -51,14 +51,14 @@ Feature: dav-versions
     And the version folder of file "/davtest.txt-newdav-regular" for user "Alice" should contain "1" element
     And the version folder of file "/davtest.txt-olddav-oldchunking" for user "Alice" should contain "1" element
 
-  @issue-ocis-reva-17 @issue-ocis-reva-56 @notToImplementOnOCIS @newChunking @issue-ocis-1321
+  @issue-ocis-reva-17 @issue-ocis-reva-56 @newChunking @issue-ocis-1321
   Scenario: Upload a file twice and versions are available using new chunking
     When user "Alice" uploads file "filesForUpload/davtest.txt" to "/davtest.txt" in 2 chunks with new chunking and using the WebDAV API
     And user "Alice" uploads file "filesForUpload/davtest.txt" to "/davtest.txt" in 2 chunks with new chunking and using the WebDAV API
     Then the HTTP status code of responses on each endpoint should be "201, 204" respectively
     And the version folder of file "/davtest.txt" for user "Alice" should contain "1" element
 
-  @issue-ocis-reva-17 @issue-ocis-reva-56 @notToImplementOnOCIS @newChunking @issue-ocis-1321
+  @issue-ocis-reva-17 @issue-ocis-reva-56 @newChunking @issue-ocis-1321
   Scenario: Upload a file twice and versions are available using async upload
     Given the administrator has enabled async operations
     When user "Alice" uploads file "filesForUpload/davtest.txt" asynchronously to "/davtest.txt" in 2 chunks with new chunking and using the WebDAV API
@@ -109,12 +109,12 @@ Feature: dav-versions
     Examples:
       | dav-path | status-code |
       | old      | 201         |
-    @notToImplementOnOCIS @newChunking @issue-ocis-1321
+    @newChunking @issue-ocis-1321
     Examples:
       | dav-path | status-code |
       | new      | 204         |
 
-  @skipOnStorage:ceph @files_primary_s3-issue-161 @notToImplementOnOCIS @newChunking @issue-ocis-1321 @issue-ocis-reva-17 @issue-ocis-reva-56 @skipOnStorage:scality
+  @skipOnStorage:ceph @files_primary_s3-issue-161 @newChunking @issue-ocis-1321 @issue-ocis-reva-17 @issue-ocis-reva-56 @skipOnStorage:scality
   Scenario: Uploading a file asynchronously does create the correct version that can be restored
     Given the administrator has enabled async operations
     And user "Alice" has uploaded file with content "textfile0" to "textfile0.txt"
@@ -143,7 +143,7 @@ Feature: dav-versions
     When user "Brian" sends HTTP method "PROPFIND" to URL "/remote.php/dav/meta/<<FILEID>>"
     Then the HTTP status code should be "400" or "404"
 
-  @files_sharing-app-required @notToImplementOnOCIS
+  @files_sharing-app-required
   Scenario: User can access meta folder of a file which is owned by somebody else but shared with that user
     Given user "Brian" has been created with default attributes and without skeleton files
     And user "Alice" has uploaded file with content "123" to "/davtest.txt"
@@ -157,7 +157,7 @@ Feature: dav-versions
     Then the HTTP status code should be "200"
     And the version folder of fileId "<<FILEID>>" for user "Brian" should contain "1" element
 
-  @files_sharing-app-required @notToImplementOnOCIS
+  @files_sharing-app-required
   Scenario: sharer of a file can see the old version information when the sharee changes the content of the file
     Given user "Brian" has been created with default attributes and without skeleton files
     And user "Alice" has uploaded file with content "First content" to "sharefile.txt"
@@ -166,7 +166,7 @@ Feature: dav-versions
     Then the HTTP status code should be "204"
     And the version folder of file "/sharefile.txt" for user "Alice" should contain "1" element
 
-  @files_sharing-app-required @notToImplementOnOCIS
+  @files_sharing-app-required
   Scenario: sharer of a file can restore the original content of a shared file after the file has been modified by the sharee
     Given user "Brian" has been created with default attributes and without skeleton files
     And user "Alice" has uploaded file with content "First content" to "sharefile.txt"
@@ -177,7 +177,7 @@ Feature: dav-versions
     And the content of file "/sharefile.txt" for user "Alice" should be "First content"
     And the content of file "/sharefile.txt" for user "Brian" should be "First content"
 
-  @files_sharing-app-required @notToImplementOnOCIS
+  @files_sharing-app-required
   Scenario: sharer can restore a file inside a shared folder modified by sharee
     Given user "Brian" has been created with default attributes and without skeleton files
     And user "Alice" has created folder "/sharingfolder"
@@ -189,7 +189,7 @@ Feature: dav-versions
     And the content of file "/sharingfolder/sharefile.txt" for user "Alice" should be "First content"
     And the content of file "/sharingfolder/sharefile.txt" for user "Brian" should be "First content"
 
-  @files_sharing-app-required @notToImplementOnOCIS
+  @files_sharing-app-required
   Scenario: sharee can restore a file inside a shared folder modified by sharee
     Given user "Brian" has been created with default attributes and without skeleton files
     And user "Alice" has created folder "/sharingfolder"
@@ -201,7 +201,7 @@ Feature: dav-versions
     And the content of file "/sharingfolder/sharefile.txt" for user "Alice" should be "First content"
     And the content of file "/sharingfolder/sharefile.txt" for user "Brian" should be "First content"
 
-  @files_sharing-app-required @notToImplementOnOCIS
+  @files_sharing-app-required
   Scenario: sharer can restore a file inside a shared folder created by sharee and modified by sharer
     Given user "Brian" has been created with default attributes and without skeleton files
     And user "Alice" has created folder "/sharingfolder"
@@ -213,7 +213,7 @@ Feature: dav-versions
     And the content of file "/sharingfolder/sharefile.txt" for user "Alice" should be "First content"
     And the content of file "/sharingfolder/sharefile.txt" for user "Brian" should be "First content"
 
-  @files_sharing-app-required @notToImplementOnOCIS
+  @files_sharing-app-required
   Scenario: sharee can restore a file inside a shared folder created by sharee and modified by sharer
     Given user "Brian" has been created with default attributes and without skeleton files
     And user "Alice" has created folder "/sharingfolder"
@@ -225,7 +225,7 @@ Feature: dav-versions
     And the content of file "/sharingfolder/sharefile.txt" for user "Alice" should be "First content"
     And the content of file "/sharingfolder/sharefile.txt" for user "Brian" should be "First content"
 
-  @files_sharing-app-required @notToImplementOnOCIS
+  @files_sharing-app-required
   Scenario: sharer can restore a file inside a shared folder created by sharee and modified by sharee
     Given user "Brian" has been created with default attributes and without skeleton files
     And user "Alice" has created folder "/sharingfolder"
@@ -237,7 +237,7 @@ Feature: dav-versions
     And the content of file "/sharingfolder/sharefile.txt" for user "Alice" should be "old content"
     And the content of file "/sharingfolder/sharefile.txt" for user "Brian" should be "old content"
 
-  @files_sharing-app-required @notToImplementOnOCIS
+  @files_sharing-app-required
   Scenario: sharee can restore a file inside a shared folder created by sharer and modified by sharer
     Given user "Brian" has been created with default attributes and without skeleton files
     And user "Alice" has created folder "/sharingfolder"
@@ -249,7 +249,7 @@ Feature: dav-versions
     And the content of file "/sharingfolder/sharefile.txt" for user "Alice" should be "old content"
     And the content of file "/sharingfolder/sharefile.txt" for user "Brian" should be "old content"
 
-  @files_sharing-app-required @notToImplementOnOCIS
+  @files_sharing-app-required
   Scenario: sharee can restore a file inside a shared folder created by sharer and modified by sharer, when the folder has been moved by the sharee
     Given user "Brian" has been created with default attributes and without skeleton files
     And user "Alice" has created folder "/sharingfolder"
@@ -263,7 +263,7 @@ Feature: dav-versions
     And the content of file "/sharingfolder/sharefile.txt" for user "Alice" should be "old content"
     And the content of file "/received/sharingfolder/sharefile.txt" for user "Brian" should be "old content"
 
-  @files_sharing-app-required @notToImplementOnOCIS
+  @files_sharing-app-required
   Scenario: sharee can restore a shared file created and modified by sharer, when the file has been moved by the sharee (file is at the top level of the sharer)
     Given user "Brian" has been created with default attributes and without skeleton files
     And user "Alice" has uploaded file with content "old content" to "/sharefile.txt"
@@ -276,7 +276,7 @@ Feature: dav-versions
     And the content of file "/sharefile.txt" for user "Alice" should be "old content"
     And the content of file "/received/sharefile.txt" for user "Brian" should be "old content"
 
-  @files_sharing-app-required @notToImplementOnOCIS
+  @files_sharing-app-required
   Scenario: sharee can restore a shared file created and modified by sharer, when the file has been moved by the sharee (file is inside a folder of the sharer)
     Given user "Brian" has been created with default attributes and without skeleton files
     And user "Alice" has created folder "/sharingfolder"
@@ -290,7 +290,7 @@ Feature: dav-versions
     And the content of file "/sharingfolder/sharefile.txt" for user "Alice" should be "old content"
     And the content of file "/received/sharefile.txt" for user "Brian" should be "old content"
 
-  @files_sharing-app-required @issue-ocis-1289 @issue-ocis-1321 @notToImplementOnOCIS
+  @files_sharing-app-required @issue-ocis-1289 @issue-ocis-1321
   Scenario: sharer can restore a file inside a group shared folder modified by sharee
     Given user "Brian" has been created with default attributes and without skeleton files
     And user "Carol" has been created with default attributes and without skeleton files
@@ -308,7 +308,7 @@ Feature: dav-versions
     And the content of file "/sharingfolder/sharefile.txt" for user "Brian" should be "First content"
     And the content of file "/sharingfolder/sharefile.txt" for user "Carol" should be "First content"
 
-  @files_sharing-app-required @notToImplementOnOCIS @issue-ocis-1238
+  @files_sharing-app-required @issue-ocis-1238
   Scenario Outline: Moving a file (with versions) into a shared folder as the sharee and as the sharer
     Given using <dav_version> DAV path
     And user "Brian" has been created with default attributes and without skeleton files
@@ -335,7 +335,7 @@ Feature: dav-versions
       | old         | Brian |
       | new         | Brian |
 
-  @files_sharing-app-required @notToImplementOnOCIS @issue-ocis-1238
+  @files_sharing-app-required @issue-ocis-1238
   Scenario Outline: Moving a file (with versions) out of a shared folder as the sharee and as the sharer
     Given using <dav_version> DAV path
     And user "Brian" has been created with default attributes and without skeleton files
@@ -361,7 +361,7 @@ Feature: dav-versions
       | old         | Brian |
       | new         | Brian |
 
-  @files_sharing-app-required @issue-ocis-1238 @notToImplementOnOCIS
+  @files_sharing-app-required @issue-ocis-1238
   Scenario: Receiver tries to get file versions of unshared file from the sharer
     Given user "Brian" has been created with default attributes and without skeleton files
     And user "Alice" has uploaded file with content "textfile0" to "textfile0.txt"
@@ -371,7 +371,7 @@ Feature: dav-versions
     Then the HTTP status code should be "404"
     And the value of the item "//s:exception" in the response about user "Alice" should be "Sabre\DAV\Exception\NotFound"
 
-  @skipOnStorage:ceph @files_primary_s3-issue-161 @files_sharing-app-required @notToImplementOnOCIS
+  @skipOnStorage:ceph @files_primary_s3-issue-161 @files_sharing-app-required
   Scenario: Receiver tries get file versions of shared file from the sharer
     Given user "Brian" has been created with default attributes and without skeleton files
     And user "Alice" has uploaded file with content "textfile0" to "textfile0.txt"

--- a/tests/acceptance/features/apiVersions/fileVersionsSharingToShares.feature
+++ b/tests/acceptance/features/apiVersions/fileVersionsSharingToShares.feature
@@ -125,7 +125,7 @@ Feature: dav-versions
     And the content of file "/sharingfolder/sharefile.txt" for user "Alice" should be "old content"
     And the content of file "/Shares/sharingfolder/sharefile.txt" for user "Brian" should be "old content"
 
-  @files_sharing-app-required @notToImplementOnOCIS
+  @files_sharing-app-required
   Scenario: sharee can restore a file inside a shared folder created by sharer and modified by sharer, when the folder has been moved by the sharee
     Given user "Brian" has been created with default attributes and without skeleton files
     And user "Alice" has created folder "/sharingfolder"
@@ -140,7 +140,7 @@ Feature: dav-versions
     And the content of file "/sharingfolder/sharefile.txt" for user "Alice" should be "old content"
     And the content of file "/received/sharingfolder/sharefile.txt" for user "Brian" should be "old content"
 
-  @files_sharing-app-required @notToImplementOnOCIS
+  @files_sharing-app-required
   Scenario: sharee can restore a shared file created and modified by sharer, when the file has been moved by the sharee (file is at the top level of the sharer)
     Given user "Brian" has been created with default attributes and without skeleton files
     And user "Alice" has uploaded file with content "old content" to "/sharefile.txt"
@@ -154,7 +154,7 @@ Feature: dav-versions
     And the content of file "/sharefile.txt" for user "Alice" should be "old content"
     And the content of file "/received/sharefile.txt" for user "Brian" should be "old content"
 
-  @files_sharing-app-required @notToImplementOnOCIS
+  @files_sharing-app-required
   Scenario: sharee can restore a shared file created and modified by sharer, when the file has been moved by the sharee (file is inside a folder of the sharer)
     Given user "Brian" has been created with default attributes and without skeleton files
     And user "Alice" has created folder "/sharingfolder"
@@ -238,15 +238,10 @@ Feature: dav-versions
     And as "Brian" file "/testshare/testfile.txt" should not exist
     And the version folder of file "/testfile.txt" for user "<mover>" should contain "2" elements
 
-    @notToImplementOnOCIS
     Examples:
       | dav_version | mover | src-folder        |
       | old         | Alice | /Shares/testshare |
       | new         | Alice | /Shares/testshare |
-
-
-    Examples:
-      | dav_version | mover | src-folder |
       | old         | Brian | /testshare |
       | new         | Brian | /testshare |
 

--- a/tests/acceptance/features/apiWebdavDelete/deleteFolder.feature
+++ b/tests/acceptance/features/apiWebdavDelete/deleteFolder.feature
@@ -47,7 +47,7 @@ Feature: delete folder
       | old         |
       | new         |
 
-  @files_sharing-app-required @notToImplementOnOCIS
+  @files_sharing-app-required
   Scenario Outline: delete a folder when there is a default folder for received shares
     Given using <dav_version> DAV path
     And the administrator has set the default folder for received shares to "<share_folder>"
@@ -69,7 +69,7 @@ Feature: delete folder
       | new         | ReceivedShares  |
       | new         | /ReceivedShares |
 
-  @files_sharing-app-required @notToImplementOnOCIS
+  @files_sharing-app-required
   Scenario Outline: delete a folder when there is a default folder for received shares that is a multi-level path
     Given using <dav_version> DAV path
     And the administrator has set the default folder for received shares to "/My/Received/Shares"

--- a/tests/acceptance/features/apiWebdavLocks/exclusiveLocks.feature
+++ b/tests/acceptance/features/apiWebdavLocks/exclusiveLocks.feature
@@ -21,7 +21,7 @@ Feature: there can be only one exclusive lock on a resource
       | new      | shared     |
       | new      | exclusive  |
 
-  @notToImplementOnOCIS
+
   Scenario Outline: if a parent resource is exclusively locked a child resource cannot be locked again
     Given using <dav-path> DAV path
     And user "Alice" has created folder "PARENT"
@@ -40,7 +40,7 @@ Feature: there can be only one exclusive lock on a resource
       | new      | shared     |
       | new      | exclusive  |
 
-  @notToImplementOnOCIS
+
   Scenario Outline: if a parent resource is exclusively locked with depth 0 a child resource can be locked again
     Given using <dav-path> DAV path
     And user "Alice" has created folder "PARENT"
@@ -60,7 +60,7 @@ Feature: there can be only one exclusive lock on a resource
       | new      | shared     |
       | new      | exclusive  |
 
-  @skipOnOcV10 @issue-34358 @notToImplementOnOCIS
+  @skipOnOcV10 @issue-34358
   Scenario Outline: if a child resource is exclusively locked a parent resource cannot be locked again
     Given using <dav-path> DAV path
     And user "Alice" has created folder "PARENT"
@@ -79,7 +79,7 @@ Feature: there can be only one exclusive lock on a resource
       | new      | shared     |
       | new      | exclusive  |
 
-  @notToImplementOnOCIS
+
   Scenario Outline: if a child resource is exclusively locked a parent resource can be locked with depth 0
     Given using <dav-path> DAV path
     And user "Alice" has created folder "PARENT"

--- a/tests/acceptance/features/apiWebdavLocks/exclusiveLocksOc10Issue34358.feature
+++ b/tests/acceptance/features/apiWebdavLocks/exclusiveLocksOc10Issue34358.feature
@@ -1,4 +1,4 @@
-@api @notToImplementOnOCIS @issue-ocis-reva-172
+@api @issue-ocis-reva-172
 Feature: there can be only one exclusive lock on a resource
 
   @issue-34358

--- a/tests/acceptance/features/apiWebdavLocks/folder.feature
+++ b/tests/acceptance/features/apiWebdavLocks/folder.feature
@@ -4,7 +4,7 @@ Feature: lock folders
   Background:
     Given user "Alice" has been created with default attributes and without skeleton files
 
-  @smokeTest @notToImplementOnOCIS
+  @smokeTest
   Scenario Outline: upload to a locked folder
     Given using <dav-path> DAV path
     And user "Alice" has created folder "FOLDER"
@@ -20,7 +20,7 @@ Feature: lock folders
       | new      | shared     |
       | new      | exclusive  |
 
-  @notToImplementOnOCIS
+
   Scenario Outline: upload to a subfolder of a locked folder
     Given using <dav-path> DAV path
     And user "Alice" has created folder "PARENT"
@@ -37,7 +37,7 @@ Feature: lock folders
       | new      | shared     |
       | new      | exclusive  |
 
-  @smokeTest @notToImplementOnOCIS
+  @smokeTest
   Scenario Outline: create folder in a locked folder
     Given using <dav-path> DAV path
     And user "Alice" has created folder "FOLDER"
@@ -53,7 +53,7 @@ Feature: lock folders
       | new      | shared     |
       | new      | exclusive  |
 
-  @notToImplementOnOCIS
+
   Scenario Outline: create folder in a subfolder of a locked folder
     Given using <dav-path> DAV path
     And user "Alice" has created folder "PARENT"
@@ -70,7 +70,7 @@ Feature: lock folders
       | new      | shared     |
       | new      | exclusive  |
 
-  @notToImplementOnOCIS
+
   Scenario Outline: Move file out of a locked folder
     Given using <dav-path> DAV path
     And user "Alice" has created folder "PARENT"
@@ -88,7 +88,7 @@ Feature: lock folders
       | new      | shared     |
       | new      | exclusive  |
 
-  @notToImplementOnOCIS
+
   Scenario Outline: Move file out of a locked sub folder one level higher into locked parent folder
     Given using <dav-path> DAV path
     And user "Alice" has created folder "PARENT"
@@ -107,7 +107,7 @@ Feature: lock folders
       | new      | shared     |
       | new      | exclusive  |
 
-  @notToImplementOnOCIS
+
   Scenario Outline: lockdiscovery of a locked folder
     Given using <dav-path> DAV path
     And user "Alice" has created folder "PARENT"

--- a/tests/acceptance/features/apiWebdavLocks/publicLink.feature
+++ b/tests/acceptance/features/apiWebdavLocks/publicLink.feature
@@ -1,4 +1,4 @@
-@api @smokeTest @public_link_share-feature-required @files_sharing-app-required @issue-ocis-reva-172 @notToImplementOnOCIS
+@api @smokeTest @public_link_share-feature-required @files_sharing-app-required @issue-ocis-reva-172
 Feature: persistent-locking in case of a public link
 
   Background:

--- a/tests/acceptance/features/apiWebdavLocks/publicLinkLockdiscovery.feature
+++ b/tests/acceptance/features/apiWebdavLocks/publicLinkLockdiscovery.feature
@@ -1,4 +1,4 @@
-@api @smokeTest @public_link_share-feature-required @files_sharing-app-required @issue-ocis-reva-172 @notToImplementOnOCIS
+@api @smokeTest @public_link_share-feature-required @files_sharing-app-required @issue-ocis-reva-172
 Feature: LOCKDISCOVERY for public links
 
   Background:

--- a/tests/acceptance/features/apiWebdavLocks/requestsWithToken.feature
+++ b/tests/acceptance/features/apiWebdavLocks/requestsWithToken.feature
@@ -4,7 +4,7 @@ Feature: actions on a locked item are possible if the token is sent with the req
   Background:
     Given user "Alice" has been created with default attributes and without skeleton files
 
-  @smokeTest @notToImplementOnOCIS
+  @smokeTest
   Scenario Outline: rename a file in a locked folder
     Given using <dav-path> DAV path
     And user "Alice" has created folder "PARENT"
@@ -22,7 +22,7 @@ Feature: actions on a locked item are possible if the token is sent with the req
       | new      | shared     |
       | new      | exclusive  |
 
-  @smokeTest @notToImplementOnOCIS
+  @smokeTest
   Scenario Outline: move a file into a locked folder
     Given using <dav-path> DAV path
     And user "Alice" has created folder "FOLDER"
@@ -41,7 +41,7 @@ Feature: actions on a locked item are possible if the token is sent with the req
       | new      | shared     |
       | new      | exclusive  |
 
-  @smokeTest @notToImplementOnOCIS
+  @smokeTest
   Scenario Outline: move a file into a locked folder is impossible when using the wrong token
     Given using <dav-path> DAV path
     And user "Alice" has created folder "FOLDER"
@@ -63,7 +63,7 @@ Feature: actions on a locked item are possible if the token is sent with the req
       | new      | shared     |
       | new      | exclusive  |
 
-  @skipOnOcV10 @issue-34338 @files_sharing-app-required @notToImplementOnOCIS
+  @skipOnOcV10 @issue-34338 @files_sharing-app-required
   Scenario Outline: share receiver cannot rename a file in a folder locked by the owner even when sending the locktoken
     Given using <dav-path> DAV path
     And user "Alice" has created folder "PARENT"
@@ -84,7 +84,7 @@ Feature: actions on a locked item are possible if the token is sent with the req
       | new      | shared     |
       | new      | exclusive  |
 
-  @files_sharing-app-required @notToImplementOnOCIS
+  @files_sharing-app-required
   Scenario Outline: public cannot overwrite a file in a folder locked by the owner even when sending the locktoken
     Given user "Alice" has created folder "PARENT"
     And user "Alice" has uploaded file with content "ownCloud test text file parent" to "PARENT/parent.txt"

--- a/tests/acceptance/features/apiWebdavLocks/requestsWithTokenOc10Issue34338.feature
+++ b/tests/acceptance/features/apiWebdavLocks/requestsWithTokenOc10Issue34338.feature
@@ -1,4 +1,4 @@
-@api @notToImplementOnOCIS @issue-ocis-reva-172
+@api @issue-ocis-reva-172
 Feature: actions on a locked item are possible if the token is sent with the request
 
   @issue-34338 @files_sharing-app-required

--- a/tests/acceptance/features/apiWebdavLocks/requestsWithTokenOc10Issue34360.feature
+++ b/tests/acceptance/features/apiWebdavLocks/requestsWithTokenOc10Issue34360.feature
@@ -1,4 +1,4 @@
-@api @notToImplementOnOCIS @issue-ocis-reva-172
+@api @issue-ocis-reva-172
 Feature: actions on a locked item are possible if the token is sent with the request
 
   @issue-34360 @files_sharing-app-required

--- a/tests/acceptance/features/apiWebdavLocks2/resharedSharesToRoot.feature
+++ b/tests/acceptance/features/apiWebdavLocks2/resharedSharesToRoot.feature
@@ -1,4 +1,4 @@
-@api @files_sharing-app-required @issue-ocis-reva-172 @issue-ocis-reva-11 @notToImplementOnOCIS
+@api @files_sharing-app-required @issue-ocis-reva-172 @issue-ocis-reva-11
 Feature: lock should propagate correctly if a share is reshared
 
   Background:

--- a/tests/acceptance/features/apiWebdavLocks2/resharedSharesToShares.feature
+++ b/tests/acceptance/features/apiWebdavLocks2/resharedSharesToShares.feature
@@ -1,4 +1,4 @@
-@api @files_sharing-app-required @issue-ocis-reva-172 @issue-ocis-reva-11 @notToImplementOnOCIS
+@api @files_sharing-app-required @issue-ocis-reva-172 @issue-ocis-reva-11
 Feature: lock should propagate correctly if a share is reshared
 
   Background:

--- a/tests/acceptance/features/apiWebdavLocks2/setTimeout.feature
+++ b/tests/acceptance/features/apiWebdavLocks2/setTimeout.feature
@@ -1,4 +1,4 @@
-@api @smokeTest @public_link_share-feature-required @issue-ocis-reva-172 @notToImplementOnOCIS
+@api @smokeTest @public_link_share-feature-required @issue-ocis-reva-172
 Feature: set timeouts of LOCKS
 
   Background:

--- a/tests/acceptance/features/apiWebdavLocks2/setTimeoutSharesToRoot.feature
+++ b/tests/acceptance/features/apiWebdavLocks2/setTimeoutSharesToRoot.feature
@@ -1,4 +1,4 @@
-@api @smokeTest @public_link_share-feature-required @files_sharing-app-required @issue-ocis-reva-172 @notToImplementOnOCIS
+@api @smokeTest @public_link_share-feature-required @files_sharing-app-required @issue-ocis-reva-172
 Feature: set timeouts of LOCKS on shares
 
   Background:

--- a/tests/acceptance/features/apiWebdavLocks2/setTimeoutSharesToShares.feature
+++ b/tests/acceptance/features/apiWebdavLocks2/setTimeoutSharesToShares.feature
@@ -1,4 +1,4 @@
-@api @smokeTest @public_link_share-feature-required @files_sharing-app-required @issue-ocis-reva-172 @notToImplementOnOCIS
+@api @smokeTest @public_link_share-feature-required @files_sharing-app-required @issue-ocis-reva-172
 Feature: set timeouts of LOCKS on shares
 
   Background:

--- a/tests/acceptance/features/apiWebdavLocks3/independentLocks.feature
+++ b/tests/acceptance/features/apiWebdavLocks3/independentLocks.feature
@@ -5,7 +5,7 @@ Feature: independent locks
   Background:
     Given user "Alice" has been created with default attributes and without skeleton files
 
-  @notToImplementOnOCIS
+
   Scenario Outline: locking a folder does not lock other items with the same name in other parts of the file system
     Given using <dav-path> DAV path
     And user "Alice" has created folder "locked"
@@ -27,7 +27,7 @@ Feature: independent locks
       | new      | shared     |
       | new      | exclusive  |
 
-  @notToImplementOnOCIS
+
   Scenario Outline: locking a folder on the root level does not lock other folders with the same name in other parts of the file system
     Given using <dav-path> DAV path
     And user "Alice" has created folder "notlocked"

--- a/tests/acceptance/features/apiWebdavLocks3/independentLocksShareToRoot.feature
+++ b/tests/acceptance/features/apiWebdavLocks3/independentLocksShareToRoot.feature
@@ -1,4 +1,4 @@
-@api @issue-ocis-reva-172 @notToImplementOnOCIS
+@api @issue-ocis-reva-172
 Feature: independent locks
   Make sure all locks are independent and don't interact with other items that have the same name
 

--- a/tests/acceptance/features/apiWebdavLocks3/independentLocksShareToShares.feature
+++ b/tests/acceptance/features/apiWebdavLocks3/independentLocksShareToShares.feature
@@ -8,7 +8,7 @@ Feature: independent locks
     And user "Alice" has been created with default attributes and without skeleton files
     And user "Brian" has been created with default attributes and without skeleton files
 
-  @notToImplementOnOCIS
+
   Scenario Outline: locking a received share does not lock other shares that had the same name on the sharer side (shares from different users)
     Given using <dav-path> DAV path
     And user "Carol" has been created with default attributes and without skeleton files
@@ -30,7 +30,7 @@ Feature: independent locks
       | new      | shared     |
       | new      | exclusive  |
 
-  @notToImplementOnOCIS
+
   Scenario Outline: locking a received share does not lock other shares that had the same name on the sharer side (shares from the same user)
     Given using <dav-path> DAV path
     And user "Alice" has created folder "locked/"

--- a/tests/acceptance/features/apiWebdavLocksUnlock/lockBreakersGroups.feature
+++ b/tests/acceptance/features/apiWebdavLocksUnlock/lockBreakersGroups.feature
@@ -1,4 +1,4 @@
-@api @issue-ocis-2413 @notToImplementOnOCIS
+@api @issue-ocis-2413
 Feature: UNLOCK locked items
 
   Background:

--- a/tests/acceptance/features/apiWebdavLocksUnlock/unlock.feature
+++ b/tests/acceptance/features/apiWebdavLocksUnlock/unlock.feature
@@ -4,7 +4,7 @@ Feature: UNLOCK locked items
   Background:
     Given user "Alice" has been created with default attributes and without skeleton files
 
-  @smokeTest @notToImplementOnOCIS
+  @smokeTest
   Scenario Outline: unlock a single lock set by the user itself
     Given using <dav-path> DAV path
     And user "Alice" has created folder "PARENT"
@@ -40,7 +40,7 @@ Feature: UNLOCK locked items
       | old      |
       | new      |
 
-  @notToImplementOnOCIS
+
   Scenario Outline: unlocking a file that was locked by the user locking the folder above is not possible
     Given using <dav-path> DAV path
     And user "Alice" has created folder "PARENT"
@@ -74,7 +74,7 @@ Feature: UNLOCK locked items
       | shared     |
       | exclusive  |
 
-  @notToImplementOnOCIS
+
   Scenario Outline: unlocking a file or folder does not unlock another folder with the same name in another part of the file system
     Given using <dav-path> DAV path
     And user "Alice" has created folder "locked"

--- a/tests/acceptance/features/apiWebdavLocksUnlock/unlockOc10Issue34302.feature
+++ b/tests/acceptance/features/apiWebdavLocksUnlock/unlockOc10Issue34302.feature
@@ -1,4 +1,4 @@
-@api @notToImplementOnOCIS @issue-ocis-reva-172
+@api @issue-ocis-reva-172
 Feature: UNLOCK locked items
 
   @issue-34302 @files_sharing-app-required

--- a/tests/acceptance/features/apiWebdavLocksUnlock/unlockSharingToRoot.feature
+++ b/tests/acceptance/features/apiWebdavLocksUnlock/unlockSharingToRoot.feature
@@ -1,4 +1,4 @@
-@api @issue-ocis-reva-172 @files_sharing-app-required @notToImplementOnOCIS
+@api @issue-ocis-reva-172 @files_sharing-app-required
 Feature: UNLOCK locked items (sharing)
 
   Background:

--- a/tests/acceptance/features/apiWebdavLocksUnlock/unlockSharingToShares.feature
+++ b/tests/acceptance/features/apiWebdavLocksUnlock/unlockSharingToShares.feature
@@ -47,7 +47,7 @@ Feature: UNLOCK locked items (sharing)
       | new      | shared     |
       | new      | exclusive  |
 
-  @notToImplementOnOCIS
+
   Scenario Outline: as share receiver unlocking a shared folder locked by the file owner is not possible. To unlock use the owners locktoken
     Given using <dav-path> DAV path
     And user "Alice" has created folder "PARENT/CHILD"
@@ -125,7 +125,7 @@ Feature: UNLOCK locked items (sharing)
       | new      | shared     |
       | new      | exclusive  |
 
-  @notToImplementOnOCIS
+
   Scenario Outline: as owner unlocking a shared folder locked by the share receiver is not possible. To unlock use the receivers locktoken
     Given using <dav-path> DAV path
     And user "Alice" has created folder "PARENT/CHILD"

--- a/tests/acceptance/features/apiWebdavMove1/moveFileAsync.feature
+++ b/tests/acceptance/features/apiWebdavMove1/moveFileAsync.feature
@@ -1,4 +1,4 @@
-@api @issue-ocis-reva-14 @notToImplementOnOCIS
+@api @issue-ocis-reva-14
 Feature: move (rename) file
   As a user
   I want to be able to move and rename files asynchronously

--- a/tests/acceptance/features/apiWebdavMove1/moveFileToBlacklistedNameAsync.feature
+++ b/tests/acceptance/features/apiWebdavMove1/moveFileToBlacklistedNameAsync.feature
@@ -1,4 +1,4 @@
-@api @issue-ocis-reva-14 @notToImplementOnOCIS
+@api @issue-ocis-reva-14
 Feature: users cannot move (rename) a file to a blacklisted name
   As an administrator
   I want to be able to prevent users from moving (renaming) files to specified file names

--- a/tests/acceptance/features/apiWebdavMove1/moveFileToExcludedDirectoryAsync.feature
+++ b/tests/acceptance/features/apiWebdavMove1/moveFileToExcludedDirectoryAsync.feature
@@ -1,4 +1,4 @@
-@api @issue-ocis-reva-14 @notToImplementOnOCIS
+@api @issue-ocis-reva-14
 Feature: users cannot move (rename) a file to or into an excluded directory
   As an administrator
   I want to be able to exclude directories (folders) from being processed. Any attempt to rename an existing file or folder to one of those names should be refused.

--- a/tests/acceptance/features/apiWebdavOperations/downloadFile.feature
+++ b/tests/acceptance/features/apiWebdavOperations/downloadFile.feature
@@ -44,7 +44,7 @@ Feature: download file
       | old         |
       | new         |
 
-  @smokeTest @notToImplementOnOCIS
+  @smokeTest
   Scenario Outline: Downloading a file should serve security headers
     Given using <dav_version> DAV path
     When user "Alice" downloads file "/welcome.txt" using the WebDAV API
@@ -65,7 +65,7 @@ Feature: download file
       | old         |
       | new         |
 
-  @notToImplementOnOCIS
+
   Scenario Outline: Doing a GET with a web login should work without CSRF token on the new backend
     Given using <dav_version> DAV path
     And user "Alice" has logged in to a web-style session
@@ -77,7 +77,7 @@ Feature: download file
       | old         |
       | new         |
 
-  @notToImplementOnOCIS
+
   Scenario Outline: Doing a GET with a web login should work with CSRF token on the new backend
     Given using <dav_version> DAV path
     And user "Alice" has logged in to a web-style session

--- a/tests/acceptance/features/apiWebdavOperations/listFiles.feature
+++ b/tests/acceptance/features/apiWebdavOperations/listFiles.feature
@@ -173,13 +173,10 @@ Feature: list files
       | /simple-folder1/simple-folder2/welcome.txt                   |
       | /simple-folder1/simple-folder2/simple-folder3                |
       | /simple-folder1/simple-folder2/simple-folder3/simple-folder4 |
-    @notToImplementOnOCIS @issue-ocis-2079
+    @issue-ocis-2079
     Examples:
       | dav_version |
       | old         |
-
-    Examples:
-      | dav_version |
       | new         |
 
 
@@ -206,13 +203,10 @@ Feature: list files
       | /simple-folder1/simple-folder2                               |
       | /simple-folder1/textfile0.txt                                |
       | /simple-folder1/simple-folder2/simple-folder3/simple-folder4 |
-    @notToImplementOnOCIS @issue-ocis-2079
+    @issue-ocis-2079
     Examples:
       | dav_version |
       | old         |
-
-    Examples:
-      | dav_version |
       | new         |
 
   @depthInfinityPropfindEnabled
@@ -238,13 +232,10 @@ Feature: list files
       | /simple-folder1/simple-folder2/welcome.txt                   |
       | /simple-folder1/simple-folder2/simple-folder3                |
       | /simple-folder1/simple-folder2/simple-folder3/simple-folder4 |
-    @notToImplementOnOCIS @issue-ocis-2079
+    @issue-ocis-2079
     Examples:
       | dav_version |
       | old         |
-
-    Examples:
-      | dav_version |
       | new         |
 
 
@@ -348,13 +339,10 @@ Feature: list files
     And user "Alice" has created a public link share of folder "simple-folder"
     When the public lists the resources in the last created public link with depth "infinity" using the WebDAV API
     Then the HTTP status code should be "412"
-    @notToImplementOnOCIS @issue-ocis-2079
+    @issue-ocis-2079
     Examples:
       | dav_version |
       | old         |
-
-    Examples:
-      | dav_version |
       | new         |
 
   @depthInfinityPropfindDisabled

--- a/tests/acceptance/features/apiWebdavOperations/propfind.feature
+++ b/tests/acceptance/features/apiWebdavOperations/propfind.feature
@@ -18,12 +18,12 @@ Feature: PROPFIND
       | header | value   |
       | depth  | <depth> |
     Then the HTTP status code should be "<http_status>"
-    @notToImplementOnOCIS @depthInfinityPropfindEnabled
+    @depthInfinityPropfindEnabled
     Examples:
       | dav_path                    | depth_infinity_allowed | depth    | http_status |
       | /remote.php/dav/files/alice | 1                      | 0        | 207         |
       | /remote.php/dav/files/alice | 1                      | infinity | 207         |
-    @notToImplementOnOCIS @depthInfinityPropfindDisabled
+    @depthInfinityPropfindDisabled
     Examples:
       | dav_path                    | depth_infinity_allowed | depth    | http_status |
       | /remote.php/dav/files/alice | 0                      | 0        | 207         |

--- a/tests/acceptance/features/apiWebdavPreviews/previews.feature
+++ b/tests/acceptance/features/apiWebdavPreviews/previews.feature
@@ -89,7 +89,7 @@ Feature: previews of files downloaded through the webdav API
     Then the HTTP status code should be "200"
     And the downloaded image should be "32" pixels wide and "32" pixels high
 
-  @notToImplementOnOCIS
+
   Scenario: download previews of shared files (to root)
     Given user "Brian" has been created with default attributes and without skeleton files
     And user "Alice" has uploaded file "filesForUpload/lorem.txt" to "/parent.txt"
@@ -184,7 +184,7 @@ Feature: previews of files downloaded through the webdav API
     Then the HTTP status code should be "204"
     And as user "Alice" the preview of "/parent.txt" with width "32" and height "32" should have been changed
 
-  @notToImplementOnOCIS
+
   Scenario: when owner updates a shared file, previews for sharee are also updated
     Given user "Brian" has been created with default attributes and without skeleton files
     And user "Alice" has uploaded file "filesForUpload/lorem.txt" to "/parent.txt"
@@ -264,7 +264,7 @@ Feature: previews of files downloaded through the webdav API
     And as user "Brian" the preview of "Shares/FOLDER/lorem.txt" with width "32" and height "32" should have been changed
     And as user "Carol" the preview of "Shares/FOLDER/lorem.txt" with width "32" and height "32" should have been changed
 
-  @notToImplementOnOCIS
+
   Scenario: JPEG preview quality can be determined by config
     Given user "Alice" has uploaded file "filesForUpload/testavatar.jpg" to "/testavatar_low.jpg"
     And the administrator has updated system config key "previewJPEGImageDisplayQuality" with value "1"

--- a/tests/acceptance/features/apiWebdavProperties2/getFileProperties.feature
+++ b/tests/acceptance/features/apiWebdavProperties2/getFileProperties.feature
@@ -214,7 +214,7 @@ Feature: get file properties
       | old         |
       | new         |
 
-  @notToImplementOnOCIS
+
   Scenario Outline: Doing a PROPFIND with a web login should work with CSRF token on the new backend
     Given using <dav_version> DAV path
     And user "Alice" has uploaded file "filesForUpload/textfile.txt" to "/somefile.txt"

--- a/tests/acceptance/features/apiWebdavUpload1/uploadFileAsyncUsingNewChunking.feature
+++ b/tests/acceptance/features/apiWebdavUpload1/uploadFileAsyncUsingNewChunking.feature
@@ -1,4 +1,4 @@
-@api @issue-ocis-reva-56 @notToImplementOnOCIS @newChunking @issue-ocis-1321
+@api @issue-ocis-reva-56 @newChunking @issue-ocis-1321
 Feature: upload file using new chunking
   As a user
   I want to be able to upload "large" files in chunks asynchronously

--- a/tests/acceptance/features/apiWebdavUpload1/uploadFileToBlacklistedName.feature
+++ b/tests/acceptance/features/apiWebdavUpload1/uploadFileToBlacklistedName.feature
@@ -8,7 +8,7 @@ Feature: users cannot upload a file to a blacklisted name
     Given using OCS API version "1"
     And user "Alice" has been created with default attributes and without skeleton files
 
-  @issue-ocis-reva-15 @notToImplementOnOCIS
+  @issue-ocis-reva-15
   Scenario Outline: upload a file to a filename that is banned by default
     Given using <dav_version> DAV path
     When user "Alice" uploads file with content "uploaded content" to ".htaccess" using the WebDAV API

--- a/tests/acceptance/features/apiWebdavUpload1/uploadFileToBlacklistedNameAsyncUsingNewChunking.feature
+++ b/tests/acceptance/features/apiWebdavUpload1/uploadFileToBlacklistedNameAsyncUsingNewChunking.feature
@@ -1,4 +1,4 @@
-@api @issue-ocis-reva-56 @notToImplementOnOCIS @newChunking @issue-ocis-1321
+@api @issue-ocis-reva-56 @newChunking @issue-ocis-1321
 Feature: users cannot upload a file to a blacklisted name using new chunking
   As an administrator
   I want to be able to prevent users from uploading files to specified file names

--- a/tests/acceptance/features/apiWebdavUpload1/uploadFileToExcludedDirectoryAsyncUsingNewChunking.feature
+++ b/tests/acceptance/features/apiWebdavUpload1/uploadFileToExcludedDirectoryAsyncUsingNewChunking.feature
@@ -1,4 +1,4 @@
-@api @issue-ocis-reva-56 @notToImplementOnOCIS @newChunking @issue-ocis-1321
+@api @issue-ocis-reva-56 @newChunking @issue-ocis-1321
 Feature: users cannot upload a file to or into an excluded directory using new chunking
   As an administrator
   I want to be able to exclude directories (folders) from being processed. Any attempt to upload a file to one of those names should be refused.

--- a/tests/acceptance/features/apiWebdavUpload2/uploadFileToBlacklistedNameUsingNewChunking.feature
+++ b/tests/acceptance/features/apiWebdavUpload2/uploadFileToBlacklistedNameUsingNewChunking.feature
@@ -1,4 +1,4 @@
-@api @issue-ocis-reva-56 @notToImplementOnOCIS @newChunking @issue-ocis-1321
+@api @issue-ocis-reva-56 @newChunking @issue-ocis-1321
 Feature: users cannot upload a file to a blacklisted name using new chunking
   As an administrator
   I want to be able to prevent users from uploading files to specified file names

--- a/tests/acceptance/features/apiWebdavUpload2/uploadFileToBlacklistedNameUsingOldChunking.feature
+++ b/tests/acceptance/features/apiWebdavUpload2/uploadFileToBlacklistedNameUsingOldChunking.feature
@@ -9,7 +9,7 @@ Feature: users cannot upload a file to a blacklisted name using old chunking
     And using old DAV path
     And user "Alice" has been created with default attributes and without skeleton files
 
-  @skipOnOcV10 @issue-36645 @notToImplementOnOCIS
+  @skipOnOcV10 @issue-36645
   Scenario: Upload a file to a filename that is banned by default using old chunking
     When user "Alice" uploads file "filesForUpload/textfile.txt" to "/.htaccess" in 3 chunks using the WebDAV API
     Then the HTTP status code should be "403"

--- a/tests/acceptance/features/apiWebdavUpload2/uploadFileToBlacklistedNameUsingOldChunkingOc10Issue36645.feature
+++ b/tests/acceptance/features/apiWebdavUpload2/uploadFileToBlacklistedNameUsingOldChunkingOc10Issue36645.feature
@@ -1,4 +1,4 @@
-@notToImplementOnOCIS @api @issue-ocis-reva-15
+@api @issue-ocis-reva-15
 Feature: users cannot upload a file to a blacklisted name using old chunking
   As an administrator
   I want to be able to prevent users from uploading files to specified file names

--- a/tests/acceptance/features/apiWebdavUpload2/uploadFileToExcludedDirectoryUsingNewChunking.feature
+++ b/tests/acceptance/features/apiWebdavUpload2/uploadFileToExcludedDirectoryUsingNewChunking.feature
@@ -1,4 +1,4 @@
-@api @issue-ocis-reva-56 @notToImplementOnOCIS @newChunking @issue-ocis-1321
+@api @issue-ocis-reva-56 @newChunking @issue-ocis-1321
 Feature: users cannot upload a file to or into an excluded directory using new chunking
   As an administrator
   I want to be able to exclude directories (folders) from being processed. Any attempt to upload a file to one of those names should be refused.

--- a/tests/acceptance/features/apiWebdavUpload2/uploadFileToExcludedDirectoryUsingOldChunkingOc10Issue36645.feature
+++ b/tests/acceptance/features/apiWebdavUpload2/uploadFileToExcludedDirectoryUsingOldChunkingOc10Issue36645.feature
@@ -1,4 +1,4 @@
-@notToImplementOnOCIS @api @issue-ocis-reva-15
+@api @issue-ocis-reva-15
 Feature: users cannot upload a file to or into an excluded directory using old chunking
   As an administrator
   I want to be able to exclude directories (folders) from being processed. Any attempt to upload a file to one of those names should be refused.

--- a/tests/acceptance/features/apiWebdavUpload2/uploadFileUsingNewChunking.feature
+++ b/tests/acceptance/features/apiWebdavUpload2/uploadFileUsingNewChunking.feature
@@ -1,4 +1,4 @@
-@api @issue-ocis-reva-56 @notToImplementOnOCIS @newChunking @issue-ocis-1321
+@api @issue-ocis-reva-56 @newChunking @issue-ocis-1321
 Feature: upload file using new chunking
   As a user
   I want to be able to upload "large" files in chunks

--- a/tests/acceptance/features/apiWebdavUpload2/uploadFileUsingOldChunkingOc10Issue36115.feature
+++ b/tests/acceptance/features/apiWebdavUpload2/uploadFileUsingOldChunkingOc10Issue36115.feature
@@ -1,4 +1,4 @@
-@notToImplementOnOCIS @api @issue-ocis-reva-17
+@api @issue-ocis-reva-17
 Feature: upload file using old chunking
   As a user
   I want to be able to upload "large" files in chunks

--- a/tests/acceptance/features/cliCreateLocalStorage/createLocalStorageOc10Issue36713.feature
+++ b/tests/acceptance/features/cliCreateLocalStorage/createLocalStorageOc10Issue36713.feature
@@ -10,7 +10,7 @@ Feature: create local storage from the command line
       | Alice    |
       | Brian    |
 
-  @issue-36713 @notToImplementOnOCIS
+  @issue-36713
   Scenario: create local storage that already exists
     Given the administrator has created the local storage mount "local_storage2"
     And the administrator has uploaded file with content "this is a file in local storage" to "/local_storage2/file-in-local-storage.txt"

--- a/tests/acceptance/features/cliCreateLocalStorage/createLocalStorageOc10Issue36719.feature
+++ b/tests/acceptance/features/cliCreateLocalStorage/createLocalStorageOc10Issue36719.feature
@@ -1,4 +1,4 @@
-@cli @local_storage @files_external-app-required @skipOnLDAP @issue-36719 @notToImplementOnOCIS
+@cli @local_storage @files_external-app-required @skipOnLDAP @issue-36719
 Feature: create local storage from the command line
   As an admin
   I want to create local storage from the command line

--- a/tests/acceptance/features/cliLocalStorage/scanLocalStorageOc10Issue33670.feature
+++ b/tests/acceptance/features/cliLocalStorage/scanLocalStorageOc10Issue33670.feature
@@ -1,4 +1,4 @@
-@cli @local_storage @files_external-app-required @issue-33670 @notToImplementOnOCIS
+@cli @local_storage @files_external-app-required @issue-33670
 Feature: Scanning files on local storage
   As an admin
   I want to be able to control the scanning of local storage for changes

--- a/tests/acceptance/features/cliMain/transferOwnership.feature
+++ b/tests/acceptance/features/cliMain/transferOwnership.feature
@@ -204,14 +204,10 @@ Feature: transfer-ownership
     Then the command should have been successful
     And the public should be able to download the last publicly shared file using the <webdav_api_version> public WebDAV API without a password and the content should be "Random data"
 
-    @notToImplementOnOCIS @issue-ocis-2079
+    @issue-ocis-2079
     Examples:
       | webdav_api_version |
       | old                |
-
-
-    Examples:
-      | webdav_api_version |
       | new                |
 
   @skipOnEncryptionType:user-keys @files_sharing-app-required @skipOnFilesClassifier @issue-files-classifier-292

--- a/tests/acceptance/features/cliProvisioning/editUserOc10Issue23603.feature
+++ b/tests/acceptance/features/cliProvisioning/editUserOc10Issue23603.feature
@@ -1,4 +1,4 @@
-@cli @skipOnLDAP @notToImplementOnOCIS
+@cli @skipOnLDAP
 Feature: edit users
   As an admin
   I want to be able to edit user information

--- a/tests/acceptance/features/cliProvisioning/resetUserPasswordOc10Issue36985.feature
+++ b/tests/acceptance/features/cliProvisioning/resetUserPasswordOc10Issue36985.feature
@@ -1,4 +1,4 @@
-@cli @email @skipOnLDAP @notToImplementOnOCIS
+@cli @email @skipOnLDAP
 Feature: reset user password
   As an admin
   I want to be able to reset a user's password

--- a/tests/acceptance/features/webUIAdminSettings/adminStorageSettingsOC10Issue36803.feature
+++ b/tests/acceptance/features/webUIAdminSettings/adminStorageSettingsOC10Issue36803.feature
@@ -1,4 +1,4 @@
-@webUI @insulated @disablePreviews @admin_settings-feature-required @local_storage @files_external-app-required @notToImplementOnOCIS
+@webUI @insulated @disablePreviews @admin_settings-feature-required @local_storage @files_external-app-required
 Feature: admin storage settings
   As an admin
   I want to be able to manage external storages on the ownCloud server

--- a/tests/acceptance/features/webUISharingExternal2/acceptDeclineFederatedSharesOc10Issue34742.feature
+++ b/tests/acceptance/features/webUISharingExternal2/acceptDeclineFederatedSharesOc10Issue34742.feature
@@ -20,7 +20,7 @@ Feature: Federation Sharing - sharing with users on other cloud storages
     And user "Alice" has logged in using the webUI
     And parameter "auto_accept_trusted" of app "federatedfilesharing" has been set to "no"
 
-  @issue-34742 @notToImplementOnOCIS
+  @issue-34742
   Scenario: User-based & global auto accepting is enabled but remote server is not trusted
     Given parameter "auto_accept_trusted" of app "federatedfilesharing" has been set to "yes"
     And parameter "autoAddServers" of app "federation" has been set to "0"

--- a/tests/acceptance/features/webUISharingInternalUsers1/miscShareWithUsersOc10Issue35787.feature
+++ b/tests/acceptance/features/webUISharingInternalUsers1/miscShareWithUsersOc10Issue35787.feature
@@ -1,7 +1,7 @@
 @webUI @insulated @disablePreviews @files_sharing-app-required
 Feature: misc scenarios on sharing with internal users
 
-  @issue-35787 @notToImplementOnOCIS
+  @issue-35787
   Scenario: share a file after changing its content to a user before the user has logged in
     Given these users have been created with default attributes and without skeleton files:
       | username |

--- a/tests/acceptance/features/webUISharingPublic2/allowGroupToCreatePublicLinks.feature
+++ b/tests/acceptance/features/webUISharingPublic2/allowGroupToCreatePublicLinks.feature
@@ -1,4 +1,4 @@
-@webUI @files_sharing-app-required @notToImplementOnOcis
+@webUI @files_sharing-app-required
 Feature: public share sharers groups setting
   As an admin
   I should be able to allow only certain groups to create public links

--- a/tests/acceptance/features/webUISharingPublic2/savePublicLinkShareOc10Issue38763.feature
+++ b/tests/acceptance/features/webUISharingPublic2/savePublicLinkShareOc10Issue38763.feature
@@ -12,7 +12,7 @@ Feature: Save public shares created by oC users
     Given using server "LOCAL"
     And user "Alice" has been created with default attributes and without skeleton files
 
-  @issue-38763 @notToImplementOnOCIS
+  @issue-38763
   Scenario: mount public link share of a folder and the sharer deletes the folder
     Given user "Brian" has been created with default attributes and without skeleton files
     And user "Alice" has created folder "/PARENT"
@@ -34,7 +34,7 @@ Feature: Save public shares created by oC users
     When the user browses to the files page
     Then folder "PARENT" should not be listed on the webUI
 
-  @issue-38763 @notToImplementOnOCIS
+  @issue-38763
   Scenario: mount public link share of a folder in remote server and the sharer deletes the folder
     Given using server "REMOTE"
     And user "Brian" has been created with default attributes and without skeleton files

--- a/tests/acceptance/features/webUIWebdavLocks/locksOc10Issue33867.feature
+++ b/tests/acceptance/features/webUIWebdavLocks/locksOc10Issue33867.feature
@@ -1,4 +1,4 @@
-@webUI @notToImplementOnOCIS @insulated @disablePreviews
+@webUI @insulated @disablePreviews
 Feature: Locks
   As a user
   I would like to be able to see what lock are on files and folders

--- a/tests/acceptance/features/webUIWebdavLocks/locksOc10Issue34315.feature
+++ b/tests/acceptance/features/webUIWebdavLocks/locksOc10Issue34315.feature
@@ -1,4 +1,4 @@
-@webUI @notToImplementOnOCIS @insulated @disablePreviews
+@webUI @insulated @disablePreviews
 Feature: Locks
   As a user
   I would like to be able to see what lock are on files and folders


### PR DESCRIPTION
## Description
- This PR removes scenario tag `@notToImplementOnOcis`  from the feature files.
- Depends upon PR https://github.com/owncloud/core/pull/40598 
## Related Issue
Part of issue 
- https://github.com/owncloud/core/issues/40572

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
- CI

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Database schema changes (next release will require increase of minor version instead of patch)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [x] Tests only (no source changes)

## Checklist:
<!-- Tick the checkboxes when done. -->
<!-- Raise documentation ticket in https://github.com/owncloud/documentation -->
- [ ] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 
- [ ] Changelog item, see [TEMPLATE](https://github.com/owncloud/core/blob/master/changelog/TEMPLATE)
