### PR TITLE
Fix quota for 32 bits. Some vars could be float instead of integer

### DIFF
--- a/apps/dav/lib/Connector/Sabre/Node.php
+++ b/apps/dav/lib/Connector/Sabre/Node.php
@@ -220,7 +220,7 @@ abstract class Node implements \Sabre\DAV\INode {
 	 * size because the actual size value isn't returned by google. This function
 	 * will return null in this case)
 	 *
-	 * @return integer|null
+	 * @return integer|float|null
 	 */
 	public function getSize() {
 		$size = $this->info->getSize();

--- a/apps/dav/lib/Connector/Sabre/QuotaPlugin.php
+++ b/apps/dav/lib/Connector/Sabre/QuotaPlugin.php
@@ -179,8 +179,8 @@ class QuotaPlugin extends \Sabre\DAV\ServerPlugin {
 	 * This method is called before any HTTP method and validates there is enough free space to store the file
 	 *
 	 * @param string $path path of the user's home
-	 * @param int $length size to check whether it fits
-	 * @param int $extraSpace additional space granted, usually used when overwriting files
+	 * @param int|float $length size to check whether it fits
+	 * @param int|float $extraSpace additional space granted, usually used when overwriting files
 	 * @throws InsufficientStorage
 	 * @return bool
 	 */

--- a/apps/dav/lib/Connector/Sabre/QuotaPlugin.php
+++ b/apps/dav/lib/Connector/Sabre/QuotaPlugin.php
@@ -204,25 +204,20 @@ class QuotaPlugin extends \Sabre\DAV\ServerPlugin {
 				$path = \rtrim($parentPath, '/') . '/' . $info['name'];
 			}
 			$freeSpace = $this->getFreeSpace($path);
-			// workaround to guarantee compatibility on 32-bit systems as otherwise this would cause an int overflow on such systems
-			// when $freeSpace is above the max supported value. $freeSpace should be a float so we are using the <= 0.0 comparison
-			if (PHP_INT_SIZE === 4) {
-				$availableSpace = $freeSpace + $extraSpace;
-				if ($freeSpace !== FileInfo::SPACE_UNKNOWN && $freeSpace !== FileInfo::SPACE_UNLIMITED && (($length > $availableSpace) || ($availableSpace <= 0.0))) {
-					if (isset($chunkHandler)) {
-						$chunkHandler->cleanup();
-					}
-					throw new InsufficientStorage();
+			if ($freeSpace === false) {
+				$freeSpace = 0;
+			}
+			// There could be cases where both $freeSpace and $extraSpace are floats:
+			// * $freeSpace could come from local storage, which calls disk_free_space, which returns float
+			// * $extraSpace could come from the DB. "size" column is bigint, which is returned as string. The storage
+			// cache uses `0 + $data['size']` where the $data['size'] should be a string, which should return an int if
+			// the result fits inside, but it could also be a float if it doesn't (more likely in 32 bits)
+			$availableSpace = $freeSpace + $extraSpace;
+			if ($freeSpace !== FileInfo::SPACE_UNKNOWN && $freeSpace !== FileInfo::SPACE_UNLIMITED && (($length > $availableSpace) || ($availableSpace <= 0.0))) {
+				if (isset($chunkHandler)) {
+					$chunkHandler->cleanup();
 				}
-			} else {
-				// freeSpace might be false, or an int. Anyway, make sure that availableSpace will be an int.
-				$availableSpace = (int) $freeSpace + $extraSpace;
-				if ($freeSpace !== FileInfo::SPACE_UNKNOWN && $freeSpace !== FileInfo::SPACE_UNLIMITED && (($length > $availableSpace) || ($availableSpace === 0))) {
-					if (isset($chunkHandler)) {
-						$chunkHandler->cleanup();
-					}
-					throw new InsufficientStorage();
-				}
+				throw new InsufficientStorage();
 			}
 		}
 		return true;

--- a/apps/dav/lib/Upload/ChunkingPlugin.php
+++ b/apps/dav/lib/Upload/ChunkingPlugin.php
@@ -98,6 +98,7 @@ class ChunkingPlugin extends ServerPlugin {
 			return;
 		}
 		$actualSize = $this->sourceNode->getSize();
+		// $actualSize could be either an int or a float
 		if ($expectedSize != $actualSize) {
 			throw new BadRequest("Chunks on server do not sum up to $expectedSize but to $actualSize");
 		}

--- a/lib/private/Files/FileInfo.php
+++ b/lib/private/Files/FileInfo.php
@@ -173,7 +173,7 @@ class FileInfo implements \OCP\Files\FileInfo, \ArrayAccess {
 	}
 
 	/**
-	 * @return int
+	 * @return int|float
 	 */
 	public function getSize() {
 		return isset($this->data['size']) ? $this->data['size'] : 0;

--- a/lib/private/Files/Node/Node.php
+++ b/lib/private/Files/Node/Node.php
@@ -191,7 +191,7 @@ class Node implements \OCP\Files\Node {
 	}
 
 	/**
-	 * @return int
+	 * @return int|float
 	 * @throws InvalidPathException
 	 * @throws NotFoundException
 	 */

--- a/lib/private/Files/Storage/Node.php
+++ b/lib/private/Files/Storage/Node.php
@@ -245,7 +245,7 @@ abstract class Node implements FilesNode {
 	/**
 	 * Get the size of the file or folder in bytes
 	 *
-	 * @return int
+	 * @return int|float
 	 * @throws \OCP\Files\StorageNotAvailableException
 	 */
 	public function getSize() {

--- a/lib/public/Files/Cache/ICacheEntry.php
+++ b/lib/public/Files/Cache/ICacheEntry.php
@@ -80,7 +80,10 @@ interface ICacheEntry {
 	/**
 	 * Get the file size in bytes
 	 *
-	 * @return int
+	 * It should return the size as integer, but it could return it
+	 * as float if the size doesn't fit
+	 *
+	 * @return int|float
 	 * @since 9.0.0
 	 */
 	public function getSize();

--- a/lib/public/Files/FileInfo.php
+++ b/lib/public/Files/FileInfo.php
@@ -74,7 +74,7 @@ interface FileInfo {
 	/**
 	 * Get the size in bytes for the file or folder
 	 *
-	 * @return int
+	 * @return int|foat
 	 * @since 7.0.0
 	 */
 	public function getSize();

--- a/lib/public/Files/Node.php
+++ b/lib/public/Files/Node.php
@@ -136,7 +136,10 @@ interface Node extends FileInfo {
 	/**
 	 * Get the size of the file or folder in bytes
 	 *
-	 * @return int
+	 * An integer should be returned. A float can also be returned,
+	 * usually if the size doesn't fit in an integer
+	 *
+	 * @return int|float
 	 * @throws InvalidPathException
 	 * @throws NotFoundException
 	 * @since 6.0.0

--- a/lib/public/Files/Storage/IStorage.php
+++ b/lib/public/Files/Storage/IStorage.php
@@ -316,8 +316,13 @@ interface IStorage {
 	/**
 	 * see http://php.net/manual/en/function.free_space.php
 	 *
+	 * This method should return an int if possible. If the free space doesn't fit in
+	 * an integer, a float can be used instead
+	 * The local storage implementation uses the disk_free_space function, which returns
+	 * a float.
+	 *
 	 * @param string $path
-	 * @return int|false
+	 * @return int|float|false
 	 * @throws StorageNotAvailableException if the storage is temporarily not available
 	 * @since 9.0.0
 	 */


### PR DESCRIPTION
<!--
Thanks for submitting a change to ownCloud!

This is the bug tracker for the Server component. Find other components at https://github.com/owncloud/core/blob/master/.github/CONTRIBUTING.md#guidelines

For fixing potential security issues please see https://owncloud.com/security/

To make it possible for us to get your change reviewed and merged please carefully fill out the requested information below.

Please note that any kind of change needs first be submitted to the master branch which holds the next version of ownCloud.

Please set the following labels:

- Set label "3 - To review" for review or "2 - Development" if the PR still has open tasks
- Assignment: assign to self
- Milestone: set the same as the ticket this PR fixes, or "development" by default
- Reviewers: pick at least one
-->

## Description
The type of some variables seems to be different than the ones we expect based on some conditions.
In particular, 32 bits systems seem to use floats instead of integers in some of our "getSize" methods, which was causing problems because we expected only integers. Quota calculation was affected by this.

The problem with the quota is fixed with this PR also for 32 bits systems because we've taken into consideration that the size could be either an integer or a float.
Most of the "getSize" methods have been adjusted so the PHPDoc shows the right information. The behavior of the methods hasn't been touched (no new issues should happen)

## Related Issue
https://github.com/owncloud/core/pull/40709

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?
Not tested with 32 bits but with 64 bits. I don't see any problem

Test1
1. Create a user with 0B quota
2. The user can't create a folder.
3. The user can't upload files.

Test2
1. Create a user with 1.5GB quota
2. Upload a 1GB file. The upload works
3. Upload another 1GB file. Error shows not enough free space.

Test3
1. Create a user with 2.5GB quota
2. Upload a 1GB file to "/file.bin"
3. Upload another 1GB file to "/t1/file.bin"
4. Copy "/file.bin" to "/zzz/file.bin". Error shows not enough quota

Test4
1. Create a user with 2.5GB quota
2. Upload a 1GB file to "/file.bin"
3. Upload another 1GB file to "/t1/file.bin"
4. Copy "/file.bin" into "/t1/file.bin". This is successful because the file is overwritten.

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Database schema changes (next release will require increase of minor version instead of patch)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [ ] Tests only (no source changes)

## Checklist:
<!-- Tick the checkboxes when done. -->
<!-- Raise documentation ticket in https://github.com/owncloud/documentation -->
- [ ] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 
- [ ] Changelog item, see [TEMPLATE](https://github.com/owncloud/core/blob/master/changelog/TEMPLATE)
