### PR TITLE
Enforce 2fa with exclusion groups

### DIFF
--- a/changelog/unreleased/40830
+++ b/changelog/unreleased/40830
@@ -1,0 +1,9 @@
+Enhancement: Enforce 2-factor authentication
+
+2-factor authentication can be enforced now. The feature requires at least
+an app implementing the 2-factor, otherwise no enforcement will be done.
+If the 2-factor authentication is enforced, all users will be required to
+use a 2-factor authentication app. Some specific groups selected by the admin
+can be excluded to let those users bypass the 2-factor authentication.
+
+https://github.com/owncloud/core/pull/40830

--- a/lib/private/Authentication/TwoFactorAuth/Manager.php
+++ b/lib/private/Authentication/TwoFactorAuth/Manager.php
@@ -160,6 +160,10 @@ class Manager {
 			}
 		}
 
+		// if 2-factor is enforced, we must not filter out providers that
+		// might not be enabled or configured. The providers are expected
+		// to handle this problem on their own, usually by allowing
+		// configuration (at least partially) in the challenge page.
 		if ($this->isTwoFactorEnforcedForUser($user)) {
 			return $providers;
 		}

--- a/lib/private/Server.php
+++ b/lib/private/Server.php
@@ -402,7 +402,14 @@ class Server extends ServerContainer implements IServerContainer, IServiceLoader
 		});
 
 		$this->registerService('\OC\Authentication\TwoFactorAuth\Manager', function (Server $c) {
-			return new \OC\Authentication\TwoFactorAuth\Manager($c->getAppManager(), $c->getSession(), $c->getConfig(), $c->getRequest(), $c->getLogger());
+			return new \OC\Authentication\TwoFactorAuth\Manager(
+				$c->getAppManager(),
+				$c->getSession(),
+				$c->getGroupManager(),
+				$c->getConfig(),
+				$c->getRequest(),
+				$c->getLogger()
+			);
 		});
 
 		$this->registerService('NavigationManager', function (Server $c) {

--- a/lib/private/Settings/SettingsManager.php
+++ b/lib/private/Settings/SettingsManager.php
@@ -49,6 +49,7 @@ use OC\Settings\Panels\Personal\Version;
 use OC\Settings\Panels\Personal\Tokens;
 use OC\Settings\Panels\Personal\Cors;
 use OC\Settings\Panels\Personal\Quota;
+use OC\Settings\Panels\Admin\Enforce2fa;
 use OC\Settings\Panels\Admin\BackgroundJobs;
 use OC\Settings\Panels\Admin\Certificates;
 use OC\Settings\Panels\Admin\Encryption;
@@ -236,6 +237,7 @@ class SettingsManager implements ISettingsManager {
 	private function getBuiltInPanels($type) {
 		if ($type === 'admin') {
 			return [
+				Enforce2fa::class,
 				LegacyAdmin::class,
 				BackgroundJobs::class,
 				Logging::class,

--- a/settings/Panels/Admin/Enforce2fa.php
+++ b/settings/Panels/Admin/Enforce2fa.php
@@ -32,7 +32,7 @@ class Enforce2fa implements ISettings {
 	}
 
 	public function getPriority() {
-		return 0;
+		return 50;
 	}
 
 	public function getPanel() {

--- a/settings/Panels/Admin/Enforce2fa.php
+++ b/settings/Panels/Admin/Enforce2fa.php
@@ -1,0 +1,49 @@
+<?php
+/**
+ * @copyright Copyright (c) 2023, ownCloud GmbH
+ * @license AGPL-3.0
+ *
+ * This code is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License, version 3,
+ * as published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License, version 3,
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>
+ *
+ */
+
+namespace OC\Settings\Panels\Admin;
+
+use OCP\Settings\ISettings;
+use OCP\Template;
+use OCP\IConfig;
+
+class Enforce2fa implements ISettings {
+	/** @var IConfig */
+	protected $config;
+
+	public function __construct(IConfig $config) {
+		$this->config = $config;
+	}
+
+	public function getPriority() {
+		return 0;
+	}
+
+	public function getPanel() {
+		$enforce2faExcludedGroups = \json_decode($this->config->getAppValue('core', 'enforce_2fa_excluded_groups', '[]'), true);
+		$tmpl = new Template('settings', 'panels/admin/enforce2fa');
+		$tmpl->assign('enforce2fa', $this->config->getAppValue('core', 'enforce_2fa', 'no') === 'yes');
+		$tmpl->assign('enforce2faExcludedGroups', \implode('|', $enforce2faExcludedGroups));
+		return $tmpl;
+	}
+
+	public function getSectionID() {
+		return 'security';
+	}
+}

--- a/settings/js/panels/enforce2fa.js
+++ b/settings/js/panels/enforce2fa.js
@@ -1,0 +1,19 @@
+$(document).ready(function() {
+
+	var enforce2faGroupsList = $('#enforce_2fa_excluded_groups');
+	OC.Settings.setupGroupsSelect(enforce2faGroupsList);
+	enforce2faGroupsList.change(function(ev) {
+		OC.AppConfig.setValue('core', 'enforce_2fa_excluded_groups', JSON.stringify(ev.val || []));
+	});
+
+	$('#enforce_2fa').change(function() {
+		var name = $(this).attr('name');
+		var value;
+		if (this.checked) {
+			value = 'yes';
+		} else {
+			value = 'no';
+		}
+		OC.AppConfig.setValue('core', name, value);
+	});
+});

--- a/settings/templates/panels/admin/enforce2fa.php
+++ b/settings/templates/panels/admin/enforce2fa.php
@@ -1,0 +1,33 @@
+<?php
+script('settings', 'panels/enforce2fa');
+?>
+<div class="section" id="2fa">
+	<h2 class="app-name"><?php p($l->t('Two-factor Authentication'));?></h2>
+	<p>
+		<em><?php p($l->t('This section requires a two-factor authentication app to be installed in ownCloud')); ?></em>
+	</p>
+	<h3><?php p($l->t('Enforce two-factor authentication')); ?></h3>
+	<p><?php p($l->t('Before enforcing the two-factor authentication, check the following requirements:')); ?></p>
+	<ul>
+		<li><?php p($l->t('At least a two-factor authentication app is installed and enabled in ownCloud.')); ?></li>
+		<li><?php p($l->t('The users can setup at least a two-factor app from the challenge page. Some apps might not be prepared for this')); ?></li>
+	</ul>
+	<p><?php p($l->t('The "twofactor_totp" app fulfills those requirements, and might be used as a fallback so the users can enter their accounts in order to configure other two-factor authentication apps')); ?></p>
+	<br/>
+	<p>
+	<input type="checkbox" id="enforce_2fa" name="enforce_2fa" value="1" <?php if ($_['enforce2fa']) {
+		print_unescaped('checked="checked"');
+	}?> />
+	<label for="enforce_2fa"><?php p($l->t('Enforce two-factor authentication to all the users')); ?></label>
+	</p>
+	<br/>
+	<p>
+		<?php p($l->t('Exclude the following groups of enforcing the two-factor authentication')); ?>
+		<br />
+		<input name="enforce_2fa_excluded_groups" type="hidden" id="enforce_2fa_excluded_groups" value="<?php p($_['enforce2faExcludedGroups']) ?>" style="width: 400px">
+		<em>
+			<br />
+			<?php p($l->t('Users in these groups can use two-factor authentication on their own')); ?>
+		</em>
+	</p>
+</div>

--- a/settings/templates/panels/admin/enforce2fa.php
+++ b/settings/templates/panels/admin/enforce2fa.php
@@ -9,8 +9,8 @@ script('settings', 'panels/enforce2fa');
 	<h3><?php p($l->t('Enforce two-factor authentication')); ?></h3>
 	<p><?php p($l->t('Before enforcing the two-factor authentication, check the following requirements:')); ?></p>
 	<ul>
-		<li><?php p($l->t('At least a two-factor authentication app is installed and enabled in ownCloud.')); ?></li>
-		<li><?php p($l->t('The users can setup at least a two-factor app from the challenge page. Some apps might not be prepared for this')); ?></li>
+		<li><?php p($l->t('At least one two-factor authentication app is installed and enabled in ownCloud.')); ?></li>
+		<li><?php p($l->t('The users can setup at least one two-factor app from the challenge page. Some apps might not be prepared for this')); ?></li>
 	</ul>
 	<p><?php p($l->t('The "twofactor_totp" app fulfills those requirements, and might be used as a fallback so the users can enter their accounts in order to configure other two-factor authentication apps')); ?></p>
 	<br/>
@@ -22,12 +22,12 @@ script('settings', 'panels/enforce2fa');
 	</p>
 	<br/>
 	<p>
-		<?php p($l->t('Exclude the following groups of enforcing the two-factor authentication')); ?>
+		<?php p($l->t('Exclude the following groups from enforcing two-factor authentication')); ?>
 		<br />
 		<input name="enforce_2fa_excluded_groups" type="hidden" id="enforce_2fa_excluded_groups" value="<?php p($_['enforce2faExcludedGroups']) ?>" style="width: 400px">
 		<em>
 			<br />
-			<?php p($l->t('Users in these groups can use two-factor authentication on their own')); ?>
+			<?php p($l->t('Note: Users in these groups can use two-factor authentication on their own')); ?>
 		</em>
 	</p>
 </div>

--- a/tests/Settings/Panels/Admin/Enforce2faTest.php
+++ b/tests/Settings/Panels/Admin/Enforce2faTest.php
@@ -1,0 +1,61 @@
+<?php
+/**
+ *
+ * @copyright Copyright (c) 2023, ownCloud GmbH
+ * @license AGPL-3.0
+ *
+ * This code is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License, version 3,
+ * as published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License, version 3,
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>
+ *
+ */
+
+namespace Tests\Settings\Panels\Admin;
+
+use OC\Settings\Panels\Admin\Enforce2fa;
+use OCP\IConfig;
+
+/**
+ * @package Tests\Settings\Panels\Admin
+ */
+class Enforce2faTest extends \Test\TestCase {
+	/** @var IConfig */
+	private $config;
+	/** @var Enforce2fa */
+	private $panel;
+
+	protected function setUp(): void {
+		parent::setUp();
+		$this->config = $this->createMock(IConfig::class);
+
+		$this->panel = new Enforce2fa($this->config);
+	}
+
+	public function testGetSection() {
+		$this->assertSame('security', $this->panel->getSectionID());
+	}
+
+	public function testGetPriority() {
+		$this->assertSame(0, $this->panel->getPriority());
+	}
+
+	public function testGetPanel() {
+		$this->config->method('getAppValue')
+			->will($this->returnValueMap([
+				['core', 'enforce_2fa', 'no', 'yes'],
+				['core', 'enforce_2fa_excluded_groups', '[]', '["group1", "group2"]'],
+			]));
+
+		$tmplHtml = $this->panel->getPanel()->fetchPage();
+		$this->assertMatchesRegularExpression('/<input.*id="enforce_2fa".*checked="checked"/', $tmplHtml);
+		$this->assertMatchesRegularExpression('/<input.*id="enforce_2fa_excluded_groups".*value="group1|group2"/', $tmplHtml);
+	}
+}

--- a/tests/Settings/Panels/Admin/Enforce2faTest.php
+++ b/tests/Settings/Panels/Admin/Enforce2faTest.php
@@ -44,7 +44,7 @@ class Enforce2faTest extends \Test\TestCase {
 	}
 
 	public function testGetPriority() {
-		$this->assertSame(0, $this->panel->getPriority());
+		$this->assertSame(50, $this->panel->getPriority());
 	}
 
 	public function testGetPanel() {


### PR DESCRIPTION
<!--
Thanks for submitting a change to ownCloud!

This is the bug tracker for the Server component. Find other components at https://github.com/owncloud/core/blob/master/.github/CONTRIBUTING.md#guidelines

For fixing potential security issues please see https://owncloud.com/security/

To make it possible for us to get your change reviewed and merged please carefully fill out the requested information below.

Please note that any kind of change needs first be submitted to the master branch which holds the next version of ownCloud.

Please set the following labels:

- Set label "3 - To review" for review or "2 - Development" if the PR still has open tasks
- Assignment: assign to self
- Milestone: set the same as the ticket this PR fixes, or "development" by default
- Reviewers: pick at least one
-->

## Description
Allow the admin to enforce 2fa usage. A 2fa app must be installed and enabled, otherwise this setting will be ignored and all the users will able to login normally.
The admin can also exclude certain groups from the 2fa enforcement. The users belonging to those groups won't have the 2fa enforced, but they can still use 2fa if they want.

## Related Issue
https://github.com/owncloud/enterprise/issues/5219

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?
Manually tested along with the "twofactor_totp" app

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Database schema changes (next release will require increase of minor version instead of patch)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [ ] Tests only (no source changes)

## Checklist:
<!-- Tick the checkboxes when done. -->
<!-- Raise documentation ticket in https://github.com/owncloud/documentation -->
- [x] Code changes
- [x] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 
- [ ] Changelog item, see [TEMPLATE](https://github.com/owncloud/core/blob/master/changelog/TEMPLATE)
