### PR TITLE
Fix X-Robots-Tag header valid values check

### DIFF
--- a/changelog/unreleased/40715
+++ b/changelog/unreleased/40715
@@ -4,4 +4,4 @@ Setup checks now allows other values other than "none" for X-Robots-Tag header.
 If "none" or "noindex" and "nofollow" are missing, a security warning is raised.
 Previously a header value with "noindex" and "nofollow" wasn't allowed event if it was valid.
 
-<https://github.com/owncloud/core/pull/40715>
+https://github.com/owncloud/core/pull/40715

--- a/changelog/unreleased/40715
+++ b/changelog/unreleased/40715
@@ -1,4 +1,4 @@
-Bugfix: X-Robots-Tag header valid values check
+Enhancement: Improve X-Robots-Tag header values check
 
 Setup checks now allows other values other than "none" for X-Robots-Tag header.
 If "none" or "noindex" and "nofollow" are missing, a security warning is raised.

--- a/changelog/unreleased/40715
+++ b/changelog/unreleased/40715
@@ -1,0 +1,7 @@
+Bugfix: X-Robots-Tag header valid values check
+
+Setup checks now allows other values other than "none" for X-Robots-Tag header.
+If "none" or "noindex" and "nofollow" are missing, a security warning is raised.
+Previously a header value with "noindex" and "nofollow" wasn't allowed event if it was valid.
+
+<https://github.com/owncloud/core/pull/40715>

--- a/changelog/unreleased/40715
+++ b/changelog/unreleased/40715
@@ -2,6 +2,6 @@ Enhancement: Improve X-Robots-Tag header values check
 
 Setup checks now allows other values other than "none" for X-Robots-Tag header.
 If "none" or "noindex" and "nofollow" are missing, a security warning is raised.
-Previously a header value with "noindex" and "nofollow" wasn't allowed event if it was valid.
+Previously a header value with "noindex" and "nofollow" wasn't allowed even though it was valid.
 
 https://github.com/owncloud/core/pull/40715

