### PR TITLE
[docs-only] Fix auto-provision in config.apps.sample

### DIFF
--- a/config/config.apps.sample.php
+++ b/config/config.apps.sample.php
@@ -273,7 +273,7 @@ $CONFIG = [
  * login using openid connect. The config parameters `mode` and `search-attribute` will be used
  * to create a unique user so that the lookup mechanism can find the user again. This is where
  * an LDAP setup is usually required. The profile picture will only be transferred upon account
- * creation, but will not get updated afterwards like when it get changed.
+ * creation, but will not be updated afterwards if it changes in the connected IdP.
  * If `auto-provision` is not setup or required, it is expected that the user exists and you
  * MUST declare this with `['enabled' => false]` like shown in the Easy Setup example.
  * `auto-provision` holds several sub keys, see the example setup with the explanations below.

--- a/config/config.apps.sample.php
+++ b/config/config.apps.sample.php
@@ -273,7 +273,7 @@ $CONFIG = [
  * login using openid connect. The config parameters `mode` and `search-attribute` will be used
  * to create a unique user so that the lookup mechanism can find the user again. This is where
  * an LDAP setup is usually required. The profile picture will only be transferred upon account
- * creation, but will not get updatd afterwards like when it get changed.
+ * creation, but will not get updated afterwards like when it get changed.
  * If `auto-provision` is not setup or required, it is expected that the user exists and you
  * MUST declare this with `['enabled' => false]` like shown in the Easy Setup example.
  * `auto-provision` holds several sub keys, see the example setup with the explanations below.

--- a/config/config.apps.sample.php
+++ b/config/config.apps.sample.php
@@ -269,11 +269,12 @@ $CONFIG = [
  * login without requiring the user to click a button. The default is `false`.
  *
  * auto-provision::
- * If auto-provision is setup, an ownCloud user will be created if not exists, after successful
+ * If `auto-provision` is setup, an ownCloud user will be created if not exists, after successful
  * login using openid connect. The config parameters `mode` and `search-attribute` will be used
  * to create a unique user so that the lookup mechanism can find the user again. This is where
- * an LDAP setup is usually required.
- * If auto-provision is not setup or required, it is expected that the user exists and you
+ * an LDAP setup is usually required. The profile picture will only be transferred upon account
+ * creation, but will not get updatd afterwards like when it get changed.
+ * If `auto-provision` is not setup or required, it is expected that the user exists and you
  * MUST declare this with `['enabled' => false]` like shown in the Easy Setup example.
  * `auto-provision` holds several sub keys, see the example setup with the explanations below.
  *
@@ -387,12 +388,8 @@ $CONFIG = [
 		  // auto-update user account info with current information provided by the
 		  // OpenID Connect provider account attributes, that will be updated,
 		  // can be specified in `attributes` config option
-		'auto-provision' => [
-			'update' => [
-				  // enable the user info auto-update mode
-				'enabled' => true,
-			],
-		],
+		'update' => ['enabled' => true],
+		  // enable the user info auto-update mode
 	],
 	  // `mode` and `search-attribute` will be used to create a unique user in ownCloud
 	'mode' => 'email',


### PR DESCRIPTION
## Description
Correct the `auto-provision` description and key in `config.apps.sample`

## Related Issue
- Fixes https://github.com/owncloud/openidconnect/issues/278

## Motivation and Context
Fix and clarification

## How Has This Been Tested?
local tested including php style fix

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Database schema changes (next release will require increase of minor version instead of patch)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [ ] Tests only (no source changes)

## Checklist:
<!-- Tick the checkboxes when done. -->
<!-- Raise documentation ticket in https://github.com/owncloud/documentation -->
- [ ] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [x] Documentation ticket raised: `config-to-docs` run post merging this PR
- [ ] Changelog item, see [TEMPLATE](https://github.com/owncloud/core/blob/master/changelog/TEMPLATE)
