### PR TITLE
[tests-only][full-ci]Skip `versions` related `webUI` test on old `oc10` versions

### DIFF
--- a/tests/acceptance/features/webUIFiles/versions.feature
+++ b/tests/acceptance/features/webUIFiles/versions.feature
@@ -11,7 +11,7 @@ Feature: Versions of a file
       | username |
       | Alice    |
 
-  @skipOnStorage:ceph @files_primary_s3-issue-67
+  @skipOnStorage:ceph @files_primary_s3-issue-67 @skipOnOcV10.10 @skipOnOcV10.11
   Scenario: upload new file with same name to see if current version and noncurrent versions are shown
     Given user "Alice" has uploaded file with content "some content" to "/randomfile.txt"
     And user "Alice" has logged in using the webUI
@@ -22,7 +22,7 @@ Feature: Versions of a file
     Then the content of file "randomfile.txt" for user "Alice" should be "new lorem content"
     And the versions list should contain 3 entries
 
-
+  @skipOnOcV10.10 @skipOnOcV10.11
   Scenario: restoring file to old version changes the content of the file
     Given user "Alice" has uploaded file with content "lorem content" to "/randomfile.txt"
     And user "Alice" has logged in using the webUI
@@ -32,7 +32,7 @@ Feature: Versions of a file
     And the user restores the file to last version using the webUI
     Then the content of file "randomfile.txt" for user "Alice" should be "lorem content"
 
-  @files_sharing-app-required
+  @files_sharing-app-required @skipOnOcV10.10 @skipOnOcV10.11
   Scenario: sharee can see the current version and noncurrent versions of a file
     Given user "Brian" has been created with default attributes and without skeleton files
     And user "Alice" has uploaded file with content "lorem content" to "/randomfile.txt"
@@ -45,7 +45,7 @@ Feature: Versions of a file
     Then the content of file "randomfile.txt" for user "Brian" should be "new lorem content"
     And the versions list should contain 3 entries
 
-  @skipOnStorage:ceph @files_primary_s3-issue-155
+  @skipOnStorage:ceph @files_primary_s3-issue-155 @skipOnOcV10.10 @skipOnOcV10.11
   Scenario: file versions should show only current version on the webUI after deleting versions
     Given user "Alice" has uploaded file with content "lorem content" to "/randomfile.txt"
     And user "Alice" has uploaded file with content "lorem" to "/randomfile.txt"
@@ -56,7 +56,7 @@ Feature: Versions of a file
     When the user browses directly to display the "versions" details of file "randomfile.txt" in folder "/"
     And the versions list should contain 1 entries
 
-  @skipOnStorage:ceph @files_primary_s3-issue-155
+  @skipOnStorage:ceph @files_primary_s3-issue-155 @skipOnOcV10.10 @skipOnOcV10.11
   Scenario: file versions cannot be seen on the webUI only for user whose versions is deleted
     Given user "Brian" has been created with default attributes and without skeleton files
     And user "Alice" has uploaded file with content "lorem content" to "/randomfile.txt"
@@ -74,7 +74,7 @@ Feature: Versions of a file
     And the user browses directly to display the "versions" details of file "randomfile.txt" in folder "/"
     Then the versions list should contain 2 entries
 
-  @skipOnStorage:ceph @files_primary_s3-issue-155
+  @skipOnStorage:ceph @files_primary_s3-issue-155 @skipOnOcV10.10 @skipOnOcV10.11
   Scenario: file versions show only current version on the webUI for all users after deleting versions for all users
     Given user "Brian" has been created with default attributes and without skeleton files
     And user "Alice" has uploaded file with content "lorem content" to "/randomfile.txt"
@@ -92,7 +92,7 @@ Feature: Versions of a file
     And the user browses directly to display the "versions" details of file "randomfile.txt" in folder "/"
     Then the versions list should contain 1 entries
 
-  @skipOnStorage:ceph @files_primary_s3-issue-67
+  @skipOnStorage:ceph @files_primary_s3-issue-67 @skipOnOcV10.10 @skipOnOcV10.11
   Scenario: versions author is displayed
     Given the administrator has enabled the file version storage feature
     And user "Alice" has uploaded file with content "some content" to "/randomfile.txt"
@@ -106,7 +106,7 @@ Feature: Versions of a file
       | 1     | Alice  |
       | 2     | Alice  |
 
-  @skipOnStorage:ceph @files_primary_s3-issue-67
+  @skipOnStorage:ceph @files_primary_s3-issue-67 @skipOnOcV10.10 @skipOnOcV10.11
   Scenario: sharee can see the versions' respective author
     Given the administrator has enabled the file version storage feature
     And user "Brian" has been created with default attributes and without skeleton files
@@ -127,7 +127,7 @@ Feature: Versions of a file
       | 3     | Alice  |
       | 4     | Alice  |
 
-  @skipOnStorage:ceph @files_primary_s3-issue-67
+  @skipOnStorage:ceph @files_primary_s3-issue-67 @skipOnOcV10.10 @skipOnOcV10.11
   Scenario: sharee can see the versions' respective author after version restore
     Given the administrator has enabled the file version storage feature
     And user "Brian" has been created with default attributes and without skeleton files


### PR DESCRIPTION
### Description
This PR skips versions related `webUI` tests on older versions of `oc10`

### Fixes the nightly failure in 
https://drone.owncloud.com/owncloud/encryption
https://drone.owncloud.com/owncloud/files_primary_s3/3446

### Related issue
This related issue is skipped on API files versions with this issue: https://github.com/owncloud/QA/issues/798