### PR TITLE
occ encryption:encrypt-all should not auto-enable user-key encryption

### DIFF
--- a/changelog/unreleased/40702
+++ b/changelog/unreleased/40702
@@ -1,0 +1,7 @@
+Change: Do not auto-enable user-key ecryption
+
+Executing occ encryption:encrypt-all would not auto-enable user-key encryption.
+
+https://github.com/owncloud/core/pull/40702
+https://github.com/owncloud/enterprise/issues/4939
+https://doc.owncloud.com/docs/next/server_release_notes.html#deprecation-note-for-user-key-storage-encryption

--- a/changelog/unreleased/40702
+++ b/changelog/unreleased/40702
@@ -1,6 +1,6 @@
 Change: Do not auto-enable user-key ecryption
 
-Executing occ encryption:encrypt-all would not auto-enable user-key encryption.
+Executing occ encryption:encrypt-all will no longer auto-enable user-key encryption.
 
 https://github.com/owncloud/core/pull/40702
 https://github.com/owncloud/enterprise/issues/4939

--- a/core/Command/Encryption/EncryptAll.php
+++ b/core/Command/Encryption/EncryptAll.php
@@ -115,10 +115,7 @@ class EncryptAll extends Command {
 		$masterKeyEnabled = $this->config->getAppValue('encryption', 'useMasterKey', '');
 		$userKeyEnabled = $this->config->getAppValue('encryption', 'userSpecificKey', '');
 		if (($masterKeyEnabled === '') && ($userKeyEnabled === '')) {
-			/**
-			 * Enable user specific encryption if nothing is enabled.
-			 */
-			$this->config->setAppValue('encryption', 'userSpecificKey', '1');
+			throw new \Exception('None of the encryption modules is enabled');
 		}
 
 		$output->writeln("\n");


### PR DESCRIPTION
## Description
With OC10.7 the user-key encyption has been deprecated. This PR makes it not possible to auto-enable user-key encryption when no module is selected when executing `occ encryption:encrypt-all`

## Related Issue
- Implements https://doc.owncloud.com/docs/next/server_release_notes.html#deprecation-note-for-user-key-storage-encryption
- Implements https://github.com/owncloud/enterprise/issues/4939

## Types of changes
- [x] Technical debt

## Checklist:
- [x] Code changes
- [x] Unit tests added
- [x] Acceptance tests added
- [x] Documentation ticket (not needed)
- [x] Changelog item, see [TEMPLATE](https://github.com/owncloud/core/blob/master/changelog/TEMPLATE)
