### PR TITLE
do not unlink destination when copying versions when encryption is enabled

### DIFF
--- a/changelog/unreleased/40531
+++ b/changelog/unreleased/40531
@@ -8,4 +8,5 @@ Current version of the file now can be published, which increases major version 
 - Migrate from deprecated save_version_author to save_version_metadata
 
 https://github.com/owncloud/core/pull/40531
+https://github.com/owncloud/core/pull/40641
 https://github.com/owncloud/enterprise/issues/5286

--- a/lib/private/Files/Storage/Wrapper/Encryption.php
+++ b/lib/private/Files/Storage/Wrapper/Encryption.php
@@ -384,7 +384,14 @@ class Encryption extends Wrapper {
 
 		// need to stream copy file by file in case we copy between a encrypted
 		// and a unencrypted storage
-		$this->unlink($path2);
+
+		if (!($this->isVersion($path2) || $this->isVersion($path1))) {
+			// NOTE: this is legacy code-path, and it is not clear why this is needed for standard files,
+			// however for versions we should not unlink, because versions should always use the
+			// key from the original file. Just create a 1:1 copy and done
+			// ref. https://github.com/owncloud/encryption/issues/383
+			$this->unlink($path2);
+		}
 		$result = $this->copyFromStorage($this, $path1, $path2);
 
 		return $result;


### PR DESCRIPTION
## Description

Due to a change in how file versions are restored as of https://github.com/owncloud/core/pull/40531 , now version file is being copied instead of moved. 

However, there is a problem that encryption wrapper did not have proper handling for versions like it does in different parts of a code e.g. `rename`. It resulted in unlink operation being executed that removed file keys from original file, but then when version was copied other parts of the code having version handling correct just copied the contents. This effectively corrupted the file.

REMARK: it is not fully clear why for normal files it was required to unlink file before copying it. It seems for versions that codepath was never used (at least to my research).

## Related Issue
- Fixes https://github.com/owncloud/encryption/issues/383
- https://github.com/owncloud/enterprise/issues/5286
- https://github.com/owncloud/core/pull/40531

## How Has This Been Tested?
- manually in the developer instance
  - [x] test with normal fs for file and folder
  - [x] test with normal fs for shared file file and folder
  - [x] test with trashbin for file and folder
  - [x] test with objectstore (it should be properly disabled)
  - [x] test with encryption (metafiles are plaintext, files/versions encrypted)
- unit/acceptance tests

Enable the feature and test generating new versions e.g. in shared folder on a document with TextEditor/OnlyOffice/Collabora

```
occ app:enable encryption
occ encryption:enable
occ encryption:select-encryption-type masterkey -y

occ a:e files_texteditor
occ a:e richdocuments

occ config:system:set file_storage.save_version_metadata --value true --type boolean

export OC_PASS=test
occ user:add --email alice@test.com --password-from-env alice
occ user:add --email brian@test.com --password-from-env brian
occ user:add --email carol@test.com --password-from-env carol

occ group:add grp1
occ group:add-member grp1 --member alice
occ group:add-member grp1 --member brian
occ group:add-member grp1 --member carol

occ config:system:set versions_retention_obligation --value 'auto,0'

occ background:queue:execute --force --accept-warning 15
```

## Types of changes
- [x] Bugfix

## Checklist:
- [x] Base code changes
- [x] Unit tests added
- [x] Acceptance tests added
- [x] Changelog item, see [TEMPLATE](https://github.com/owncloud/core/blob/master/changelog/TEMPLATE)
- [x] Docs update


