### PR TITLE
The header title and claim is rendered as escaped HTML in files_sharing public template.

### DIFF
--- a/apps/files_sharing/templates/public.php
+++ b/apps/files_sharing/templates/public.php
@@ -59,11 +59,11 @@ OCP\Util::addHeader('meta', ['property' => "og:image", 'content' => $_['previewI
 		 data-owner-display-name="<?php p($_['displayName']) ?>" data-owner="<?php p($_['owner']) ?>" data-name="<?php p($_['filename']) ?>">
 		<a href="<?php print_unescaped(link_to('', 'index.php')); ?>" title="" id="owncloud-public">
 			<h1 class="logo-icon">
-				<?php p($theme->getHTMLName()); ?>
+				<?php print_unescaped($theme->getHTMLName()); ?>
 			</h1>
 		</a>
 
-		<div id="logo-claim" style="display:none;"><?php p($theme->getLogoClaim()); ?></div>
+		<div id="logo-claim" style="display:none;"><?php print_unescaped($theme->getLogoClaim()); ?></div>
 		<?php
 			if ($_['canDownload']) {
 				?>

--- a/changelog/unreleased/40606
+++ b/changelog/unreleased/40606
@@ -1,0 +1,8 @@
+Bugfix: Fix header title and claim is rendered as escaped HTML in files_sharing public template
+
+The files_sharing application template was escaping the HTML from
+the title and claim provided by the theme. This caused raw HTML
+to be displayed in the page header.
+
+https://github.com/owncloud/core/issues/40605
+https://github.com/owncloud/core/pull/40606

--- a/changelog/unreleased/40606
+++ b/changelog/unreleased/40606
@@ -1,4 +1,4 @@
-Bugfix: Fix header title and claim is rendered as escaped HTML in files_sharing public template
+Bugfix: Fix header title and claim rendered as escaped HTML
 
 The files_sharing application template was escaping the HTML from
 the title and claim provided by the theme. This caused raw HTML


### PR DESCRIPTION
<!--
Thanks for submitting a change to ownCloud!

This is the bug tracker for the Server component. Find other components at https://github.com/owncloud/core/blob/master/.github/CONTRIBUTING.md#guidelines

For fixing potential security issues please see https://owncloud.com/security/

To make it possible for us to get your change reviewed and merged please carefully fill out the requested information below.

Please note that any kind of change needs first be submitted to the master branch which holds the next version of ownCloud.

Please set the following labels:

- Set label "3 - To review" for review or "2 - Development" if the PR still has open tasks
- Assignment: assign to self
- Milestone: set the same as the ticket this PR fixes, or "development" by default
- Reviewers: pick at least one
-->

## Description
The files_sharing public template escaped the Theme HTML title and claim. The raw HTML markup is shown.

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
- Fixes #40605 

## Motivation and Context
The header in the public pages shows raw HTML code instead of the theme markup requested.

## How Has This Been Tested?
Check with a browser that it doesn't show the HTML markup.

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Database schema changes (next release will require increase of minor version instead of patch)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [ ] Tests only (no source changes)

## Checklist:
<!-- Tick the checkboxes when done. -->
<!-- Raise documentation ticket in https://github.com/owncloud/documentation -->
- [x] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 
- [x] Changelog item, see [TEMPLATE](https://github.com/owncloud/core/blob/master/changelog/TEMPLATE)
