### PR TITLE
[tests-only] Handle possible null original-location in tryToDeleteFileFromTrashbin

### DIFF
--- a/tests/acceptance/features/bootstrap/TrashbinContext.php
+++ b/tests/acceptance/features/bootstrap/TrashbinContext.php
@@ -586,7 +586,10 @@ class TrashbinContext implements Context {
 		$numItemsDeleted = 0;
 
 		foreach ($listing as $entry) {
-			if ($entry['original-location'] === $originalPath) {
+			// The entry for the trashbin root can have original-location null.
+			// That is reasonable, because the trashbin root is not something that can be restored.
+			$originalLocation = $entry['original-location'] ?? '';
+			if (\trim($originalLocation, '/') === $originalPath) {
 				$trashItemHRef = $this->convertTrashbinHref($entry['href']);
 				$response = $this->featureContext->makeDavRequest(
 					$asUser,


### PR DESCRIPTION
## Description
In ocis PR https://github.com/owncloud/ocis/pull/6408 we needed to handle the possibility that a response to a trashbin-list request could have an entry(s) that have `original-location` set to null.

Add the same changes here in core so that the test code will handle this if it ever happens.

## How Has This Been Tested?
CI

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Database schema changes (next release will require increase of minor version instead of patch)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [x] Tests only (no source changes)

## Checklist:
- [ ] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 
- [ ] Changelog item, see [TEMPLATE](https://github.com/owncloud/core/blob/master/changelog/TEMPLATE)
