### PR TITLE
Ocm via sciencemesh for 10.12

### DIFF
--- a/apps/files_sharing/lib/Controller/ShareesController.php
+++ b/apps/files_sharing/lib/Controller/ShareesController.php
@@ -385,10 +385,8 @@ class ShareesController extends OCSController {
 		$pluginClass = $this->config->getSystemValue('sharing.remoteShareesSearch');
 		if ($pluginClass !== '') {
 			$this->result['remotes'] = [];
-			$app = new Application();
-			$container = $app->getContainer();
 			/** @var \OCP\Share\IRemoteShareesSearch $plugin */
-			$plugin = $container->query($pluginClass);
+			$plugin = \OC::$server->query($pluginClass);
 			$result = $plugin->search($search);
 			$this->result['exact']['remotes'] = $result;
 			$this->reachedEndFor[] = 'remotes';

--- a/apps/files_sharing/lib/Controller/ShareesController.php
+++ b/apps/files_sharing/lib/Controller/ShareesController.php
@@ -41,6 +41,7 @@ use OCP\IUser;
 use OCP\IUserManager;
 use OCP\IUserSession;
 use OCP\Share;
+use OCA\Files_Sharing\AppInfo\Application;
 use OCA\Files_Sharing\SharingBlacklist;
 use OCP\Util\UserSearch;
 
@@ -381,6 +382,18 @@ class ShareesController extends OCSController {
 	 * @return void
 	 */
 	protected function getRemote($search) {
+		$pluginClass = $this->config->getSystemValue('sharing.remoteShareesSearch');
+		if ($pluginClass !== '') {
+			$this->result['remotes'] = [];
+			$app = new Application();
+			$container = $app->getContainer();
+			/** @var \OCP\Share\IRemoteShareesSearch $plugin */
+			$plugin = $container->query($pluginClass);
+			$result = $plugin->search($search);
+			$this->result['exact']['remotes'] = $result;
+			$this->reachedEndFor[] = 'remotes';
+			return;
+		}
 		$this->result['remotes'] = [];
 		// Fetch remote search properties from app config
 		/**

--- a/apps/files_sharing/tests/API/ShareesTest.php
+++ b/apps/files_sharing/tests/API/ShareesTest.php
@@ -1513,7 +1513,8 @@ class ShareesTest extends TestCase {
 
 		$configMap = [
 			['trusted_domains', [], ['trusted.domain.tld', 'trusted2.domain.tld']],
-			['accounts.enable_medial_search', true, true]
+			['accounts.enable_medial_search', true, true],
+			['sharing.remoteShareesSearch', '', '']
 		];
 
 		$this->config->expects($this->any())

--- a/changelog/unreleased/40577
+++ b/changelog/unreleased/40577
@@ -1,0 +1,10 @@
+Enhancement: Add support for OCM via ScienceMesh
+
+
+We've added an if-statement in the files_sharing ShareesController
+code that searches for remote sharees. When the 'sciencemesh' app
+is installed, use it instead of the federatedfilesharing app to
+find sharee matches for OCM sharing.
+
+https://github.com/owncloud/core/issues/40577
+https://github.com/pondersource/oc-sciencemesh/pull/39

--- a/changelog/unreleased/40577
+++ b/changelog/unreleased/40577
@@ -2,9 +2,11 @@ Enhancement: Add support for OCM via ScienceMesh
 
 
 We've added an if-statement in the files_sharing ShareesController
-code that searches for remote sharees. When the 'sciencemesh' app
-is installed, use it instead of the federatedfilesharing app to
-find sharee matches for OCM sharing.
+code that searches for remote sharees. When `sharing.remoteShareesSearch`
+defines a plugin that implements `IRemoteShareesSearch`, for instance the
+'ScienceMeshSearchPlugin' from the 'sciencemesh' app or similar,
+use it instead of the federatedfilesharing app to find sharee matches for
+OCM sharing.
 
 https://github.com/owncloud/core/issues/40577
 https://github.com/pondersource/oc-sciencemesh/pull/39

--- a/changelog/unreleased/40577
+++ b/changelog/unreleased/40577
@@ -3,8 +3,8 @@ Enhancement: Add support for OCM via ScienceMesh
 
 We've added an if-statement in the files_sharing ShareesController
 code that searches for remote sharees. When the config entry
-`sharing.remoteShareesSearch` is set to the name of a class that
-is registered in the server container and that implements
+`sharing.remoteShareesSearch` is set to the name of a class
+that is registered in the server container and that implements
 `IRemoteShareesSearch`, for instance the 'ScienceMeshSearchPlugin'
 that the 'sciencemesh' app registers, use it instead of the
 federatedfilesharing app to find sharee matches for OCM sharing.

--- a/changelog/unreleased/40577
+++ b/changelog/unreleased/40577
@@ -2,11 +2,12 @@ Enhancement: Add support for OCM via ScienceMesh
 
 
 We've added an if-statement in the files_sharing ShareesController
-code that searches for remote sharees. When `sharing.remoteShareesSearch`
-defines a plugin that implements `IRemoteShareesSearch`, for instance the
-'ScienceMeshSearchPlugin' from the 'sciencemesh' app or similar,
-use it instead of the federatedfilesharing app to find sharee matches for
-OCM sharing.
+code that searches for remote sharees. When the config entry
+`sharing.remoteShareesSearch` is set to the name of a class that
+is registered in the server container and that implements
+`IRemoteShareesSearch`, for instance the 'ScienceMeshSearchPlugin'
+that the 'sciencemesh' app registers, use it instead of the
+federatedfilesharing app to find sharee matches for OCM sharing.
 
 https://github.com/owncloud/core/issues/40577
 https://github.com/pondersource/oc-sciencemesh/pull/39

--- a/lib/public/Share/IRemoteShareesSearch.php
+++ b/lib/public/Share/IRemoteShareesSearch.php
@@ -1,0 +1,49 @@
+<?php
+/**
+ * @author Michiel de Jong <michiel@pondersource.com>
+ *
+ * @copyright Copyright (c) 2018, ownCloud GmbH
+ * @license AGPL-3.0
+ *
+ * This code is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License, version 3,
+ * as published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License, version 3,
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>
+ *
+ */
+
+namespace OCP\Share;
+
+/**
+ * Interface IRemoteShareesSearch
+ * Used in the ShareesController of the files_sharing app.
+ * See the 'sciencemesh' app for an example implementation
+ * of this interface.
+ *
+ * @package OCP\Share
+ * @since 10.12.0
+ */
+interface IRemoteShareesSearch {
+	/**
+	 * Return the identifier of this provider.
+	 * @param string search string for autocomplete
+	 * @return array[] this function should return an array
+	 * where each element is an associative array, containing:
+	 * - label: a string to display as label
+	 * - value: an associative array containing:
+	 *   - shareType: int, to be used as share type
+	 *   - shareWith: string, identifying the sharee
+	 *   - server (optional): string, URL of the server, e.g.
+	 * https://github.com/owncloud/core/blob/v10.12.0-beta.1/apps/files_sharing/lib/Controller/ShareesController.php#L421
+	 *
+	 * @since 10.12.0
+	 */
+	public function search($search);
+}


### PR DESCRIPTION
# Description
This is a rebase of PR #40577 to go to `release-10.12.0` branch.

I have left the changelog linking to #40577 because that PR actually has all the discussion etc., so it will be more useful to be linked in the changelog.

## Related Issue
- Fixes #40576

## Motivation and Context
This is needed for OC-10 instances that want to join https://sciencemesh.io

## How Has This Been Tested?
- test environment:
  - GitPod from https://github.com/cs3org/ocm-test-suite
  - run ./gitpod-init.sh
  - run ./scripts/clean.sh
  - run ./scripts/orro-testing.sh
  - go the Firefox browser-in-a-browser that is exposed to port 5800
  - in there, navigate to https://oc1.docker (einstein / relativity)
  - create a local user 'john'
  - using the ScienceMesh app, generate an invite
  - accept the invite on oc2.docker (marie / radioactivity)
  - confirm that marie is now a ScienceMesh contact of einstein on oc1.docker
- test case 1: sharing via ScienceMesh
  - as einstein on oc1.docker, share a file and start typing "m..." as the sharee
  - as marie on oc2.docker, accept the share
  - check the revaoc1.docker logs and see that the sharing happened via oc1 -> revaoc1 -> revaoc2 -> oc2
- test case 2: sharing via local
  - as einstein on oc1.docker, share a file and start typing "jo..." as the sharee
  - it should offer to share with John as a local user

## Screenshots (if appropriate):
<img width="1656" alt="Screenshot 2023-01-13 at 13 53 37" src="https://user-images.githubusercontent.com/408412/212324749-155a6ba1-53de-43fc-8ad8-c3ba6fcf2c06.png">

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Database schema changes (next release will require increase of minor version instead of patch)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [ ] Tests only (no source changes)

## Checklist:
- [x] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 
- [x] Changelog item, see [TEMPLATE](https://github.com/owncloud/core/blob/master/changelog/TEMPLATE)
