### PR TITLE
fix: in case root on CacheJail is an empty string we should not prefi…

### DIFF
--- a/lib/private/Files/Cache/Wrapper/CacheJail.php
+++ b/lib/private/Files/Cache/Wrapper/CacheJail.php
@@ -49,9 +49,12 @@ class CacheJail extends CacheWrapper {
 	protected function getSourcePath($path) {
 		if ($path === '') {
 			return $this->root;
-		} else {
-			return $this->root . '/' . \ltrim($path, '/');
 		}
+		if ($this->root === '') {
+			return \ltrim($path, '/');
+		}
+
+		return $this->root . '/' . \ltrim($path, '/');
 	}
 
 	/**


### PR DESCRIPTION
…x the path with a /

## Description

- In case `root` is an empty string this method creates a path with a leading `/`
- this path is used when querying the table `oc_file_cache`
- paths in `oc_file_cache` a never store with a leading `/`
- as a result queries never hit entries which results in chaos
- `class Jail` is already using the same implementation: https://github.com/owncloud/core/blob/0efca5ee4e44340907925d58527e65eda7d63f03/lib/private/Files/Storage/Wrapper/Jail.php#L55

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
- test environment:
- test case 1:
- test case 2:
- ...

## Screenshots (if appropriate):
![Screenshot from 2023-03-08 09-40-21](https://user-images.githubusercontent.com/1005065/223681239-3f1b15ce-218d-47cb-8c07-31bfbe3893a8.png)

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Database schema changes (next release will require increase of minor version instead of patch)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [ ] Tests only (no source changes)

## Checklist:
<!-- Tick the checkboxes when done. -->
<!-- Raise documentation ticket in https://github.com/owncloud/documentation -->
- [ ] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 
- [ ] Changelog item, see [TEMPLATE](https://github.com/owncloud/core/blob/master/changelog/TEMPLATE)
