### PR TITLE
[tests-only][full-ci]Make a paramater accept null values

### DIFF
--- a/tests/acceptance/features/bootstrap/Provisioning.php
+++ b/tests/acceptance/features/bootstrap/Provisioning.php
@@ -1388,7 +1388,7 @@ trait Provisioning {
 		$bodyTable = new TableNode(
 			[['userid', $user], ['password', $password], ['groups[]', $group]]
 		);
-		
+
 		$this->ocsContext->userSendsHTTPMethodToOcsApiEndpointWithBody(
 			$this->getAdminUsername(),
 			"POST",
@@ -2108,7 +2108,7 @@ trait Provisioning {
 			$displayName
 		);
 		$this->theHTTPStatusCodeShouldBeSuccess();
-		
+
 		$this->rememberUserDisplayName($targetUser, $displayName);
 	}
 	/**
@@ -2759,7 +2759,7 @@ trait Provisioning {
 	 * @param string|null $password
 	 * @param string|null $displayName
 	 * @param string|null $email
-	 * @param bool $shouldExist
+	 * @param bool|null $shouldExist
 	 *
 	 * @return void
 	 * @throws JsonException
@@ -2769,7 +2769,7 @@ trait Provisioning {
 		?string $password,
 		?string $displayName = null,
 		?string $email = null,
-		bool $shouldExist = true
+		?bool $shouldExist = true
 	):void {
 		$user = $this->getActualUsername($user);
 		$normalizedUsername = $this->normalizeUsername($user);


### PR DESCRIPTION
This PR makes the `$shouldExist` parameter of function `addUserToCreatedUsersList` to accept the null value.
This will fix the error in https://github.com/owncloud/impersonate/issues/227 which is currently failing with error 
```
Type error: Argument 5 passed to FeatureContext::addUserToCreatedUsersList() must be of the type bool, null given, called in /var/www/owncloud/testrunner/apps/impersonate/tests/acceptance/features/bootstrap/ImpersonateAppContext.php on line 123 (Behat\Testwork\Call\Exception\FatalThrowableError)
```

This will fix that. 

Fixes: https://github.com/owncloud/impersonate/issues/227