### PR TITLE
[tests-only][full-ci]Added default value for `skipImportLdif` as `false` And `$occLastCode` as null

### DIFF
--- a/tests/acceptance/features/bootstrap/FeatureContext.php
+++ b/tests/acceptance/features/bootstrap/FeatureContext.php
@@ -355,7 +355,7 @@ class FeatureContext extends BehatVariablesContext {
 	 * @var string
 	 */
 	private $ldapGroupSchema;
-	private bool $skipImportLdif;
+	private bool $skipImportLdif = false;
 	private array $toDeleteDNs = [];
 	private array $ldapCreatedUsers = [];
 	private array $ldapCreatedGroups = [];

--- a/tests/acceptance/features/bootstrap/FeatureContext.php
+++ b/tests/acceptance/features/bootstrap/FeatureContext.php
@@ -169,7 +169,7 @@ class FeatureContext extends BehatVariablesContext {
 	/**
 	 * return code of last command
 	 */
-	private ?int $occLastCode;
+	private ?int $occLastCode = null;
 	/**
 	 * stdout of last command
 	 */


### PR DESCRIPTION
### Description
This change in the PR https://github.com/owncloud/core/pull/40754 refactors the variable `$skipImportLdif`. But does not defines the initial value. This PR defines the initial value of `$skipImportLdif` as `false`.
And also `$occLastCode` default as null.

### Related Issue:
https://github.com/owncloud/user_ldap/issues/784
https://github.com/owncloud/richdocuments/issues/490