### PR TITLE
[tests-only] allow plain acceptance test output

### DIFF
--- a/tests/acceptance/lint-expected-failures.sh
+++ b/tests/acceptance/lint-expected-failures.sh
@@ -1,15 +1,30 @@
 #!/usr/bin/env bash
 
 log_error() {
-	echo -e "\e[31m$1\e[0m"
+	if [ -n "${PLAIN_OUTPUT}" ]
+	then
+		echo -e "$1"
+	else
+		echo -e "\e[31m$1\e[0m"
+	fi
 }
 
 log_info() {
-	echo -e "\e[34m$1\e[0m"
+	if [ -n "${PLAIN_OUTPUT}" ]
+	then
+		echo -e "$1"
+	else
+		echo -e "\e[34m$1\e[0m"
+	fi
 }
 
 log_success() {
-	echo -e "\e[32m$1\e[0m"
+	if [ -n "${PLAIN_OUTPUT}" ]
+	then
+		echo -e "$1"
+	else
+		echo -e "\e[32m$1\e[0m"
+	fi
 }
 
 declare -A scenarioLines


### PR DESCRIPTION
## Description
Make the same changes as done in ocis https://github.com/owncloud/ocis/pull/5598 so that it works the same way.

When using GitHub workflows (for example, in cs3org/reva) the acceptance test output is not being formatted nicely. There are lots of escape sequences that would normally select different colors for text. But the escape sequences are being shown, rather than rendering the colors.

This PR allows the acceptance tests to be run with plain output by defining the environment variable PLAIN_OUTPUT when running the tests. Just defining it is enough, the value does not matter.

## How Has This Been Tested?
CI

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Database schema changes (next release will require increase of minor version instead of patch)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [x] Tests only (no source changes)

## Checklist:
- [ ] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 
- [ ] Changelog item, see [TEMPLATE](https://github.com/owncloud/core/blob/master/changelog/TEMPLATE)
