### PR TITLE
Adjust parameters for guzzle7

### DIFF
--- a/apps/federatedfilesharing/lib/Notifications.php
+++ b/apps/federatedfilesharing/lib/Notifications.php
@@ -355,7 +355,7 @@ class Notifications {
 					'timeout' => 10,
 					'connect_timeout' => 10,
 				];
-				$sendAs = $useOcm === true ? 'json' : 'body';
+				$sendAs = $useOcm === true ? 'json' : 'form_params';
 				$options[$sendAs] = $fields;
 				$response = $client->post($endpoint, $options);
 				$result['result'] = $response->getBody();

--- a/apps/federation/lib/BackgroundJob/RequestSharedSecret.php
+++ b/apps/federation/lib/BackgroundJob/RequestSharedSecret.php
@@ -140,7 +140,7 @@ class RequestSharedSecret extends Job {
 			$result = $this->httpClient->post(
 				$target . $this->endPoint,
 				[
-					'body' => [
+					'form_params' => [
 						'url' => $source,
 						'token' => $token,
 					],

--- a/apps/federation/tests/BackgroundJob/RequestSharedSecretTest.php
+++ b/apps/federation/tests/BackgroundJob/RequestSharedSecretTest.php
@@ -139,7 +139,7 @@ class RequestSharedSecretTest extends TestCase {
 			->with(
 				$target . '/ocs/v2.php/apps/federation/api/v1/request-shared-secret?format=json',
 				[
-					'body' =>
+					'form_params' =>
 						[
 							'url' => $source,
 							'token' => $token

--- a/lib/private/HTTPHelper.php
+++ b/lib/private/HTTPHelper.php
@@ -107,7 +107,7 @@ class HTTPHelper {
 			$response = $client->post(
 				$url,
 				[
-					'body' => $fields,
+					'form_params' => $fields,
 					'connect_timeout' => 10,
 				]
 			);

--- a/lib/private/Http/Client/Client.php
+++ b/lib/private/Http/Client/Client.php
@@ -219,10 +219,10 @@ class Client implements IClient {
 	 *
 	 * @param string $uri
 	 * @param array $options Array such as
-	 *              'body' => [
-	 *                  'field' => 'abc',
-	 *                  'other_field' => '123',
-	 *                  'file_name' => fopen('/path/to/file', 'r'),
+	 *              'multipart' => [
+	 *                  ['name' => 'field', 'contents' => 'abc'],
+	 *                  ['name' => 'other_field', 'contents' => '123'],
+	 *                  ['name' => 'file_name', 'contents' => fopen('/path/to/file', 'r'), 'filename' => 'custom_name.txt'],
 	 *              ],
 	 *              'headers' => [
 	 *                  'foo' => 'bar',
@@ -253,10 +253,10 @@ class Client implements IClient {
 	 *
 	 * @param string $uri
 	 * @param array $options Array such as
-	 *              'body' => [
-	 *                  'field' => 'abc',
-	 *                  'other_field' => '123',
-	 *                  'file_name' => fopen('/path/to/file', 'r'),
+	 *              'multipart' => [
+	 *                  ['name' => 'field', 'contents' => 'abc'],
+	 *                  ['name' => 'other_field', 'contents' => '123'],
+	 *                  ['name' => 'file_name', 'contents' => fopen('/path/to/file', 'r'), 'filename' => 'custom_name.txt'],
 	 *              ],
 	 *              'headers' => [
 	 *                  'foo' => 'bar',
@@ -287,10 +287,10 @@ class Client implements IClient {
 	 *
 	 * @param string $uri
 	 * @param array $options Array such as
-	 *              'body' => [
-	 *                  'field' => 'abc',
-	 *                  'other_field' => '123',
-	 *                  'file_name' => fopen('/path/to/file', 'r'),
+	 *              'multipart' => [
+	 *                  ['name' => 'field', 'contents' => 'abc'],
+	 *                  ['name' => 'other_field', 'contents' => '123'],
+	 *                  ['name' => 'file_name', 'contents' => fopen('/path/to/file', 'r'), 'filename' => 'custom_name.txt'],
 	 *              ],
 	 *              'headers' => [
 	 *                  'foo' => 'bar',
@@ -321,10 +321,10 @@ class Client implements IClient {
 	 *
 	 * @param string $uri
 	 * @param array $options Array such as
-	 *              'body' => [
-	 *                  'field' => 'abc',
-	 *                  'other_field' => '123',
-	 *                  'file_name' => fopen('/path/to/file', 'r'),
+	 *              'multipart' => [
+	 *                  ['name' => 'field', 'contents' => 'abc'],
+	 *                  ['name' => 'other_field', 'contents' => '123'],
+	 *                  ['name' => 'file_name', 'contents' => fopen('/path/to/file', 'r'), 'filename' => 'custom_name.txt'],
 	 *              ],
 	 *              'headers' => [
 	 *                  'foo' => 'bar',

--- a/lib/public/Http/Client/IClient.php
+++ b/lib/public/Http/Client/IClient.php
@@ -88,10 +88,10 @@ interface IClient {
 	 * Sends a POST request
 	 * @param string $uri
 	 * @param array $options Array such as
-	 *              'body' => [
-	 *                  'field' => 'abc',
-	 *                  'other_field' => '123',
-	 *                  'file_name' => fopen('/path/to/file', 'r'),
+	 *              'multipart' => [
+	 *                  ['name' => 'field', 'contents' => 'abc'],
+	 *                  ['name' => 'other_field', 'contents' => '123'],
+	 *                  ['name' => 'file_name', 'contents' => fopen('/path/to/file', 'r'), 'filename' => 'custom_name.txt'],
 	 *              ],
 	 *              'headers' => [
 	 *                  'foo' => 'bar',
@@ -118,10 +118,10 @@ interface IClient {
 	 * Sends a PUT request
 	 * @param string $uri
 	 * @param array $options Array such as
-	 *              'body' => [
-	 *                  'field' => 'abc',
-	 *                  'other_field' => '123',
-	 *                  'file_name' => fopen('/path/to/file', 'r'),
+	 *              'multipart' => [
+	 *                  ['name' => 'field', 'contents' => 'abc'],
+	 *                  ['name' => 'other_field', 'contents' => '123'],
+	 *                  ['name' => 'file_name', 'contents' => fopen('/path/to/file', 'r'), 'filename' => 'custom_name.txt'],
 	 *              ],
 	 *              'headers' => [
 	 *                  'foo' => 'bar',
@@ -148,10 +148,10 @@ interface IClient {
 	 * Sends a DELETE request
 	 * @param string $uri
 	 * @param array $options Array such as
-	 *              'body' => [
-	 *                  'field' => 'abc',
-	 *                  'other_field' => '123',
-	 *                  'file_name' => fopen('/path/to/file', 'r'),
+	 *              'multipart' => [
+	 *                  ['name' => 'field', 'contents' => 'abc'],
+	 *                  ['name' => 'other_field', 'contents' => '123'],
+	 *                  ['name' => 'file_name', 'contents' => fopen('/path/to/file', 'r'), 'filename' => 'custom_name.txt'],
 	 *              ],
 	 *              'headers' => [
 	 *                  'foo' => 'bar',
@@ -178,10 +178,10 @@ interface IClient {
 	 * Sends a options request
 	 * @param string $uri
 	 * @param array $options Array such as
-	 *              'body' => [
-	 *                  'field' => 'abc',
-	 *                  'other_field' => '123',
-	 *                  'file_name' => fopen('/path/to/file', 'r'),
+	 *              'multipart' => [
+	 *                  ['name' => 'field', 'contents' => 'abc'],
+	 *                  ['name' => 'other_field', 'contents' => '123'],
+	 *                  ['name' => 'file_name', 'contents' => fopen('/path/to/file', 'r'), 'filename' => 'custom_name.txt'],
 	 *              ],
 	 *              'headers' => [
 	 *                  'foo' => 'bar',

--- a/tests/lib/HTTPHelperTest.php
+++ b/tests/lib/HTTPHelperTest.php
@@ -63,7 +63,7 @@ class HTTPHelperTest extends \Test\TestCase {
 			->with(
 				'https://owncloud.com',
 				[
-					'body' => [
+					'form_params' => [
 						'Foo' => 'Bar',
 					],
 					'connect_timeout' => 10,
@@ -97,7 +97,7 @@ class HTTPHelperTest extends \Test\TestCase {
 			->with(
 				'https://owncloud.com',
 				[
-					'body' => [
+					'form_params' => [
 						'Foo' => 'Bar',
 					],
 					'connect_timeout' => 10,


### PR DESCRIPTION
<!--
Thanks for submitting a change to ownCloud!

This is the bug tracker for the Server component. Find other components at https://github.com/owncloud/core/blob/master/.github/CONTRIBUTING.md#guidelines

For fixing potential security issues please see https://owncloud.com/security/

To make it possible for us to get your change reviewed and merged please carefully fill out the requested information below.

Please note that any kind of change needs first be submitted to the master branch which holds the next version of ownCloud.

Please set the following labels:

- Set label "3 - To review" for review or "2 - Development" if the PR still has open tasks
- Assignment: assign to self
- Milestone: set the same as the ticket this PR fixes, or "development" by default
- Reviewers: pick at least one
-->

## Description
Fixes some bugs caused by the guzzle upgrade
* I'm not sure about the federated sharing notifications. Request should reach the server, but I had problems with the share. I don't know if there is a bug lurking around, or it was caused by any of my changes in order to trigger the behavior. Anyway, it seems out of scope.
  I assume this was left because the default behavior is to use OCM, not the old mechanism. With OCM, the parameters use "json", so there is no problem.
* The federation background job seems awkward and likely untested. That's a bug that is now fixed
* For the HTTPHelper, I think it's deprecated and it's only used in the old sharing 1.0. I don't think we use sharing 1.0 anywhere. It seems dead code, but anyway, the issue with guzzle should be fixed, although not tested.

So it seems the only real bug, at least in core, is with the background job of the federation app. The other 2 shouldn't trigger.

## Related Issue
https://github.com/owncloud/core/issues/40649

## Motivation and Context
Issue with the background job needs to be fixed. There is also comments that needs to be updated.

## How Has This Been Tested?
Manually tested except the one for the HTTPHelper, which is a blind change.

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Database schema changes (next release will require increase of minor version instead of patch)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [ ] Tests only (no source changes)

## Checklist:
<!-- Tick the checkboxes when done. -->
<!-- Raise documentation ticket in https://github.com/owncloud/documentation -->
- [x] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 
- [ ] Changelog item, see [TEMPLATE](https://github.com/owncloud/core/blob/master/changelog/TEMPLATE)
