### PR TITLE
fix: verify tag name length upon creation

### DIFF
--- a/apps/dav/lib/SystemTag/SystemTagPlugin.php
+++ b/apps/dav/lib/SystemTag/SystemTagPlugin.php
@@ -161,7 +161,7 @@ class SystemTagPlugin extends \Sabre\DAV\ServerPlugin {
 	 * @throws Conflict if a tag with the same properties already exists
 	 * @throws UnsupportedMediaType if the content type is not supported
 	 */
-	private function createTag($data, $contentType = 'application/json') {
+	private function createTag($data, $contentType = 'application/json'): ISystemTag {
 		if (\explode(';', $contentType)[0] === 'application/json') {
 			$data = \json_decode($data, true);
 		} else {
@@ -170,6 +170,9 @@ class SystemTagPlugin extends \Sabre\DAV\ServerPlugin {
 
 		if (!isset($data['name'])) {
 			throw new BadRequest('Missing "name" attribute');
+		}
+		if (\strlen($data['name']) > 64) {
+			throw new BadRequest('Tag name too long');
 		}
 
 		$tagName = $data['name'];

--- a/changelog/unreleased/40726
+++ b/changelog/unreleased/40726
@@ -1,5 +1,5 @@
 Change: fix name length check on federated shares
 
-A federated share with a too long name results in inaccessible data.
+A federated share with a too long name results in potentially inaccessible data.
 
 https://github.com/owncloud/core/pull/40726

--- a/changelog/unreleased/40804
+++ b/changelog/unreleased/40804
@@ -1,0 +1,5 @@
+Change: fix name length check on system tag creation
+
+A system tag with a too long name results in potentially inaccessible data.
+
+https://github.com/owncloud/core/pull/40804


### PR DESCRIPTION
## Description
There is currently no input validation on the length of the tag name.
On a system using sqlite this can result in super long tag names and can result in crashes all over the place. But it is sqlite - not production critical.
On systems using other dbs we see the data being cut of (potentially exceptions?) which does not lead to crashes.

Never the less proper input validation is the way

## How Has This Been Tested?
- :robot: 

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Database schema changes (next release will require increase of minor version instead of patch)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [ ] Tests only (no source changes)

## Checklist:
<!-- Tick the checkboxes when done. -->
<!-- Raise documentation ticket in https://github.com/owncloud/documentation -->
- [x] Code changes
- [x] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 
- [x] Changelog item, see [TEMPLATE](https://github.com/owncloud/core/blob/master/changelog/TEMPLATE)
