### PR TITLE
[tests-only][full-ci]Skip user creation related test below OcV10.12

### DIFF
--- a/tests/acceptance/features/apiProvisioning-v1/getUser.feature
+++ b/tests/acceptance/features/apiProvisioning-v1/getUser.feature
@@ -7,7 +7,7 @@ Feature: get user
   Background:
     Given using OCS API version "1"
 
-  @smokeTest
+  @smokeTest @skipOnOcV10.10 @skipOnOcV10.11
   Scenario: admin gets an existing user
     Given these users have been created with default attributes and without skeleton files:
       | username       | displayname    |
@@ -20,6 +20,19 @@ Feature: get user
     And the free, used, total and relative quota returned by the API should exist and be valid numbers
     And the last login returned by the API should be a current Unix timestamp
     And the creation time returned by the API should be a current Unix timestamp
+
+  @smokeTest @skipOnOcV10.12
+  Scenario: admin gets an existing user
+    Given these users have been created with default attributes and without skeleton files:
+      | username       | displayname    |
+      | brand-new-user | Brand New User |
+    When the administrator retrieves the information of user "brand-new-user" using the provisioning API
+    Then the OCS status code should be "100"
+    And the HTTP status code should be "200"
+    And the display name returned by the API should be "Brand New User"
+    And the quota definition returned by the API should be "default"
+    And the free, used, total and relative quota returned by the API should exist and be valid numbers
+    And the last login returned by the API should be a current Unix timestamp
 
 
   Scenario Outline: admin gets an existing user with special characters in the username

--- a/tests/acceptance/features/apiProvisioning-v2/getUser.feature
+++ b/tests/acceptance/features/apiProvisioning-v2/getUser.feature
@@ -7,7 +7,7 @@ Feature: get user
   Background:
     Given using OCS API version "2"
 
-  @smokeTest
+  @smokeTest @skipOnOcV10.10 @skipOnOcV10.11
   Scenario: admin gets an existing user
     Given these users have been created with default attributes and without skeleton files:
       | username       | displayname    |
@@ -20,6 +20,19 @@ Feature: get user
     And the free, used, total and relative quota returned by the API should exist and be valid numbers
     And the last login returned by the API should be a current Unix timestamp
     And the creation time returned by the API should be a current Unix timestamp
+
+  @smokeTest @skipOnOcV10.12
+  Scenario: admin gets an existing user
+    Given these users have been created with default attributes and without skeleton files:
+      | username       | displayname    |
+      | brand-new-user | Brand New User |
+    When the administrator retrieves the information of user "brand-new-user" using the provisioning API
+    Then the OCS status code should be "200"
+    And the HTTP status code should be "200"
+    And the display name returned by the API should be "Brand New User"
+    And the quota definition returned by the API should be "default"
+    And the free, used, total and relative quota returned by the API should exist and be valid numbers
+    And the last login returned by the API should be a current Unix timestamp
 
 
   Scenario Outline: admin gets an existing user with special characters in the username

--- a/tests/acceptance/features/webUISettingsMenu/settingsMenu.feature
+++ b/tests/acceptance/features/webUISettingsMenu/settingsMenu.feature
@@ -49,7 +49,7 @@ Feature: add users
       | Alice    | seconds ago |
       | Brian    | never       |
 
-
+  @skipOnOcV10.10 @skipOnOcV10.11
   Scenario: administrator should be able to see creation time of a user
     When the administrator enables the setting "Show creation time" in the User Management page using the webUI
     Then the administrator should be able to see the creation time of these users in the User Management page:


### PR DESCRIPTION
## Description
This PR skips user creation time-related tests below OcV10.12

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
- Fixes <[Nightly failure](https://github.com/owncloud/files_primary_s3/issues/650)>
- https://github.com/owncloud/encryption/issues/381

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
- Locally

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Database schema changes (next release will require increase of minor version instead of patch)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [x] Tests only (no source changes)

## Checklist:
<!-- Tick the checkboxes when done. -->
<!-- Raise documentation ticket in https://github.com/owncloud/documentation -->
- [ ] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 
- [ ] Changelog item, see [TEMPLATE](https://github.com/owncloud/core/blob/master/changelog/TEMPLATE)
