### PR TITLE
[tests-only] [full-ci] Update vendor-bin dependencies

### DIFF
--- a/vendor-bin/behat/composer.json
+++ b/vendor-bin/behat/composer.json
@@ -1,6 +1,6 @@
 {
     "require": {
-        "behat/behat": "^3.11",
+        "behat/behat": "^3.13",
         "behat/gherkin": "^4.9",
         "behat/mink": "1.7.1",
         "behat/mink-extension": "^2.3",
@@ -11,7 +11,7 @@
         "symfony/translation": "^4.4",
         "sabre/xml": "^2.2",
         "guzzlehttp/guzzle": "^7.5",
-        "phpunit/phpunit": "^9.5",
+        "phpunit/phpunit": "^9.6",
         "laminas/laminas-ldap": "^2.15",
         "ankitpokhrel/tus-php": "^2.3",
         "helmich/phpunit-json-assert": "^3.4"

--- a/vendor-bin/owncloud-codestyle/composer.json
+++ b/vendor-bin/owncloud-codestyle/composer.json
@@ -1,5 +1,5 @@
 {
     "require": {
-      "owncloud/coding-standard": "^4.0"
+      "owncloud/coding-standard": "^4.1"
     }
   }

--- a/vendor-bin/phpstan/composer.json
+++ b/vendor-bin/phpstan/composer.json
@@ -1,5 +1,5 @@
 {
     "require": {
-        "phpstan/phpstan": "^1.9"
+        "phpstan/phpstan": "^1.10"
     }
 }


### PR DESCRIPTION
## Description
I just made a new release 4.1.0 of owncloud coding-standard https://github.com/owncloud/coding-standard/releases/tag/4.1.0

That uses a newer version of php-cs-fixer, which passes locally for me.

This PR updates the version numbers of dependencies in `vendor-bin` to the current minor versions that are in use. That can be helpful when there are problems with some new release of a dependency - at least we have "documented" which minor version is currently working correctly.

## How Has This Been Tested?
CI

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Database schema changes (next release will require increase of minor version instead of patch)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [x] Tests only (no source changes)

## Checklist:
- [ ] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 
- [ ] Changelog item, see [TEMPLATE](https://github.com/owncloud/core/blob/master/changelog/TEMPLATE)
