### PR TITLE
[tests-only] Adjust unit tests for Symfony 5

### DIFF
--- a/apps/federatedfilesharing/tests/NotificationsTest.php
+++ b/apps/federatedfilesharing/tests/NotificationsTest.php
@@ -341,14 +341,14 @@ class NotificationsTest extends \Test\TestCase {
 	public function testDeclineEvent() {
 		$dispatcher = \OC::$server->getEventDispatcher();
 		$event = $dispatcher->dispatch(
-			DeclineShare::class,
 			new DeclineShare(
 				[
 					'remote_id' => '4354353',
 					'remote' => 'http://localhost',
 					'share_token' => 'ohno'
 				]
-			)
+			),
+			DeclineShare::class
 		);
 		$this->assertInstanceOf(DeclineShare::class, $event);
 	}

--- a/apps/federation/tests/TrustedServersTest.php
+++ b/apps/federation/tests/TrustedServersTest.php
@@ -74,6 +74,12 @@ class TrustedServersTest extends TestCase {
 			->disableOriginalConstructor()->getMock();
 		$this->dispatcher = $this->getMockBuilder('Symfony\Component\EventDispatcher\EventDispatcherInterface')
 			->disableOriginalConstructor()->getMock();
+		$this->dispatcher->expects($this->any())->method('dispatch')
+			->will(
+				$this->returnCallback(function ($object) {
+					return $object;
+				})
+			);
 		$this->httpClientService = $this->createMock('OCP\Http\Client\IClientService');
 		$this->httpClient = $this->createMock('OCP\Http\Client\IClient');
 		$this->response = $this->createMock('OCP\Http\Client\IResponse');

--- a/apps/files/tests/Controller/ViewControllerTest.php
+++ b/apps/files/tests/Controller/ViewControllerTest.php
@@ -75,6 +75,12 @@ class ViewControllerTest extends TestCase {
 		$this->l10n = $this->createMock('\OCP\IL10N');
 		$this->config = $this->createMock('\OCP\IConfig');
 		$this->eventDispatcher = $this->createMock('\Symfony\Component\EventDispatcher\EventDispatcherInterface');
+		$this->eventDispatcher->expects($this->any())->method('dispatch')
+			->will(
+				$this->returnCallback(function ($object) {
+					return $object;
+				})
+			);
 		$this->userSession = $this->createMock('\OCP\IUserSession');
 		$this->appManager = $this->createMock('\OCP\App\IAppManager');
 		$this->user = $this->createMock('\OCP\IUser');

--- a/apps/files_sharing/tests/HooksTest.php
+++ b/apps/files_sharing/tests/HooksTest.php
@@ -147,7 +147,7 @@ class HooksTest extends \Test\TestCase {
 			'resolvedWebLink' => null,
 			'resolvedDavLink' => null,
 		]);
-		$this->eventDispatcher->dispatch('files.resolvePrivateLink', $event);
+		$this->eventDispatcher->dispatch($event, 'files.resolvePrivateLink');
 
 		$this->assertEquals('/owncloud/index.php/apps/files/?view=sharingin&scrollto=123', $event->getArgument('resolvedWebLink'));
 		$this->assertNull($event->getArgument('resolvedDavLink'));
@@ -168,7 +168,7 @@ class HooksTest extends \Test\TestCase {
 			'resolvedWebLink' => null,
 			'resolvedDavLink' => null,
 		]);
-		$this->eventDispatcher->dispatch('files.resolvePrivateLink', $event);
+		$this->eventDispatcher->dispatch($event, 'files.resolvePrivateLink');
 
 		$this->assertNull($event->getArgument('resolvedWebLink'));
 		$this->assertNull($event->getArgument('resolvedDavLink'));
@@ -182,7 +182,7 @@ class HooksTest extends \Test\TestCase {
 		$this->sharingAllowlist->expects($this->once())->method('setPublicShareSharersGroupsAllowlist')->with([]);
 
 		$event = new GenericEvent($group);
-		$this->eventDispatcher->dispatch('group.postDelete', $event);
+		$this->eventDispatcher->dispatch($event, 'group.postDelete');
 	}
 
 	public function testPublishShareNotification() {
@@ -196,7 +196,7 @@ class HooksTest extends \Test\TestCase {
 			'share' => ['id' => '123'],
 			'shareObject' => $share,
 		]);
-		$this->eventDispatcher->dispatch('share.afterCreate', $event);
+		$this->eventDispatcher->dispatch($event, 'share.afterCreate');
 	}
 
 	public function testDiscardShareNotification() {
@@ -210,7 +210,7 @@ class HooksTest extends \Test\TestCase {
 			'share' => ['id' => '123'],
 			'shareObject' => $share,
 		]);
