### PR TITLE
Prevent 507 Insufficient Storage on 32-bit systems

### DIFF
--- a/apps/dav/lib/Connector/Sabre/QuotaPlugin.php
+++ b/apps/dav/lib/Connector/Sabre/QuotaPlugin.php
@@ -214,14 +214,15 @@ class QuotaPlugin extends \Sabre\DAV\ServerPlugin {
 					}
 					throw new InsufficientStorage();
 				}
-			}
-			// freeSpace might be false, or an int. Anyway, make sure that availableSpace will be an int.
-			$availableSpace = (int) $freeSpace + $extraSpace;
-			if ($freeSpace !== FileInfo::SPACE_UNKNOWN && $freeSpace !== FileInfo::SPACE_UNLIMITED && (($length > $availableSpace) || ($availableSpace === 0))) {
-				if (isset($chunkHandler)) {
-					$chunkHandler->cleanup();
+			} else {
+				// freeSpace might be false, or an int. Anyway, make sure that availableSpace will be an int.
+				$availableSpace = (int) $freeSpace + $extraSpace;
+				if ($freeSpace !== FileInfo::SPACE_UNKNOWN && $freeSpace !== FileInfo::SPACE_UNLIMITED && (($length > $availableSpace) || ($availableSpace === 0))) {
+					if (isset($chunkHandler)) {
+						$chunkHandler->cleanup();
+					}
+					throw new InsufficientStorage();
 				}
-				throw new InsufficientStorage();
 			}
 		}
 		return true;

--- a/apps/dav/lib/Connector/Sabre/QuotaPlugin.php
+++ b/apps/dav/lib/Connector/Sabre/QuotaPlugin.php
@@ -205,7 +205,7 @@ class QuotaPlugin extends \Sabre\DAV\ServerPlugin {
 			}
 			$freeSpace = $this->getFreeSpace($path);
 			// workaround to guarantee compatibility on 32-bit systems as otherwise this would cause an int overflow on such systems
-			// in case $freeSpace is above the max supported value. $freeSpace should be a float so we are using the <= 0.0 comparison
+			// when $freeSpace is above the max supported value. $freeSpace should be a float so we are using the <= 0.0 comparison
 			if (PHP_INT_SIZE === 4) {
 				$availableSpace = $freeSpace + $extraSpace;
 				if ($freeSpace !== FileInfo::SPACE_UNKNOWN && $freeSpace !== FileInfo::SPACE_UNLIMITED && (($length > $availableSpace) || ($availableSpace <= 0.0))) {

--- a/changelog/unreleased/40709
+++ b/changelog/unreleased/40709
@@ -1,0 +1,3 @@
+Bugfix: Prevent 507 Insufficient Storage on 32-bit systems
+
+With the introduction of https://github.com/owncloud/core/pull/40567 compatibility to 32-bit systems broke as we are now casting $freeSpace to int and this caused an integer overflow on such systems when the free space was above the max supported value. We added therefore an additional check for 32-bit systems in QuotaPlugin.php.


### PR DESCRIPTION
## Description
Prevent 507 Insufficient Storage on 32-bit systems

## Related Issue
- https://github.com/owncloud/core/issues/40695
- https://github.com/owncloud/enterprise/issues/5654

## Motivation and Context
With the introduction of https://github.com/owncloud/core/commit/c3687864a3f820445be2a5ef9db543d4fb6e7ed9 we apparently broke compatibility to 32-bit systems as we are now casting `$freeSpace` to int and this is causing an integer overflow on such systems when the free space is above the max supported value. We added therefore an additional check for 32-bit systems in QuotaPlugin.php.

## How Has This Been Tested?
- Feedback from users reporting this in https://github.com/owncloud/core/issues/40695

## Types of changes
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Database schema changes (next release will require increase of minor version instead of patch)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [ ] Tests only (no source changes)

## Checklist:
- [X] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised
- [X] Changelog item