### PR TITLE
revert logic to expose free_space, but keep availableStorage config

### DIFF
--- a/changelog/10.12.0_2023-02-24/40389
+++ b/changelog/10.12.0_2023-02-24/40389
@@ -1,6 +1,9 @@
 Change: Allow specifying available space for objectstorages
 
-Before this change, objectstorages were reporting only infinite storage space. This could have caused problems in other apps that rely on this storage method, e.g. metrics app that monitors available space
+Objectstorages are reporting only unknown storage space. This causes problems in other apps that rely on this storage method, e.g. metrics app that monitors available space. Now, new configuration in the storage level is added, allowing for using the system configuration variable by the apps or further extension of storage class for objectstorage.
 
 https://github.com/owncloud/core/pull/40389
+https://github.com/owncloud/core/pull/40669
+https://github.com/owncloud/core/issues/40665
 https://github.com/owncloud/enterprise/issues/5384
+https://github.com/owncloud/enterprise/issues/5006

--- a/lib/private/Files/ObjectStore/ObjectStoreStorage.php
+++ b/lib/private/Files/ObjectStore/ObjectStoreStorage.php
@@ -49,9 +49,11 @@ class ObjectStoreStorage extends \OC\Files\Storage\Common {
 	 */
 	protected $id;
 	/**
+	 * NOTE: if storage allows to calculate space used, this value could be used to compute free_space
+	 *
 	 * @var int|null $availableStorage
 	 */
-	private $availableStorage;
+	protected $availableStorage;
 	/**
 	 * @var \OC\User\User $user
 	 */
@@ -430,39 +432,18 @@ class ObjectStoreStorage extends \OC\Files\Storage\Common {
 	}
 
 	/**
-	 * overwrite this method if objectstorage supports getting total bucket objects size
+	 * Getting total free space for objectstorage is very compute intensive,
+	 * as would need to sum storage size from all the user storages
+	 * from root storagefilecache. However, one could have background job that daily
+	 * computes free_space for buckets, or return from storage if allowed.
 	 *
-	 * @return int
-	 */
-	protected function getTotalUsedStorage() {
-		$rootInfo = Filesystem::getFileInfo('/', false);
-		return $rootInfo->getSize();
-	}
-
-	/**
-	 * get the free space in the object storage as indicated by the objectstore config
-	 *
-	 * NOTE: getting total free space for objectstorage is not possible,
-	 *       and this can only be set to administrator allowed volume
-	 *       e.g. due to billing or monitoring concerns
+	 * For the moment return SPACE_UNKNOWN
 	 *
 	 * @param string $path
 	 * @return int
 	 */
 	public function free_space($path) {
-		if (isset($this->availableStorage)) {
-			$used = $this->getTotalUsedStorage();
-			if ($used < 0) {
-				$used = 0;
-			}
-
-			$free = $this->availableStorage - $used;
-			if ($free < 0) {
-				return 0;
-			}
-			return $free;
-		}
-		return FileInfo::SPACE_UNLIMITED;
+		return FileInfo::SPACE_UNKNOWN;
 	}
 
 	public function touch($path, $mtime = null) {

--- a/tests/lib/Files/ObjectStore/ObjectStoreTest.php
+++ b/tests/lib/Files/ObjectStore/ObjectStoreTest.php
@@ -97,10 +97,11 @@ class ObjectStoreTest extends TestCase {
 	}
 	public function providersFreeSpace() {
 		return [
-			[100, 10, 90],
-			[100, -1, 100],
-			[100, 110, 0],
-			[null, 10, FileInfo::SPACE_UNLIMITED]
+			[100, 10, FileInfo::SPACE_UNKNOWN],
+			[100, -1, FileInfo::SPACE_UNKNOWN],
+			[100, 110, FileInfo::SPACE_UNKNOWN],
+			[null, 10, FileInfo::SPACE_UNKNOWN],
+			[null, 10, FileInfo::SPACE_UNKNOWN]
 		];
 	}
 
@@ -112,13 +113,12 @@ class ObjectStoreTest extends TestCase {
 	 */
 	public function testFreeSpace($availableStorage, $usedStorage, $expected) {
 		$objectStore = $this->getMockBuilder(ObjectStoreStorage::class)
-			->setMethods(['getTotalUsedStorage'])
+			->onlyMethods([])
 			->setConstructorArgs([[
 				'objectstore' => $this->impl,
 				'availableStorage' => $availableStorage
 			]])
 			->getMock();
-		$objectStore->method('getTotalUsedStorage')->willReturn($usedStorage);
 		$free = $objectStore->free_space('test');
 		$this->assertEquals($expected, $free);
 	}


### PR DESCRIPTION
This is a copy of PR #40669 with just 1 commit and targeted to `release-10.12.0`

The original PR text was:

- fixes https://github.com/owncloud/core/issues/40665
- related https://github.com/owncloud/enterprise/issues/5006 , https://github.com/owncloud/core/pull/40389
- needed for https://github.com/owncloud/metrics/pull/159

The issue here is that originally when doing https://github.com/owncloud/core/pull/40389 I somehow mixed the storage_id for S3 bucket with the user urns storage_id's . So when matching with filecache I though it represents that one. 

However I was wrong, and used the wrong storage .. also the correct filecache entry for the entire bucket is always showing 0 size. 

In this PR, I just expose the config entry for availableStorage, so that apps could use it. Please note that this PR reverts logic to expose this on storage level, so all "quota" calculations wont work. If we want to make it work on storage level, something like background job that calculates this size would need to be done. However, metrics app does not require that complexity and it can simply just use that parameters as in https://github.com/owncloud/metrics/pull/159