### PR TITLE
[full-ci] fix: remove `php occ encryption:select-encryption-type` from drone

### DIFF
--- a/.drone.star
+++ b/.drone.star
@@ -294,7 +294,6 @@ config = {
                 "commands": [
                     "php occ maintenance:singleuser --on",
                     "php occ encryption:enable",
-                    "php occ encryption:select-encryption-type masterkey --yes",
                     "php occ encryption:encrypt-all --yes",
                     "php occ encryption:status",
                     "php occ maintenance:singleuser --off",

--- a/tests/acceptance/features/bootstrap/EncryptionContext.php
+++ b/tests/acceptance/features/bootstrap/EncryptionContext.php
@@ -85,46 +85,6 @@ class EncryptionContext implements Context {
 	}
 
 	/**
-	 * @param string $encryptionType
-	 *
-	 * @return void
-	 * @throws Exception
-	 */
-	public function setEncryptionTypeUsingTheOccCommand(string $encryptionType):int {
-		return($this->featureContext->runOcc(
-			["encryption:select-encryption-type", $encryptionType, "-y"]
-		)
-		);
-	}
-
-	/**
-	 * @When the administrator sets the encryption type to :encryptionType using the occ command
-	 *
-	 * @param string $encryptionType
-	 *
-	 * @return void
-	 * @throws Exception
-	 */
-	public function theAdministratorSetsEncryptionTypeToUsingTheOccCommand(string $encryptionType):void {
-		$this->featureContext->setOccLastCode(
-			$this->setEncryptionTypeUsingTheOccCommand($encryptionType)
-		);
-	}
-
-	/**
-	 * @Given the administrator has set the encryption type to :encryptionType
-	 *
-	 * @param string $encryptionType
-	 *
-	 * @return void
-	 * @throws Exception
-	 */
-	public function theAdministratorHasSetEncryptionTypeToUsingTheOccCommand(string $encryptionType):void {
-		$this->setEncryptionTypeUsingTheOccCommand($encryptionType);
-		$this->occContext->theCommandShouldHaveBeenSuccessful();
-	}
-
-	/**
 	 * @return void
 	 * @throws Exception
 	 */

--- a/tests/acceptance/features/bootstrap/OccContext.php
+++ b/tests/acceptance/features/bootstrap/OccContext.php
@@ -669,16 +669,6 @@ class OccContext implements Context {
 	}
 
 	/**
-	 * @Given the administrator has selected master key encryption type using the occ command
-	 *
-	 * @return void
-	 * @throws Exception
-	 */
-	public function theAdministratorHasSelectedMasterKeyEncryptionTypeUsingTheOccCommand():void {
-		$this->featureContext->runOcc(['encryption:select-encryption-type', "masterkey --yes"]);
-	}
-
-	/**
 	 * @When the administrator imports security certificate from file :filename in temporary storage on the system under test
 	 *
 	 * @param string $filename


### PR DESCRIPTION
## Description
Neccessary change due to https://github.com/owncloud/encryption/pull/389


## How Has This Been Tested?
- :robot: 


## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Database schema changes (next release will require increase of minor version instead of patch)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Technical debt
- [ ] Tests only (no source changes)

## Checklist:
<!-- Tick the checkboxes when done. -->
<!-- Raise documentation ticket in https://github.com/owncloud/documentation -->
- [ ] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 
- [ ] Changelog item, see [TEMPLATE](https://github.com/owncloud/core/blob/master/changelog/TEMPLATE)
