### PR TITLE
feat: add OC.Files.Client.unlock() and add lock token to putFileContents

### DIFF
--- a/apps/files/l10n/es_EC.js
+++ b/apps/files/l10n/es_EC.js
@@ -1,0 +1,6 @@
+OC.L10N.register(
+    "files",
+    {
+    "Files" : "Archivos"
+},
+"nplurals=3; plural=n == 1 ? 0 : n != 0 && n % 1000000 == 0 ? 1 : 2;");

--- a/apps/files/l10n/es_EC.json
+++ b/apps/files/l10n/es_EC.json
@@ -1,0 +1,4 @@
+{ "translations": {
+    "Files" : "Archivos"
+},"pluralForm" :"nplurals=3; plural=n == 1 ? 0 : n != 0 && n % 1000000 == 0 ? 1 : 2;"
+}

--- a/apps/files/l10n/pt_BR.js
+++ b/apps/files/l10n/pt_BR.js
@@ -21,6 +21,7 @@ OC.L10N.register(
     "Target folder does not exist any more" : "Pasta de destino não existe mais",
     "The file {file} is currently locked, please try again later" : "O arquivo {file} está bloqueado, por favor tente novamente mais tarde",
     "Not enough free space" : "Não há espaço livre suficiente",
+    "Failed to upload the file \"{fileName}\": {error}" : "Falha ao carregar o arquivo \"{fileName}\": {error}",
     "Uploading..." : "Enviando...",
     "..." : "...",
     "{loadedSize} of {totalSize} ({bitrate})" : "{loadedSize} de {totalSize} ({bitrate})",

--- a/apps/files/l10n/pt_BR.json
+++ b/apps/files/l10n/pt_BR.json
@@ -19,6 +19,7 @@
     "Target folder does not exist any more" : "Pasta de destino não existe mais",
     "The file {file} is currently locked, please try again later" : "O arquivo {file} está bloqueado, por favor tente novamente mais tarde",
     "Not enough free space" : "Não há espaço livre suficiente",
+    "Failed to upload the file \"{fileName}\": {error}" : "Falha ao carregar o arquivo \"{fileName}\": {error}",
     "Uploading..." : "Enviando...",
     "..." : "...",
     "{loadedSize} of {totalSize} ({bitrate})" : "{loadedSize} de {totalSize} ({bitrate})",

--- a/core/js/files/client.js
+++ b/core/js/files/client.js
@@ -777,6 +777,16 @@
 			return promise;
 		},
 
