### PR TITLE
Fix share into share move scenario

### DIFF
--- a/apps/files_sharing/lib/Updater.php
+++ b/apps/files_sharing/lib/Updater.php
@@ -57,6 +57,7 @@ class Updater {
 
 		$shares = $shareManager->getSharesBy($userFolder->getOwner()->getUID(), \OCP\Share::SHARE_TYPE_USER, $src, false, -1);
 		$shares = \array_merge($shares, $shareManager->getSharesBy($userFolder->getOwner()->getUID(), \OCP\Share::SHARE_TYPE_GROUP, $src, false, -1));
+                $shares = \array_merge($shares, $shareManager->getSharesBy($userFolder->getOwner()->getUID(), \OCP\Share::SHARE_TYPE_LINK, $src, false, -1));
 
 		// If the path we move is not a share we don't care
 		if (empty($shares)) {

--- a/apps/files_sharing/lib/Updater.php
+++ b/apps/files_sharing/lib/Updater.php
@@ -57,7 +57,7 @@ class Updater {
 
 		$shares = $shareManager->getSharesBy($userFolder->getOwner()->getUID(), \OCP\Share::SHARE_TYPE_USER, $src, false, -1);
 		$shares = \array_merge($shares, $shareManager->getSharesBy($userFolder->getOwner()->getUID(), \OCP\Share::SHARE_TYPE_GROUP, $src, false, -1));
-                $shares = \array_merge($shares, $shareManager->getSharesBy($userFolder->getOwner()->getUID(), \OCP\Share::SHARE_TYPE_LINK, $src, false, -1));
+		$shares = \array_merge($shares, $shareManager->getSharesBy($userFolder->getOwner()->getUID(), \OCP\Share::SHARE_TYPE_LINK, $src, false, -1));
 
 		// If the path we move is not a share we don't care
 		if (empty($shares)) {

--- a/changelog/unreleased/40612
+++ b/changelog/unreleased/40612
@@ -1,0 +1,6 @@
+Bugfix: Fix share into share move scenario
+
+Public links were lost upon moving share into another share as the share owner was not correctly set. This has been now partially fixed.
+
+https://github.com/owncloud/core/pull/40612
+https://github.com/owncloud/enterprise/issues/5565


### PR DESCRIPTION
## Description

### Scenario:

Given three users Alice, Bob and Charlie.

Alice shares a folder X with Bob.
Bob shares a file Y with Charlie.
Bob shares a file Z via a public link.

Bob moves Y and Z into the shared folder X.

What is expected:

Alice becomes owner of the files Y and Z.
The share for Charlie on Y and the public link on Z become visible to both Alice and Bob.

What happens:

Alice becomes owner of the files Y and Z.
The share for Charlie on Y becomes visible to Alice and Bob.
The public link on Z is only visible to Bob, not visible to Alice. Owner is not updated to Alice.

## Related Issue
- https://github.com/owncloud/enterprise/issues/5565

## Motivation and Context
Public links are lost upon moving share into another share as the share owner is not correctly set.

## How Has This Been Tested?

Manually by reproducing the scenario above.

## Types of changes
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Database schema changes (next release will require increase of minor version instead of patch)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [ ] Tests only (no source changes)

## Checklist:
- [X] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised
- [ ] Changelog item

@IljaN FYI.