### PR TITLE
Bump version to 10.13.0 prealpha

### DIFF
--- a/version.php
+++ b/version.php
@@ -25,10 +25,10 @@
 // We only can count up. The 4. digit is only for the internal patchlevel to trigger DB upgrades
 // between betas, final and RCs. This is _not_ the public version number. Reset minor/patchlevel
 // when updating major/minor version number.
-$OC_Version = [10, 12, 1, 3];
+$OC_Version = [10, 13, 0, 0];
 
 // The human-readable string
-$OC_VersionString = '10.12.1';
+$OC_VersionString = '10.13.0 prealpha';
 
 $OC_VersionCanBeUpgradedFrom = [[8, 2, 11],[9, 0, 9],[9, 1]];
 


### PR DESCRIPTION
## Description
There have been enough changes in core master that the next release from master will be 10.13.0, and it will be useful for oC10 apps that start using new/changed things from core to be able to specify this core min-version, or to take other action that depends on the core code in use.

Bump to 10.13.0 prealpha (similar to what was done for 10.12 in PR #40565 in January 2023)

## How Has This Been Tested?
CI

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Database schema changes (next release will require increase of minor version instead of patch)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [ ] Tests only (no source changes)

## Checklist:
- [ ] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 
- [ ] Changelog item, see [TEMPLATE](https://github.com/owncloud/core/blob/master/changelog/TEMPLATE)
