### PR TITLE
Add command to remove obsolete storages from the filecache

### DIFF
--- a/apps/files/appinfo/info.xml
+++ b/apps/files/appinfo/info.xml
@@ -29,6 +29,7 @@
 		<command>OCA\Files\Command\CheckCache</command>
 		<command>OCA\Files\Command\Scan</command>
 		<command>OCA\Files\Command\DeleteOrphanedFiles</command>
+		<command>OCA\Files\Command\RemoveStorageCache</command>
 		<command>OCA\Files\Command\TransferOwnership</command>
 		<command>OCA\Files\Command\TroubleshootTransferOwnership</command>
 		<command>OCA\Files\Command\VerifyChecksums</command>

--- a/apps/files/lib/Command/RemoveStorageCache.php
+++ b/apps/files/lib/Command/RemoveStorageCache.php
@@ -1,0 +1,163 @@
+<?php
+/**
+ * @copyright Copyright (c) 2023, ownCloud GmbH
+ * @license AGPL-3.0
+ *
+ * This code is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License, version 3,
+ * as published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License, version 3,
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>
+ *
+ */
+
+namespace OCA\Files\Command;
+
+use OCP\IDBConnection;
+use OCP\DB\QueryBuilder\IQueryBuilder;
+use Symfony\Component\Console\Helper\ProgressBar;
+use Symfony\Component\Console\Command\Command;
+use Symfony\Component\Console\Input\InputArgument;
+use Symfony\Component\Console\Input\InputOption;
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Output\OutputInterface;
+
+/**
+ * Remove the target storage from the oc_storages tables, and remove the
+ * related files from the oc_filecache table.
+ */
+class RemoveStorageCache extends Command {
+	private const DEFAULT_CHUNK_SIZE = 1000;
+
+	/** @var IDBConnection */
+	private $connection;
+
+	public function __construct(IDBConnection $connection) {
+		parent::__construct();
+		$this->connection = $connection;
+	}
+
+	protected function configure() {
+		$this
+			->setName('files:remove-storage')
+			->setDescription('Remove a storage from the storages table and the related files from the filecache table')
+			->addArgument(
+				'storage-id',
+				InputArgument::REQUIRED,
+				'The numeric id of the storage'
+			)->addOption(
+				'chunk-size',
+				null,
+				InputOption::VALUE_REQUIRED,
+				'The number of rows that will be deleted at the same time',
+				self::DEFAULT_CHUNK_SIZE
+			);
+	}
+
+	protected function execute(InputInterface $input, OutputInterface $output) {
+		$storage_id = \intval($input->getArgument('storage-id'));
+		if ($storage_id <= 0) {
+			$output->writeln('<error>The storage id provided isn\'t valid</error>');
+			return 1;
+		}
+
+		$chunk_size = \intval($input->getOption('chunk-size'));
+		if ($chunk_size <= 0) {
+			$chunk_size = self::DEFAULT_CHUNK_SIZE;
+		}
+
+		$this->removeStorage($storage_id);
+		$nfiles = $this->countCachedFiles($storage_id);
+
+		if ($nfiles <= 0) {
+			$output->writeln('No files found for the target storage');
+			return 0;
+		}
+
+		$bar = new ProgressBar($output);
+		$bar->start($nfiles);
+		while (($maxId = $this->getMaxFileidInRange($storage_id, $chunk_size)) > 0) {
+			$ndeleted = $this->removeCachedFiles($storage_id, $maxId);
+			$bar->advance($ndeleted);
+		}
+		$bar->finish();
+		return 0;
+	}
+
+	/**
+	 * Remove the storage_id from the oc_storages table.
+	 * @return int the number of rows deleted from the table
+	 */
+	private function removeStorage(int $storage_id) {
+		$qb = $this->connection->getQueryBuilder();
+		$result = $qb->delete('storages')
+			->where($qb->expr()->eq('numeric_id', $qb->createNamedParameter($storage_id, IQueryBuilder::PARAM_INT)))
+			->execute();
+		return (int)$result;
+	}
+
+	/**
+	 * Count the number of rows for the storage_id
+	 * @return int the number of rows for the target storage
+	 */
+	private function countCachedFiles(int $storage_id) {
+		$qb = $this->connection->getQueryBuilder();
+		$result = $qb->select($qb->createFunction('count(*) as `count`'))
+			->from('filecache')
+			->where($qb->expr()->eq('storage', $qb->createNamedParameter($storage_id, IQueryBuilder::PARAM_INT)))
+			->execute();
+
+		$row = $result->fetch();
+		$result->closeCursor();
+
+		return (int)$row['count'];
+	}
+
+	/**
+	 * Get the maximum fileid found in the first results of the storage_id
+	 * If there is no file in the storage, 0 will be returned.
+	 * The rows can be deleted by filtering by the storage_id and with
+	 * the fileid lower or equal to the returned fileid
+	 * @return int the maximum fileid found
+	 */
+	private function getMaxFileidInRange(int $storage_id, $maxResults) {
+		$qb = $this->connection->getQueryBuilder();
+		$result = $qb->select('fileid')
+			->from('filecache')
+			->where($qb->expr()->eq('storage', $qb->createNamedParameter($storage_id, IQueryBuilder::PARAM_INT)))
+			->orderBy('fileid', 'ASC')
+			->setMaxResults($maxResults)
+			->execute();
+
+		$maxId = 0;
+		while (($row = $result->fetch()) !== false) {
+			if ($maxId < (int)$row['fileid']) {
+				$maxId = (int)$row['fileid'];
+			}
+		}
+
+		$result->closeCursor();
+		return $maxId;
+	}
+
+	/**
+	 * Remove the files in the oc_filecache table with the target storage_id and
+	 * with fileid lower or equal to the $max
+	 * @return int the number of removed rows
+	 */
+	private function removeCachedFiles(int $storage_id, int $max) {
+		$qb = $this->connection->getQueryBuilder();
+		$result = $qb->delete('filecache')
+			->where($qb->expr()->eq('storage', $qb->createNamedParameter($storage_id, IQueryBuilder::PARAM_INT)))
+			->andWhere($qb->expr()->lte('fileid', $qb->createNamedParameter($max)))
+			->execute();
+
+		return (int)$result;
+	}
+}

