### PR TITLE
[unit-tests] Restore services in teardown

### DIFF
--- a/tests/Core/Command/User/ReportTest.php
+++ b/tests/Core/Command/User/ReportTest.php
@@ -70,6 +70,12 @@ class ReportTest extends TestCase {
 		$this->loginAsUser('admin');
 	}
 
+	protected function tearDown(): void {
+		parent::tearDown();
+		$this->restoreService('AllConfig');
+		$this->restoreService('AppManager');
+	}
+
 	public function objectStorageProvider() {
 		return [
 			[true],
@@ -131,8 +137,6 @@ EOS;
 
 		if ($objectStorageUsed) {
 			$this->assertStringContainsString('We detected that the instance is running on a S3 primary object storage, user directories count might not be accurate', $output);
-			$this->restoreService('AllConfig');
-			$this->restoreService('AppManager');
 		}
 	}
 


### PR DESCRIPTION
## Description
> In general, if the test class needs to overwrite services, it should be placed in the setUp method, and restoring the service should be placed in the tearDown method. If it's only one test requiring the service overwrite, you can do it in the test itself, but the restoring should still be placed in the tearDown method in order to ensure it's reverted even if the test fails (which isn't the case)

See https://github.com/owncloud/update-testing/issues/45#issuecomment-1412016147

## Related Issue
Part of https://github.com/owncloud/update-testing/issues/45

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?
- test environment: tested in https://drone.owncloud.com/owncloud/update-testing/2008/1/7 (only two failures)
```
There were 2 failures:
```
vs (without this teardown)
```bash
There were 865 errors:
```
 
## Screenshots (if appropriate):

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Database schema changes (next release will require increase of minor version instead of patch)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Technical debt
- [x] Tests only (no source changes)

## Checklist:
- [ ] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 
- [ ] Changelog item, see [TEMPLATE](https://github.com/owncloud/core/blob/master/changelog/TEMPLATE)
