### PR TITLE
fix: add index on oc_filecache over size, parent and storage to speed…

### DIFF
--- a/changelog/unreleased/40633
+++ b/changelog/unreleased/40633
@@ -1,0 +1,5 @@
+Bugfix: Add index on oc_filecache
+
+This index can help to speed-up bulk file operations.
+
+https://github.com/owncloud/core/issues/40633

--- a/core/Migrations/Version20230210073645.php
+++ b/core/Migrations/Version20230210073645.php
@@ -1,0 +1,17 @@
+<?php
+namespace OC\Migrations;
+
+use Doctrine\DBAL\Schema\Schema;
+use Doctrine\DBAL\Schema\SchemaException;
+use OCP\Migration\ISchemaMigration;
+
+class Version20230210073645 implements ISchemaMigration {
+	/**
+	 * @throws SchemaException
+	 */
+	public function changeSchema(Schema $schema, array $options): void {
+		$prefix = $options['tablePrefix'];
+		$table = $schema->getTable("{$prefix}filecache");
+		$table->addIndex(['parent', 'storage', 'size']);
+	}
+}

--- a/core/Migrations/Version20230210073645.php
+++ b/core/Migrations/Version20230210073645.php
@@ -12,6 +12,6 @@ class Version20230210073645 implements ISchemaMigration {
 	public function changeSchema(Schema $schema, array $options): void {
 		$prefix = $options['tablePrefix'];
 		$table = $schema->getTable("{$prefix}filecache");
-		$table->addIndex(['parent', 'storage', 'size']);
+		$table->addIndex(['parent', 'storage', 'size'], 'fs_parent_storage_size');
 	}
 }

--- a/version.php
+++ b/version.php
@@ -25,7 +25,7 @@
 // We only can count up. The 4. digit is only for the internal patchlevel to trigger DB upgrades
 // between betas, final and RCs. This is _not_ the public version number. Reset minor/patchlevel
 // when updating major/minor version number.
-$OC_Version = [10, 12, 0, 1];
+$OC_Version = [10, 12, 0, 2];
 
 // The human-readable string
 $OC_VersionString = '10.12.0 prealpha';


### PR DESCRIPTION
… up Cache::calculateFolderSize
## Description
Folder sizes are computed quite often - especially on massive file upload.

### Before
```
-> Aggregate: sum(oc_filecache.size), min(oc_filecache.size)  (cost=1.26 rows=1) (actual time=0.118..0.119 rows=1 loops=1)
    -> Filter: (oc_filecache.`storage` = 1)  (cost=1.25 rows=0.05) (actual time=0.109..0.112 rows=5 loops=1)
        -> Index lookup on oc_filecache using fs_parent_name_hash (parent=1), with index condition: (oc_filecache.parent = 1)  (cost=1.25 rows=5) (actual time=0.108..0.110 rows=5 loops=1)
```

### After
```
-> Aggregate: sum(oc_filecache.size)  (cost=1.63 rows=1) (actual time=0.013..0.013 rows=1 loops=1)
    -> Filter: (oc_filecache.parent = 1)  (cost=1.13 rows=5) (actual time=0.008..0.011 rows=5 loops=1)
        -> Covering index lookup on oc_filecache using fs_parent_storage_size (parent=1, storage=1)  (cost=1.13 rows=5) (actual time=0.006..0.008 rows=5 loops=1)

```

## Related Issue
- Fixes https://github.com/owncloud/enterprise/issues/5595

## How Has This Been Tested?
- :robot: 

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Database schema changes (next release will require increase of minor version instead of patch)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [ ] Tests only (no source changes)

## Checklist:
<!-- Tick the checkboxes when done. -->
<!-- Raise documentation ticket in https://github.com/owncloud/documentation -->
- [ ] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 
- [ ] Changelog item, see [TEMPLATE](https://github.com/owncloud/core/blob/master/changelog/TEMPLATE)
