### PR TITLE
[tests-only][full-ci] Get ocs code from the provided response

### DIFF
--- a/tests/acceptance/features/bootstrap/FeatureContext.php
+++ b/tests/acceptance/features/bootstrap/FeatureContext.php
@@ -1649,12 +1649,15 @@ class FeatureContext extends BehatVariablesContext {
 	/**
 	 * returns json decoded body content of a json response as an object
 	 *
+	 * @param ResponseInterface|null $response
+	 *
 	 * @return object
 	 */
-	public function getJsonDecodedResponseBodyContent():?object {
-		if ($this->response !== null) {
-			$this->response->getBody()->rewind();
-			return json_decode($this->response->getBody()->getContents());
+	public function getJsonDecodedResponseBodyContent(ResponseInterface $response = null):?object {
+		$response = $response ?? $this->response;
+		if ($response !== null) {
+			$response->getBody()->rewind();
+			return json_decode($response->getBody()->getContents());
 		}
 		return null;
 	}

--- a/tests/acceptance/features/bootstrap/OCSContext.php
+++ b/tests/acceptance/features/bootstrap/OCSContext.php
@@ -932,7 +932,7 @@ class OCSContext implements Context {
 	 * @throws Exception
 	 */
 	public function getOCSResponseStatusCode(ResponseInterface $response):string {
-		$jsonResponse = $this->featureContext->getJsonDecodedResponseBodyContent();
+		$jsonResponse = $this->featureContext->getJsonDecodedResponseBodyContent($response);
 		if (\is_object($jsonResponse) && $jsonResponse->ocs->meta->statuscode) {
 			return (string) $jsonResponse->ocs->meta->statuscode;
 		}


### PR DESCRIPTION
## Description
JSON parsing in `getOCSResponseStatusCode` was not parsing the provided response object but instead was parsing the saved response object which lead to the failure like this https://github.com/owncloud/notifications/issues/373

## Related Issue
- Fixes https://github.com/owncloud/notifications/issues/373

## Motivation and Context

## How Has This Been Tested?
- test environment: local

## Screenshots (if appropriate):

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Database schema changes (next release will require increase of minor version instead of patch)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [x] Tests only (no source changes)

## Checklist:
- [ ] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 
- [ ] Changelog item, see [TEMPLATE](https://github.com/owncloud/core/blob/master/changelog/TEMPLATE)
