### PR TITLE
make sure to use json for federation post and get

### DIFF
--- a/apps/federation/lib/BackgroundJob/GetSharedSecret.php
+++ b/apps/federation/lib/BackgroundJob/GetSharedSecret.php
@@ -64,7 +64,7 @@ class GetSharedSecret extends Job {
 	/** @var bool */
 	protected $retainJob = false;
 
-	private $endPoint = '/ocs/v2.php/apps/federation/api/v1/shared-secret?format=json';
+	private $endPoint = '/ocs/v2.php/apps/federation/api/v1/shared-secret';
 
 	/**
 	 * RequestSharedSecret constructor.
@@ -142,15 +142,15 @@ class GetSharedSecret extends Job {
 		try {
 			$result = $this->httpClient->get(
 				$target . $this->endPoint,
-				[
-					'query' =>
-						[
-							'url' => $source,
-							'token' => $token
-						],
+				array(
+					'query' => array(
+						'url' => $source,
+						'token' => $token,
+						'format' => 'json'
+					),
 					'timeout' => 3,
 					'connect_timeout' => 3,
-				]
+				)
 			);
 
 			$status = $result->getStatusCode();

--- a/apps/federation/lib/BackgroundJob/GetSharedSecret.php
+++ b/apps/federation/lib/BackgroundJob/GetSharedSecret.php
@@ -142,15 +142,15 @@ class GetSharedSecret extends Job {
 		try {
 			$result = $this->httpClient->get(
 				$target . $this->endPoint,
-				array(
-					'query' => array(
+				[
+					'query' => [
 						'url' => $source,
 						'token' => $token,
 						'format' => 'json'
-					),
+					],
 					'timeout' => 3,
 					'connect_timeout' => 3,
-				)
+				]
 			);
 
 			$status = $result->getStatusCode();

--- a/apps/federation/lib/BackgroundJob/RequestSharedSecret.php
+++ b/apps/federation/lib/BackgroundJob/RequestSharedSecret.php
@@ -139,15 +139,15 @@ class RequestSharedSecret extends Job {
 		try {
 			$result = $this->httpClient->post(
 				$target . $this->endPoint,
-				array(
-					'form_params' => array(
+				[
+					'form_params' => [
 						'url' => $source,
 						'token' => $token,
 						'format' => 'json'
-					),
+					],
 					'timeout' => 3,
 					'connect_timeout' => 3,
-				)
+				]
 			);
 
 			$status = $result->getStatusCode();

--- a/apps/federation/lib/BackgroundJob/RequestSharedSecret.php
+++ b/apps/federation/lib/BackgroundJob/RequestSharedSecret.php
@@ -58,7 +58,7 @@ class RequestSharedSecret extends Job {
 	/** @var TrustedServers */
 	private $trustedServers;
 
-	private $endPoint = '/ocs/v2.php/apps/federation/api/v1/request-shared-secret?format=json';
+	private $endPoint = '/ocs/v2.php/apps/federation/api/v1/request-shared-secret';
 
 	/** @var ILogger */
 	private $logger;
@@ -139,14 +139,15 @@ class RequestSharedSecret extends Job {
 		try {
 			$result = $this->httpClient->post(
 				$target . $this->endPoint,
-				[
-					'form_params' => [
+				array(
+					'form_params' => array(
 						'url' => $source,
 						'token' => $token,
-					],
+						'format' => 'json'
+					),
 					'timeout' => 3,
 					'connect_timeout' => 3,
-				]
+				)
 			);
 
 			$status = $result->getStatusCode();

--- a/apps/federation/tests/BackgroundJob/GetSharedSecretTest.php
+++ b/apps/federation/tests/BackgroundJob/GetSharedSecretTest.php
@@ -151,12 +151,13 @@ class GetSharedSecretTest extends TestCase {
 			->willReturn($source);
 		$this->httpClient->expects($this->once())->method('get')
 			->with(
-				$target . '/ocs/v2.php/apps/federation/api/v1/shared-secret?format=json',
+				$target . '/ocs/v2.php/apps/federation/api/v1/shared-secret',
 				[
 					'query' =>
 						[
 							'url' => $source,
-							'token' => $token
+							'token' => $token,
+							'format' => 'json'
 						],
 					'timeout' => 3,
 					'connect_timeout' => 3,

--- a/apps/federation/tests/BackgroundJob/RequestSharedSecretTest.php
+++ b/apps/federation/tests/BackgroundJob/RequestSharedSecretTest.php
@@ -137,12 +137,13 @@ class RequestSharedSecretTest extends TestCase {
 			->willReturn($source);
 		$this->httpClient->expects($this->once())->method('post')
 			->with(
-				$target . '/ocs/v2.php/apps/federation/api/v1/request-shared-secret?format=json',
+				$target . '/ocs/v2.php/apps/federation/api/v1/request-shared-secret',
 				[
 					'form_params' =>
 						[
 							'url' => $source,
-							'token' => $token
+							'token' => $token,
+							'format' => 'json'
 						],
 					'timeout' => 3,
 					'connect_timeout' => 3,

--- a/changelog/unreleased/40815
+++ b/changelog/unreleased/40815
@@ -1,0 +1,9 @@
+Bugfix: Always use json for federation post and get to exchange tokens
+
+After update of guzzle, it was no longer possible to request format of response to be json when adding in query parameter. One of OCSAuthAPIController fed instances was receiving requests without a hint that JSON needs to be used, and returned XML. On the other hand, OCSAuthAPIController expects only JSON for exchange, and thus failed to parse the message.
+Now the exchange is correctly done. 
+
+WARNING: the patch/fix needs to be applied on all federated severs that are not yet "paired" and have the issue with guzzle library. Otherwise pairing will not work.
+
+https://github.com/owncloud/core/pull/40815
+https://github.com/owncloud/enterprise/issues/5676


### PR DESCRIPTION
## Description
After update of guzzle , it was no longer possible to request format of response to be json when adding in query parameter. Because default OCSController method assigns xml https://github.com/owncloud/core/blob/v10.12.0/lib/public/AppFramework/OCSController.php#L143-L146 , it was returning XML, but `apps/federation/lib/Controller/OCSAuthAPIController.php` expects JSON. 

Now exchange is correctly performed, and servers are marked "green"

**_WARNING: the patch/fix needs to be applied on all federated severs that are not yet "paired" and have the issue with guzzle library. Otherwise pairing will not work._**

Remarks:
- the initial pairing still leaves systems in "yellow" boxes state, but what is important is that both servers correctly exchanged "shared secret and have entries properly updated. To speed up the process, after adding trusted servers in UI force background jobs for "GetSharedSecret" and/or "RequestSharedSecret"
```
occ background:queue:execute --force --accept-warning 19
occ background:queue:execute --force --accept-warning 20 
```
- to make the instances green, run below commands
```
occ dav:sync-system-addressbook
occ federation:sync-addressbook
```

## Related Issue
- Fixes https://github.com/owncloud/enterprise/issues/5676

## Types of changes
- [x] Bugfix

## Checklist:
- [x] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [x] Documentation ticket (not needed)
- [x] Changelog item, see [TEMPLATE](https://github.com/owncloud/core/blob/master/changelog/TEMPLATE)
