### PR TITLE
Align to new Google authorization URI

### DIFF
--- a/apps/files_external/ajax/oauth2.php
+++ b/apps/files_external/ajax/oauth2.php
@@ -38,7 +38,7 @@ if (isset($_POST['client_id'], $_POST['client_secret'], $_POST['redirect'])) {
 	$client->setClientSecret((string)$_POST['client_secret']);
 	$client->setRedirectUri((string)$_POST['redirect']);
 	$client->setScopes(['https://www.googleapis.com/auth/drive']);
-	$client->setApprovalPrompt('force');
+	$client->setPrompt('consent');
 	$client->setAccessType('offline');
 	if (isset($_POST['step'])) {
 		$step = $_POST['step'];

--- a/changelog/unreleased/40783
+++ b/changelog/unreleased/40783
@@ -1,0 +1,3 @@
+Bugfix: Align to new accounts.google.com authorization URI
+
+Core 10.12.1 brought an update of the google/apiclient from version 2.12.6 to 2.13.1. However, in version 2.13.0 the accounts.google.com authorization URI has been updated. This change breaks old code that uses the "setApprovalPrompt('force')" instead of the newer "setPrompt('consent')" method, as this endpoint does not support the legacy approval prompt parameter. This has been now fixed.

--- a/changelog/unreleased/40783
+++ b/changelog/unreleased/40783
@@ -1,3 +1,6 @@
 Bugfix: Align to new accounts.google.com authorization URI
 
 Core 10.12.1 brought an update of the google/apiclient from version 2.12.6 to 2.13.1. However, in version 2.13.0 the accounts.google.com authorization URI has been updated. This change breaks old code that uses the "setApprovalPrompt('force')" instead of the newer "setPrompt('consent')" method, as this endpoint does not support the legacy approval prompt parameter. This has been now fixed.
+
+https://github.com/owncloud/core/pull/40783
+https://github.com/owncloud/core/issues/40777


### PR DESCRIPTION
## Description
Align to new Google authorization URI in order to make GDrive integration working again.

## Related Issue
- https://github.com/owncloud/core/issues/40777

## Motivation and Context

Core 10.12.1 brought an update of the google/apiclient from version 2.12.6 to 2.13.1. However, in version 2.13.0 the accounts.google.com authorization URI has been updated. This change breaks old code that uses `setApprovalPrompt('force')` instead of the newer `setPrompt('consent')` method, as this endpoint does not support the legacy approval prompt parameter.

Sources:

- https://github.com/googleapis/google-api-php-client/releases/tag/v2.13.0
- https://github.com/googleapis/google-api-php-client/pull/2275#issuecomment-1367424475

## How Has This Been Tested?
Manually on a fresh or updated 10.12.1 instance. Without this fix new GDrive external storages cannot be mounted, with it integration is working again.

## Types of changes
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Database schema changes (next release will require increase of minor version instead of patch)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [ ] Tests only (no source changes)

## Checklist:
- [X] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised
- [X] Changelog item