### PR TITLE
[tests-only][full-ci] Implement new webui steps to check sidebar navs and details tabs 

### DIFF
--- a/tests/acceptance/features/bootstrap/WebUIFilesContext.php
+++ b/tests/acceptance/features/bootstrap/WebUIFilesContext.php
@@ -451,7 +451,7 @@ class WebUIFilesContext extends RawMinkContext implements Context {
 	public function theTabNameDetailsPanelShouldNotBeVisible(string $tabName):void {
 		$detailsDialog = $this->filesPage->getDetailsDialog();
 		Assert::assertFalse(
-			$detailsDialog->isDetailsPanelVisible($tabName),
+			$detailsDialog->isDetailsTabAvailable($tabName),
 			"the $tabName panel is visible in the details panel but should not be"
 		);
 	}

--- a/tests/acceptance/features/bootstrap/WebUIGeneralContext.php
+++ b/tests/acceptance/features/bootstrap/WebUIGeneralContext.php
@@ -681,6 +681,34 @@ class WebUIGeneralContext extends RawMinkContext implements Context {
 	}
 
 	/**
+	 * @Then the user should see :sidebarItem sidebar navigation on the webUI
+	 *
+	 * @param string $sidebarItem
+	 *
+	 * @return void
+	 */
+	public function theUserShouldSeeSidebarNavigation(string $sidebarItem):void {
+		Assert::assertTrue(
+			$this->owncloudPage->isSidebarNavVisible($sidebarItem),
+			"the sidebar navigation '$sidebarItem' is not visible but should be"
+		);
+	}
+
+	/**
+	 * @Then the user should not see :sidebarItem sidebar navigation on the webUI
+	 *
+	 * @param string $sidebarItem
+	 *
+	 * @return void
+	 */
+	public function theUserShouldNotSeeSidebarNavigation(string $sidebarItem):void {
+		Assert::assertFalse(
+			$this->owncloudPage->isSidebarNavVisible($sidebarItem),
+			"the sidebar navigation '$sidebarItem' is visible but should not be"
+		);
+	}
+
+	/**
 	 * @BeforeScenario @webUI
 	 *
 	 * @param BeforeScenarioScope $scope

--- a/tests/acceptance/features/lib/FilesPageElement/DetailsDialog.php
+++ b/tests/acceptance/features/lib/FilesPageElement/DetailsDialog.php
@@ -407,6 +407,32 @@ class DetailsDialog extends OwncloudPage {
 	}
 
 	/**
+	 * checks if the requested tab in the details tab is available
+	 *
+	 * @param string $tabName
+	 *
+	 * @return bool
+	 */
+	public function isDetailsTabAvailable(string $tabName): bool {
+		try {
+			$tabXpath = $this->getSubstitutedValueInXpath($this->tabSwitchBtnXpath, $this->getDetailsTabId($tabName));
+			$tab = $this->detailsDialogElement->find(
+				"xpath",
+				$tabXpath
+			);
+			$this->assertElementNotNull(
+				$tab,
+				__METHOD__ .
+				" could not find details tab with id '$tabName'"
+			);
+			$visible = $tab->isVisible();
+		} catch (ElementNotFoundException $e) {
+			$visible = false;
+		}
+		return $visible;
+	}
+
+	/**
 	 *
 	 * @return NodeElement of the whole container holding the thumbnail
 	 * @throws ElementNotFoundException

--- a/tests/acceptance/features/lib/OwncloudPage.php
+++ b/tests/acceptance/features/lib/OwncloudPage.php
@@ -45,6 +45,17 @@ class OwncloudPage extends Page {
 	protected $avatarImgXpath = ".//div[@id='settings']//div[contains(@class, 'avatardiv')]/img";
 	protected $titleXpath = ".//title";
 	protected $searchBoxId = "searchbox";
+	protected $sidebarNavXpath = "//li[@data-id='%s']";
+	private $sidebarItemId = [
+		'All files' => "files",
+		'Favorites' => "favorites",
+		'Shared with you' => "sharingin",
+		'Shared with others' => "sharingout",
+		'Shared with others' => "sharingout",
+		'Shared by link' => "sharinglinks",
+		'Tags' => "systemtagsfilter",
+		'Deleted files' => "trashbin",
+	];
 
 	/**
 	 * used to store the unchanged path string when $path gets changed
@@ -913,5 +924,46 @@ class OwncloudPage extends Page {
 		if ($element === null) {
 			throw new ElementNotFoundException($message);
 		}
+	}
+
+	/**
+	 * Lookup the id for the requested sidebar item.
+	 * If the id is not known, then return the passed-in parameter as the id.
+	 *
+	 * @param string $sidebar e.g. All files, Tags, Deleted files
+	 *
+	 * @return string
+	 */
+	public function getSidebarItemId(string $sidebar): string {
+		if (isset($this->sidebarItemId[$sidebar])) {
+			$id = $this->sidebarItemId[$sidebar];
+		} else {
+			$id = $sidebar;
+		}
+		return $id;
+	}
+
+	/**
+	 *
+	 * @param string $sidebar
+	 *
+	 * @return bool
+	 */
+	public function isSidebarNavVisible(string $sidebar): bool {
+		try {
+			$sidebarNav = $this->find(
+				"xpath",
+				\sprintf($this->sidebarNavXpath, $this->getSidebarItemId($sidebar))
+			);
+			$this->assertElementNotNull(
+				$sidebarNav,
+				__METHOD__ .
+				" could not find '$sidebar' sidebar navigation"
+			);
+			$visible = $sidebarNav->isVisible();
+		} catch (ElementNotFoundException $e) {
+			$visible = false;
+		}
+		return $visible;
 	}
 }


### PR DESCRIPTION
## Description
Added necessary steps implementation required for https://github.com/owncloud/guests/issues/523, https://github.com/owncloud/guests/pull/550

New steps:
```
@Then the user should see :sidebarItem sidebar navigation on the webUI
@Then the user should not see :sidebarItem sidebar navigation on the webUI
```

Refactored step: the tab visibility is now determined by the attr `data-tabid` of tab instead of `id` that only appears when the tab is opened (which we cannot do when we are expecting the tab to be not visible)
```
@Then the :tabName details panel should not be visible
```

## Related Issue
https://github.com/owncloud/guests/issues/523

## Motivation and Context

## How Has This Been Tested?
- test environment:

## Screenshots (if appropriate):

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Database schema changes (next release will require increase of minor version instead of patch)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [ ] Tests only (no source changes)

## Checklist:
- [ ] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 
- [ ] Changelog item, see [TEMPLATE](https://github.com/owncloud/core/blob/master/changelog/TEMPLATE)
