### PR TITLE
Allow stream wrappers not to provide the underlying stream

### DIFF
--- a/lib/private/legacy/image.php
+++ b/lib/private/legacy/image.php
@@ -578,11 +578,19 @@ class OC_Image implements \OCP\IImage {
 				if (\method_exists($streamObj, 'getSource')) {
 					// underlying stream must be adjusted too
 					$stream = $streamObj->getSource();
+					if (!$stream) {
+						// current streamObj doesn't wrap any other stream opened with `fopen`,
+						// or it's the last one of the chain
+						break;
+					}
 					$metadata = \stream_get_meta_data($stream);
 				} else {
 					// can't access to the underlying stream, so we'll stop here
 					$this->logger->warning(
-						"Cannot get the underlying stream of class " . \get_class($streamObj) . "with uri {$metadata['uri']}",
+						"Cannot get the underlying stream of class " . \get_class($streamObj) .
+						" with uri {$metadata['uri']}. The " . \get_class($streamObj) .
+						" class should have a \"getSource\" method returning the underlying" .
+						" stream, or false / null if it isn't wrapping any other stream",
 						['app' => 'core']
 					);
 					break;


### PR DESCRIPTION
This is mainly for streams that don't wrap another one, or use a stream not provided by the native fopen function such as smbclient_open

**NOTE**: This PR targets the release branch.

<!--
Thanks for submitting a change to ownCloud!

This is the bug tracker for the Server component. Find other components at https://github.com/owncloud/core/blob/master/.github/CONTRIBUTING.md#guidelines

For fixing potential security issues please see https://owncloud.com/security/

To make it possible for us to get your change reviewed and merged please carefully fill out the requested information below.

Please note that any kind of change needs first be submitted to the master branch which holds the next version of ownCloud.

Please set the following labels:

- Set label "3 - To review" for review or "2 - Development" if the PR still has open tasks
- Assignment: assign to self
- Milestone: set the same as the ticket this PR fixes, or "development" by default
- Reviewers: pick at least one
-->

## Description
Provide a way not to provide the source of the stream, otherwise we'd get an annoying log complaining about the missing `getSource` method in the stream, or we could get real errors if the last stream isn't native.

## Related Issue
No opened issue yet.

## Motivation and Context
Prevent annoying logs. The flow still works without problems, but the log will keep appearing

## How Has This Been Tested?
Manually tested
1. Setup lastest OC master code (10.12.0rc2 - 61a8c68451bb6e044a098fe821c75ff32f1b1a29) with the WND app
2. Setup an external storage with the WND app
3. Upload an image to the external storage through ownCloud

The warning log appears.

Note that this PR won't solve the issue by itself. It requires changes in the WND app.
Changes in the app (not core) are expected to be backwards-compatible.

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Database schema changes (next release will require increase of minor version instead of patch)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [ ] Tests only (no source changes)

## Checklist:
<!-- Tick the checkboxes when done. -->
<!-- Raise documentation ticket in https://github.com/owncloud/documentation -->
- [x] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 
- [ ] Changelog item, see [TEMPLATE](https://github.com/owncloud/core/blob/master/changelog/TEMPLATE)


Expected logs with this PR:
```
{"reqId":"3hxA7CSmglRj6RwCDqKJ","level":2,"time":"2023-02-28T09:42:33+00:00","remoteAddr":"10.0.2.27","user":"mountainUser1@mountain.tree.prv","app":"core","method":"GET","url":"\/remote.php\/dav\/files\/mountainUser1@mountain.tree.prv\/WindowsNetworkDrive\/foonly1\/kHlkYy0hYhvngkpQHcCnAkt5T28.gif?c=63fdcc8977b4c&x=32&y=32&forceIcon=0&preview=1","message":"Cannot get the underlying stream of class OCA\\windows_network_drive\\lib\\smbwrapper\\SMBStream with uri wnd:\/\/smb:\/\/WIN-EJBVQCVTVFU.mountain.tree.prv\/foobar\/foonly1\/kHlkYy0hYhvngkpQHcCnAkt5T28.gif. The OCA\\windows_network_drive\\lib\\smbwrapper\\SMBStream class should has a \"getSource\" method returning the underlying stream, or false \/ null if it isn't wrapping any other stream"}
```
As told in the log, the app will provide such method (still to be done)