### PR TITLE
fix permission bits when enforcing rw links

### DIFF
--- a/core/js/sharedialoglinkshareview.js
+++ b/core/js/sharedialoglinkshareview.js
@@ -116,14 +116,31 @@
 			return (permissions) ? parseInt(permissions, 10) : OC.PERMISSION_READ;
 		},
 
+		/**
+		 * These are all cases as per OCA.Share.ShareDialogLinkShareView.render,
+		 * matching passwordMustBeEnforced from server side
+		 * 
+		 * @returns {boolean}
+		 */
 		_shouldRequirePassword: function() {
-			// matching passwordMustBeEnforced from server side
 			var permissions = this._getPermissions();
-			var roEnforcement = permissions === OC.PERMISSION_READ && this.configModel.get('enforceLinkPasswordReadOnly');
-			var woEnforcement = permissions === OC.PERMISSION_CREATE && this.configModel.get('enforceLinkPasswordWriteOnly');
-			var rwEnforcement = (permissions === (OC.PERMISSION_READ | OC.PERMISSION_CREATE) && this.configModel.get('enforceLinkPasswordReadWrite'));
-			var rwdEnforcement = (permissions === (OC.PERMISSION_READ | OC.PERMISSION_UPDATE | OC.PERMISSION_CREATE | OC.PERMISSION_DELETE) && this.configModel.get('enforceLinkPasswordReadWriteDelete'));
-			if (roEnforcement || woEnforcement || rwEnforcement || rwdEnforcement) {
+
+			// Download / View (file and folder)
+			var publicRead = permissions === OC.PERMISSION_READ && this.configModel.get('enforceLinkPasswordReadOnly');
+
+			// Upload only (File Drop folder)
+			var publicUploadFolder = permissions === OC.PERMISSION_CREATE && this.configModel.get('enforceLinkPasswordWriteOnly');
+
+			// Download / View / Upload (folder)
+			var publicReadUploadFolder = (permissions === (OC.PERMISSION_READ | OC.PERMISSION_CREATE) && this.configModel.get('enforceLinkPasswordReadWrite'));
+
+			// Download / View / Upload / Edit (folder)
+			var publicReadWriteFolder = (permissions === (OC.PERMISSION_READ | OC.PERMISSION_UPDATE | OC.PERMISSION_CREATE | OC.PERMISSION_DELETE) && this.configModel.get('enforceLinkPasswordReadWriteDelete'));
+
+			// Download / View / Edit (file)
+			var publicReadWriteFile = (permissions === (OC.PERMISSION_READ | OC.PERMISSION_UPDATE) && this.configModel.get('enforceLinkPasswordReadWriteDelete'));
+
+			if (publicRead || publicUploadFolder || publicReadUploadFolder || publicReadWriteFolder || publicReadWriteFile) {
 				return true;
 			} else {
 				return false;

--- a/lib/private/Share20/Manager.php
+++ b/lib/private/Share20/Manager.php
@@ -224,7 +224,7 @@ class Manager implements IManager {
 		$rwdEnforcement = ($permissions === (\OCP\Constants::PERMISSION_READ | \OCP\Constants::PERMISSION_UPDATE | \OCP\Constants::PERMISSION_CREATE | \OCP\Constants::PERMISSION_DELETE)) &&
 			$this->shareApiLinkEnforcePasswordReadWriteDelete();
 		// use read & write enforcement for the rest of the cases
-		$rwEnforcement = ($permissions === (\OCP\Constants::PERMISSION_READ | \OCP\Constants::PERMISSION_CREATE)) && $this->shareApiLinkEnforcePasswordReadWrite();
+		$rwEnforcement = ($permissions === (\OCP\Constants::PERMISSION_READ | \OCP\Constants::PERMISSION_UPDATE)) && $this->shareApiLinkEnforcePasswordReadWrite();
 		if ($roEnforcement || $woEnforcement || $rwEnforcement || $rwdEnforcement) {
 			return true;
 		} else {

--- a/lib/private/Share20/Manager.php
+++ b/lib/private/Share20/Manager.php
@@ -213,19 +213,31 @@ class Manager implements IManager {
 	}
 
 	/**
-	 * Check if a password must be enforced if the shared has those permissions
+	 * Check if a password must be enforced if the shared has those permissions.
+	 * These are roles as per OCA.Share.ShareDialogLinkShareView.render in the UI
+	 *
 	 * @param int $permissions \OCP\Constants::PERMISSION_* ("|" can be use for sets of permissions)
 	 * @return bool true if the password must be enforced, false otherwise
 	 */
 	protected function passwordMustBeEnforced($permissions) {
-		$roEnforcement = $permissions === \OCP\Constants::PERMISSION_READ && $this->shareApiLinkEnforcePasswordReadOnly();
-		$woEnforcement = $permissions === \OCP\Constants::PERMISSION_CREATE && $this->shareApiLinkEnforcePasswordWriteOnly();
-		// use read, write & delete enforcement for the case
-		$rwdEnforcement = ($permissions === (\OCP\Constants::PERMISSION_READ | \OCP\Constants::PERMISSION_UPDATE | \OCP\Constants::PERMISSION_CREATE | \OCP\Constants::PERMISSION_DELETE)) &&
+		// Download / View (file and folder)
+		$publicRead = $permissions === \OCP\Constants::PERMISSION_READ && $this->shareApiLinkEnforcePasswordReadOnly();
+
+		// Upload only (File Drop folder)
+		$publicUploadFolder = $permissions === \OCP\Constants::PERMISSION_CREATE && $this->shareApiLinkEnforcePasswordWriteOnly();
+
+		// Download / View / Upload (folder)
+		$publicReadUploadFolder = ($permissions === (\OCP\Constants::PERMISSION_READ | \OCP\Constants::PERMISSION_CREATE)) && $this->shareApiLinkEnforcePasswordReadWrite();
+
+		// Download / View / Upload / Edit (folder)
+		$publicReadWriteFolder = ($permissions === (\OCP\Constants::PERMISSION_READ | \OCP\Constants::PERMISSION_UPDATE | \OCP\Constants::PERMISSION_CREATE | \OCP\Constants::PERMISSION_DELETE)) &&
 			$this->shareApiLinkEnforcePasswordReadWriteDelete();
-		// use read & write enforcement for the rest of the cases
-		$rwEnforcement = ($permissions === (\OCP\Constants::PERMISSION_READ | \OCP\Constants::PERMISSION_UPDATE)) && $this->shareApiLinkEnforcePasswordReadWrite();
-		if ($roEnforcement || $woEnforcement || $rwEnforcement || $rwdEnforcement) {
+
+		// Download / View / Edit (file)
+		$publicReadWriteFile = ($permissions === (\OCP\Constants::PERMISSION_READ | \OCP\Constants::PERMISSION_UPDATE)) &&
+			$this->shareApiLinkEnforcePasswordReadWriteDelete();
+		
+		if ($publicRead || $publicUploadFolder || $publicReadUploadFolder || $publicReadWriteFolder || $publicReadWriteFile) {
 			return true;
 		} else {
 			return false;

--- a/tests/lib/Share20/ManagerTest.php
+++ b/tests/lib/Share20/ManagerTest.php
@@ -646,7 +646,7 @@ class ManagerTest extends \Test\TestCase {
 		$manager->getShareById('default:42');
 	}
 
-	public function testPasswordMustBeEnforcedForReadOnly() {
+	public function testPasswordMustBeEnforcedForPublicRead() {
 		$this->config->method('getAppValue')->will($this->returnValueMap([
 			['core', 'shareapi_enforce_links_password_read_only', 'no', 'yes'],
 			['core', 'shareapi_enforce_links_password_read_write', 'no', 'yes'],
@@ -654,20 +654,11 @@ class ManagerTest extends \Test\TestCase {
 			['core', 'shareapi_enforce_links_password_write_delete', 'no', 'yes'],
 		]));
 
+		// Download / View (file and folder)
 		$this->assertTrue($this->invokePrivate($this->manager, 'passwordMustBeEnforced', [\OCP\Constants::PERMISSION_READ]));
 	}
 
-	public function testPasswordMustBeEnforcedForReadWrite() {
-		$this->config->method('getAppValue')->will($this->returnValueMap([
-			['core', 'shareapi_enforce_links_password_read_only', 'no', 'yes'],
-			['core', 'shareapi_enforce_links_password_read_write', 'no', 'yes'],
-			['core', 'shareapi_enforce_links_password_write_only', 'no', 'yes'],
-		]));
-
-		$this->assertTrue($this->invokePrivate($this->manager, 'passwordMustBeEnforced', [\OCP\Constants::PERMISSION_READ | \OCP\Constants::PERMISSION_UPDATE]));
-	}
-
-	public function testPasswordMustBeEnforcedForReadWriteDelete() {
+	public function testPasswordMustBeEnforcedForPublicUploadFolder() {
 		$this->config->method('getAppValue')->will($this->returnValueMap([
 			['core', 'shareapi_enforce_links_password_read_only', 'no', 'yes'],
 			['core', 'shareapi_enforce_links_password_read_write', 'no', 'yes'],
@@ -675,6 +666,30 @@ class ManagerTest extends \Test\TestCase {
 			['core', 'shareapi_enforce_links_password_write_only', 'no', 'yes'],
 		]));
 
+		// Upload only (File Drop folder)
+		$this->assertTrue($this->invokePrivate($this->manager, 'passwordMustBeEnforced', [\OCP\Constants::PERMISSION_CREATE]));
+	}
+
+	public function testPasswordMustBeEnforcedForPublicReadUploadFolder() {
+		$this->config->method('getAppValue')->will($this->returnValueMap([
+			['core', 'shareapi_enforce_links_password_read_only', 'no', 'yes'],
+			['core', 'shareapi_enforce_links_password_read_write', 'no', 'yes'],
+			['core', 'shareapi_enforce_links_password_write_only', 'no', 'yes'],
+		]));
+
+		// Download / View / Upload (folder)
+		$this->assertTrue($this->invokePrivate($this->manager, 'passwordMustBeEnforced', [\OCP\Constants::PERMISSION_READ | \OCP\Constants::PERMISSION_CREATE]));
+	}
+
+	public function testPasswordMustBeEnforcedForPublicReadWriteFolder() {
+		$this->config->method('getAppValue')->will($this->returnValueMap([
+			['core', 'shareapi_enforce_links_password_read_only', 'no', 'yes'],
+			['core', 'shareapi_enforce_links_password_read_write', 'no', 'yes'],
+			['core', 'shareapi_enforce_links_password_read_write_delete', 'no', 'yes'],
+			['core', 'shareapi_enforce_links_password_write_only', 'no', 'yes'],
+		]));
+
+		// Download / View / Upload / Edit (folder)
 		$this->assertTrue($this->invokePrivate(
 			$this->manager,
 			'passwordMustBeEnforced',
@@ -682,7 +697,7 @@ class ManagerTest extends \Test\TestCase {
 		));
 	}
 
-	public function testPasswordMustBeEnforcedForWriteOnly() {
+	public function testPasswordMustBeEnforcedForPublicReadWriteFile() {
 		$this->config->method('getAppValue')->will($this->returnValueMap([
 			['core', 'shareapi_enforce_links_password_read_only', 'no', 'yes'],
 			['core', 'shareapi_enforce_links_password_read_write', 'no', 'yes'],
@@ -690,10 +705,15 @@ class ManagerTest extends \Test\TestCase {
 			['core', 'shareapi_enforce_links_password_write_only', 'no', 'yes'],
 		]));
 
-		$this->assertTrue($this->invokePrivate($this->manager, 'passwordMustBeEnforced', [\OCP\Constants::PERMISSION_CREATE]));
+		// Download / View / Edit (file)
+		$this->assertTrue($this->invokePrivate(
+			$this->manager,
+			'passwordMustBeEnforced',
+			[\OCP\Constants::PERMISSION_READ | \OCP\Constants::PERMISSION_UPDATE]
+		));
 	}
 
-	public function testPasswordMustBeEnforcedForReadOnlyNotEnforced() {
+	public function testPasswordMustBeEnforcedForPublicReadNotEnforced() {
 		$this->config->method('getAppValue')->will($this->returnValueMap([
 			['core', 'shareapi_enforce_links_password_read_only', 'no', 'no'],
 			['core', 'shareapi_enforce_links_password_read_write', 'no', 'yes'],
@@ -701,10 +721,22 @@ class ManagerTest extends \Test\TestCase {
 			['core', 'shareapi_enforce_links_password_write_only', 'no', 'yes'],
 		]));
 
+		// Download / View (file and folder)
 		$this->assertFalse($this->invokePrivate($this->manager, 'passwordMustBeEnforced', [\OCP\Constants::PERMISSION_READ]));
 	}
 
-	public function testPasswordMustBeEnforcedForReadWriteNotEnforced() {
+	public function testPasswordMustBeEnforcedForPublicUploadFolderNotEnforced() {
+		$this->config->method('getAppValue')->will($this->returnValueMap([
+			['core', 'shareapi_enforce_links_password_read_only', 'no', 'yes'],
+			['core', 'shareapi_enforce_links_password_read_write', 'no', 'yes'],
+			['core', 'shareapi_enforce_links_password_read_write_delete', 'no', 'yes'],
+			['core', 'shareapi_enforce_links_password_write_only', 'no', 'no'],
+		]));
+
+		$this->assertFalse($this->invokePrivate($this->manager, 'passwordMustBeEnforced', [\OCP\Constants::PERMISSION_CREATE]));
+	}
+
+	public function testPasswordMustBeEnforcedForPublicReadUploadFolderNotEnforced() {
 		$this->config->method('getAppValue')->will($this->returnValueMap([
 			['core', 'shareapi_enforce_links_password_read_only', 'no', 'yes'],
 			['core', 'shareapi_enforce_links_password_read_write', 'no', 'no'],
@@ -715,7 +747,7 @@ class ManagerTest extends \Test\TestCase {
 		$this->assertFalse($this->invokePrivate($this->manager, 'passwordMustBeEnforced', [\OCP\Constants::PERMISSION_ALL]));
 	}
 
-	public function testPasswordMustBeEnforcedForReadWriteDeleteNotEnforced() {
+	public function testPasswordMustBeEnforcedForPublicReadWriteFolderNotEnforced() {
 		$this->config->method('getAppValue')->will($this->returnValueMap([
 			['core', 'shareapi_enforce_links_password_read_only', 'no', 'yes'],
 			['core', 'shareapi_enforce_links_password_read_write', 'no', 'no'],
@@ -730,15 +762,19 @@ class ManagerTest extends \Test\TestCase {
 		));
 	}
 
-	public function testPasswordMustBeEnforcedForWriteOnlyNotEnforced() {
+	public function testPasswordMustBeEnforcedForPublicReadWriteFileNotEnforced() {
 		$this->config->method('getAppValue')->will($this->returnValueMap([
 			['core', 'shareapi_enforce_links_password_read_only', 'no', 'yes'],
-			['core', 'shareapi_enforce_links_password_read_write', 'no', 'yes'],
-			['core', 'shareapi_enforce_links_password_read_write_delete', 'no', 'yes'],
-			['core', 'shareapi_enforce_links_password_write_only', 'no', 'no'],
+			['core', 'shareapi_enforce_links_password_read_write', 'no', 'no'],
+			['core', 'shareapi_enforce_links_password_read_write_delete', 'no', 'no'],
+			['core', 'shareapi_enforce_links_password_write_only', 'no', 'yes'],
 		]));
 
-		$this->assertFalse($this->invokePrivate($this->manager, 'passwordMustBeEnforced', [\OCP\Constants::PERMISSION_CREATE]));
+		$this->assertFalse($this->invokePrivate(
+			$this->manager,
+			'passwordMustBeEnforced',
+			[\OCP\Constants::PERMISSION_READ | \OCP\Constants::PERMISSION_UPDATE]
+		));
 	}
 
 	public function testVerifyPasswordHook() {

--- a/tests/lib/Share20/ManagerTest.php
+++ b/tests/lib/Share20/ManagerTest.php
@@ -664,7 +664,7 @@ class ManagerTest extends \Test\TestCase {
 			['core', 'shareapi_enforce_links_password_write_only', 'no', 'yes'],
 		]));
 
-		$this->assertTrue($this->invokePrivate($this->manager, 'passwordMustBeEnforced', [\OCP\Constants::PERMISSION_READ | \OCP\Constants::PERMISSION_CREATE]));
+		$this->assertTrue($this->invokePrivate($this->manager, 'passwordMustBeEnforced', [\OCP\Constants::PERMISSION_READ | \OCP\Constants::PERMISSION_UPDATE]));
 	}
 
 	public function testPasswordMustBeEnforcedForReadWriteDelete() {


### PR DESCRIPTION
## Description
The bits READ UPDATE CREATE DELETE are used to differentiate the differnrt types of shares.
passwordMustBeEnforced() maps these bits to the read-only, read-write, read-write-delete, write-only settings.
This code is used for both, files and foldes. with files, the logic was wrong, in such a way, that no setting would enforce passwords on a Download/View/Edit type file share.

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
- Fixes #40699 

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?
* Tested wit no enforcement: all file and folder link types can be set without a password.
* Tested with exactly one type enforced, (all four after another): the correct folder link type is enforced; the two file link types correspond to the first two enforcement settings.
* Tested with all types enforced: No file or folder link can be created without a password.

- test environment:
keyboard + hands + eyes

## Screenshots (if appropriate):

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Database schema changes (next release will require increase of minor version instead of patch)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [ ] Tests only (no source changes)

## Checklist:
- [x] Code changes
- [x] Unit tests added
- [x] Acceptance tests added
- [x] Documentation ticket raised: <link> 
- [ ] Changelog item, see [TEMPLATE](https://github.com/owncloud/core/blob/master/changelog/TEMPLATE)
