### PR TITLE
[tests-only] Do not try to revert LDAP settings of a deleted config

### DIFF
--- a/tests/acceptance/features/bootstrap/Provisioning.php
+++ b/tests/acceptance/features/bootstrap/Provisioning.php
@@ -865,6 +865,12 @@ trait Provisioning {
 				['ldap:delete-config', $configId],
 				$this->getStepLineRef()
 			);
+			// The LDAP config has been deleted, so any settings that were
+			// changed in that config do not need to be reverted.
+			// Remove the memory of those settings.
+			if (isset($this->oldLdapConfig[$configId])) {
+				unset($this->oldLdapConfig[$configId]);
+			}
 		}
 		foreach ($this->oldLdapConfig as $configId => $settings) {
 			foreach ($settings as $configKey => $configValue) {


### PR DESCRIPTION
## Description
Some LDAP test scenarios use multiple LDAP server configs to test environments that have multiple LDAP server connections etc. The after-scenario methods delete these extra LDAP configs.

The test code also remembers what settings were changed in LDAP configs and tries to revert them.

But if an LDAP config is deleted in the after-scenario then there is no point trying to revert the settings of that LDAP config. Each attempt to revert a setting will get an error from the `occ ldap:set-config` command - "Invalid configID"

user_ldap PR https://github.com/owncloud/user_ldap/pull/787 has fixed the `ldap:set-config` command so that it now exits with an error status in that case. And so the CI of that PR is failing.

This core PR fixes the test code so that it will not call `ldap:set-config` for configs that have been deleted.

## How Has This Been Tested?
CI

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Database schema changes (next release will require increase of minor version instead of patch)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [x] Tests only (no source changes)

## Checklist:
- [ ] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 
- [ ] Changelog item, see [TEMPLATE](https://github.com/owncloud/core/blob/master/changelog/TEMPLATE)
