### PR TITLE
[tests-only] [full-ci] PHP Ubuntu22.04

### DIFF
--- a/.drone.star
+++ b/.drone.star
@@ -30,7 +30,7 @@ THEGEEKLAB_DRONE_GITHUB_COMMENT = "thegeeklab/drone-github-comment:1"
 TOOLHIPPIE_CALENS = "toolhippie/calens:latest"
 WEBHIPPIE_REDIS = "webhippie/redis:latest"
 
-DEFAULT_PHP_VERSION = "7.4"
+DEFAULT_PHP_VERSION = "7.4-ubuntu22.04"
 DEFAULT_NODEJS_VERSION = "14"
 
 dir = {


### PR DESCRIPTION
## Description
WIP - This replaces #40123 

Note: current master uses PHP 7.4 with Ubuntu 20.04 - see PR #40417 
The `owncloudci/php:7.4` docker image uses Ubuntu 20.04 as its base nowadays.

## Related Issue

## How Has This Been Tested?
CI

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Database schema changes (next release will require increase of minor version instead of patch)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [ ] Tests only (no source changes)

## Checklist:
- [ ] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 
- [ ] Changelog item, see [TEMPLATE](https://github.com/owncloud/core/blob/master/changelog/TEMPLATE)
