### PR TITLE
fix: use correct l10n folder when theme is enabled and apps_path is a…

### DIFF
--- a/changelog/unreleased/40607
+++ b/changelog/unreleased/40607
@@ -1,0 +1,8 @@
+Bugfix: Use correct themed l10n app folder when app lives outside of server root
+
+When an app_path is pointing outside of the ownCloud server root or uses an
+symlink under certain conditions the l10n folder points to an invalid location
+and results in a crash of the server. This happened due to the assumption that
+app paths always start with the server root path.
+
+https://github.com/owncloud/core/pull/40607


### PR DESCRIPTION
… symlink

## Description
Due to magic path operations an instance could explode under following constellation:
- theme enabled
- symlinked oc installation like `/var/www/owncloud` -> `/var/www/owncloud-10.12.13-crazy.long-name`

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?
- :hand: 
- unit test will follow


## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Database schema changes (next release will require increase of minor version instead of patch)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [ ] Tests only (no source changes)

## Checklist:
<!-- Tick the checkboxes when done. -->
<!-- Raise documentation ticket in https://github.com/owncloud/documentation -->
- [x] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 
- [ ] Changelog item, see [TEMPLATE](https://github.com/owncloud/core/blob/master/changelog/TEMPLATE)
