### PR TITLE
refactor isNewPermissionHigher

### DIFF
--- a/apps/federatedfilesharing/lib/FedShareManager.php
+++ b/apps/federatedfilesharing/lib/FedShareManager.php
@@ -322,7 +322,7 @@ class FedShareManager {
 	 */
 	public function updatePermissions(IShare $share, int $permissions): void {
 		# permissions can only be reduced but not upgraded
-		if (Permissions::isNewPermissionHigher($share->getPermissions(), $permissions)) {
+		if (!Permissions::isNewPermissionHigher($share->getPermissions(), $permissions)) {
 			$share->setPermissions($permissions);
 			$this->federatedShareProvider->update($share);
 		}

--- a/apps/federatedfilesharing/lib/Ocm/Permissions.php
+++ b/apps/federatedfilesharing/lib/Ocm/Permissions.php
@@ -79,6 +79,6 @@ class Permissions {
 	}
 
 	public static function isNewPermissionHigher(int $existingPermission, int $newPermission): bool {
-		return ($existingPermission | $newPermission) === $existingPermission;
+		return ($existingPermission | $newPermission) !== $existingPermission;
 	}
 }


### PR DESCRIPTION
## Description
`isNewPermissionHigher` currently actually returns the answer to "is new permission not higher than current permission" ("is new permission less than or equal to current permission"), so the name is misleading.

The code that calls it works fine.

This PR refactors the code inside `isNewPermissionHigher` so it reverses the logic. And it reverses the logic of the function that calls it.

An alternative would be to rename the function to `isNewPermissionEqualOrLower`


## How Has This Been Tested?
CI

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Database schema changes (next release will require increase of minor version instead of patch)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [ ] Tests only (no source changes)

## Checklist:
- [ ] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 
- [ ] Changelog item, see [TEMPLATE](https://github.com/owncloud/core/blob/master/changelog/TEMPLATE)
