### PR TITLE
Hide last log in column if disabled

### DIFF
--- a/changelog/unreleased/40771
+++ b/changelog/unreleased/40771
@@ -1,0 +1,6 @@
+Change: fix hiding Last Login column on Users page
+
+The Last Login column on the Users page is now correctly hidden if the setting
+is initially unchecked.
+
+https://github.com/owncloud/core/pull/40771

--- a/settings/js/users/users.js
+++ b/settings/js/users/users.js
@@ -1108,6 +1108,8 @@ $(document).ready(function () {
 
 	if ($('#CheckboxLastLogin').is(':checked')) {
 		$("#userlist .lastLogin").show();
+	} else {
+		$("#userlist .lastLogin").hide();
 	}
 	// Option to display/hide the "Last Login" column
 	$('#CheckboxLastLogin').click(function() {

--- a/tests/acceptance/features/bootstrap/WebUIFilesContext.php
+++ b/tests/acceptance/features/bootstrap/WebUIFilesContext.php
@@ -256,8 +256,8 @@ class WebUIFilesContext extends RawMinkContext implements Context {
 	}
 
 	/**
-	 * @When the user browses to the files page
-	 * @Given the user has browsed to the files page
+	 * @When the user/administrator browses to the files page
+	 * @Given the user/administrator has browsed to the files page
 	 *
 	 * @return void
 	 * @throws Exception

--- a/tests/acceptance/features/bootstrap/WebUIUsersContext.php
+++ b/tests/acceptance/features/bootstrap/WebUIUsersContext.php
@@ -609,8 +609,7 @@ class WebUIUsersContext extends RawMinkContext implements Context {
 		foreach ($table as $row) {
 			$user = $this->featureContext->getActualUsername($row['username']);
 			$visible = $this->usersPage->isQuotaColumnOfUserVisible($user);
-			Assert::assertEquals(
-				true,
+			Assert::assertTrue(
 				$visible,
 				__METHOD__
 				. " The quota of user '"
@@ -633,8 +632,7 @@ class WebUIUsersContext extends RawMinkContext implements Context {
 		foreach ($table as $row) {
 			$user = $this->featureContext->getActualUsername($row['username']);
 			$visible = $this->usersPage->isQuotaColumnOfUserVisible($user);
-			Assert::assertEquals(
-				false,
+			Assert::assertFalse(
 				$visible,
 				__METHOD__
 				. " The quota of user '"
@@ -657,8 +655,7 @@ class WebUIUsersContext extends RawMinkContext implements Context {
 		foreach ($table as $row) {
 			$user = $this->featureContext->getActualUsername($row['username']);
 			$visible = $this->usersPage->isPasswordColumnOfUserVisible($user);
-			Assert::assertEquals(
-				true,
+			Assert::assertTrue(
 				$visible,
 				__METHOD__
 				. " The password of user '"
@@ -681,8 +678,7 @@ class WebUIUsersContext extends RawMinkContext implements Context {
 		foreach ($table as $row) {
 			$user = $this->featureContext->getActualUsername($row['username']);
 			$visible = $this->usersPage->isPasswordColumnOfUserVisible($user);
-			Assert::assertEquals(
-				false,
+			Assert::assertFalse(
 				$visible,
 				__METHOD__
 				. " The password of user '"
@@ -753,6 +749,32 @@ class WebUIUsersContext extends RawMinkContext implements Context {
 				. "' is not contained in the last login of '"
 				. $user
 				. "'."
+			);
+		}
+	}
+
+	/**
+	 * @Then /^the administrator should not be able to see the last login of these users in the User Management page:$/
+	 *
+	 * @param TableNode $table table of usernames and last logins with a heading | username | and | last logins |
+	 *
+	 * @return void
+	 * @throws ElementNotVisible
+	 * @throws Exception
+	 */
+	public function theAdministratorShouldNotBeAbleToSeeLastLoginOfTheseUsers(
+		TableNode $table
+	):void {
+		$this->featureContext->verifyTableNodeColumns($table, ['username']);
+		foreach ($table as $row) {
+			$user = $this->featureContext->getActualUsername($row['username']);
+
+			Assert::assertFalse(
+				$this->usersPage->isLastLoginColumnOfUserVisible($user),
+				__METHOD__
+				. " The last login of user '"
+				. $user
+				. "' was expected not to be visible to the administrator in the User Management page, but is visible."
 			);
 		}
 	}

--- a/tests/acceptance/features/lib/UsersPage.php
+++ b/tests/acceptance/features/lib/UsersPage.php
@@ -271,6 +271,31 @@ class UsersPage extends OwncloudPage {
 	/**
 	 * @param string $username
 	 *
+	 * @return bool
+	 * @throws ElementNotFoundException
+	 * @throws Exception
+	 */
+	public function isLastLoginColumnOfUserVisible(string $username): bool {
+		$userTr = $this->findUserInTable($username);
+		$userLastLogin = $userTr->find('xpath', $this->lastLoginXpath);
+
+		if ($userLastLogin === null) {
+			throw new ElementNotFoundException(
+				__METHOD__ .
+				" xpath $this->lastLoginXpath " .
+				"last login column of user " . $username . " not found"
+			);
+		}
+
+		if (!$userLastLogin->isVisible()) {
+			return false;
+		}
+		return true;
+	}
+
+	/**
+	 * @param string $username
+	 *
 	 * @return string storage location of user
 	 * @throws ElementNotFoundException|ElementNotVisible|Exception
 	 */

--- a/tests/acceptance/features/webUISettingsMenu/settingsMenu.feature
+++ b/tests/acceptance/features/webUISettingsMenu/settingsMenu.feature
@@ -49,6 +49,24 @@ Feature: add users
       | Alice    | seconds ago |
       | Brian    | never       |
 
+
+  Scenario: administrator should not be able to see last login of a user when the UI setting is disabled
+    When the administrator disables the setting "Show last log in" in the User Management page using the webUI
+    Then the administrator should not be able to see the last login of these users in the User Management page:
+      | username |
+      | Alice    |
+      | Brian    |
+
+
+  Scenario: administrator should not be able to see last login of a user when the UI setting is disabled
+    When the administrator disables the setting "Show last log in" in the User Management page using the webUI
+    And the user browses to the files page
+    And the administrator browses to the users page
+    Then the administrator should not be able to see the last login of these users in the User Management page:
+      | username |
+      | Alice    |
+      | Brian    |
+
   @skipOnOcV10.10 @skipOnOcV10.11
   Scenario: administrator should be able to see creation time of a user
     When the administrator enables the setting "Show creation time" in the User Management page using the webUI


### PR DESCRIPTION
## Description
When the Users page is first displayed, if the "Show last log in" setting is off, the hide the "Last Login" column.

1st commit adds 2 new acceptance test scenario, the 2nd scenario fails before the fix.

2nd commit fixes the issue and the tests pass.

## Related Issue
- Fixes https://github.com/owncloud/enterprise/issues/5711

## How Has This Been Tested?
CI and manual check.
1) admin browses to the users page
2) turn off "Show last login" - the Last Login column disappears - good.
3) Browse away to the Files page, then back to the Users page

Before the fix: "Last Login" column is shown, but the checkbox is off - bad.

fter the fix: "Last Login" column is not shown - good.

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Database schema changes (next release will require increase of minor version instead of patch)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [ ] Tests only (no source changes)

## Checklist:
- [x] Code changes
- [ ] Unit tests added
- [x] Acceptance tests added
- [ ] Documentation ticket raised: <link> 
- [ ] Changelog item, see [TEMPLATE](https://github.com/owncloud/core/blob/master/changelog/TEMPLATE)
