### PR TITLE
fix: do not accept federated shares where the name is too long

### DIFF
--- a/apps/federatedfilesharing/lib/Controller/RequestHandlerController.php
+++ b/apps/federatedfilesharing/lib/Controller/RequestHandlerController.php
@@ -26,6 +26,7 @@
 
 namespace OCA\FederatedFileSharing\Controller;
 
+use OC\Files\View;
 use OC\OCS\Result;
 use OCA\FederatedFileSharing\Address;
 use OCA\FederatedFileSharing\AddressHandler;
@@ -37,6 +38,7 @@ use OCA\FederatedFileSharing\Ocm\Exception\NotImplementedException;
 use OCA\FederatedFileSharing\Ocm\Exception\OcmException;
 use OCP\AppFramework\Http;
 use OCP\AppFramework\OCSController;
+use OCP\Files\InvalidPathException;
 use OCP\IRequest;
 use OCP\IUserManager;
 
@@ -120,7 +122,7 @@ class RequestHandlerController extends OCSController {
 				]
 			);
 
-			if (!\OCP\Util::isValidFileName($name)) {
+			if (!$this->isFileNameValid($name)) {
 				throw new BadRequestException(
 					'The mountpoint name contains invalid characters.'
 				);
@@ -405,5 +407,19 @@ class RequestHandlerController extends OCSController {
 		}
 
 		return new Result();
+	}
+
+	private function isFileNameValid(?string $name): bool {
+		if ($name === null) {
+			return false;
+		}
+		$v = new View();
+		try {
+			# new shares will show up in user home - therefore we test with /
+			$v->verifyPath('/', $name);
+		} catch (InvalidPathException $e) {
+			return false;
+		}
+		return true;
 	}
 }

--- a/changelog/unreleased/40702
+++ b/changelog/unreleased/40702
@@ -1,4 +1,4 @@
-Change: Do not auto-enable user-key ecryption
+Change: Do not auto-enable user-key encryption
 
 Executing occ encryption:encrypt-all will no longer auto-enable user-key encryption.
 

--- a/changelog/unreleased/40726
+++ b/changelog/unreleased/40726
@@ -1,0 +1,5 @@
+Change: fix name length check on federated shares
+
+A federated share with a too long name results in inaccessible data.
+
+https://github.com/owncloud/core/pull/40726


### PR DESCRIPTION
## Description
Federated shares with a too long name can result in in accessible shares on the receiving server

## Related Issue
- Fixes <issue_link>

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
- test environment:
- test case 1:
- test case 2:
- ...

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Database schema changes (next release will require increase of minor version instead of patch)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [ ] Tests only (no source changes)

## Checklist:
<!-- Tick the checkboxes when done. -->
<!-- Raise documentation ticket in https://github.com/owncloud/documentation -->
- [ ] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 
- [ ] Changelog item, see [TEMPLATE](https://github.com/owncloud/core/blob/master/changelog/TEMPLATE)
