### PR TITLE
Fix two-factor enable over API

### DIFF
--- a/apps/provisioning_api/lib/Users.php
+++ b/apps/provisioning_api/lib/Users.php
@@ -320,7 +320,7 @@ class Users {
 				}
 				break;
 			case 'two_factor_auth_enabled':
-				if ($parameters['_put']['value'] === true) {
+				if ($parameters['_put']['value'] === 'true') {
 					$this->twoFactorAuthManager->enableTwoFactorAuthentication($targetUser);
 				} else {
 					$this->twoFactorAuthManager->disableTwoFactorAuthentication($targetUser);

--- a/apps/provisioning_api/tests/UsersTest.php
+++ b/apps/provisioning_api/tests/UsersTest.php
@@ -1154,7 +1154,7 @@ class UsersTest extends OriginalTest {
 		$this->setupIsUserAccessibleMock($loggedInUser, $targetUser, false);
 
 		$expected = new Result(null, 100);
-		$this->assertEquals($expected, $this->api->editUser(['userid' => 'UserToEdit', '_put' => ['key' => 'two_factor_auth_enabled', 'value' => true]]));
+		$this->assertEquals($expected, $this->api->editUser(['userid' => 'UserToEdit', '_put' => ['key' => 'two_factor_auth_enabled', 'value' => 'true']]));
 	}
 
 	public function testEditUserAdminUserSelfEditChangeValidQuota(): void {

--- a/changelog/unreleased/40617
+++ b/changelog/unreleased/40617
@@ -1,0 +1,5 @@
+Bugfix: Enable 2FA via provisioning API
+
+Two factor authentication can now be enabled using the provisioning api.
+
+https://github.com/owncloud/core/issues/40617


### PR DESCRIPTION
## Description

Fix reactivation of two-factor auth when using provisioning API.

## Motivation and Context
Using the provisioning API for reenabling two-factor auth for an user is currently broken.

1. Running:

```
curl -X PUT http://admin:admin@example.com/ocs/v1.php/cloud/users/user1 -d key="two_factor_auth_enabled" -d value="false"
```

correctly disable two-factor auth for that user. The configkey `two_factor_auth_disabled` is correctly set to the configvalue `1` in `oc_preferences` and user can normally login with username/password.

2. However, running:

 ```
curl -X PUT http://admin:admin@example.com/ocs/v1.php/cloud/users/user1 -d key="two_factor_auth_enabled" -d value="true"
```

does not correctly reenable two-factor auth for the user. The configkey `two_factor_auth_disabled` is not removed from the `oc_preferences` table and two-factor is still not enforced.

## How Has This Been Tested?

Manually: by following the steps above.

## Types of changes
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Database schema changes (next release will require increase of minor version instead of patch)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [ ] Tests only (no source changes)

## Checklist:
- [X] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised
- [ ] Changelog item
