### PR TITLE
fix/optimize preview cleanup query

### DIFF
--- a/changelog/unreleased/40800
+++ b/changelog/unreleased/40800
@@ -1,0 +1,7 @@
+Bugfix: Fix query used to delete thumbnails
+
+Fixed query that detects unused thumbnails to prevent unnecessary
+deletes and potential recreations.
+
+https://github.com/owncloud/core/issues/40800
+https://github.com/owncloud/core/pull/40801

--- a/tests/lib/PreviewCleanupTest.php
+++ b/tests/lib/PreviewCleanupTest.php
@@ -97,6 +97,18 @@ class PreviewCleanupTest extends TestCase {
 		# create preview
 		$thumbnailFolderUser2 = $this->createPreview($sharedTextFile, $rootFolder, $sharedTextFileId);
 
+		# assert thumbnail exists after createPreview
+		self::assertTrue($thumbnailFolderUser1->nodeExists($textFileId));
+		self::assertTrue($thumbnailFolderUser2->nodeExists($sharedTextFileId));
+
+		# run cleanup command
+		$cmd = new PreviewCleanup(\OC::$server->getDatabaseConnection());
+		$cmd->process();
+
+		# assert thumbnail still exists after cleanup run without deleting
+		self::assertTrue($thumbnailFolderUser1->nodeExists($textFileId));
+		self::assertTrue($thumbnailFolderUser2->nodeExists($sharedTextFileId));
+
 		# delete file
 		$textFile->delete();
 


### PR DESCRIPTION
<!--
Thanks for submitting a change to ownCloud!

This is the bug tracker for the Server component. Find other components at https://github.com/owncloud/core/blob/master/.github/CONTRIBUTING.md#guidelines

For fixing potential security issues please see https://owncloud.com/security/

To make it possible for us to get your change reviewed and merged please carefully fill out the requested information below.

Please note that any kind of change needs first be submitted to the master branch which holds the next version of ownCloud.

Please set the following labels:

- Set label "3 - To review" for review or "2 - Development" if the PR still has open tasks
- Assignment: assign to self
- Milestone: set the same as the ticket this PR fixes, or "development" by default
- Reviewers: pick at least one
-->

## Description
Fix to PreviewCleanup query

## Related Issue
- Fixes #40800 

## Motivation and Context
Keeps the faster response time, returns the correct data, prevents unnecessary thumbnail deletes/recreations.

## How Has This Been Tested?
- test environment: Docker owncloud/server:10.12 (current version 10.12.1.3)
Updated lib/private/PreviewCleanup.php with new query
ran occ previews:cleanup
saw that only the correct thunbnails were deleted.
Test run against MariaDB 10.11.3

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Database schema changes (next release will require increase of minor version instead of patch)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [ ] Tests only (no source changes)

## Checklist:
<!-- Tick the checkboxes when done. -->
<!-- Raise documentation ticket in https://github.com/owncloud/documentation -->
- [X] Code changes
- [x] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 
- [x] Changelog item, see [TEMPLATE](https://github.com/owncloud/core/blob/master/changelog/TEMPLATE)