--- a/core/js/setupchecks.js
+++ b/core/js/setupchecks.js
@@ -245,8 +245,12 @@
 				};
 
 				for (var header in securityHeaders) {
-					if (!xhr.getResponseHeader(header) || header === 'X-Robots-Tag') {
-						xRobotsTagValues = xhr.getResponseHeader(header).split(',').map(item=>item.trim())
+					if (header === 'X-Robots-Tag') {
+						xRobotsTagValues = [];
+						if(xhr.getResponseHeader(header)) {
+							xRobotsTagValues = xhr.getResponseHeader(header).split(',').map(item=>item.trim());
+						}
+
 						if (!xRobotsTagValues.includes('none') && !(xRobotsTagValues.includes('noindex') && xRobotsTagValues.includes('nofollow'))) {
 							messages.push({
 								msg: t('core', 'The "{header}" HTTP header is misconfigured. Expected values are "none" or "noindex, nofollow". This is a potential security or privacy risk and we recommend adjusting this setting.', {header: header}),

--- a/core/js/setupchecks.js
+++ b/core/js/setupchecks.js
@@ -247,18 +247,22 @@
 				for (var header in securityHeaders) {
 					if (header === 'X-Robots-Tag') {
 						xRobotsTagValues = [];
-						if(xhr.getResponseHeader(header)) {
-							xRobotsTagValues = xhr.getResponseHeader(header).split(',').map(item=>item.trim());
+						if (xhr.getResponseHeader(header)) {
+							xRobotsTagValues = xhr.getResponseHeader(header).split(',').map(function(item) {
+								return item.trim();
+							});
 						}
 
-						if (!xRobotsTagValues.includes('none') && !(xRobotsTagValues.includes('noindex') && xRobotsTagValues.includes('nofollow'))) {
+						var hasNoneDirective = xRobotsTagValues.indexOf('none') !== -1;
+            			var hasNoIndexAndNoFollowDirectives = xRobotsTagValues.indexOf('noindex') !== -1 && xRobotsTagValues.indexOf('nofollow') !== -1;
+
+						if (!hasNoneDirective && !hasNoIndexAndNoFollowDirectives) {
 							messages.push({
 								msg: t('core', 'The "{header}" HTTP header is misconfigured. Expected values are "none" or "noindex, nofollow". This is a potential security or privacy risk and we recommend adjusting this setting.', {header: header}),
 								type: OC.SetupChecks.MESSAGE_TYPE_WARNING
 							});
 						}
-					}
-					else if(!xhr.getResponseHeader(header) || xhr.getResponseHeader(header).toLowerCase() !== securityHeaders[header].toLowerCase()) {
+					} else if (!xhr.getResponseHeader(header) || xhr.getResponseHeader(header).toLowerCase() !== securityHeaders[header].toLowerCase()) {
 						messages.push({
 						    msg: t('core', 'The "{header}" HTTP header is not configured to equal to "{expected}". This is a potential security or privacy risk and we recommend adjusting this setting.', {header: header, expected: securityHeaders[header]}),
 						    type: OC.SetupChecks.MESSAGE_TYPE_WARNING

--- a/core/js/setupchecks.js
+++ b/core/js/setupchecks.js
@@ -245,22 +245,16 @@
 				};
 
 				for (var header in securityHeaders) {
-					if (!xhr.getResponseHeader(header)) {
-						messages.push({
-						    msg: t('core', 'The "{header}" HTTP header is missing. This is a potential security or privacy risk and we recommend adjusting this setting.', {header: header}),
-						    type: OC.SetupChecks.MESSAGE_TYPE_WARNING
-						});
-					}
-					else if (header === 'X-Robots-Tag') {
+					if (!xhr.getResponseHeader(header) || header === 'X-Robots-Tag') {
 						xRobotsTagValues = xhr.getResponseHeader(header).split(',').map(item=>item.trim())
 						if (!xRobotsTagValues.includes('none') && !(xRobotsTagValues.includes('noindex') && xRobotsTagValues.includes('nofollow'))) {
 							messages.push({
-								msg: t('core', 'The "{header}" HTTP header is misconfigured. Expected values are none or noindex and nofollow. This is a potential security or privacy risk and we recommend adjusting this setting.', {header: header}),
+								msg: t('core', 'The "{header}" HTTP header is misconfigured. Expected values are "none" or "noindex, nofollow". This is a potential security or privacy risk and we recommend adjusting this setting.', {header: header}),
 								type: OC.SetupChecks.MESSAGE_TYPE_WARNING
 							});
 						}
 					}
-					else if(xhr.getResponseHeader(header).toLowerCase() !== securityHeaders[header].toLowerCase()) {
+					else if(!xhr.getResponseHeader(header) || xhr.getResponseHeader(header).toLowerCase() !== securityHeaders[header].toLowerCase()) {
 						messages.push({
 						    msg: t('core', 'The "{header}" HTTP header is not configured to equal to "{expected}". This is a potential security or privacy risk and we recommend adjusting this setting.', {header: header, expected: securityHeaders[header]}),
 						    type: OC.SetupChecks.MESSAGE_TYPE_WARNING

--- a/core/js/setupchecks.js
+++ b/core/js/setupchecks.js
@@ -254,7 +254,7 @@
 						}
 
 						var hasNoneDirective = xRobotsTagValues.indexOf('none') !== -1;
-            			var hasNoIndexAndNoFollowDirectives = xRobotsTagValues.indexOf('noindex') !== -1 && xRobotsTagValues.indexOf('nofollow') !== -1;
+						var hasNoIndexAndNoFollowDirectives = xRobotsTagValues.indexOf('noindex') !== -1 && xRobotsTagValues.indexOf('nofollow') !== -1;
 
 						if (!hasNoneDirective && !hasNoIndexAndNoFollowDirectives) {
 							messages.push({

--- a/core/js/setupchecks.js
+++ b/core/js/setupchecks.js
@@ -245,22 +245,22 @@
 				};
 
 				for (var header in securityHeaders) {
-					securityIssue = false;
-					
 					if (!xhr.getResponseHeader(header)) {
-						securityIssue = true;
+						messages.push({
+						    msg: t('core', 'The "{header}" HTTP header is missing. This is a potential security or privacy risk and we recommend adjusting this setting.', {header: header}),
+						    type: OC.SetupChecks.MESSAGE_TYPE_WARNING
+						});
 					}
 					else if (header === 'X-Robots-Tag') {
 						xRobotsTagValues = xhr.getResponseHeader(header).split(',').map(item=>item.trim())
 						if (!xRobotsTagValues.includes('none') && !(xRobotsTagValues.includes('noindex') && xRobotsTagValues.includes('nofollow'))) {
-							securityIssue = true;
+							messages.push({
+								msg: t('core', 'The "{header}" HTTP header is misconfigured. Expected values are none or noindex and nofollow. This is a potential security or privacy risk and we recommend adjusting this setting.', {header: header}),
+								type: OC.SetupChecks.MESSAGE_TYPE_WARNING
+							});
 						}
 					}
 					else if(xhr.getResponseHeader(header).toLowerCase() !== securityHeaders[header].toLowerCase()) {
-						securityIssue = true;
-					}
-				
-					if (securityIssue) {
 						messages.push({
 						    msg: t('core', 'The "{header}" HTTP header is not configured to equal to "{expected}". This is a potential security or privacy risk and we recommend adjusting this setting.', {header: header, expected: securityHeaders[header]}),
 						    type: OC.SetupChecks.MESSAGE_TYPE_WARNING

--- a/core/js/tests/specs/setupchecksSpec.js
+++ b/core/js/tests/specs/setupchecksSpec.js
@@ -422,9 +422,8 @@ describe('OC.SetupChecks tests', function() {
 					msg: 'The "X-Content-Type-Options" HTTP header is not configured to equal to "nosniff". This is a potential security or privacy risk and we recommend adjusting this setting.',
 					type: OC.SetupChecks.MESSAGE_TYPE_WARNING
 				}, {
-					msg: 'The "X-Robots-Tag" HTTP header is not configured to equal to "none". This is a potential security or privacy risk and we recommend adjusting this setting.',
+					msg: 'The "X-Robots-Tag" HTTP header is misconfigured. Expected values are "none" or "noindex, nofollow". This is a potential security or privacy risk and we recommend adjusting this setting.',
 					type: OC.SetupChecks.MESSAGE_TYPE_WARNING
-
 				}, {
 					msg: 'The "X-Frame-Options" HTTP header is not configured to equal to "SAMEORIGIN". This is a potential security or privacy risk and we recommend adjusting this setting.',
 					type: OC.SetupChecks.MESSAGE_TYPE_WARNING


### PR DESCRIPTION
## Description

Currently the only accepted value for the robots tag is `none` but:

- duplicate headers are acceptable https://stackoverflow.com/questions/4371328/are-duplicate-http-response-headers-acceptable
- the value `none` is only used by Google. Check this https://developer.mozilla.org/en-US/docs/Web/HTML/Element/meta/name and https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers. 
- `X-Robots-Tag': 'noindex nofollow'`, should be considered as valid


## Related Issue
- Fixes [#40713](https://github.com/owncloud/core/issues/40713)

## Motivation and Context
Allow all the possible values of x-robots-tag header and handle duplicate headers if OC is behind a proxy

## How Has This Been Tested?
- test environment: fully working environment with OC 10.12 (docker)
- test case 1: x-robots-tag header values: `'none, noindex, nofollow, nosnippet, noarchive'`
- test case 2: x-robots-tag header values: `'none, nosnippet, noarchive'`
- test case 3: x-robots-tag header values: `'none'`
- test case 4: x-robots-tag header values: `'nofollow, nosnippet'` [security warning raised]
- test case 5: x-robots-tag header values: `'nosnippet, noarchive'` [security warning raised]
- test case 6: x-robots-tag header values: `'noindex, nofollow'`
- test case 7: x-robots-tag header values: `''` [security warning raised]

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)

## Checklist:
- [x] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 
- [x] Changelog item, see [TEMPLATE](https://github.com/owncloud/core/blob/master/changelog/TEMPLATE)
