### PR TITLE
Use getHome in ChunkLocationProvider.php

### DIFF
--- a/apps/dav/lib/Upload/ChunkLocationProvider.php
+++ b/apps/dav/lib/Upload/ChunkLocationProvider.php
@@ -63,7 +63,7 @@ class ChunkLocationProvider implements IMountProvider {
 		$chunkBaseDir = $this->config->getSystemValue('dav.chunk_base_dir', '');
 		if ($chunkBaseDir === '') {
 			// this is needed as otherwise the returned mount point will be in the home storage rather
-			// than in the "local" external storage and this would cause troubles when applying quota.
+			// than in the "local" external storage and this would cause trouble when applying quota.
 			$cacheDir = $user->getHome();
 			return [
 				new MountPoint(Local::class, '/' . $user->getUID() . '/uploads', ['datadir' => $cacheDir . '/uploads'], $loader)

--- a/apps/dav/lib/Upload/ChunkLocationProvider.php
+++ b/apps/dav/lib/Upload/ChunkLocationProvider.php
@@ -64,9 +64,9 @@ class ChunkLocationProvider implements IMountProvider {
 		if ($chunkBaseDir === '') {
 			// this is needed as otherwise the returned mount point will be in the home storage rather
 			// than in the "local" external storage and this would cause troubles when applying quota.
-			$cacheDir = $this->config->getSystemValue('datadirectory');
+			$cacheDir = $user->getHome();
 			return [
-				new MountPoint(Local::class, '/' . $user->getUID() . '/uploads', ['datadir' => $cacheDir . '/' . $user->getUID() . '/uploads', $loader])
+				new MountPoint(Local::class, '/' . $user->getUID() . '/uploads', ['datadir' => $cacheDir . '/uploads'], $loader)
 			];
 		} else {
 			$cacheDir = \rtrim($chunkBaseDir, '/') . '/' . $user->getUID();
@@ -74,7 +74,7 @@ class ChunkLocationProvider implements IMountProvider {
 				\mkdir($cacheDir, 0770, true);
 			}
 			return [
-				new MountPoint(Local::class, '/' . $user->getUID() . '/uploads', ['datadir' => $cacheDir, $loader])
+				new MountPoint(Local::class, '/' . $user->getUID() . '/uploads', ['datadir' => $cacheDir], $loader)
 			];
 		}
 	}


### PR DESCRIPTION
## Description
Use `getHome()` in ChunkLocationProvider.php

## Related Issue
- https://github.com/owncloud/enterprise/issues/5647

## Motivation and Context
When using the `home_folder_naming_rule` attribute for defining the home directories for LDAP users (configurable over the LDAP wizard) chunks of users' uploads are wrongly created under the default data directory rather than inside the configured home directory.

This is because currently  https://github.com/owncloud/core/blob/v10.12.0/apps/dav/lib/Upload/ChunkLocationProvider.php#L67-L70 is missing a check for such cases. It seems therefore better to rely on the `getHome()` method for getting the user's home.

## How Has This Been Tested?
Manually by setting the `home_folder_naming_rule` attribute for defining the home directories for LDAP users and observing chunks are now uploaded inside the configured home directory. 

## Types of changes
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Database schema changes (next release will require increase of minor version instead of patch)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [ ] Tests only (no source changes)

## Checklist:
- [X] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised
- [ ] Changelog item
