### PR TITLE
Default setting for receiving fed-shares to off

### DIFF
--- a/apps/federatedfilesharing/lib/FederatedShareProvider.php
+++ b/apps/federatedfilesharing/lib/FederatedShareProvider.php
@@ -1056,7 +1056,7 @@ class FederatedShareProvider implements IShareProvider {
 	 * @return bool
 	 */
 	public function isIncomingServer2serverShareEnabled() {
-		$result = $this->config->getAppValue('files_sharing', 'incoming_server2server_share_enabled', 'yes');
+		$result = $this->config->getAppValue('files_sharing', 'incoming_server2server_share_enabled', 'no');
 		return ($result === 'yes') ? true : false;
 	}
 

--- a/apps/federatedfilesharing/tests/FederatedShareProviderTest.php
+++ b/apps/federatedfilesharing/tests/FederatedShareProviderTest.php
@@ -937,7 +937,7 @@ class FederatedShareProviderTest extends \Test\TestCase {
 	 */
 	public function testIsIncomingServer2serverShareEnabled($isEnabled, $expected) {
 		$this->config->expects($this->once())->method('getAppValue')
-			->with('files_sharing', 'incoming_server2server_share_enabled', 'yes')
+			->with('files_sharing', 'incoming_server2server_share_enabled', 'no')
 			->willReturn($isEnabled);
 
 		$this->assertSame(

--- a/changelog/unreleased/40736
+++ b/changelog/unreleased/40736
@@ -1,0 +1,9 @@
+Change: Don't enable incoming federated share requests by default
+
+Federated share requests can be used for spamming the user with unwanted shares.
+Therefore, we decided to disable incoming federated share requests by default.
+
+Please revise your setting under Settings > Admin > Sharing > Federation
+> Allow users on this server to receive shares from other servers
+
+https://github.com/owncloud/core/pull/40736


### PR DESCRIPTION
<!--
Thanks for submitting a change to ownCloud!

This is the bug tracker for the Server component. Find other components at https://github.com/owncloud/core/blob/master/.github/CONTRIBUTING.md#guidelines

For fixing potential security issues please see https://owncloud.com/security/

To make it possible for us to get your change reviewed and merged please carefully fill out the requested information below.

Please note that any kind of change needs first be submitted to the master branch which holds the next version of ownCloud.

Please set the following labels:

- Set label "3 - To review" for review or "2 - Development" if the PR still has open tasks
- Assignment: assign to self
- Milestone: set the same as the ticket this PR fixes, or "development" by default
- Reviewers: pick at least one
-->

## Description
Don't enable incoming federated share requests by default


## Motivation and Context

Federated share requests can be used for spamming the user with unwanted shares.
Therefore, we decided to disable incoming federated share requests by default.

## How Has This Been Tested?
:robot: , :hand: 


## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Database schema changes (next release will require increase of minor version instead of patch)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [ ] Tests only (no source changes)

## Checklist:
<!-- Tick the checkboxes when done. -->
<!-- Raise documentation ticket in https://github.com/owncloud/documentation -->
- [x] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 
- [x] Changelog item, see [TEMPLATE](https://github.com/owncloud/core/blob/master/changelog/TEMPLATE)
