### PR TITLE
Remove addgroup from user

### DIFF
--- a/changelog/unreleased/40770
+++ b/changelog/unreleased/40770
@@ -1,0 +1,8 @@
+Change: Remove the "add group" button from the dropdowns in the users page
+
+The "add group" button has been removed from the dropdowns because the
+behavior was confusing. You can still create new groups in the users
+page by using the "add group" button in the top left corner of the users page.
+The dropdowns will only select existing groups, but they won't add new groups.
+
+https://github.com/owncloud/core/pull/40770

--- a/settings/Controller/GroupsController.php
+++ b/settings/Controller/GroupsController.php
@@ -113,7 +113,7 @@ class GroupsController extends Controller {
 		if ($groupObj = $this->groupManager->createGroup($id)) {
 			return new DataResponse(
 				[
-					'id' => $groupObj->getGID(),
+					'gid' => $groupObj->getGID(),
 					'name' => $groupObj->getDisplayName(),
 				],
 				Http::STATUS_CREATED
@@ -185,13 +185,13 @@ class GroupsController extends Controller {
 					$groupObject = $this->groupManager->get($group);
 					if ($backend->implementsActions($backend::ADD_TO_GROUP)) {
 						$assignableGroups[$groupObject->getGID()] = [
-							'id' => $groupObject->getGID(),
+							'gid' => $groupObject->getGID(),
 							'name' => $groupObject->getDisplayName(),
 						];
 					}
 					if ($backend->implementsActions($backend::REMOVE_FROM_GROUP)) {
 						$removableGroups[$groupObject->getGID()] = [
-							'id' => $groupObject->getGID(),
+							'gid' => $groupObject->getGID(),
 							'name' => $groupObject->getDisplayName(),
 						];
 					}
@@ -203,13 +203,13 @@ class GroupsController extends Controller {
 				$backend = $subAdminGroup->getBackend();
 				if ($backend->implementsActions($backend::ADD_TO_GROUP)) {
 					$assignableGroups[$subAdminGroup->getGID()] = [
-						'id' => $subAdminGroup->getGID(),
+						'gid' => $subAdminGroup->getGID(),
 						'name' => $subAdminGroup->getDisplayName(),
 					];
 				}
 				if ($backend->implementsActions($backend::REMOVE_FROM_GROUP)) {
 					$removableGroups[$subAdminGroup->getGID()] = [
-						'id' => $subAdminGroup->getGID(),
+						'gid' => $subAdminGroup->getGID(),
 						'name' => $subAdminGroup->getDisplayName()
 					];
 				}

--- a/settings/Controller/GroupsController.php
+++ b/settings/Controller/GroupsController.php
@@ -182,15 +182,14 @@ class GroupsController extends Controller {
 
 				$groups = $backend->getGroups();
 				foreach ($groups as $group) {
+					$groupObject = $this->groupManager->get($group);
 					if ($backend->implementsActions($backend::ADD_TO_GROUP)) {
-						$groupObject = $this->groupManager->get($group);
 						$assignableGroups[$groupObject->getGID()] = [
 							'id' => $groupObject->getGID(),
 							'name' => $groupObject->getDisplayName(),
 						];
 					}
 					if ($backend->implementsActions($backend::REMOVE_FROM_GROUP)) {
-						$groupObject = $this->groupManager->get($group);
 						$removableGroups[$groupObject->getGID()] = [
 							'id' => $groupObject->getGID(),
 							'name' => $groupObject->getDisplayName(),

--- a/settings/Controller/GroupsController.php
+++ b/settings/Controller/GroupsController.php
@@ -184,11 +184,17 @@ class GroupsController extends Controller {
 				foreach ($groups as $group) {
 					if ($backend->implementsActions($backend::ADD_TO_GROUP)) {
 						$groupObject = $this->groupManager->get($group);
-						$assignableGroups[$groupObject->getGID()] = $groupObject->getDisplayName();
+						$assignableGroups[$groupObject->getGID()] = [
+							'id' => $groupObject->getGID(),
+							'name' => $groupObject->getDisplayName(),
+						];
 					}
 					if ($backend->implementsActions($backend::REMOVE_FROM_GROUP)) {
 						$groupObject = $this->groupManager->get($group);
-						$removableGroups[$groupObject->getGID()] = $groupObject->getDisplayName();
+						$removableGroups[$groupObject->getGID()] = [
+							'id' => $groupObject->getGID(),
+							'name' => $groupObject->getDisplayName(),
+						];
 					}
 				}
 			}
@@ -197,10 +203,16 @@ class GroupsController extends Controller {
 			foreach ($subAdminGroups as $subAdminGroup) {
 				$backend = $subAdminGroup->getBackend();
 				if ($backend->implementsActions($backend::ADD_TO_GROUP)) {
-					$assignableGroups[$subAdminGroup->getGID()] = $subAdminGroup->getDisplayName();
+					$assignableGroups[$subAdminGroup->getGID()] = [
+						'id' => $subAdminGroup->getGID(),
+						'name' => $subAdminGroup->getDisplayName(),
+					];
 				}
 				if ($backend->implementsActions($backend::REMOVE_FROM_GROUP)) {
-					$removableGroups[$subAdminGroup->getGID()] = $subAdminGroup->getDisplayName();
+					$removableGroups[$subAdminGroup->getGID()] = [
+						'id' => $subAdminGroup->getGID(),
+						'name' => $subAdminGroup->getDisplayName()
+					];
 				}
 			}
 		}

--- a/settings/Controller/GroupsController.php
+++ b/settings/Controller/GroupsController.php
@@ -110,10 +110,11 @@ class GroupsController extends Controller {
 				Http::STATUS_CONFLICT
 			);
 		}
-		if ($this->groupManager->createGroup($id)) {
+		if ($groupObj = $this->groupManager->createGroup($id)) {
 			return new DataResponse(
 				[
-					'groupname' => $id
+					'id' => $groupObj->getGID(),
+					'name' => $groupObj->getDisplayName(),
 				],
 				Http::STATUS_CREATED
 			);
@@ -175,12 +176,20 @@ class GroupsController extends Controller {
 
 		if ($this->groupManager->isAdmin($currentUser->getUID())) {
 			foreach ($this->groupManager->getBackends() as $backend) {
-				$groups = $backend->getGroups();
-				if ($backend->implementsActions($backend::ADD_TO_GROUP)) {
-					\array_push($assignableGroups, ...$groups);
+				if (!$backend->implementsActions($backend::ADD_TO_GROUP) && !$backend->implementsActions($backend::REMOVE_FROM_GROUP)) {
+					continue;
 				}
-				if ($backend->implementsActions($backend::REMOVE_FROM_GROUP)) {
-					\array_push($removableGroups, ...$groups);
+
+				$groups = $backend->getGroups();
+				foreach ($groups as $group) {
+					if ($backend->implementsActions($backend::ADD_TO_GROUP)) {
+						$groupObject = $this->groupManager->get($group);
+						$assignableGroups[$groupObject->getGID()] = $groupObject->getDisplayName();
+					}
+					if ($backend->implementsActions($backend::REMOVE_FROM_GROUP)) {
+						$groupObject = $this->groupManager->get($group);
+						$removableGroups[$groupObject->getGID()] = $groupObject->getDisplayName();
+					}
 				}
 			}
 		} elseif ($subAdmin->isSubAdmin($currentUser)) {
@@ -188,10 +197,10 @@ class GroupsController extends Controller {
 			foreach ($subAdminGroups as $subAdminGroup) {
 				$backend = $subAdminGroup->getBackend();
 				if ($backend->implementsActions($backend::ADD_TO_GROUP)) {
-					$assignableGroups[] = $subAdminGroup->getGID();
+					$assignableGroups[$subAdminGroup->getGID()] = $subAdminGroup->getDisplayName();
 				}
 				if ($backend->implementsActions($backend::REMOVE_FROM_GROUP)) {
-					$removableGroups[] = $subAdminGroup->getGID();
+					$removableGroups[$subAdminGroup->getGID()] = $subAdminGroup->getDisplayName();
 				}
 			}
 		}

--- a/settings/ajax/togglegroups.php
+++ b/settings/ajax/togglegroups.php
@@ -86,7 +86,7 @@ if ($action === "add" && \OC::$server->getGroupManager()->isInGroup($username, $
 			"username" => $username,
 			"action" => $action,
 			"group" => [
-				"id" => $targetGroupObject->getGid(),
+				"gid" => $targetGroupObject->getGID(),
 				"name" => $targetGroupObject->getDisplayName(),
 			],
 		]
@@ -97,7 +97,7 @@ if ($action === "add" && \OC::$server->getGroupManager()->isInGroup($username, $
 			"username" => $username,
 			"action" => $action,
 			"group" => [
-				"id" => $targetGroupObject->getGid(),
+				"gid" => $targetGroupObject->getGID(),
 				"name" => $targetGroupObject->getDisplayName(),
 			],
 		]

--- a/settings/ajax/togglegroups.php
+++ b/settings/ajax/togglegroups.php
@@ -81,9 +81,27 @@ if (\OC::$server->getGroupManager()->inGroup($username, $group)) {
 }
 
 if ($action === "add" && \OC::$server->getGroupManager()->isInGroup($username, $group)) {
-	OC_JSON::success(["data" => ["username" => $username, "action" => $action, "groupname" => $group]]);
+	OC_JSON::success([
+		"data" => [
+			"username" => $username,
+			"action" => $action,
+			"group" => [
+				"id" => $targetGroupObject->getGid(),
+				"name" => $targetGroupObject->getDisplayName(),
+			],
+		]
+	]);
 } elseif ($action === "remove" && !\OC::$server->getGroupManager()->isInGroup($username, $group)) {
-	OC_JSON::success(["data" => ["username" => $username, "action" => $action, "groupname" => $group]]);
+	OC_JSON::success([
+		"data" => [
+			"username" => $username,
+			"action" => $action,
+			"group" => [
+				"id" => $targetGroupObject->getGid(),
+				"name" => $targetGroupObject->getDisplayName(),
+			],
+		]
+	]);
 } else {
 	OC_JSON::error();
 }

--- a/settings/js/users/groups.js
+++ b/settings/js/users/groups.js
@@ -24,11 +24,11 @@ var GroupList;
 			this.$sortGroupBy = $el;
 		},
 
-		addGroup: function (gid, usercount) {
+		addGroup: function (gid, name, usercount) {
 			var $li = $(
 				'<li class="isgroup" data-gid="' + gid + '" data-usercount="0">' +
 				'	<a href="#" class="dorename">' +
-				'		<span class="groupname">' + gid + '</span>' +
+				'		<span class="groupname">' + name + '</span>' +
 				'		<span class="usercount tag"></span>' +
 				'	</a>' +
 				'	<span class="utils">' +
@@ -149,10 +149,11 @@ var GroupList;
 					id: groupname
 				},
 				function (result) {
-					if (result.groupname) {
-						var addedGroup = result.groupname;
-						UserList.availableGroups = $.unique($.merge(UserList.availableGroups, [addedGroup]));
-						GroupList.addGroup(result.groupname);
+					if (result.id) {
+						var newGroups = {};
+						newGroups[result.id] = result.name;
+						UserList.availableGroups = $.extend(UserList.availableGroups, newGroups);
+						GroupList.addGroup(result.id, result.name);
 					}
 					GroupList.toggleAddGroup();
 				}).fail(function(result) {
@@ -184,7 +185,7 @@ var GroupList;
 									GroupList.setUserCount(GroupList.getGroupLI(group.name).first(), group.usercount);
 								}
 								else {
-									var $li = GroupList.addGroup(group.name, group.usercount);
+									var $li = GroupList.addGroup(group.id, group.name, group.usercount);
 
 									$li.addClass('appear transparent');
 									lis.push($li);

--- a/settings/js/users/groups.js
+++ b/settings/js/users/groups.js
@@ -149,11 +149,11 @@ var GroupList;
 					id: groupname
 				},
 				function (result) {
-					if (result.id) {
+					if (result.gid) {
 						var newGroups = {};
-						newGroups[result.id] = result.name;
+						newGroups[result.gid] = result.name;
 						UserList.availableGroups = $.extend(UserList.availableGroups, newGroups);
-						GroupList.addGroup(result.id, result.name);
+						GroupList.addGroup(result.gid, result.name);
 					}
 					GroupList.toggleAddGroup();
 				}).fail(function(result) {
@@ -185,7 +185,7 @@ var GroupList;
 									GroupList.setUserCount(GroupList.getGroupLI(group.name).first(), group.usercount);
 								}
 								else {
-									var $li = GroupList.addGroup(group.id, group.name, group.usercount);
+									var $li = GroupList.addGroup(group.gid, group.name, group.usercount);
 
 									$li.addClass('appear transparent');
 									lis.push($li);

--- a/settings/js/users/users.js
+++ b/settings/js/users/users.js
@@ -499,7 +499,10 @@ var UserList = {
 							if (UserList.availableGroups[groupId] === undefined &&
 								response.data.action === 'add'
 							) {
-								UserList.availableGroups[groupId] = groupName;
+								UserList.availableGroups[groupId] = {
+									'id': groupId,
+									'name': groupName
+								};
 							}
 
 							if (response.data.action === 'add') {
@@ -675,7 +678,7 @@ var UserList = {
 			$groupsSelect = $('<select multiple="multiple" class="subadminsselect multiselect button" title="' + placeholder + '"></select>')
 		}
 
-		function createItem(id, groupname) {
+		function createItem(id, group) {
 			if (isSubadminSelect) {
 				// this is solely for the dropdown menu "Group Admin for"
 				if (id === 'admin') {
@@ -683,7 +686,7 @@ var UserList = {
 					return;
 				}
 
-				$groupsSelect.append($('<option value="' + escapeHTML(id) + '">' + escapeHTML(groupname) + '</option>'));
+				$groupsSelect.append($('<option value="' + escapeHTML(id) + '">' + escapeHTML(group['name']) + '</option>'));
 				// return as we need to bypass the following group restrictions here
 				return;
 			}
@@ -692,14 +695,14 @@ var UserList = {
 			var groupIsAssignable = assignableGroups.has(id);
 			var groupIsRemovable = removableGroups.has(id);
 			if (!groupIsChecked && !groupIsAssignable) {
-				$groupsSelect.append($('<option value="' + escapeHTML(id) + '" disabled="disabled">' + escapeHTML(groupname) + '</option>'));
+				$groupsSelect.append($('<option value="' + escapeHTML(id) + '" disabled="disabled">' + escapeHTML(group['name']) + '</option>'));
 				return;
 			}
 			if (groupIsChecked && !groupIsRemovable) {
-				$groupsSelect.append($('<option value="' + escapeHTML(id) + '" disabled="disabled">' + escapeHTML(groupname) + '</option>'));
+				$groupsSelect.append($('<option value="' + escapeHTML(id) + '" disabled="disabled">' + escapeHTML(group['name']) + '</option>'));
 				return;
 			}
-			$groupsSelect.append($('<option value="' + escapeHTML(id) + '">' + escapeHTML(groupname) + '</option>'));
+			$groupsSelect.append($('<option value="' + escapeHTML(id) + '">' + escapeHTML(group['name']) + '</option>'));
 		}
 
 		$.ajax({
@@ -712,7 +715,10 @@ var UserList = {
 				this.availableGroups = {};
 				$.each(result.data.assignableGroups, function(id, group) {
 					assignableGroups.add(id);
-					that.availableGroups[id] = group;
+					that.availableGroups[id] = {
+						'id': id,
+						'name': group['name']
+					};
 				});
 				$.each(result.data.removableGroups, function(id, group) {
 					removableGroups.add(id);
@@ -752,7 +758,7 @@ var UserList = {
 					var gid = e.checked[i];
 					groups[gid] = {
 						'id': gid,
-						'name': that.availableGroups[gid]
+						'name': that.availableGroups[gid]['name']
 					};
 				}
 				UserList._updateGroupListLabel($td, groups);
@@ -1021,7 +1027,10 @@ $(document).ready(function () {
 						var gid = result.groups[i]['id'];
 						var displayname = result.groups[i]['name'];
 						if (UserList.availableGroups[gid] === undefined) {
-							UserList.availableGroups[gid] = displayname;
+							UserList.availableGroups[gid] = {
+								'id': gid,
+								'name': displayname
+							};
 						}
 						$li = GroupList.getGroupLI(gid);
 						userCount = GroupList.getUserCount($li);

--- a/settings/js/users/users.js
+++ b/settings/js/users/users.js
@@ -514,40 +514,8 @@ var UserList = {
 				);
 			};
 		}
-		var addGroup = function (select, group) {
-			group = escapeHTML(group).trim();
-			if (GroupList.isGroupNameValid(group) !== true) {
-				return false;
-			}
 
-			var groupAlreadyInList = false;
-
-			select.parent().find('li').each(function (index, entry) {
-				if ($(entry).find('label').attr('title') === group) {
-					groupAlreadyInList = true;
-					return false;
-				}
-			});
-
-			if (groupAlreadyInList) {
-				OC.Notification.showTemporary(t('settings', 'Error creating group: {message}', {
-					message: t('settings', 'Group already exists')
-				}));
-				return false;
-			}
-
-			GroupList.addGroup(group);
-		};
-		var label;
-		if (oc_isadmin) {
-			label = t('settings', 'add group');
-		}
-		else {
-			label = null;
-		}
 		$element.multiSelect({
-			createCallback: addGroup,
-			createText: label,
 			selectedFirst: true,
 			checked: checked,
 			oncheck: checkHandler,
@@ -1091,7 +1059,7 @@ $(document).ready(function () {
 			OC.AppConfig.setValue('core', 'umgmt_show_storage_location', 'false');
 		}
 	});
-     
+
         if ($('#CheckboxCreationTime').is(':checked')) {
                 $("#userlist .creationTime").show();
         }

--- a/settings/js/users/users.js
+++ b/settings/js/users/users.js
@@ -1009,7 +1009,7 @@ $(document).ready(function () {
 			function (result) {
 				if (result.groups) {
 					for (var i in result.groups) {
-						var gid = result.groups[i];
+						var gid = result.groups[i]['id'];
 						if (UserList.availableGroups.indexOf(gid) === -1) {
 							UserList.availableGroups.push(gid);
 						}

--- a/settings/js/users/users.js
+++ b/settings/js/users/users.js
@@ -756,7 +756,7 @@ var UserList = {
 				var groups = {};
 				for (var i in e.checked) {
 					var gid = e.checked[i];
-					var groupInfo = $td.data('groups')[gid] ?? that.availableGroups[gid];
+					var groupInfo = $td.data('groups')[gid] ? $td.data('groups')[gid] : that.availableGroups[gid];
 					groups[gid] = {
 						'gid': gid,
 						'name': groupInfo['name']

--- a/settings/templates/users/main.php
+++ b/settings/templates/users/main.php
@@ -20,10 +20,16 @@ style('settings', 'settings');
 $userlistParams = [];
 $allGroups = [];
 foreach ($_["adminGroup"] as $group) {
-	$allGroups[$group['id']] = $group['name'];
+	$allGroups[$group['id']] = [
+		'id' => $group['id'],
+		'name' => $group['name'],
+	];
 }
 foreach ($_["groups"] as $group) {
-	$allGroups[$group['id']] = $group['name'];
+	$allGroups[$group['id']] = [
+		'id' => $group['id'],
+		'name' => $group['name'],
+	];
 }
 $userlistParams['subadmingroups'] = $allGroups;
 $userlistParams['allGroups'] = \json_encode($allGroups);

--- a/settings/templates/users/main.php
+++ b/settings/templates/users/main.php
@@ -18,12 +18,12 @@ script('core', [
 style('settings', 'settings');
 
 $userlistParams = [];
-$allGroups= [];
+$allGroups = [];
 foreach ($_["adminGroup"] as $group) {
-	$allGroups[] = $group['name'];
+	$allGroups[] = $group['id'];
 }
 foreach ($_["groups"] as $group) {
-	$allGroups[] = $group['name'];
+	$allGroups[] = $group['id'];
 }
 $userlistParams['subadmingroups'] = $allGroups;
 $userlistParams['allGroups'] = \json_encode($allGroups);

--- a/settings/templates/users/main.php
+++ b/settings/templates/users/main.php
@@ -20,14 +20,14 @@ style('settings', 'settings');
 $userlistParams = [];
 $allGroups = [];
 foreach ($_["adminGroup"] as $group) {
-	$allGroups[$group['id']] = [
-		'id' => $group['id'],
+	$allGroups[$group['gid']] = [
+		'gid' => $group['id'],
 		'name' => $group['name'],
 	];
 }
 foreach ($_["groups"] as $group) {
-	$allGroups[$group['id']] = [
-		'id' => $group['id'],
+	$allGroups[$group['gid']] = [
+		'gid' => $group['id'],
 		'name' => $group['name'],
 	];
 }

--- a/settings/templates/users/main.php
+++ b/settings/templates/users/main.php
@@ -20,10 +20,10 @@ style('settings', 'settings');
 $userlistParams = [];
 $allGroups = [];
 foreach ($_["adminGroup"] as $group) {
-	$allGroups[] = $group['id'];
+	$allGroups[$group['id']] = $group['name'];
 }
 foreach ($_["groups"] as $group) {
-	$allGroups[] = $group['id'];
+	$allGroups[$group['id']] = $group['name'];
 }
 $userlistParams['subadmingroups'] = $allGroups;
 $userlistParams['allGroups'] = \json_encode($allGroups);

--- a/settings/templates/users/main.php
+++ b/settings/templates/users/main.php
@@ -33,9 +33,7 @@ foreach ($_["groups"] as $group) {
 }
 $userlistParams['subadmingroups'] = $allGroups;
 $userlistParams['allGroups'] = \json_encode($allGroups);
-$items = \array_flip($userlistParams['subadmingroups']);
-unset($items['admin']);
-$userlistParams['subadmingroups'] = \array_flip($items);
+unset($userlistParams['subadmingroups']['admin']);
 
 translation('settings');
 ?>

--- a/tests/Settings/Controller/GroupsControllerTest.php
+++ b/tests/Settings/Controller/GroupsControllerTest.php
@@ -279,7 +279,7 @@ class GroupsControllerTest extends \Test\TestCase {
 
 		$expectedResponse = new DataResponse(
 			[
-				'id' => 'NewGroup',
+				'gid' => 'NewGroup',
 				'name' => 'A New Group',
 			],
 			Http::STATUS_CREATED
@@ -417,7 +417,7 @@ class GroupsControllerTest extends \Test\TestCase {
 			[
 				'data' => [
 					'assignableGroups' => [
-						'assignableGroup' => ['id' => 'assignableGroup', 'name' => 'assignable Group KO'],
+						'assignableGroup' => ['gid' => 'assignableGroup', 'name' => 'assignable Group KO'],
 					],
 					'removableGroups' => [],
 				],
@@ -479,10 +479,10 @@ class GroupsControllerTest extends \Test\TestCase {
 			[
 				'data' => [
 					'assignableGroups' => [
-						'assignableGroup' => ['id' => 'assignableGroup', 'name' => 'assignable Group KO'],
+						'assignableGroup' => ['gid' => 'assignableGroup', 'name' => 'assignable Group KO'],
 					],
 					'removableGroups' => [
-						'assignableGroup' => ['id' => 'assignableGroup', 'name' => 'assignable Group KO'],
+						'assignableGroup' => ['gid' => 'assignableGroup', 'name' => 'assignable Group KO'],
 					],
 				],
 				\OC\AppFramework\Http::STATUS_OK
@@ -587,12 +587,12 @@ class GroupsControllerTest extends \Test\TestCase {
 			[
 				'data' => [
 					'assignableGroups' => [
-						'MyGroup1' => ['id' => 'MyGroup1', 'name' => 'My Group 1'],
-						'group2' => ['id' => 'group2', 'name' => 'G2'],
+						'MyGroup1' => ['gid' => 'MyGroup1', 'name' => 'My Group 1'],
+						'group2' => ['gid' => 'group2', 'name' => 'G2'],
 					],
 					'removableGroups' => [
-						'MyGroup1' => ['id' => 'MyGroup1', 'name' => 'My Group 1'],
-						'group2' => ['id' => 'group2', 'name' => 'G2'],
+						'MyGroup1' => ['gid' => 'MyGroup1', 'name' => 'My Group 1'],
+						'group2' => ['gid' => 'group2', 'name' => 'G2'],
 					],
 				],
 				\OC\AppFramework\Http::STATUS_OK

--- a/tests/Settings/Controller/GroupsControllerTest.php
+++ b/tests/Settings/Controller/GroupsControllerTest.php
@@ -262,6 +262,10 @@ class GroupsControllerTest extends \Test\TestCase {
 	}
 
 	public function testCreateSuccessful() {
+		$group = $this->createMock(IGroup::class);
+		$group->method('getGID')->willReturn('NewGroup');
+		$group->method('getDisplayName')->willReturn('A New Group');
+
 		$this->container['GroupManager']
 			->expects($this->once())
 			->method('groupExists')
@@ -271,11 +275,12 @@ class GroupsControllerTest extends \Test\TestCase {
 			->expects($this->once())
 			->method('createGroup')
 			->with('NewGroup')
-			->will($this->returnValue(true));
+			->willReturn($group);
 
 		$expectedResponse = new DataResponse(
 			[
-				'groupname' => 'NewGroup'
+				'id' => 'NewGroup',
+				'name' => 'A New Group',
 			],
 			Http::STATUS_CREATED
 		);
@@ -371,6 +376,10 @@ class GroupsControllerTest extends \Test\TestCase {
 			->method('getUser')
 			->willReturn($user);
 
+		$aGroup = $this->createMock(IGroup::class);
+		$aGroup->method('getGID')->willReturn('assignableGroup');
+		$aGroup->method('getDisplayName')->willReturn('assignable Group KO');
+
 		$subadmin = $this->createMock(SubAdmin::class);
 		$subadmin->method('isSubAdmin')
 			->with($this->equalTo($user))
@@ -385,15 +394,20 @@ class GroupsControllerTest extends \Test\TestCase {
 			->method('isAdmin')
 			->with($userid)
 			->willReturn(true);
+		$this->container['GroupManager']
+			->expects($this->once())
+			->method('get')
+			->with('assignableGroup')
+			->willReturn($aGroup);
 		$assignableGroups = ['assignableGroup'];
 		$backend = $this->createMock('\OCP\GroupInterface');
 		$backend
 			->expects($this->once())
 			->method('getGroups')
 			->willReturn($assignableGroups);
-		$backend->expects($this->exactly(2))
+		$backend->expects($this->exactly(3))
 			->method('implementsActions')
-			->willReturn(true, false);
+			->willReturn(true, true, false);  // first add_to_group check will skip the second check
 		$this->container['GroupManager']
 			->expects($this->once())
 			->method('getBackends')
@@ -402,7 +416,9 @@ class GroupsControllerTest extends \Test\TestCase {
 		$expectedResponse = new DataResponse(
 			[
 				'data' => [
-					'assignableGroups' => $assignableGroups,
+					'assignableGroups' => [
+						'assignableGroup' => ['id' => 'assignableGroup', 'name' => 'assignable Group KO'],
+					],
 					'removableGroups' => [],
 				],
 				\OC\AppFramework\Http::STATUS_OK
@@ -432,15 +448,14 @@ class GroupsControllerTest extends \Test\TestCase {
 			->willReturn(true);
 
 		$group1 = $this->createMock(IGroup::class);
-		$group1->method('getBackend')
-			->willReturn($backend);
-		$group1->method('getGID')
-			->willReturn('MyGroup1');
+		$group1->method('getBackend')->willReturn($backend);
+		$group1->method('getGID')->willReturn('MyGroup1');
+		$group1->method('getDisplayName')->willReturn('My Group 1');
+
 		$group2 = $this->createMock(IGroup::class);
-		$group2->method('getBackend')
-			->willReturn($backend);
-		$group2->method('getGID')
-			->willReturn('group2');
+		$group2->method('getBackend')->willReturn($backend);
+		$group2->method('getGID')->willReturn('group2');
+		$group2->method('getDisplayName')->willReturn('G2');
 
 		$subadmin = $this->createMock(SubAdmin::class);
 		$subadmin->method('isSubAdmin')
@@ -458,8 +473,14 @@ class GroupsControllerTest extends \Test\TestCase {
 		$expectedResponse = new DataResponse(
 			[
 				'data' => [
-					'assignableGroups' => ['MyGroup1', 'group2'],
-					'removableGroups' => ['MyGroup1', 'group2'],
+					'assignableGroups' => [
+						'MyGroup1' => ['id' => 'MyGroup1', 'name' => 'My Group 1'],
+						'group2' => ['id' => 'group2', 'name' => 'G2'],
+					],
+					'removableGroups' => [
+						'MyGroup1' => ['id' => 'MyGroup1', 'name' => 'My Group 1'],
+						'group2' => ['id' => 'group2', 'name' => 'G2'],
+					],
 				],
 				\OC\AppFramework\Http::STATUS_OK
 			]


### PR DESCRIPTION
<!--
Thanks for submitting a change to ownCloud!

This is the bug tracker for the Server component. Find other components at https://github.com/owncloud/core/blob/master/.github/CONTRIBUTING.md#guidelines

For fixing potential security issues please see https://owncloud.com/security/

To make it possible for us to get your change reviewed and merged please carefully fill out the requested information below.

Please note that any kind of change needs first be submitted to the master branch which holds the next version of ownCloud.

Please set the following labels:

- Set label "3 - To review" for review or "2 - Development" if the PR still has open tasks
- Assignment: assign to self
- Milestone: set the same as the ticket this PR fixes, or "development" by default
- Reviewers: pick at least one
-->

## Description
This PR includes 3 changes:
* Remove the "add group" button from the dropdowns. New groups can be added from the "add group" button in the top left side of the page. The dropdowns will only be used to select or deselect groups.
* Fix issue with the group count in the left sidebar when a new group was created (group count still shows only if ldap is disabled)
* Use group's displayname in more places in the web UI

The 3rd point should be mostly transparent. The places where the displayname wasn't used are mostly pointing to local groups, whose id and displayname matches. There are still a couple of messages using the group id, but those will require more changes.

## Related Issue
https://github.com/owncloud/enterprise/issues/5684

## Motivation and Context
The "add group" button was removed because the behavior could cause confusion, specially when creating a new user: the groups weren't created until the user was created, but they appear as such in the web UI.

The changes in the displayname shouldn't be noticed, but the web UI should be more prepared now

## How Has This Been Tested?


## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Database schema changes (next release will require increase of minor version instead of patch)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [ ] Tests only (no source changes)

## Checklist:
<!-- Tick the checkboxes when done. -->
<!-- Raise documentation ticket in https://github.com/owncloud/documentation -->
- [ ] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 
- [ ] Changelog item, see [TEMPLATE](https://github.com/owncloud/core/blob/master/changelog/TEMPLATE)
