### PR TITLE
Exit with success when signing-key has been set

### DIFF
--- a/changelog/unreleased/40794
+++ b/changelog/unreleased/40794
@@ -1,0 +1,9 @@
+Bugfix: Exit with success when signing-key has been set
+
+The "occ security:sign-key:create" command exited with status 1 even when the
+signing key was successfully created. This has been corrected. The command
+now exits with status zero (0) when the command succeeded.
+
+For all occ commands, zero (0) is success, any other value indicates a problem.
+
+https://github.com/owncloud/core/pull/40794

--- a/core/Command/Security/CreateSignKey.php
+++ b/core/Command/Security/CreateSignKey.php
@@ -58,7 +58,7 @@ class CreateSignKey extends Base {
 			->addArgument(
 				'user',
 				InputArgument::REQUIRED,
-				'The is of the user'
+				'The id of the user'
 			);
 	}
 
@@ -82,6 +82,6 @@ class CreateSignKey extends Base {
 		}
 		$newSigningKey = $this->secureRandom->generate(64);
 		$this->config->setUserValue($uid, 'core', 'signing-key', $newSigningKey, $signingKey);
-		return 1;
+		return 0;
 	}
 }


### PR DESCRIPTION
## Description
See the changelog text:

The "occ security:sign-key:create" command exited with status 1 even when the
signing key was successfully created. This has been corrected. The command
now exits with status zero (0) when the command succeeded.

## How Has This Been Tested?
Before:
```
$ php occ security:sign-key:create joan
$ echo $?
1
```

After:
```
$ php occ security:sign-key:create joan
$ echo $?
0
```

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Database schema changes (next release will require increase of minor version instead of patch)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [ ] Tests only (no source changes)

## Checklist:
- [ ] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 
- [ ] Changelog item, see [TEMPLATE](https://github.com/owncloud/core/blob/master/changelog/TEMPLATE)
