### PR TITLE
Update Google.php (cover variable initialisation not passing the else statement)

### DIFF
--- a/apps/files_external/lib/Lib/Storage/Google.php
+++ b/apps/files_external/lib/Lib/Storage/Google.php
@@ -474,6 +474,8 @@ class Google extends \OCP\Files\Storage\StorageAdapter {
 		if ($file) {
 			$newFile = $this->getDriveFile($path2);
 			$toUpdate = new DriveFile();
+			$addedParent = '';
+			$removedParent = '';
 			if (\dirname($path1) === \dirname($path2)) {
 				if ($newFile) {
 					// rename to the name of the target file, could be an office file without extension

--- a/changelog/unreleased/40822
+++ b/changelog/unreleased/40822
@@ -1,4 +1,4 @@
-Bugfix: Deleting a file in a Google Drive mount can throw an undefined variable error
+Bugfix: Rare undefined variable error when using a Google Drive mount
 
 There can be the rare case that deleting a file from a Google Drive mount can throw an undefined variable error. Though the process completes without further issues, no errors should be thrown. This fix initializes the variables for these cases properly making the error go away.
 

--- a/changelog/unreleased/40822
+++ b/changelog/unreleased/40822
@@ -1,0 +1,6 @@
+Bugfix: Deleting a file in a Google Drive mount can throw an undefined variable error
+
+There can be the rare case that deleting a file from a Google Drive mount can throw an undefined variable error. Though the process completes without further issues, no errors should be thrown. This fix initializes the variables for these cases properly making the error go away.
+
+https://github.com/owncloud/core/pull/40822
+https://github.com/owncloud/core/issues/40802


### PR DESCRIPTION
## Description
There can be the case that two varibles are not defined when not passing the else statement throwing an `undefined variable` error. This is now fixed as both variables are now initialized.

## Related Issue
Fixes: https://github.com/owncloud/core/issues/40802 (Deleting a file in a Google Drive Mount throws an error)

## Motivation and Context
No error should be thrown, code quality.

## How Has This Been Tested?

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Database schema changes (next release will require increase of minor version instead of patch)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [ ] Tests only (no source changes)

## Checklist:
<!-- Tick the checkboxes when done. -->
<!-- Raise documentation ticket in https://github.com/owncloud/documentation -->
- [x] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 
- [ ] Changelog item, see [TEMPLATE](https://github.com/owncloud/core/blob/master/changelog/TEMPLATE)
