### PR TITLE
feat: occ user:sync - support abbreviations for backend classes for e…

### DIFF
--- a/changelog/unreleased/40640
+++ b/changelog/unreleased/40640
@@ -1,0 +1,7 @@
+Enhancement: Improve UX on occ user:sync
+
+Backend class aliases have been added to improve usability of this command.
+
+https://github.com/owncloud/core/pull/40640
+
+


### PR DESCRIPTION
…asier usage

## Description
It is quite inconvenient to type in the full php class name as argument to this command.
To provide a better UX abbreviations are now possible and act as alias for the php classes

```
 ➭ php7.4 ./occ help user:sync 
Description:
  Synchronize users from a given backend to the accounts table.

Usage:
  user:sync [options] [--] [<backend-class>]

Arguments:
  backend-class                                        The quoted PHP class name for the backend, eg
                                                       - LDAP:          "OCA\User_LDAP\User_Proxy"
                                                       - Samba:         "OCA\User\SMB"
                                                       - Shibboleth:    "OCA\User_Shibboleth\UserBackend"
                                                       For easier usage of these three cases you can also use 'ldap', 'samba' or 'shibboleth
```
 
## Motivation and Context
Better UX

## How Has This Been Tested?
- :hand: 


## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Database schema changes (next release will require increase of minor version instead of patch)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [ ] Tests only (no source changes)

## Checklist:
<!-- Tick the checkboxes when done. -->
<!-- Raise documentation ticket in https://github.com/owncloud/documentation -->
- [ ] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 
- [x] Changelog item, see [TEMPLATE](https://github.com/owncloud/core/blob/master/changelog/TEMPLATE)
