### PR TITLE
Flatten folder structure from drag & drop for public file upload

### DIFF
--- a/apps/files_sharing/js/PublicUploadView.js
+++ b/apps/files_sharing/js/PublicUploadView.js
@@ -73,6 +73,15 @@
 		},
 
 		_onUploadBeforeAdd: function(upload) {
+			// Flatten out any subdirectories.
+			// When the user wants to upload folder via drag and drop, the foldername
+			// (and possible further subdirectores) are in relativePath.
+			// This will cause uploader.ensureFolderExists() to fail, as it picks up the
+			// extra path components via getFullPath().
+			// Subdirectories are not needed here. We want all files in the upload folder, flat.
+			// To allow folder upload via drag and drop, we only need to clear out relativePath.
+			// This works nicely together with the autorename feature.
+			upload.getFile().relativePath = '';
 			// add autorename header to deduplicate names on the server in case of conflict
 			upload.setConflictMode(OC.FileUpload.CONFLICT_MODE_AUTORENAME_SERVER);
 		},

--- a/apps/files_sharing/js/PublicUploadView.js
+++ b/apps/files_sharing/js/PublicUploadView.js
@@ -73,6 +73,16 @@
 		},
 
 		_onUploadBeforeAdd: function(upload) {
+                       var file = upload.getFile();
+                        if (file.isDirectory) {
+                               // We don't create folders in PublicUploadView.
+                                // One case has been observed, where we enter here:
+                                // An empty folder is dropped into the input field.
+                                // We can skip this "file" by setting a target folder outside the share.
+                                // This triggers a sanity check in the uploader and no MKCOL occurs.
+                                upload.setTargetFolder("..");
+                        }
+
 			// Flatten out any subdirectories.
 			// When the user wants to upload folder via drag and drop, the foldername
 			// (and possible further subdirectores) are in relativePath.
@@ -82,6 +92,7 @@
 			// To allow folder upload via drag and drop, we only need to clear out relativePath.
 			// This works nicely together with the autorename feature.
 			upload.getFile().relativePath = '';
+
 			// add autorename header to deduplicate names on the server in case of conflict
 			upload.setConflictMode(OC.FileUpload.CONFLICT_MODE_AUTORENAME_SERVER);
 		},

--- a/apps/files_sharing/tests/js/PublicUploadViewSpec.js
+++ b/apps/files_sharing/tests/js/PublicUploadViewSpec.js
@@ -72,7 +72,8 @@ describe('OCA.Sharing.PublicUploadView tests', function() {
 	describe('uploading', function() {
 		it('sets conflict mode to autorename on server side', function() {
 			var dummyUpload = {
-				setConflictMode: sinon.stub()
+				setConflictMode: sinon.stub(),
+				getFile: sinon.stub().returns( { relativePath: '/sub/' } )
 			};
 			dummyUploader.trigger('beforeadd', dummyUpload);
 

--- a/apps/files_sharing/tests/js/PublicUploadViewSpec.js
+++ b/apps/files_sharing/tests/js/PublicUploadViewSpec.js
@@ -73,6 +73,7 @@ describe('OCA.Sharing.PublicUploadView tests', function() {
 		it('sets conflict mode to autorename on server side', function() {
 			var dummyUpload = {
 				setConflictMode: sinon.stub(),
+				setTargetFolder: sinon.stub(),
 				getFile: sinon.stub().returns( { relativePath: '/sub/' } )
 			};
 			dummyUploader.trigger('beforeadd', dummyUpload);

--- a/changelog/unreleased/40643
+++ b/changelog/unreleased/40643
@@ -1,0 +1,9 @@
+Enhancement: Drag & Drop folders into public file upload
+
+Previously only files were accepted via drag & drop.
+Users can now also drag folders into a public link that has the filedrop flag.
+When adding a folder, the hierarchy is flattened out and
+all files are added without any subfolders. Name collisons are avoided as usual.
+
+https://github.com/owncloud/core/pull/40643
+https://github.com/owncloud/enterprise/issues/5489


### PR DESCRIPTION
This allows drag & drop to work with folders too. The code change is minimal, as all the code top pick up files from subdirectories is already there. It only missed the step to actually remove subdirecory levels from the path before uploading.

<!--
Thanks for submitting a change to ownCloud!

This is the bug tracker for the Server component. Find other components at https://github.com/owncloud/core/blob/master/.github/CONTRIBUTING.md#guidelines

For fixing potential security issues please see https://owncloud.com/security/

To make it possible for us to get your change reviewed and merged please carefully fill out the requested information below.

Please note that any kind of change needs first be submitted to the master branch which holds the next version of ownCloud.

Please set the following labels:

- Set label "3 - To review" for review or "2 - Development" if the PR still has open tasks
- Assignment: assign to self
- Milestone: set the same as the ticket this PR fixes, or "development" by default
- Reviewers: pick at least one
-->

## Description
Add missing piece for folder drag & drop with public file drop.
Drag & drop uses javascript code to generate a list of files.
With one file or multiple files selected, this is a list of filenames and disregards the folders where they came from.
With one ore multiple folders selected, the list of filenames includes relative pathnames, the selected folder and potentially subdorectories within that folder.

In case of normal file view the uploader implements creating of the subdirectory levels so that the structure of the selected tree is faithfully reproduced on the server.
In case of a public file drop, subdirectories cannot be created. And as agreed in https://github.com/owncloud/enterprise/issues/5489#issuecomment-1430908616 it is also not wanted.

File Drop as implemented in PublicFileView.js already uses the same mechanics as normal drag drop fir files view, so 99% of the code for folder drop is already present. The missing piece is the subfolder problem. 
It is actually sufficient, to remove the subfolders (as stored in file.relativePath) and the upload succeeds.

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
- Fixes https://github.com/owncloud/enterprise/issues/5489


## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
Folder upload never worked on Public file Drop. 

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Manual testing with files, folders, multiple files, multiple folders selected in drag and drop; 
both with public file drop view and normal file view.

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Database schema changes (next release will require increase of minor version instead of patch)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [ ] Tests only (no source changes)

## Checklist:
<!-- Tick the checkboxes when done. -->
<!-- Raise documentation ticket in https://github.com/owncloud/documentation -->
- [ ] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 
- [ ] Changelog item, see [TEMPLATE](https://github.com/owncloud/core/blob/master/changelog/TEMPLATE)
