### PR TITLE
[full-ci] Remove loader in ChunkLocationProvider.php

### DIFF
--- a/apps/dav/lib/Upload/ChunkLocationProvider.php
+++ b/apps/dav/lib/Upload/ChunkLocationProvider.php
@@ -66,7 +66,7 @@ class ChunkLocationProvider implements IMountProvider {
 			// than in the "local" external storage and this would cause trouble when applying quota.
 			$cacheDir = $user->getHome();
 			return [
-				new MountPoint(Local::class, '/' . $user->getUID() . '/uploads', ['datadir' => $cacheDir . '/uploads'], $loader)
+				new MountPoint(Local::class, '/' . $user->getUID() . '/uploads', ['datadir' => $cacheDir . '/uploads'])
 			];
 		} else {
 			$cacheDir = \rtrim($chunkBaseDir, '/') . '/' . $user->getUID();
@@ -74,7 +74,7 @@ class ChunkLocationProvider implements IMountProvider {
 				\mkdir($cacheDir, 0770, true);
 			}
 			return [
-				new MountPoint(Local::class, '/' . $user->getUID() . '/uploads', ['datadir' => $cacheDir], $loader)
+				new MountPoint(Local::class, '/' . $user->getUID() . '/uploads', ['datadir' => $cacheDir])
 			];
 		}
 	}


### PR DESCRIPTION
## Description
Remove loader in ChunkLocationProvider.php. Follow-up of https://github.com/owncloud/core/pull/40700.

## Related Issue
- https://github.com/owncloud/firewall/issues/742
- https://github.com/owncloud/core/pull/40693

## Motivation and Context
File Firewall acceptance tests were failing after merging https://github.com/owncloud/core/pull/40693 as we changed the position of the loader in the constructor. We now remove the loader and use the empty storage factory.

## How Has This Been Tested?
Ran File Firewall acceptance tests locally and make sure that following scenarios pass (they were previously failing):

```
webUILimitUpload/limituploadbasedonsize.feature:29
webUILimitUpload/limituploadbasedonsize.feature:37
webUILimitFileAccess/limitfileaccessbasedonrequesttype.feature:13
```

## Types of changes
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Database schema changes (next release will require increase of minor version instead of patch)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [ ] Tests only (no source changes)

## Checklist:
- [X] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised
- [ ] Changelog item