### PR TITLE
Add loginInOwnCloud to Log::$methodsWithSensitiveParameters

### DIFF
--- a/changelog/unreleased/40792
+++ b/changelog/unreleased/40792
@@ -1,0 +1,3 @@
+Bugfix: Filter sensitive data in log for Session::loginInOwnCloud
+
+https://github.com/owncloud/core/pull/40792

--- a/lib/private/Log.php
+++ b/lib/private/Log.php
@@ -81,7 +81,7 @@ class Log implements ILogger {
 		'validateUserPass',
 		'loginWithPassword',
 		'createSessionToken',
-                'loginInOwnCloud',
+		'loginInOwnCloud',
 
 		// TokenProvider
 		'getToken',

--- a/lib/private/Log.php
+++ b/lib/private/Log.php
@@ -81,6 +81,7 @@ class Log implements ILogger {
 		'validateUserPass',
 		'loginWithPassword',
 		'createSessionToken',
+                'loginInOwnCloud',
 
 		// TokenProvider
 		'getToken',


### PR DESCRIPTION
## Description
`loginInOwnCloud` contains sensitive data in the argument list and needs therefore to be added to the list of methods where sensitive parameters are being obfuscated.

## How Has This Been Tested?
- manually

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Database schema changes (next release will require increase of minor version instead of patch)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [ ] Tests only (no source changes)

## Checklist:
- [x] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised
- [ ] Changelog item