### PR TITLE
chore: remove unused openidconnect config option `use-token-introspec…

### DIFF
--- a/config/config.apps.sample.php
+++ b/config/config.apps.sample.php
@@ -337,14 +337,6 @@ $CONFIG = [
  * If set to `true` any user information will be read from the access token.
  * If set to `false` the userinfo endpoint is used (starting app version 1.1.0).
  *
- * use-token-introspection-endpoint::
- * If set to `true`, the token introspection endpoint is used to verify a given access
- * token - only needed if the access token is not a JWT. If set to `false`, the userinfo
- * endpoint is used (requires version >= 1.1.0)
- * Tokens which are not JSON WebToken (JWT) may not have information like the
- * expiry. In these cases, the OpenID Connect Provider needs to call on the token
- * introspection endpoint to get this information. The default value is `false`. See
- * https://datatracker.ietf.org/doc/html/rfc7662 for more information on token introspection.
  */
 
 /**
@@ -420,7 +412,6 @@ $CONFIG = [
 		'userinfo_endpoint' => '...'
 	],
 	'provider-url' => '...',
-	'use-token-introspection-endpoint' => true
 ],
 
 /**
@@ -435,7 +426,6 @@ $CONFIG = [
 	'loginButtonName' => 'node-oidc-provider',
 	'mode' => 'userid',
 	'search-attribute' => 'sub',
-	'use-token-introspection-endpoint' => true,
 	  // do not verify tls host or peer
 	'insecure' => true
 ],


### PR DESCRIPTION
…tion-endpoint`

## Description
see https://github.com/owncloud/openidconnect/pull/286
## Related Issue
- refs https://github.com/owncloud/openidconnect/pull/286

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
- test environment:
- test case 1:
- test case 2:
- ...

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Database schema changes (next release will require increase of minor version instead of patch)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [ ] Tests only (no source changes)

## Checklist:
<!-- Tick the checkboxes when done. -->
<!-- Raise documentation ticket in https://github.com/owncloud/documentation -->
- [ ] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 
- [ ] Changelog item, see [TEMPLATE](https://github.com/owncloud/core/blob/master/changelog/TEMPLATE)