--- a/apps/files/lib/Command/RemoveStorageCache.php
+++ b/apps/files/lib/Command/RemoveStorageCache.php
@@ -178,7 +178,7 @@ class RemoveStorageCache extends Command {
 			->from('storages', 's')
 			->leftJoin('s', 'mounts', 'm', $qb->expr()->eq('s.numeric_id', 'm.storage_id'))
 			->rightJoin('s', 'filecache', 'f', $qb->expr()->eq('s.numeric_id', 'f.storage'))
-			->groupBy('f.storage', 'm.mount_point')
+			->groupBy('f.storage', 's.id', 'm.mount_point')
 			->having($qb->expr()->isNull('m.mount_point'))
 			->execute();
 

--- a/apps/files/lib/Command/RemoveStorageCache.php
+++ b/apps/files/lib/Command/RemoveStorageCache.php
@@ -47,22 +47,22 @@ class RemoveStorageCache extends Command {
 	protected function configure() {
 		$this
 			->setName('files:remove-storage')
-			->setDescription('Remove a storage from the storages table and the related files from the filecache table')
+			->setDescription('Remove a storage from the storages table and related files from the filecache table.')
 			->addArgument(
 				'storage-id',
 				InputArgument::OPTIONAL,
-				'The numeric id of the storage'
+				'The numeric ID of the storage'
 			)->addOption(
 				'chunk-size',
 				null,
 				InputOption::VALUE_REQUIRED,
-				'The number of rows that will be deleted at the same time',
+				'The number of rows that will be deleted at the same time.',
 				self::DEFAULT_CHUNK_SIZE
 			)->addOption(
 				'show-candidates',
 				null,
 				InputOption::VALUE_NONE,
-				'Show possible candidates for obsolete storages. It might be slow'
+				'Show possible candidates for obsolete storages. This query can take a while.'
 			);
 	}
 
@@ -74,7 +74,7 @@ class RemoveStorageCache extends Command {
 
 		$storage_id = \intval($input->getArgument('storage-id'));
 		if ($storage_id <= 0) {
-			$output->writeln('<error>A valid storage id is required</error>');
+			$output->writeln('<error>A valid storage ID is required</error>');
 			return 1;
 		}
 

--- a/apps/files/lib/Command/RemoveStorageCache.php
+++ b/apps/files/lib/Command/RemoveStorageCache.php
@@ -174,18 +174,18 @@ class RemoveStorageCache extends Command {
 
 	private function showCandidates(OutputInterface $output) {
 		$qb = $this->connection->getQueryBuilder();
-		$result = $qb->select(['s.numeric_id', 's.id', $qb->createFunction('count(f.storage) as `count`')])
+		$result = $qb->select(['f.storage', 's.id', $qb->createFunction('count(f.storage) as `count`')])
 			->from('storages', 's')
 			->leftJoin('s', 'mounts', 'm', $qb->expr()->eq('s.numeric_id', 'm.storage_id'))
-			->leftJoin('s', 'filecache', 'f', $qb->expr()->eq('s.numeric_id', 'f.storage'))
-			->groupBy('s.numeric_id', 'm.mount_point', 'f.storage')
+			->rightJoin('s', 'filecache', 'f', $qb->expr()->eq('s.numeric_id', 'f.storage'))
+			->groupBy('f.storage', 'm.mount_point')
 			->having($qb->expr()->isNull('m.mount_point'))
 			->execute();
 
 		$table = new Table($output);
-		$table->setHeaders(['numeric_id', 'id', 'file_count']);
+		$table->setHeaders(['storage', 'id', 'file_count']);
 		while (($row = $result->fetch()) !== false) {
-			$table->addRow([$row['numeric_id'], $row['id'], $row['count']]);
+			$table->addRow([$row['storage'], $row['id'] ?? 'NULL', $row['count']]);
 		}
 		$table->render();
 		$result->closeCursor();

--- a/apps/files/lib/Command/RemoveStorageCache.php
+++ b/apps/files/lib/Command/RemoveStorageCache.php
@@ -174,7 +174,7 @@ class RemoveStorageCache extends Command {
 
 	private function showCandidates(OutputInterface $output) {
 		$qb = $this->connection->getQueryBuilder();
-		$result = $qb->select(['f.storage', 's.id', $qb->createFunction('count(f.storage) as `count`')])
+		$result = $qb->select(['f.storage', 's.id', $qb->createFunction('count(f.`storage`) as `count`')])
 			->from('storages', 's')
 			->leftJoin('s', 'mounts', 'm', $qb->expr()->eq('s.numeric_id', 'm.storage_id'))
 			->rightJoin('s', 'filecache', 'f', $qb->expr()->eq('s.numeric_id', 'f.storage'))
@@ -183,7 +183,7 @@ class RemoveStorageCache extends Command {
 			->execute();
 
 		$table = new Table($output);
-		$table->setHeaders(['storage', 'id', 'file_count']);
+		$table->setHeaders(['storage-id', 'name', 'file_count']);
 		while (($row = $result->fetch()) !== false) {
 			$table->addRow([$row['storage'], $row['id'] ?? 'NULL', $row['count']]);
 		}

--- a/changelog/unreleased/40779
+++ b/changelog/unreleased/40779
@@ -1,0 +1,10 @@
+Enhancement: Added occ command to remove obsolete storages
+
+Metadata coming from storages are stored in the DB. When a storage has been
+removed from ownCloud, that metadata remains in the DB.
+
+The new occ command allows you to remove that metadata stored, reducing
+the amount of space used by the DB as well as slightly improving the
+performance since there will be less entries.
+
+https://github.com/owncloud/core/pull/40779


### PR DESCRIPTION
<!--
Thanks for submitting a change to ownCloud!

This is the bug tracker for the Server component. Find other components at https://github.com/owncloud/core/blob/master/.github/CONTRIBUTING.md#guidelines

For fixing potential security issues please see https://owncloud.com/security/

To make it possible for us to get your change reviewed and merged please carefully fill out the requested information below.

Please note that any kind of change needs first be submitted to the master branch which holds the next version of ownCloud.

Please set the following labels:

- Set label "3 - To review" for review or "2 - Development" if the PR still has open tasks
- Assignment: assign to self
- Milestone: set the same as the ticket this PR fixes, or "development" by default
- Reviewers: pick at least one
-->

## Description
Provide an occ command to remove obsolete storages from the DB. The command is limited to the `oc_storages` and `oc_filecache` tables.

The recommended action plan is:
1. Remove the mount point configuration from the web UI.
2. Access to the `oc_storages` table and check which storages aren't used any longer.
3. Run the `occ files:remove-storage` command with those storages.

In case the storage is still in use, a new storage id is likely to be assigned, and you'll need to rescan the storage. This also means that the clients will think the files are new and they'll download the files.
Anyway, the files won't be touched in the backend.

## Related Issue
https://github.com/owncloud/enterprise/issues/5630

## Motivation and Context
This will help to keep the DB more tidy by removing entries that won't be needed any longer. It will also help with the performance because the dataset will be reduced

## How Has This Been Tested?
Manually tested
1. Setup an external storage with a bunch of files in it
5. Run an `occ files:scan` to bring the data into the DB
6. Remove the external storage using the web UI
7. Check the numeric storage id for the storage in the DB
8. Run the `files:remove-storage` command with the target storage id

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Database schema changes (next release will require increase of minor version instead of patch)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [ ] Tests only (no source changes)

## Checklist:
<!-- Tick the checkboxes when done. -->
<!-- Raise documentation ticket in https://github.com/owncloud/documentation -->
- [ ] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 
- [ ] Changelog item, see [TEMPLATE](https://github.com/owncloud/core/blob/master/changelog/TEMPLATE)

@mmattel for documenting the command when it's merged