### PR TITLE
Do not correct parent folders if the target isn't fully scanned

### DIFF
--- a/lib/private/Files/Cache/Cache.php
+++ b/lib/private/Files/Cache/Cache.php
@@ -849,7 +849,14 @@ class Cache implements ICache {
 	 * @param array $data (optional) meta data of the folder
 	 */
 	public function correctFolderSize($path, $data = null) {
-		$this->calculateFolderSize($path, $data);
+		$newSize = $this->calculateFolderSize($path, $data);
+		if ($newSize < 0) {
+			// newSize < 0 implies the folder needs a scan or it's
+			// shallow scanned. In both cases, we don't need to correct
+			// the parent folders
+			return;
+		}
+
 		if ($path !== '') {
 			$parent = \dirname($path);
 			if ($parent === '.' or $parent === '/') {


### PR DESCRIPTION
<!--
Thanks for submitting a change to ownCloud!

This is the bug tracker for the Server component. Find other components at https://github.com/owncloud/core/blob/master/.github/CONTRIBUTING.md#guidelines

For fixing potential security issues please see https://owncloud.com/security/

To make it possible for us to get your change reviewed and merged please carefully fill out the requested information below.

Please note that any kind of change needs first be submitted to the master branch which holds the next version of ownCloud.

Please set the following labels:

- Set label "3 - To review" for review or "2 - Development" if the PR still has open tasks
- Assignment: assign to self
- Milestone: set the same as the ticket this PR fixes, or "development" by default
- Reviewers: pick at least one
-->

## Description
If the folder we want to correct the size isn't fully scanned, there is no need to try to correct the parent folders: we can't get a proper size so they should stay as "need to scan" or "shallow scanned".

This should improve the performance a bit when the system isn't fully scanned, specially in deep folders, because we won't try to update all the parent folders unless it's needed.

## Related Issue
https://github.com/owncloud/enterprise/issues/5605

## Motivation and Context
This should reduce the DB load in some scenarios because there will be less queries to be done.

## How Has This Been Tested?
1. Prepare an external storage (SFTP for example) with "/f1/f2/f3/f4/file.txt"
2. Connect ownCloud to the external storage
3. Check that the "/SFTP" folder shows "pending" as size.
4. Traverse the directories until you reach "/SFTP/f1/f2/f3/f4/file.txt"
5. From there, traverse the directories backwards. Old "pending" sizes for the folders should show now the right size (assuming there are no additional folders you haven't traversed, such as "/SFTP/f1/f2/side_quest/")

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Database schema changes (next release will require increase of minor version instead of patch)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Technical debt
- [ ] Tests only (no source changes)

## Checklist:
<!-- Tick the checkboxes when done. -->
<!-- Raise documentation ticket in https://github.com/owncloud/documentation -->
- [x] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 
- [ ] Changelog item, see [TEMPLATE](https://github.com/owncloud/core/blob/master/changelog/TEMPLATE)