+		/**
+		 * Unlocks a previously locked path
+		 *
+		 * @param {String} path the locked path that needs to be unlocked
+		 * @param {String} token the opaque token needed to unlock the path
+		 * @param {Object} [options]
+		 * @param {bool} [options.pathIsUrl=false] whether the path is already an url or we need to build an url from it
+		 *
+		 * @return {Promise} the promise of the unlock request
+		 */
 		unlock: function(path, token, options) {
 			if (!path) {
 				throw 'Missing argument "path"';

--- a/core/l10n/pt_BR.js
+++ b/core/l10n/pt_BR.js
@@ -226,6 +226,7 @@ OC.L10N.register(
     "An error occurred. Please try again" : "Ocorreu um erro. Por favor tente novamente",
     "User" : "Usuário",
     "Group" : "Grupo",
+    "Federated Group" : "Grupo Federado",
     "Guest" : "Convidado",
     "At {server}" : "Em {server}",
     "Federated" : "Federado",

--- a/core/l10n/pt_BR.json
+++ b/core/l10n/pt_BR.json
@@ -224,6 +224,7 @@
     "An error occurred. Please try again" : "Ocorreu um erro. Por favor tente novamente",
     "User" : "Usuário",
     "Group" : "Grupo",
+    "Federated Group" : "Grupo Federado",
     "Guest" : "Convidado",
     "At {server}" : "Em {server}",
     "Federated" : "Federado",

--- a/core/l10n/tr.js
+++ b/core/l10n/tr.js
@@ -226,6 +226,7 @@ OC.L10N.register(
     "An error occurred. Please try again" : "Bir hata oluştu. Lütfen yeniden deneyin",
     "User" : "Kullanıcı",
     "Group" : "Grup",
+    "Federated Group" : "Birleştirilmiş Grup",
     "Guest" : "Misafir",
     "At {server}" : "{server} sunucusunda",
     "Federated" : "Birleşmiş",

--- a/core/l10n/tr.json
+++ b/core/l10n/tr.json
@@ -224,6 +224,7 @@
     "An error occurred. Please try again" : "Bir hata oluştu. Lütfen yeniden deneyin",
     "User" : "Kullanıcı",
     "Group" : "Grup",
+    "Federated Group" : "Birleştirilmiş Grup",
     "Guest" : "Misafir",
     "At {server}" : "{server} sunucusunda",
     "Federated" : "Birleşmiş",

--- a/tests/data/apptheme/apps/files/l10n/es_EC.js
+++ b/tests/data/apptheme/apps/files/l10n/es_EC.js
@@ -1,0 +1,6 @@
+OC.L10N.register(
+    "files",
+    {
+    "Files" : "Archivos"
+},
+"nplurals=3; plural=n == 1 ? 0 : n != 0 && n % 1000000 == 0 ? 1 : 2;");

--- a/tests/data/apptheme/apps/files/l10n/es_EC.json
+++ b/tests/data/apptheme/apps/files/l10n/es_EC.json
@@ -1,0 +1,4 @@
+{ "translations": {
+    "Files" : "Archivos"
+},"pluralForm" :"nplurals=3; plural=n == 1 ? 0 : n != 0 && n % 1000000 == 0 ? 1 : 2;"
+}

--- a/tests/data/apptheme/apps/files/l10n/pt_BR.js
+++ b/tests/data/apptheme/apps/files/l10n/pt_BR.js
@@ -21,6 +21,7 @@ OC.L10N.register(
     "Target folder does not exist any more" : "Pasta de destino não existe mais",
     "The file {file} is currently locked, please try again later" : "O arquivo {file} está bloqueado, por favor tente novamente mais tarde",
     "Not enough free space" : "Não há espaço livre suficiente",
+    "Failed to upload the file \"{fileName}\": {error}" : "Falha ao carregar o arquivo \"{fileName}\": {error}",
     "Uploading..." : "Enviando...",
     "..." : "...",
     "{loadedSize} of {totalSize} ({bitrate})" : "{loadedSize} de {totalSize} ({bitrate})",

--- a/tests/data/apptheme/apps/files/l10n/pt_BR.json
+++ b/tests/data/apptheme/apps/files/l10n/pt_BR.json
@@ -19,6 +19,7 @@
     "Target folder does not exist any more" : "Pasta de destino não existe mais",
     "The file {file} is currently locked, please try again later" : "O arquivo {file} está bloqueado, por favor tente novamente mais tarde",
     "Not enough free space" : "Não há espaço livre suficiente",
+    "Failed to upload the file \"{fileName}\": {error}" : "Falha ao carregar o arquivo \"{fileName}\": {error}",
     "Uploading..." : "Enviando...",
     "..." : "...",
     "{loadedSize} of {totalSize} ({bitrate})" : "{loadedSize} de {totalSize} ({bitrate})",

--- a/tests/data/themes/abc/apps/files/l10n/es_EC.js
+++ b/tests/data/themes/abc/apps/files/l10n/es_EC.js
@@ -1,0 +1,6 @@
+OC.L10N.register(
+    "files",
+    {
+    "Files" : "Archivos"
+},
+"nplurals=3; plural=n == 1 ? 0 : n != 0 && n % 1000000 == 0 ? 1 : 2;");

--- a/tests/data/themes/abc/apps/files/l10n/es_EC.json
+++ b/tests/data/themes/abc/apps/files/l10n/es_EC.json
@@ -1,0 +1,4 @@
+{ "translations": {
+    "Files" : "Archivos"
+},"pluralForm" :"nplurals=3; plural=n == 1 ? 0 : n != 0 && n % 1000000 == 0 ? 1 : 2;"
+}

--- a/tests/data/themes/abc/apps/files/l10n/pt_BR.js
+++ b/tests/data/themes/abc/apps/files/l10n/pt_BR.js
@@ -21,6 +21,7 @@ OC.L10N.register(
     "Target folder does not exist any more" : "Pasta de destino não existe mais",
     "The file {file} is currently locked, please try again later" : "O arquivo {file} está bloqueado, por favor tente novamente mais tarde",
     "Not enough free space" : "Não há espaço livre suficiente",
+    "Failed to upload the file \"{fileName}\": {error}" : "Falha ao carregar o arquivo \"{fileName}\": {error}",
     "Uploading..." : "Enviando...",
     "..." : "...",
     "{loadedSize} of {totalSize} ({bitrate})" : "{loadedSize} de {totalSize} ({bitrate})",

--- a/tests/data/themes/abc/apps/files/l10n/pt_BR.json
+++ b/tests/data/themes/abc/apps/files/l10n/pt_BR.json
@@ -19,6 +19,7 @@
     "Target folder does not exist any more" : "Pasta de destino não existe mais",
     "The file {file} is currently locked, please try again later" : "O arquivo {file} está bloqueado, por favor tente novamente mais tarde",
     "Not enough free space" : "Não há espaço livre suficiente",
+    "Failed to upload the file \"{fileName}\": {error}" : "Falha ao carregar o arquivo \"{fileName}\": {error}",
     "Uploading..." : "Enviando...",
     "..." : "...",
     "{loadedSize} of {totalSize} ({bitrate})" : "{loadedSize} de {totalSize} ({bitrate})",


### PR DESCRIPTION
## Description
OC.Files.Client now supports lock token in putFileContents() and unlock() was added

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
- test environment:
- test case 1:
- test case 2:
- ...

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Database schema changes (next release will require increase of minor version instead of patch)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [ ] Tests only (no source changes)

## Checklist:
<!-- Tick the checkboxes when done. -->
<!-- Raise documentation ticket in https://github.com/owncloud/documentation -->
- [ ] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 
- [ ] Changelog item, see [TEMPLATE](https://github.com/owncloud/core/blob/master/changelog/TEMPLATE)