-		$this->eventDispatcher->dispatch('share.afterDelete', $event);
+		$this->eventDispatcher->dispatch($event, 'share.afterDelete');
 	}
 
 	public function providesDataForCanGet() {
@@ -271,7 +271,7 @@ class HooksTest extends \Test\TestCase {
 
 		// Simulate direct download of file
 		$event = new GenericEvent(null, [ 'path' => $path ]);
-		$this->eventDispatcher->dispatch('file.beforeGetDirect', $event);
+		$this->eventDispatcher->dispatch($event, 'file.beforeGetDirect');
 
 		$this->assertEquals($run, !$event->hasArgument('errorMessage'));
 	}
@@ -349,7 +349,7 @@ class HooksTest extends \Test\TestCase {
 
 		// Simulate zip download of folder folder
 		$event = new GenericEvent(null, ['dir' => $dir, 'files' => $files, 'run' => true]);
-		$this->eventDispatcher->dispatch('file.beforeCreateZip', $event);
+		$this->eventDispatcher->dispatch($event, 'file.beforeCreateZip');
 
 		$this->assertEquals($run, $event->getArgument('run'));
 		$this->assertEquals($run, !$event->hasArgument('errorMessage'));
@@ -360,7 +360,7 @@ class HooksTest extends \Test\TestCase {
 
 		// Simulate zip download of folder folder
 		$event = new GenericEvent(null, ['dir' => '/test', 'files' => ['test.txt'], 'run' => true]);
-		$this->eventDispatcher->dispatch('file.beforeCreateZip', $event);
+		$this->eventDispatcher->dispatch($event, 'file.beforeCreateZip');
 
 		// It should run as this would restrict e.g. share links otherwise
 		$this->assertTrue($event->getArgument('run'));
@@ -394,7 +394,7 @@ class HooksTest extends \Test\TestCase {
 			'shareRecipient' => 'recipient_user',
 			'shareOwner' => 'owner_user',
 		]);
-		$this->eventDispatcher->dispatch('fromself.unshare', $event);
+		$this->eventDispatcher->dispatch($event, 'fromself.unshare');
 	}
 
 	public function testExtendJsConfig() {

--- a/apps/files_trashbin/tests/TrashbinTest.php
+++ b/apps/files_trashbin/tests/TrashbinTest.php
@@ -565,7 +565,7 @@ class TrashbinTest extends TestCase {
 			'resolvedWebLink' => null,
 			'resolvedDavLink' => null,
 		]);
-		\OC::$server->getEventDispatcher()->dispatch('files.resolvePrivateLink', $event);
+		\OC::$server->getEventDispatcher()->dispatch($event, 'files.resolvePrivateLink');
 
 		$this->assertEquals('/owncloud/index.php/apps/files/?view=trashbin&dir=/test.d1462861890/sub&scrollto=somefile.txt', $event->getArgument('resolvedWebLink'));
 		$this->assertNull($event->getArgument('resolvedDavLink'));

--- a/tests/Core/Command/Encryption/ChangeKeyStorageRootTest.php
+++ b/tests/Core/Command/Encryption/ChangeKeyStorageRootTest.php
@@ -26,6 +26,7 @@ use OC\Encryption\Util;
 use OC\Files\View;
 use OCP\IConfig;
 use OCP\IUserManager;
+use Symfony\Component\Console\Formatter\OutputFormatterInterface;
 use Symfony\Component\Console\Helper\QuestionHelper;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Output\OutputInterface;
@@ -71,7 +72,9 @@ class ChangeKeyStorageRootTest extends TestCase {
 		$this->outputInterface = $this->createMock('Symfony\Component\Console\Output\OutputInterface');
 		$this->userInterface = $this->createMock('\OCP\UserInterface');
 
-		$outputFormatterInterface = $this->createMock('Symfony\Component\Console\Formatter\OutputFormatterInterface');
+		$outputFormatterInterface = $this->createMock(OutputFormatterInterface::class);
+		$outputFormatterInterface->expects($this->any())->method('isDecorated')
+			->willReturn(false);
 		$this->outputInterface->expects($this->any())->method('getFormatter')
 			->willReturn($outputFormatterInterface);
 

--- a/tests/Core/Controller/RolesControllerTest.php
+++ b/tests/Core/Controller/RolesControllerTest.php
@@ -47,6 +47,7 @@ class RolesControllerTest extends TestCase {
 				'id' => 'test.tester',
 				'displayName' => 'A tester which tests ....'
 			]);
+			return $event;
 		});
 
 		$result = $controller->getRoles();

--- a/tests/lib/Encryption/DecryptAllTest.php
+++ b/tests/lib/Encryption/DecryptAllTest.php
@@ -102,8 +102,11 @@ class DecryptAllTest extends TestCase {
 		$this->userInterface = $this->getMockBuilder(UserInterface::class)
 			->disableOriginalConstructor()->getMock();
 
+		$outputFormatterInterface = $this->createMock(OutputFormatterInterface::class);
+		$outputFormatterInterface->expects($this->any())->method('isDecorated')
+			->willReturn(false);
 		$this->outputInterface->expects($this->any())->method('getFormatter')
-			->willReturn($this->createMock(OutputFormatterInterface::class));
+			->willReturn($outputFormatterInterface);
 
 		$this->instance = new DecryptAll($this->encryptionManager, $this->userManager, $this->view, $this->logger);
 

--- a/tests/lib/Repair/AppsTest.php
+++ b/tests/lib/Repair/AppsTest.php
@@ -49,6 +49,12 @@ class AppsTest extends TestCase {
 		$this->appManager = $this->createMock(IAppManager::class);
 		$this->defaults = $this->createMock(\OC_Defaults::class);
 		$this->eventDispatcher = $this->createMock(EventDispatcherInterface::class);
+		$this->eventDispatcher->expects($this->any())->method('dispatch')
+			->will(
+				$this->returnCallback(function ($object) {
+					return $object;
+				})
+			);
 		$this->config = $this->createMock(IConfig::class);
 		$this->repair = new Apps(
 			$this->appManager,


### PR DESCRIPTION
## Description
1) Adjust Symfony OutputFormatterInterface in unit tests
2) Adjust Symfony EventDispatcher dispatch method in unit tests

The tests continue to work fine with Symfony - for example, the EventDispatcher `dispatch` call in Symfony 4 supports the old and new way of calling it. In Symfony 5 only the new way is supported. So these changes get ready for Symfony 5 while still working properly with Symfony 4.

## Related Issue
Preparation for #39630 

## How Has This Been Tested?
Local run of unit tests
CI

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Database schema changes (next release will require increase of minor version instead of patch)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [x] Tests only (no source changes)

## Checklist:
- [ ] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 
- [ ] Changelog item, see [TEMPLATE](https://github.com/owncloud/core/blob/master/changelog/TEMPLATE)
