### PR TITLE
feat: add .drawio file extension to mime type mapping

### DIFF
--- a/resources/config/mimetypemapping.dist.json
+++ b/resources/config/mimetypemapping.dist.json
@@ -39,6 +39,7 @@
 	"docx": ["application/vnd.openxmlformats-officedocument.wordprocessingml.document"],
 	"dot": ["application/msword"],
 	"dotx": ["application/vnd.openxmlformats-officedocument.wordprocessingml.template"],
+	"drawio": ["application/xml"],
 	"dv": ["video/dv"],
 	"eml": ["message/rfc822"],
 	"eot": ["application/vnd.ms-fontobject"],

--- a/tests/lib/Files/Type/DetectionTest.php
+++ b/tests/lib/Files/Type/DetectionTest.php
@@ -23,10 +23,12 @@ namespace Test\Files\Type;
 
 use OC\Files\Type\Detection;
 use org\bovigo\vfs\vfsStream;
+use Test\TestCase;
+use OCP\IURLGenerator;
 
-class DetectionTest extends \Test\TestCase {
-	/** @var Detection */
-	private $detection;
+class DetectionTest extends TestCase {
+
+	private Detection $detection;
 
 	public function setUp(): void {
 		parent::setUp();
@@ -58,6 +60,10 @@ class DetectionTest extends \Test\TestCase {
 
 		$result = $this->detection->detect($dir."/testimage.png");
 		$expected = 'image/png';
+		$this->assertEquals($expected, $result);
+
+		$result = $this->detection->detect($dir."/diagram.drawio");
+		$expected = 'application/xml';
 		$this->assertEquals($expected, $result);
 	}
 
@@ -96,15 +102,18 @@ class DetectionTest extends \Test\TestCase {
 		$this->assertEquals($expected, $result);
 	}
 
+	/**
+	 * @throws \JsonException
+	 */
 	public function testMimeTypeIcon(): void {
 		$confDir = vfsStream::setup();
 		$mimetypealiases_dist = vfsStream::newFile('mimetypealiases.dist.json')->at($confDir);
 
 		//Empty alias file
-		$mimetypealiases_dist->setContent(\json_encode([], JSON_FORCE_OBJECT));
+		$mimetypealiases_dist->setContent(\json_encode([], JSON_THROW_ON_ERROR | JSON_FORCE_OBJECT));
 
 		//Mock UrlGenerator
-		$urlGenerator = $this->getMockBuilder('\OCP\IURLGenerator')
+		$urlGenerator = $this->getMockBuilder(IURLGenerator::class)
 			->disableOriginalConstructor()
 			->getMock();
 
@@ -122,7 +131,7 @@ class DetectionTest extends \Test\TestCase {
 		 * Test dir-shareed mimetype
 		 */
 		//Mock UrlGenerator
-		$urlGenerator = $this->getMockBuilder('\OCP\IURLGenerator')
+		$urlGenerator = $this->getMockBuilder(IURLGenerator::class)
 			->disableOriginalConstructor()
 			->getMock();
 
@@ -141,7 +150,7 @@ class DetectionTest extends \Test\TestCase {
 		 */
 
 		//Mock UrlGenerator
-		$urlGenerator = $this->getMockBuilder('\OCP\IURLGenerator')
+		$urlGenerator = $this->getMockBuilder(IURLGenerator::class)
 			->disableOriginalConstructor()
 			->getMock();
 
@@ -160,7 +169,7 @@ class DetectionTest extends \Test\TestCase {
 		 */
 
 		//Mock UrlGenerator
-		$urlGenerator = $this->getMockBuilder('\OCP\IURLGenerator')
+		$urlGenerator = $this->getMockBuilder(IURLGenerator::class)
 			->disableOriginalConstructor()
 			->getMock();
 
@@ -179,7 +188,7 @@ class DetectionTest extends \Test\TestCase {
 		 */
 
 		//Mock UrlGenerator
-		$urlGenerator = $this->getMockBuilder('\OCP\IURLGenerator')
+		$urlGenerator = $this->getMockBuilder(IURLGenerator::class)
 			->disableOriginalConstructor()
 			->getMock();
 
@@ -206,7 +215,7 @@ class DetectionTest extends \Test\TestCase {
 		 */
 
 		//Mock UrlGenerator
-		$urlGenerator = $this->getMockBuilder('\OCP\IURLGenerator')
+		$urlGenerator = $this->getMockBuilder(IURLGenerator::class)
 			->disableOriginalConstructor()
 			->getMock();
 
@@ -234,7 +243,7 @@ class DetectionTest extends \Test\TestCase {
 		 */
 
 		//Mock UrlGenerator
-		$urlGenerator = $this->getMockBuilder('\OCP\IURLGenerator')
+		$urlGenerator = $this->getMockBuilder(IURLGenerator::class)
 			->disableOriginalConstructor()
 			->getMock();
 
@@ -255,10 +264,10 @@ class DetectionTest extends \Test\TestCase {
 		 */
 
 		//Put alias
-		$mimetypealiases_dist->setContent(\json_encode(['foo' => 'foobar/baz'], JSON_FORCE_OBJECT));
+		$mimetypealiases_dist->setContent(\json_encode(['foo' => 'foobar/baz'], JSON_THROW_ON_ERROR | JSON_FORCE_OBJECT));
 
 		//Mock UrlGenerator
-		$urlGenerator = $this->getMockBuilder('\OCP\IURLGenerator')
+		$urlGenerator = $this->getMockBuilder(IURLGenerator::class)
 			->disableOriginalConstructor()
 			->getMock();
 


### PR DESCRIPTION
## Description
Without this an drawio file has a content type `application/octet-stream` which is not detected by drawio.
This ensures a content type of `application/xml` for *.drawio files

## Related Issue
- Fixes https://github.com/owncloud/enterprise/issues/5679

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
- test environment:
- test case 1:
- test case 2:
- ...

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Database schema changes (next release will require increase of minor version instead of patch)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [ ] Tests only (no source changes)

## Checklist:
<!-- Tick the checkboxes when done. -->
<!-- Raise documentation ticket in https://github.com/owncloud/documentation -->
- [ ] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 
- [ ] Changelog item, see [TEMPLATE](https://github.com/owncloud/core/blob/master/changelog/TEMPLATE)
