### PR TITLE
Always return an int for Symfony Command execute method

### DIFF
--- a/apps/dav/lib/Command/CleanupChunks.php
+++ b/apps/dav/lib/Command/CleanupChunks.php
@@ -65,7 +65,7 @@ class CleanupChunks extends Command {
 			);
 	}
 
-	protected function execute(InputInterface $input, OutputInterface $output) {
+	protected function execute(InputInterface $input, OutputInterface $output): int {
 		$checkUploadExistsLocal = $input->getOption('local') === true;
 		$d = $input->getArgument('minimum-age-in-days');
 		$d = \max(2, \min($d, 100));

--- a/apps/dav/lib/Command/CreateAddressBook.php
+++ b/apps/dav/lib/Command/CreateAddressBook.php
@@ -64,7 +64,7 @@ class CreateAddressBook extends Command {
 				);
 	}
 
-	protected function execute(InputInterface $input, OutputInterface $output) {
+	protected function execute(InputInterface $input, OutputInterface $output): int {
 		$user = $input->getArgument('user');
 		if (!$this->userManager->userExists($user)) {
 			throw new \InvalidArgumentException("User <$user> in unknown.");

--- a/apps/dav/lib/Command/CreateCalendar.php
+++ b/apps/dav/lib/Command/CreateCalendar.php
@@ -70,7 +70,7 @@ class CreateCalendar extends Command {
 			);
 	}
 
-	protected function execute(InputInterface $input, OutputInterface $output) {
+	protected function execute(InputInterface $input, OutputInterface $output): int {
 		$user = $input->getArgument('user');
 		if (!$this->userManager->userExists($user)) {
 			throw new \InvalidArgumentException("User <$user> in unknown.");
@@ -82,7 +82,6 @@ class CreateCalendar extends Command {
 		$groupPrincipalBackend = new GroupPrincipalBackend(
 			$this->groupManager
 		);
-		$config = \OC::$server->getConfig();
 		$random = \OC::$server->getSecureRandom();
 
 		$name = $input->getArgument('name');

--- a/apps/dav/lib/Command/SyncBirthdayCalendar.php
+++ b/apps/dav/lib/Command/SyncBirthdayCalendar.php
@@ -64,7 +64,7 @@ class SyncBirthdayCalendar extends Command {
 	 *
 	 * @return int 0 if everything went fine, or an exit code
 	 */
-	protected function execute(InputInterface $input, OutputInterface $output) {
+	protected function execute(InputInterface $input, OutputInterface $output): int {
 		$user = $input->getArgument('user');
 		if ($user !== null) {
 			if (!$this->userManager->userExists($user)) {

--- a/apps/dav/lib/Command/SyncSystemAddressBook.php
+++ b/apps/dav/lib/Command/SyncSystemAddressBook.php
@@ -50,7 +50,7 @@ class SyncSystemAddressBook extends Command {
 	 *
 	 * @return int 0 if everything went fine, or an exit code
 	 */
-	protected function execute(InputInterface $input, OutputInterface $output) {
+	protected function execute(InputInterface $input, OutputInterface $output): int {
 		$output->writeln('Syncing users ...');
 		$progress = new ProgressBar($output);
 		$progress->start();

--- a/apps/federatedfilesharing/lib/Command/PollIncomingShares.php
+++ b/apps/federatedfilesharing/lib/Command/PollIncomingShares.php
@@ -79,9 +79,9 @@ class PollIncomingShares extends Command {
 	 * @param InputInterface $input
 	 * @param OutputInterface $output
 	 *
-	 * @return int|null|void
+	 * @return int
 	 */
-	public function execute(InputInterface $input, OutputInterface $output) {
+	public function execute(InputInterface $input, OutputInterface $output): int {
 		$output->writeln("WARNING: incoming-shares:poll has been deprecated and replaced by periodic external shares cronjob. Please check Federated Cloud Sharing settings and documentation.");
 		if ($this->externalMountProvider === null) {
 			$output->writeln("Polling is not possible when files_sharing app is disabled. Please enable it with 'occ app:enable files_sharing'");
@@ -134,6 +134,7 @@ class PollIncomingShares extends Command {
 			}
 		}
 		$cursor->closeCursor();
+		return 0;
 	}
 
 	/**

--- a/apps/federation/lib/Command/SyncFederationAddressBooks.php
+++ b/apps/federation/lib/Command/SyncFederationAddressBooks.php
@@ -51,7 +51,7 @@ class SyncFederationAddressBooks extends Command {
 	 * @param OutputInterface $output
 	 * @return int
 	 */
-	protected function execute(InputInterface $input, OutputInterface $output) {
+	protected function execute(InputInterface $input, OutputInterface $output): int {
 		$progress = new ProgressBar($output);
 		$progress->start();
 		$this->syncService->syncThemAll(function ($url, $ex) use ($progress, $output) {

--- a/apps/files/lib/Command/CheckCache.php
+++ b/apps/files/lib/Command/CheckCache.php
@@ -64,7 +64,7 @@ class CheckCache extends Command {
 			);
 	}
 
-	protected function execute(InputInterface $input, OutputInterface $output) {
+	protected function execute(InputInterface $input, OutputInterface $output): int {
 		$uid = $input->getArgument('uid');
 		$userFolder = $this->rootFolder->getUserFolder($uid);  // might throw a NoUserException
 

--- a/apps/files/lib/Command/DeleteOrphanedFiles.php
+++ b/apps/files/lib/Command/DeleteOrphanedFiles.php
@@ -49,7 +49,7 @@ class DeleteOrphanedFiles extends Command {
 			->setDescription('Deletes orphaned file cache entries.');
 	}
 
-	public function execute(InputInterface $input, OutputInterface $output) {
+	public function execute(InputInterface $input, OutputInterface $output): int {
 		$deletedEntries = 0;
 
 		$query = $this->connection->getQueryBuilder();

--- a/apps/files/lib/Command/Scan.php
+++ b/apps/files/lib/Command/Scan.php
@@ -279,7 +279,7 @@ class Scan extends Base {
 		}
 	}
 
-	protected function execute(InputInterface $input, OutputInterface $output) {
+	protected function execute(InputInterface $input, OutputInterface $output): int {
 		$inputPath = $input->getOption('path');
 		$groups = $input->getOption('groups') ? \explode(',', $input->getOption('groups')) : [];
 		$groups = \array_unique(\array_merge($groups, $input->getOption('group')));

--- a/apps/files/lib/Command/TransferOwnership.php
+++ b/apps/files/lib/Command/TransferOwnership.php
@@ -139,7 +139,7 @@ class TransferOwnership extends Command {
 			);
 	}
 
-	protected function execute(InputInterface $input, OutputInterface $output) {
+	protected function execute(InputInterface $input, OutputInterface $output): int {
 		$sourceUserObject = $this->userManager->get($input->getArgument('source-user'));
 		$destinationUserObject = $this->userManager->get($input->getArgument('destination-user'));
 		if ($sourceUserObject === null) {

--- a/apps/files/lib/Command/TroubleshootTransferOwnership.php
+++ b/apps/files/lib/Command/TroubleshootTransferOwnership.php
@@ -80,7 +80,7 @@ class TroubleshootTransferOwnership extends Command {
 			);
 	}
 
-	public function execute(InputInterface $input, OutputInterface $output) {
+	public function execute(InputInterface $input, OutputInterface $output): int {
 		$type = $input->getArgument('type');
 		$fix = $input->getOption('fix');
 		$scopeUid = $input->getOption('uid');

--- a/apps/files/lib/Command/VerifyChecksums.php
+++ b/apps/files/lib/Command/VerifyChecksums.php
@@ -88,7 +88,7 @@ class VerifyChecksums extends Command {
 	 * @throws \OCP\Files\InvalidPathException
 	 * @throws \OCP\Files\StorageNotAvailableException
 	 */
-	public function execute(InputInterface $input, OutputInterface $output) {
+	public function execute(InputInterface $input, OutputInterface $output): int {
 		$pathOption = $input->getOption('path');
 		$userName = $input->getOption('user');
 

--- a/apps/files_external/lib/Command/Applicable.php
+++ b/apps/files_external/lib/Command/Applicable.php
@@ -97,7 +97,7 @@ class Applicable extends Base {
 		parent::configure();
 	}
 
-	protected function execute(InputInterface $input, OutputInterface $output) {
+	protected function execute(InputInterface $input, OutputInterface $output): int {
 		$mountId = $input->getArgument('mount_id');
 		try {
 			$mount = $this->globalService->getStorage($mountId);

--- a/apps/files_external/lib/Command/Backends.php
+++ b/apps/files_external/lib/Command/Backends.php
@@ -59,7 +59,7 @@ class Backends extends Base {
 		parent::configure();
 	}
 
-	protected function execute(InputInterface $input, OutputInterface $output) {
+	protected function execute(InputInterface $input, OutputInterface $output): int {
 		$authBackends = $this->backendService->getAuthMechanisms();
 		$storageBackends = $this->backendService->getBackends();
 

--- a/apps/files_external/lib/Command/Config.php
+++ b/apps/files_external/lib/Command/Config.php
@@ -61,7 +61,7 @@ class Config extends Base {
 		parent::configure();
 	}
 
-	protected function execute(InputInterface $input, OutputInterface $output) {
+	protected function execute(InputInterface $input, OutputInterface $output): int {
 		$mountId = $input->getArgument('mount_id');
 		$key = $input->getArgument('key');
 		try {

--- a/apps/files_external/lib/Command/Create.php
+++ b/apps/files_external/lib/Command/Create.php
@@ -117,7 +117,7 @@ class Create extends Base {
 		parent::configure();
 	}
 
-	protected function execute(InputInterface $input, OutputInterface $output) {
+	protected function execute(InputInterface $input, OutputInterface $output): int {
 		$user = $input->getOption('user');
 		$mountPoint = $input->getArgument('mount_point');
 		$storageIdentifier = $input->getArgument('storage_backend');

--- a/apps/files_external/lib/Command/Delete.php
+++ b/apps/files_external/lib/Command/Delete.php
@@ -81,7 +81,7 @@ class Delete extends Base {
 		parent::configure();
 	}
 
-	protected function execute(InputInterface $input, OutputInterface $output) {
+	protected function execute(InputInterface $input, OutputInterface $output): int {
 		$mountId = $input->getArgument('mount_id');
 		try {
 			$mount = $this->globalService->getStorage($mountId);

--- a/apps/files_external/lib/Command/Export.php
+++ b/apps/files_external/lib/Command/Export.php
@@ -44,7 +44,7 @@ class Export extends ListCommand {
 			);
 	}
 
-	protected function execute(InputInterface $input, OutputInterface $output) {
+	protected function execute(InputInterface $input, OutputInterface $output): int {
 		$listCommand = new ListCommand($this->globalService, $this->userService, $this->userSession, $this->userManager);
 		$listInput = new ArrayInput([], $listCommand->getDefinition());
 		$listInput->setArgument('user_id', $input->getArgument('user_id'));

--- a/apps/files_external/lib/Command/Import.php
+++ b/apps/files_external/lib/Command/Import.php
@@ -99,7 +99,7 @@ class Import extends Base {
 		parent::configure();
 	}
 
-	protected function execute(InputInterface $input, OutputInterface $output) {
+	protected function execute(InputInterface $input, OutputInterface $output): int {
 		$user = $input->getOption('user');
 		$path = $input->getArgument('path');
 		if ($path === '-') {

--- a/apps/files_external/lib/Command/ListCommand.php
+++ b/apps/files_external/lib/Command/ListCommand.php
@@ -111,7 +111,7 @@ class ListCommand extends Base {
 		parent::configure();
 	}
 
-	protected function execute(InputInterface $input, OutputInterface $output) {
+	protected function execute(InputInterface $input, OutputInterface $output): int {
 		if ($input->getOption('all')) {
 			/** @var  $mounts IStorageConfig[] */
 			$mounts = $this->globalService->getStorageForAllUsers();

--- a/apps/files_external/lib/Command/Verify.php
+++ b/apps/files_external/lib/Command/Verify.php
@@ -63,7 +63,7 @@ class Verify extends Base {
 		parent::configure();
 	}
 
-	protected function execute(InputInterface $input, OutputInterface $output) {
+	protected function execute(InputInterface $input, OutputInterface $output): int {
 		$mountId = $input->getArgument('mount_id');
 		$configInput = $input->getOption('config');
 

--- a/apps/files_sharing/lib/Command/CleanupRemoteStorages.php
+++ b/apps/files_sharing/lib/Command/CleanupRemoteStorages.php
@@ -56,7 +56,7 @@ class CleanupRemoteStorages extends Command {
 			);
 	}
 
-	public function execute(InputInterface $input, OutputInterface $output) {
+	public function execute(InputInterface $input, OutputInterface $output): int {
 		$remoteStorages = $this->getRemoteStorages();
 
 		$output->writeln(\count($remoteStorages) . " remote storage(s) need(s) to be checked");

--- a/apps/files_trashbin/lib/Command/CleanUp.php
+++ b/apps/files_trashbin/lib/Command/CleanUp.php
@@ -64,7 +64,7 @@ class CleanUp extends Command {
 			);
 	}
 
-	protected function execute(InputInterface $input, OutputInterface $output) {
+	protected function execute(InputInterface $input, OutputInterface $output): int {
 		$users = $input->getArgument('user_id');
 		if (!empty($users)) {
 			foreach ($users as $user) {

--- a/apps/files_trashbin/lib/Command/ExpireTrash.php
+++ b/apps/files_trashbin/lib/Command/ExpireTrash.php
@@ -67,7 +67,7 @@ class ExpireTrash extends Command {
 			);
 	}
 
-	protected function execute(InputInterface $input, OutputInterface $output) {
+	protected function execute(InputInterface $input, OutputInterface $output): int {
 		$retentionEnabled = $this->trashExpiryManager->retentionEnabled();
 		if (!$retentionEnabled) {
 			$output->writeln("Auto expiration is configured - expiration will be handled automatically.");

--- a/apps/files_versions/lib/Command/CleanUp.php
+++ b/apps/files_versions/lib/Command/CleanUp.php
@@ -57,7 +57,7 @@ class CleanUp extends Command {
 			);
 	}
 
-	protected function execute(InputInterface $input, OutputInterface $output) {
+	protected function execute(InputInterface $input, OutputInterface $output): int {
 		$users = $input->getArgument('user_id');
 		if (!empty($users)) {
 			foreach ($users as $user) {

--- a/apps/files_versions/lib/Command/ExpireVersions.php
+++ b/apps/files_versions/lib/Command/ExpireVersions.php
@@ -68,7 +68,7 @@ class ExpireVersions extends Command {
 			);
 	}
 
-	protected function execute(InputInterface $input, OutputInterface $output) {
+	protected function execute(InputInterface $input, OutputInterface $output): int {
 		$maxAge = $this->expiration->getMaxAgeAsTimestamp();
 		if (!$maxAge) {
 			$output->writeln("Auto expiration is configured - expiration will be handled automatically.");

--- a/changelog/unreleased/40793
+++ b/changelog/unreleased/40793
@@ -1,0 +1,7 @@
+Bugfix: Always return an int for the Symfony Command execute method
+
+Some occ commands could return an invalid exit status when executed.
+This has been corrected. occ commands will now always return an integer
+exit status. Zero (0) is success, any other value indicates a problem.
+
+https://github.com/owncloud/core/pull/40793

--- a/core/Command/App/CheckCode.php
+++ b/core/Command/App/CheckCode.php
@@ -78,7 +78,7 @@ class CheckCode extends Command {
 			);
 	}
 
-	protected function execute(InputInterface $input, OutputInterface $output) {
+	protected function execute(InputInterface $input, OutputInterface $output): int {
 		$appId = $input->getArgument('app-id');
 
 		$checkList = new EmptyCheck();

--- a/core/Command/App/Disable.php
+++ b/core/Command/App/Disable.php
@@ -53,7 +53,7 @@ class Disable extends Command {
 			);
 	}
 
-	protected function execute(InputInterface $input, OutputInterface $output) {
+	protected function execute(InputInterface $input, OutputInterface $output): int {
 		$appId = $input->getArgument('app-id');
 		if ($this->manager->isInstalled($appId)) {
 			try {

--- a/core/Command/App/Enable.php
+++ b/core/Command/App/Enable.php
@@ -61,7 +61,7 @@ class Enable extends Command {
 		;
 	}
 
-	protected function execute(InputInterface $input, OutputInterface $output) {
+	protected function execute(InputInterface $input, OutputInterface $output): int {
 		$appId = $input->getArgument('app-id');
 
 		if (!\OC_App::getAppPath($appId)) {

--- a/core/Command/App/GetPath.php
+++ b/core/Command/App/GetPath.php
@@ -46,9 +46,9 @@ class GetPath extends Base {
 	 *
 	 * @param InputInterface  $input  An InputInterface instance
 	 * @param OutputInterface $output An OutputInterface instance
-	 * @return null|int null or 0 if everything went fine, or an error code
+	 * @return int 0 if everything went fine, or an error code
 	 */
-	protected function execute(InputInterface $input, OutputInterface $output) {
+	protected function execute(InputInterface $input, OutputInterface $output): int {
 		$appName = $input->getArgument('app');
 		$path = \OC_App::getAppPath($appName);
 		if ($path !== false) {

--- a/core/Command/App/ListApps.php
+++ b/core/Command/App/ListApps.php
@@ -81,7 +81,7 @@ class ListApps extends Base {
 		;
 	}
 
-	protected function execute(InputInterface $input, OutputInterface $output) {
+	protected function execute(InputInterface $input, OutputInterface $output): int {
 		$appNameSubString = $input->getArgument('search-pattern');
 		$minimalView = $input->getOption('minimal');
 

--- a/core/Command/Background/Base.php
+++ b/core/Command/Background/Base.php
@@ -60,14 +60,15 @@ abstract class Base extends Command {
 	}
 
 	/**
-	* Executing this command will set the background job mode for owncloud.
-	* The mode to set is specified by the concrete sub class by implementing the
-	* getMode() function.
-	*
-	* @param InputInterface $input
-	* @param OutputInterface $output
-	*/
-	protected function execute(InputInterface $input, OutputInterface $output) {
+	 * Executing this command will set the background job mode for owncloud.
+	 * The mode to set is specified by the concrete subclass by implementing the
+	 * getMode() function.
+	 *
+	 * @param InputInterface $input
+	 * @param OutputInterface $output
+	 * @return int
+	 */
+	protected function execute(InputInterface $input, OutputInterface $output): int {
 		$mode = $this->getMode();
 		$this->config->setAppValue('core', 'backgroundjobs_mode', $mode);
 		$output->writeln("Set mode for background jobs to '$mode'");

--- a/core/Command/Background/Queue/Delete.php
+++ b/core/Command/Background/Queue/Delete.php
@@ -48,7 +48,7 @@ class Delete extends Command {
 	 * @param OutputInterface $output
 	 * @return int
 	 */
-	protected function execute(InputInterface $input, OutputInterface $output) {
+	protected function execute(InputInterface $input, OutputInterface $output): int {
 		$id = $input->getArgument('Job ID');
 
 		$job = $this->jobList->getById($id);

--- a/core/Command/Background/Queue/Execute.php
+++ b/core/Command/Background/Queue/Execute.php
@@ -64,7 +64,7 @@ class Execute extends Command {
 	 * @param InputInterface $input
 	 * @param OutputInterface $output
 	 */
-	protected function execute(InputInterface $input, OutputInterface $output) {
+	protected function execute(InputInterface $input, OutputInterface $output): int {
 		if (!$input->getOption('accept-warning')) {
 			$helper = new QuestionHelper();
 			$q = <<<EOS

--- a/core/Command/Background/Queue/Status.php
+++ b/core/Command/Background/Queue/Status.php
@@ -53,9 +53,9 @@ class Status extends Command {
 	/**
 	 * @param InputInterface $input
 	 * @param OutputInterface $output
-	 * @return void
+	 * @return int
 	 */
-	protected function execute(InputInterface $input, OutputInterface $output) {
+	protected function execute(InputInterface $input, OutputInterface $output): int {
 		$t = new Table($output);
 		$t->setHeaders(['Job ID', 'Job', 'Job Arguments', 'Last Run', 'Last Checked', 'Reserved At', 'Execution Duration (s)']);
 		$this->jobList->listJobs(function (IJob $job) use ($t) {
@@ -70,5 +70,6 @@ class Status extends Command {
 			]);
 		});
 		$t->render();
+		return 0;
 	}
 }

--- a/core/Command/Check.php
+++ b/core/Command/Check.php
@@ -46,7 +46,7 @@ class Check extends Base {
 		;
 	}
 
-	protected function execute(InputInterface $input, OutputInterface $output) {
+	protected function execute(InputInterface $input, OutputInterface $output): int {
 		$errors = \OC_Util::checkServer($this->config);
 		if (!empty($errors)) {
 			$errors = \array_map(function ($item) {

--- a/core/Command/Config/App/DeleteConfig.php
+++ b/core/Command/Config/App/DeleteConfig.php
@@ -65,7 +65,7 @@ class DeleteConfig extends Base {
 		;
 	}
 
-	protected function execute(InputInterface $input, OutputInterface $output) {
+	protected function execute(InputInterface $input, OutputInterface $output): int {
 		$appName = $input->getArgument('app');
 		$configName = $input->getArgument('name');
 

--- a/core/Command/Config/App/GetConfig.php
+++ b/core/Command/Config/App/GetConfig.php
@@ -70,9 +70,9 @@ class GetConfig extends Base {
 	 *
 	 * @param InputInterface  $input  An InputInterface instance
 	 * @param OutputInterface $output An OutputInterface instance
-	 * @return null|int null or 0 if everything went fine, or an error code
+	 * @return int 0 if everything went fine, or an error code
 	 */
-	protected function execute(InputInterface $input, OutputInterface $output) {
+	protected function execute(InputInterface $input, OutputInterface $output): int {
 		$appName = $input->getArgument('app');
 		$configName = $input->getArgument('name');
 		$defaultValue = $input->getOption('default-value');

--- a/core/Command/Config/App/SetConfig.php
+++ b/core/Command/Config/App/SetConfig.php
@@ -71,7 +71,7 @@ class SetConfig extends Base {
 		;
 	}
 
-	protected function execute(InputInterface $input, OutputInterface $output) {
+	protected function execute(InputInterface $input, OutputInterface $output): int {
 		$appName = $input->getArgument('app');
 		$configName = $input->getArgument('name');
 

--- a/core/Command/Config/Import.php
+++ b/core/Command/Config/Import.php
@@ -53,7 +53,7 @@ class Import extends Command {
 		;
 	}
 
-	protected function execute(InputInterface $input, OutputInterface $output) {
+	protected function execute(InputInterface $input, OutputInterface $output): int {
 		$importFile = $input->getArgument('file');
 		if ($importFile !== null) {
 			$content = $this->getArrayFromFile($importFile);

--- a/core/Command/Config/ListConfigs.php
+++ b/core/Command/Config/ListConfigs.php
@@ -69,7 +69,7 @@ class ListConfigs extends Base {
 		;
 	}
 
-	protected function execute(InputInterface $input, OutputInterface $output) {
+	protected function execute(InputInterface $input, OutputInterface $output): int {
 		$app = $input->getArgument('app');
 		$noSensitiveValues = !$input->getOption('private');
 

--- a/core/Command/Config/System/DeleteConfig.php
+++ b/core/Command/Config/System/DeleteConfig.php
@@ -60,7 +60,7 @@ class DeleteConfig extends Base {
 		;
 	}
 
-	protected function execute(InputInterface $input, OutputInterface $output) {
+	protected function execute(InputInterface $input, OutputInterface $output): int {
 		$configNames = $input->getArgument('name');
 		$configName = $configNames[0];
 

--- a/core/Command/Config/System/GetConfig.php
+++ b/core/Command/Config/System/GetConfig.php
@@ -65,9 +65,9 @@ class GetConfig extends Base {
 	 *
 	 * @param InputInterface  $input  An InputInterface instance
 	 * @param OutputInterface $output An OutputInterface instance
-	 * @return null|int null or 0 if everything went fine, or an error code
+	 * @return int 0 if everything went fine, or an error code
 	 */
-	protected function execute(InputInterface $input, OutputInterface $output) {
+	protected function execute(InputInterface $input, OutputInterface $output): int {
 		$configNames = $input->getArgument('name');
 		$configName = \array_shift($configNames);
 		$defaultValue = $input->getOption('default-value');

--- a/core/Command/Config/System/SetConfig.php
+++ b/core/Command/Config/System/SetConfig.php
@@ -74,7 +74,7 @@ class SetConfig extends Base {
 		;
 	}
 
-	protected function execute(InputInterface $input, OutputInterface $output) {
+	protected function execute(InputInterface $input, OutputInterface $output): int {
 		$configNames = $input->getArgument('name');
 		$configName = $configNames[0];
 		$configValue = $this->castValue($input->getOption('value'), $input->getOption('type'));

--- a/core/Command/Db/ConvertMysqlToMB4.php
+++ b/core/Command/Db/ConvertMysqlToMB4.php
@@ -59,7 +59,7 @@ class ConvertMysqlToMB4 extends Command {
 			->setDescription('Convert charset of MySQL/MariaDB to use utf8mb4.');
 	}
 
-	protected function execute(InputInterface $input, OutputInterface $output) {
+	protected function execute(InputInterface $input, OutputInterface $output): int {
 		if (!$this->connection->getDatabasePlatform() instanceof MySqlPlatform) {
 			$output->writeln("This command is only valid for MySQL/MariaDB databases.");
 			return 1;

--- a/core/Command/Db/ConvertType.php
+++ b/core/Command/Db/ConvertType.php
@@ -211,10 +211,10 @@ class ConvertType extends Command {
 	/**
 	 * @param InputInterface $input
 	 * @param OutputInterface $output
-	 * @return int|null|void
+	 * @return int
 	 * @throws \Exception
 	 */
-	protected function execute(InputInterface $input, OutputInterface $output) {
+	protected function execute(InputInterface $input, OutputInterface $output): int {
 		$output->writeln('<info>This feature is currently experimental.</info>');
 		$this->targetType = $this->connectionFactory->normalizeType($input->getArgument('type'));
 		$this->targetHostname = $input->getArgument('hostname');
@@ -252,11 +252,12 @@ class ConvertType extends Command {
 			'@phan-var \Symfony\Component\Console\Helper\QuestionHelper $dialog';
 			$continue = $dialog->ask($input, $output, new Question('<question>Continue with the conversion (y/n)? [n] </question>', false));
 			if ($continue !== 'y') {
-				return;
+				return 0;
 			}
 		}
 		$intersectingTables = \array_intersect($toTables, $fromTables);
 		$this->convertDB($fromDB, $toDB, $intersectingTables, $input, $output);
+		return 0;
 	}
 
 	/**

--- a/core/Command/Db/Migrations/ExecuteCommand.php
+++ b/core/Command/Db/Migrations/ExecuteCommand.php
@@ -54,7 +54,7 @@ class ExecuteCommand extends Command {
 		parent::configure();
 	}
 
-	public function execute(InputInterface $input, OutputInterface $output) {
+	public function execute(InputInterface $input, OutputInterface $output): int {
 		$appName = $input->getArgument('app');
 		$ms = new MigrationService($appName, $this->connection, new ConsoleOutput($output));
 		$version = $input->getArgument('version');

--- a/core/Command/Db/Migrations/GenerateCommand.php
+++ b/core/Command/Db/Migrations/GenerateCommand.php
@@ -109,7 +109,7 @@ class Version<version> implements ISqlMigration {
 		parent::configure();
 	}
 
-	public function execute(InputInterface $input, OutputInterface $output) {
+	public function execute(InputInterface $input, OutputInterface $output): int {
 		$appName = $input->getArgument('app');
 		$ms = new MigrationService($appName, $this->connection, new ConsoleOutput($output));
 

--- a/core/Command/Db/Migrations/MigrateCommand.php
+++ b/core/Command/Db/Migrations/MigrateCommand.php
@@ -51,7 +51,7 @@ class MigrateCommand extends Command {
 		parent::configure();
 	}
 
-	public function execute(InputInterface $input, OutputInterface $output) {
+	public function execute(InputInterface $input, OutputInterface $output): int {
 		$appName = $input->getArgument('app');
 		$ms = new MigrationService($appName, $this->connection, new ConsoleOutput($output));
 		$version = $input->getArgument('version');

--- a/core/Command/Db/Migrations/StatusCommand.php
+++ b/core/Command/Db/Migrations/StatusCommand.php
@@ -48,7 +48,7 @@ class StatusCommand extends Command {
 			->addArgument('app', InputArgument::REQUIRED, 'Name of the app this migration command shall work on');
 	}
 
-	public function execute(InputInterface $input, OutputInterface $output) {
+	public function execute(InputInterface $input, OutputInterface $output): int {
 		$appName = $input->getArgument('app');
 		$ms = new MigrationService($appName, $this->connection, new ConsoleOutput($output));
 

--- a/core/Command/Db/RestoreDefaultRowFormat.php
+++ b/core/Command/Db/RestoreDefaultRowFormat.php
@@ -51,7 +51,7 @@ class RestoreDefaultRowFormat extends Command {
 			->setDescription('Restore default row format of MySQL/MariaDB tables.');
 	}
 
-	protected function execute(InputInterface $input, OutputInterface $output) {
+	protected function execute(InputInterface $input, OutputInterface $output): int {
 		if (!$this->connection->getDatabasePlatform() instanceof MySqlPlatform) {
 			$output->writeln("<error>This command is only valid for MySQL/MariaDB databases.</error>");
 			return 1;

--- a/core/Command/Encryption/ChangeKeyStorageRoot.php
+++ b/core/Command/Encryption/ChangeKeyStorageRoot.php
@@ -79,7 +79,7 @@ class ChangeKeyStorageRoot extends Command {
 			);
 	}
 
-	protected function execute(InputInterface $input, OutputInterface $output) {
+	protected function execute(InputInterface $input, OutputInterface $output): int {
 		$oldRoot = $this->util->getKeyStorageRoot();
 		$newRoot = $input->getArgument('newRoot');
 

--- a/core/Command/Encryption/DecryptAll.php
+++ b/core/Command/Encryption/DecryptAll.php
@@ -132,7 +132,7 @@ class DecryptAll extends Command {
 		);
 	}
 
-	protected function execute(InputInterface $input, OutputInterface $output) {
+	protected function execute(InputInterface $input, OutputInterface $output): int {
 		$confirmed = $input->getOption('continue');
 		if (($confirmed !== 'yes') && ($confirmed !== 'no')) {
 			$output->writeln('Continue can accept either yes or no');

--- a/core/Command/Encryption/Disable.php
+++ b/core/Command/Encryption/Disable.php
@@ -50,7 +50,7 @@ class Disable extends Command {
 		;
 	}
 
-	protected function execute(InputInterface $input, OutputInterface $output) {
+	protected function execute(InputInterface $input, OutputInterface $output): int {
 		$qb = $this->db->getQueryBuilder();
 		$qb->select($qb->expr()->literal('1'))
 			->from('filecache', 'fc')

--- a/core/Command/Encryption/Enable.php
+++ b/core/Command/Encryption/Enable.php
@@ -52,7 +52,7 @@ class Enable extends Command {
 		;
 	}
 
-	protected function execute(InputInterface $input, OutputInterface $output) {
+	protected function execute(InputInterface $input, OutputInterface $output): int {
 		if ($this->encryptionManager->isEnabled()) {
 			$output->writeln('Encryption is already enabled');
 		} else {

--- a/core/Command/Encryption/EncryptAll.php
+++ b/core/Command/Encryption/EncryptAll.php
@@ -107,7 +107,7 @@ class EncryptAll extends Command {
 		);
 	}
 
-	protected function execute(InputInterface $input, OutputInterface $output) {
+	protected function execute(InputInterface $input, OutputInterface $output): int {
 		if ($this->encryptionManager->isEnabled() === false) {
 			throw new \Exception('Server side encryption is not enabled');
 		}

--- a/core/Command/Encryption/ListModules.php
+++ b/core/Command/Encryption/ListModules.php
@@ -48,7 +48,7 @@ class ListModules extends Base {
 		;
 	}
 
-	protected function execute(InputInterface $input, OutputInterface $output) {
+	protected function execute(InputInterface $input, OutputInterface $output): int {
 		$encryptionModules = $this->encryptionManager->getEncryptionModules();
 		$defaultEncryptionModuleId = $this->encryptionManager->getDefaultEncryptionModuleId();
 

--- a/core/Command/Encryption/SetDefaultModule.php
+++ b/core/Command/Encryption/SetDefaultModule.php
@@ -53,7 +53,7 @@ class SetDefaultModule extends Command {
 		;
 	}
 
-	protected function execute(InputInterface $input, OutputInterface $output) {
+	protected function execute(InputInterface $input, OutputInterface $output): int {
 		$moduleId = $input->getArgument('module');
 
 		if ($moduleId === $this->encryptionManager->getDefaultEncryptionModuleId()) {

--- a/core/Command/Encryption/ShowKeyStorageRoot.php
+++ b/core/Command/Encryption/ShowKeyStorageRoot.php
@@ -45,7 +45,7 @@ class ShowKeyStorageRoot extends Command {
 			->setDescription('Show current key storage root.');
 	}
 
-	protected function execute(InputInterface $input, OutputInterface $output) {
+	protected function execute(InputInterface $input, OutputInterface $output): int {
 		$currentRoot = $this->util->getKeyStorageRoot();
 
 		$rootDescription = $currentRoot !== '' ? $currentRoot : 'default storage location (data/)';

--- a/core/Command/Encryption/Status.php
+++ b/core/Command/Encryption/Status.php
@@ -47,7 +47,7 @@ class Status extends Base {
 		;
 	}
 
-	protected function execute(InputInterface $input, OutputInterface $output) {
+	protected function execute(InputInterface $input, OutputInterface $output): int {
 		$this->writeArrayInOutputFormat($input, $output, [
 			'enabled' => $this->encryptionManager->isEnabled(),
 			'defaultModule' => $this->encryptionManager->getDefaultEncryptionModuleId(),

--- a/core/Command/Group/Add.php
+++ b/core/Command/Group/Add.php
@@ -50,7 +50,7 @@ class Add extends Command {
 			);
 	}
 
-	protected function execute(InputInterface $input, OutputInterface $output) {
+	protected function execute(InputInterface $input, OutputInterface $output): int {
 		$groupName = $input->getArgument('group');
 		$group = $this->groupManager->get($groupName);
 		if (!$group) {

--- a/core/Command/Group/AddMember.php
+++ b/core/Command/Group/AddMember.php
@@ -62,7 +62,7 @@ class AddMember extends Command {
 			);
 	}
 
-	protected function execute(InputInterface $input, OutputInterface $output) {
+	protected function execute(InputInterface $input, OutputInterface $output): int {
 		$groupName = $input->getArgument('group');
 		$group = $this->groupManager->get($groupName);
 		$errorFound = false;

--- a/core/Command/Group/Delete.php
+++ b/core/Command/Group/Delete.php
@@ -50,7 +50,7 @@ class Delete extends Command {
 			);
 	}
 
-	protected function execute(InputInterface $input, OutputInterface $output) {
+	protected function execute(InputInterface $input, OutputInterface $output): int {
 		$groupName = $input->getArgument('group');
 		$group = $this->groupManager->get($groupName);
 		if ($group === null) {

--- a/core/Command/Group/ListGroupMembers.php
+++ b/core/Command/Group/ListGroupMembers.php
@@ -53,7 +53,7 @@ class ListGroupMembers extends Base {
 		;
 	}
 
-	protected function execute(InputInterface $input, OutputInterface $output) {
+	protected function execute(InputInterface $input, OutputInterface $output): int {
 		$groupName = $input->getArgument('group');
 		$group = $this->groupManager->get($groupName);
 		if (!$group) {

--- a/core/Command/Group/ListGroups.php
+++ b/core/Command/Group/ListGroups.php
@@ -54,7 +54,7 @@ class ListGroups extends Base {
 		;
 	}
 
-	protected function execute(InputInterface $input, OutputInterface $output) {
+	protected function execute(InputInterface $input, OutputInterface $output): int {
 		$groupNameSubString = $input->getArgument('search-pattern');
 		$groups = $this->groupManager->search($groupNameSubString, null, null, 'management', true);
 		$groups = \array_map(function ($group) {

--- a/core/Command/Group/RemoveMember.php
+++ b/core/Command/Group/RemoveMember.php
@@ -62,7 +62,7 @@ class RemoveMember extends Command {
 			);
 	}
 
-	protected function execute(InputInterface $input, OutputInterface $output) {
+	protected function execute(InputInterface $input, OutputInterface $output): int {
 		$groupName = $input->getArgument('group');
 		$group = $this->groupManager->get($groupName);
 		$errorFound = false;

--- a/core/Command/Integrity/CheckApp.php
+++ b/core/Command/Integrity/CheckApp.php
@@ -59,7 +59,7 @@ class CheckApp extends Base {
 	/**
 	 * {@inheritdoc }
 	 */
-	protected function execute(InputInterface $input, OutputInterface $output) {
+	protected function execute(InputInterface $input, OutputInterface $output): int {
 		$appid = $input->getArgument('appid');
 		$path = \strval($input->getOption('path'));
 		$result = $this->checker->verifyAppSignature($appid, $path);

--- a/core/Command/Integrity/CheckCore.php
+++ b/core/Command/Integrity/CheckCore.php
@@ -56,7 +56,7 @@ class CheckCore extends Base {
 	/**
 	 * {@inheritdoc }
 	 */
-	protected function execute(InputInterface $input, OutputInterface $output) {
+	protected function execute(InputInterface $input, OutputInterface $output): int {
 		$this->checker->runInstanceVerification();
 		$result = $this->checker->getResults();
 		$this->writeArrayInOutputFormat($input, $output, $result);

--- a/core/Command/Integrity/SignApp.php
+++ b/core/Command/Integrity/SignApp.php
@@ -73,7 +73,7 @@ class SignApp extends Command {
 	/**
 	 * {@inheritdoc }
 	 */
-	protected function execute(InputInterface $input, OutputInterface $output) {
+	protected function execute(InputInterface $input, OutputInterface $output): int {
 		$path = $input->getOption('path');
 		$privateKeyPath = $input->getOption('privateKey');
 		$keyBundlePath = $input->getOption('certificate');
@@ -82,7 +82,7 @@ class SignApp extends Command {
 			$output->writeln('This command requires the --path, --privateKey and --certificate.');
 			$output->writeln('Example: ./occ integrity:sign-app --path="/Users/lukasreschke/Programming/myapp/" --privateKey="/Users/lukasreschke/private/myapp.key" --certificate="/Users/lukasreschke/public/mycert.crt"');
 			$output->writeln('For more information please consult the documentation: '. $documentationUrl);
-			return null;
+			return 1;
 		}
 
 		$privateKey = $this->fileAccessHelper->file_get_contents($privateKeyPath);
@@ -90,12 +90,12 @@ class SignApp extends Command {
 
 		if ($privateKey === false) {
 			$output->writeln(\sprintf('Private key "%s" does not exists.', $privateKeyPath));
-			return null;
+			return 1;
 		}
 
 		if ($keyBundle === false) {
 			$output->writeln(\sprintf('Certificate "%s" does not exists.', $keyBundlePath));
-			return null;
+			return 1;
 		}
 
 		/** @var RSA $rsa */

--- a/core/Command/Integrity/SignCore.php
+++ b/core/Command/Integrity/SignCore.php
@@ -67,13 +67,13 @@ class SignCore extends Command {
 	/**
 	 * {@inheritdoc }
 	 */
-	protected function execute(InputInterface $input, OutputInterface $output) {
+	protected function execute(InputInterface $input, OutputInterface $output): int {
 		$privateKeyPath = $input->getOption('privateKey');
 		$keyBundlePath = $input->getOption('certificate');
 		$path = $input->getOption('path');
 		if ($privateKeyPath === null || $keyBundlePath === null || $path === null) {
 			$output->writeln('--privateKey, --certificate and --path are required.');
-			return null;
+			return 1;
 		}
 
 		$privateKey = $this->fileAccessHelper->file_get_contents($privateKeyPath);
@@ -81,12 +81,12 @@ class SignCore extends Command {
 
 		if ($privateKey === false) {
 			$output->writeln(\sprintf('Private key "%s" does not exists.', $privateKeyPath));
-			return null;
+			return 1;
 		}
 
 		if ($keyBundle === false) {
 			$output->writeln(\sprintf('Certificate "%s" does not exists.', $keyBundlePath));
-			return null;
+			return 1;
 		}
 
 		/** @var RSA $rsa */

--- a/core/Command/L10n/CreateJs.php
+++ b/core/Command/L10n/CreateJs.php
@@ -47,7 +47,7 @@ class CreateJs extends Command {
 			);
 	}
 
-	protected function execute(InputInterface $input, OutputInterface $output) {
+	protected function execute(InputInterface $input, OutputInterface $output): int {
 		$app = $input->getArgument('app');
 		$lang = $input->getArgument('lang');
 

--- a/core/Command/Log/Manage.php
+++ b/core/Command/Log/Manage.php
@@ -68,7 +68,7 @@ class Manage extends Command {
 		;
 	}
 
-	protected function execute(InputInterface $input, OutputInterface $output) {
+	protected function execute(InputInterface $input, OutputInterface $output): int {
 		// collate config setting to the end, to avoid partial configuration
 		$toBeSet = [];
 

--- a/core/Command/Log/OwnCloud.php
+++ b/core/Command/Log/OwnCloud.php
@@ -62,7 +62,7 @@ class OwnCloud extends Command {
 		;
 	}
 
-	protected function execute(InputInterface $input, OutputInterface $output) {
+	protected function execute(InputInterface $input, OutputInterface $output): int {
 		$toBeSet = [];
 
 		if ($input->getOption('enable')) {

--- a/core/Command/Maintenance/DataFingerprint.php
+++ b/core/Command/Maintenance/DataFingerprint.php
@@ -54,7 +54,7 @@ class DataFingerprint extends Command {
 			->setDescription('Update the systems data-fingerprint after a backup is restored.');
 	}
 
-	protected function execute(InputInterface $input, OutputInterface $output) {
+	protected function execute(InputInterface $input, OutputInterface $output): int {
 		$io = new SymfonyStyle($input, $output);
 		$warning = <<<EOD
 Setting the data fingerprint will notify desktop and mobile clients that a server backup has been restored. 

--- a/core/Command/Maintenance/Install.php
+++ b/core/Command/Maintenance/Install.php
@@ -60,7 +60,7 @@ class Install extends Command {
 			->addOption('data-dir', null, InputOption::VALUE_REQUIRED, 'Path to the data directory.', \OC::$SERVERROOT."/data");
 	}
 
-	protected function execute(InputInterface $input, OutputInterface $output) {
+	protected function execute(InputInterface $input, OutputInterface $output): int {
 		// validate the environment
 		$server = \OC::$server;
 		$setupHelper = new Setup(

--- a/core/Command/Maintenance/Mimetype/UpdateDB.php
+++ b/core/Command/Maintenance/Mimetype/UpdateDB.php
@@ -60,7 +60,7 @@ class UpdateDB extends Command {
 		;
 	}
 
-	protected function execute(InputInterface $input, OutputInterface $output) {
+	protected function execute(InputInterface $input, OutputInterface $output): int {
 		'@phan-var \OC\Files\MimetypeDetector $this->mimetypeDetector';
 		$mappings = $this->mimetypeDetector->getAllMappings();
 

--- a/core/Command/Maintenance/Mimetype/UpdateJS.php
+++ b/core/Command/Maintenance/Mimetype/UpdateJS.php
@@ -142,7 +142,7 @@ class UpdateJS extends Command {
 	 * @param OutputInterface $output
 	 * @return int
 	 */
-	protected function execute(InputInterface $input, OutputInterface $output) {
+	protected function execute(InputInterface $input, OutputInterface $output): int {
 		$fileName = \OC::$SERVERROOT.'/core/js/mimetypelist.js';
 
 		$success = \file_put_contents(

--- a/core/Command/Maintenance/Mode.php
+++ b/core/Command/Maintenance/Mode.php
@@ -56,7 +56,7 @@ class Mode extends Command {
 			);
 	}
 
-	protected function execute(InputInterface $input, OutputInterface $output) {
+	protected function execute(InputInterface $input, OutputInterface $output): int {
 		if ($input->getOption('on')) {
 			$this->config->setSystemValue('maintenance', true);
 			$output->writeln('Maintenance mode enabled');

--- a/core/Command/Maintenance/Repair.php
+++ b/core/Command/Maintenance/Repair.php
@@ -95,7 +95,7 @@ class Repair extends Command {
 			);
 	}
 
-	protected function execute(InputInterface $input, OutputInterface $output) {
+	protected function execute(InputInterface $input, OutputInterface $output): int {
 		$appSteps = $this->getAppsRepairSteps($output);
 		// Handle listing repair steps
 		$steps = \array_merge(

--- a/core/Command/Maintenance/SingleUser.php
+++ b/core/Command/Maintenance/SingleUser.php
@@ -59,7 +59,7 @@ class SingleUser extends Command {
 			);
 	}
 
-	protected function execute(InputInterface $input, OutputInterface $output) {
+	protected function execute(InputInterface $input, OutputInterface $output): int {
 		if ($input->getOption('on')) {
 			$this->config->setSystemValue('singleuser', true);
 			$output->writeln('Single user mode enabled');

--- a/core/Command/Maintenance/UpdateHtaccess.php
+++ b/core/Command/Maintenance/UpdateHtaccess.php
@@ -31,7 +31,7 @@ class UpdateHtaccess extends Command {
 			->setDescription('Updates the .htaccess file.');
 	}
 
-	protected function execute(InputInterface $input, OutputInterface $output) {
+	protected function execute(InputInterface $input, OutputInterface $output): int {
 		\OC\Setup::updateHtaccess();
 		$output->writeln('.htaccess has been updated');
 		return 0;

--- a/core/Command/Previews/Cleanup.php
+++ b/core/Command/Previews/Cleanup.php
@@ -49,7 +49,7 @@ class Cleanup extends Base {
 		;
 	}
 
-	protected function execute(InputInterface $input, OutputInterface $output) {
+	protected function execute(InputInterface $input, OutputInterface $output): int {
 		$all = $input->hasOption('all');
 		$chunk_size = $input->getArgument('chunk_size');
 		$chunk_size_valid = false;

--- a/core/Command/Security/CreateSignKey.php
+++ b/core/Command/Security/CreateSignKey.php
@@ -62,7 +62,7 @@ class CreateSignKey extends Base {
 			);
 	}
 
-	protected function execute(InputInterface $input, OutputInterface $output) {
+	protected function execute(InputInterface $input, OutputInterface $output): int {
 		$uid = $input->getArgument('user');
 		$user = $this->userManager->get($uid);
 		if ($user === null) {

--- a/core/Command/Security/ImportCertificate.php
+++ b/core/Command/Security/ImportCertificate.php
@@ -47,7 +47,7 @@ class ImportCertificate extends Base {
 			);
 	}
 
-	protected function execute(InputInterface $input, OutputInterface $output) {
+	protected function execute(InputInterface $input, OutputInterface $output): int {
 		$path = $input->getArgument('path');
 
 		if (!\file_exists($path)) {

--- a/core/Command/Security/ListCertificates.php
+++ b/core/Command/Security/ListCertificates.php
@@ -48,7 +48,7 @@ class ListCertificates extends Base {
 		parent::configure();
 	}
 
-	protected function execute(InputInterface $input, OutputInterface $output) {
+	protected function execute(InputInterface $input, OutputInterface $output): int {
 		$outputType = $input->getOption('output');
 		if ($outputType === self::OUTPUT_FORMAT_JSON || $outputType === self::OUTPUT_FORMAT_JSON_PRETTY) {
 			$certificates = \array_map(function (ICertificate $certificate) {

--- a/core/Command/Security/ListRoutes.php
+++ b/core/Command/Security/ListRoutes.php
@@ -50,7 +50,7 @@ class ListRoutes extends Base {
 		parent::configure();
 	}
 
-	protected function execute(InputInterface $input, OutputInterface $output) {
+	protected function execute(InputInterface $input, OutputInterface $output): int {
 		$outputType = $input->getOption('output');
 
 		\OC_App::loadApps();

--- a/core/Command/Security/RemoveCertificate.php
+++ b/core/Command/Security/RemoveCertificate.php
@@ -48,7 +48,7 @@ class RemoveCertificate extends Base {
 			);
 	}
 
-	protected function execute(InputInterface $input, OutputInterface $output) {
+	protected function execute(InputInterface $input, OutputInterface $output): int {
 		$name = $input->getArgument('name');
 
 		if ($this->certificateManager->removeCertificate($name)) {

--- a/core/Command/Status.php
+++ b/core/Command/Status.php
@@ -37,7 +37,7 @@ class Status extends Base {
 		;
 	}
 
-	protected function execute(InputInterface $input, OutputInterface $output) {
+	protected function execute(InputInterface $input, OutputInterface $output): int {
 		$values = [
 			'installed' => (bool) \OC::$server->getConfig()->getSystemValue('installed', false),
 			'first_install_version' => \OC::$server->getConfig()->getAppValue('core', 'first_install_version', 'unknown'),

--- a/core/Command/System/Cron.php
+++ b/core/Command/System/Cron.php
@@ -74,7 +74,7 @@ class Cron extends Command {
 	 * @param OutputInterface $output
 	 * @return int
 	 */
-	protected function execute(InputInterface $input, OutputInterface $output) {
+	protected function execute(InputInterface $input, OutputInterface $output): int {
 		if (\OCP\Util::needUpgrade()) {
 			$output->writeln('Update required, skipping cron');
 			return 1;

--- a/core/Command/TwoFactorAuth/Disable.php
+++ b/core/Command/TwoFactorAuth/Disable.php
@@ -49,7 +49,7 @@ class Disable extends Base {
 		$this->addArgument('uid', InputArgument::REQUIRED);
 	}
 
-	protected function execute(InputInterface $input, OutputInterface $output) {
+	protected function execute(InputInterface $input, OutputInterface $output): int {
 		$uid = $input->getArgument('uid');
 		$user = $this->userManager->get($uid);
 		if ($user === null) {

--- a/core/Command/TwoFactorAuth/Enable.php
+++ b/core/Command/TwoFactorAuth/Enable.php
@@ -49,7 +49,7 @@ class Enable extends Base {
 		$this->addArgument('uid', InputArgument::REQUIRED);
 	}
 
-	protected function execute(InputInterface $input, OutputInterface $output) {
+	protected function execute(InputInterface $input, OutputInterface $output): int {
 		$uid = $input->getArgument('uid');
 		$user = $this->userManager->get($uid);
 		if ($user === null) {

--- a/core/Command/Upgrade.php
+++ b/core/Command/Upgrade.php
@@ -92,8 +92,10 @@ class Upgrade extends Command {
 	 *
 	 * @param InputInterface $input input interface
 	 * @param OutputInterface $output output interface
+	 *
+	 * @return int
 	 */
-	protected function execute(InputInterface $input, OutputInterface $output) {
+	protected function execute(InputInterface $input, OutputInterface $output): int {
 		if ($output->getVerbosity() === OutputInterface::VERBOSITY_NORMAL
 			&& !$input->hasParameterOption('--verbose=0', true)) {
 			// set to more verbose on upgrade if no explicit verbosity was set

--- a/core/Command/User/Add.php
+++ b/core/Command/User/Add.php
@@ -92,7 +92,7 @@ class Add extends Command {
 			);
 	}
 
-	protected function execute(InputInterface $input, OutputInterface $output) {
+	protected function execute(InputInterface $input, OutputInterface $output): int {
 		$uid = $input->getArgument('uid');
 		if ($this->userManager->userExists($uid)) {
 			$output->writeln('<error>The user "' . $uid . '" already exists.</error>');

--- a/core/Command/User/Delete.php
+++ b/core/Command/User/Delete.php
@@ -61,7 +61,7 @@ class Delete extends Command {
 			);
 	}
 
-	protected function execute(InputInterface $input, OutputInterface $output) {
+	protected function execute(InputInterface $input, OutputInterface $output): int {
 		$uid = $input->getArgument('uid');
 		$user = $this->userManager->get($uid);
 		if ($user === null) {

--- a/core/Command/User/Disable.php
+++ b/core/Command/User/Disable.php
@@ -50,7 +50,7 @@ class Disable extends Command {
 			);
 	}
 
-	protected function execute(InputInterface $input, OutputInterface $output) {
+	protected function execute(InputInterface $input, OutputInterface $output): int {
 		$user = $this->userManager->get($input->getArgument('uid'));
 		if ($user === null) {
 			$output->writeln('<error>User does not exist</error>');

--- a/core/Command/User/Enable.php
+++ b/core/Command/User/Enable.php
@@ -50,7 +50,7 @@ class Enable extends Command {
 			);
 	}
 
-	protected function execute(InputInterface $input, OutputInterface $output) {
+	protected function execute(InputInterface $input, OutputInterface $output): int {
 		$user = $this->userManager->get($input->getArgument('uid'));
 		if ($user === null) {
 			$output->writeln('<error>User does not exist</error>');

--- a/core/Command/User/HomeListDirs.php
+++ b/core/Command/User/HomeListDirs.php
@@ -47,7 +47,7 @@ class HomeListDirs extends Base {
 			->setDescription('List all available root directories for user homes that are currently in use');
 	}
 
-	protected function execute(InputInterface $input, OutputInterface $output) {
+	protected function execute(InputInterface $input, OutputInterface $output): int {
 		if (Filesystem::isPrimaryObjectStorageEnabled() === true) {
 			$output->writeln('<info>We detected that the instance is running on a S3 primary object storage, home directories might not be accurate</info>');
 		}

--- a/core/Command/User/HomeListUsers.php
+++ b/core/Command/User/HomeListUsers.php
@@ -68,7 +68,7 @@ class HomeListUsers extends Base {
 			);
 	}
 
-	protected function execute(InputInterface $input, OutputInterface $output) {
+	protected function execute(InputInterface $input, OutputInterface $output): int {
 		if (Filesystem::isPrimaryObjectStorageEnabled() === true) {
 			$output->writeln('<info>We detected that the instance is running on a S3 primary object storage, users might not be accurate</info>');
 		}

--- a/core/Command/User/Inactive.php
+++ b/core/Command/User/Inactive.php
@@ -53,7 +53,7 @@ class Inactive extends Base {
 		parent::configure();
 	}
 
-	protected function execute(InputInterface $input, OutputInterface $output) {
+	protected function execute(InputInterface $input, OutputInterface $output): int {
 		$days = $input->getArgument('days');
 		if ((!\is_int($days) && !\ctype_digit($days)) || $days < 1) {
 			throw new InvalidArgumentException('Days must be integer and above zero');

--- a/core/Command/User/LastSeen.php
+++ b/core/Command/User/LastSeen.php
@@ -53,7 +53,7 @@ class LastSeen extends Command {
 			);
 	}
 
-	protected function execute(InputInterface $input, OutputInterface $output) {
+	protected function execute(InputInterface $input, OutputInterface $output): int {
 		$user = $this->userManager->get($input->getArgument('uid'));
 		if ($user === null) {
 			$output->writeln('<error>User does not exist</error>');

--- a/core/Command/User/ListUserGroups.php
+++ b/core/Command/User/ListUserGroups.php
@@ -59,7 +59,7 @@ class ListUserGroups extends Base {
 		;
 	}
 
-	protected function execute(InputInterface $input, OutputInterface $output) {
+	protected function execute(InputInterface $input, OutputInterface $output): int {
 		$uid = $input->getArgument('uid');
 		if (!$this->userManager->userExists($uid)) {
 			$output->writeln("<error>User $uid does not exist.</error>");

--- a/core/Command/User/ListUsers.php
+++ b/core/Command/User/ListUsers.php
@@ -93,7 +93,7 @@ class ListUsers extends Base {
 		}
 	}
 
-	protected function execute(InputInterface $input, OutputInterface $output) {
+	protected function execute(InputInterface $input, OutputInterface $output): int {
 		$userNameSubString = $input->getArgument('search-pattern');
 		$attributes = \array_map('mb_strtolower', $input->getOption('attributes'));
 		$showAllAttributes = $input->getOption('show-all-attributes');

--- a/core/Command/User/Modify.php
+++ b/core/Command/User/Modify.php
@@ -93,7 +93,7 @@ class Modify extends Base {
 		}
 	}
 
-	protected function execute(InputInterface $input, OutputInterface $output) {
+	protected function execute(InputInterface $input, OutputInterface $output): int {
 		$uid = $input->getArgument('uid');
 		$key = $input->getArgument('key');
 		$value = $input->getArgument('value');

--- a/core/Command/User/MoveHome.php
+++ b/core/Command/User/MoveHome.php
@@ -53,7 +53,7 @@ class MoveHome extends Command {
 		;
 	}
 
-	protected function execute(InputInterface $input, OutputInterface $output) {
+	protected function execute(InputInterface $input, OutputInterface $output): int {
 		$user = $this->getUser($input);
 		$userId = $user->getUID();
 		$oldHome = $user->getHome();

--- a/core/Command/User/Report.php
+++ b/core/Command/User/Report.php
@@ -57,7 +57,7 @@ class Report extends Command {
 			->setDescription('shows how many users have access');
 	}
 
-	protected function execute(InputInterface $input, OutputInterface $output) {
+	protected function execute(InputInterface $input, OutputInterface $output): int {
 		if (Filesystem::isPrimaryObjectStorageEnabled() === true) {
 			$output->writeln('<info>We detected that the instance is running on a S3 primary object storage, user directories count might not be accurate</info>');
 		}

--- a/core/Command/User/ResetPassword.php
+++ b/core/Command/User/ResetPassword.php
@@ -98,7 +98,7 @@ class ResetPassword extends Command {
 		;
 	}
 
-	protected function execute(InputInterface $input, OutputInterface $output) {
+	protected function execute(InputInterface $input, OutputInterface $output): int {
 		$username = $input->getArgument('user');
 		$emailLink = $input->getOption('send-email');
 		$displayLink = $input->getOption('output-link');

--- a/core/Command/User/Setting.php
+++ b/core/Command/User/Setting.php
@@ -153,7 +153,7 @@ class Setting extends Base {
 		}
 	}
 
-	protected function execute(InputInterface $input, OutputInterface $output) {
+	protected function execute(InputInterface $input, OutputInterface $output): int {
 		try {
 			$this->checkInput($input);
 		} catch (\InvalidArgumentException $e) {


### PR DESCRIPTION
## Description
Symfony 5 requires that the Symfony Command `execute` method always returns an `int`

It is "sort of" optional for Symfony 4, but actually we should always return an `int`

This PR:
- declares the return type to be `int`
- adjusts places where something else has been returned, so that an`int` is now returned. That will fix potential problems with some commands.

## How Has This Been Tested?
CI

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Database schema changes (next release will require increase of minor version instead of patch)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [ ] Tests only (no source changes)

## Checklist:
- [ ] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 
- [ ] Changelog item, see [TEMPLATE](https://github.com/owncloud/core/blob/master/changelog/TEMPLATE)
