### PR TITLE
Disable online updater for enterprise

### DIFF
--- a/apps/updatenotification/lib/Controller/AdminController.php
+++ b/apps/updatenotification/lib/Controller/AdminController.php
@@ -97,9 +97,20 @@ class AdminController extends Controller implements ISettings {
 		if ($this->config->getSystemValue('upgrade.disable-web', false) === true) {
 			return false;
 		}
+	   
+		if (\OC_Util::getEditionString() === 'Enterprise') {
+			return $this->displayEnterprisePanel();
+		}
 
 		return $this->displayPanel();
 	}
+
+		/**
+		 * @return TemplateResponse
+		 */
+		public function displayEnterprisePanel() {
+			return new TemplateResponse($this->appName, 'enterprise', [], '');
+		}
 
 	/**
 	 * @return TemplateResponse

--- a/apps/updatenotification/templates/enterprise.php
+++ b/apps/updatenotification/templates/enterprise.php
@@ -1,0 +1,6 @@
+<form id="oca_updatenotification_section" class="section">
+  
+        <h2 id="updater" class="app-name"><?php p($l->t('Updater')); ?></h2>
+        <?php print_unescaped($l->t('Online updater has been automatically disabled as you are currently running an ownCloud Enterprise edition. Please update your ownCloud instance manually.')) ?>
+
+</form>

--- a/changelog/unreleased/40841
+++ b/changelog/unreleased/40841
@@ -1,3 +1,5 @@
-Bugfix: Online updater is not recommended for Enterprise installations and is now automatically disabled in such cases
+Bugfix: Automatically disable online updater for enterprise 
+
+Online updater is not recommended for Enterprise installations and is now automatically disabled in such cases.
 
 https://github.com/owncloud/core/pull/40841

--- a/changelog/unreleased/40841
+++ b/changelog/unreleased/40841
@@ -1,3 +1,3 @@
-Bugfix: Online updater is not recommended for Enterprise installations and is now automatically disabled in such cases.
+Bugfix: Online updater is not recommended for Enterprise installations and is now automatically disabled in such cases
 
 https://github.com/owncloud/core/pull/40841

--- a/changelog/unreleased/40841
+++ b/changelog/unreleased/40841
@@ -1,0 +1,3 @@
+Bugfix: Online updater is not recommended for Enterprise installations and is now automatically disabled in such cases.
+
+https://github.com/owncloud/core/pull/40841


### PR DESCRIPTION
## Description
Online updater is not recommended for Enterprise installations and needs therefore to be automatically disabled in such cases.

## How Has This Been Tested?
- manually by switching between Community and Enterprise edition and checking that the online updater template is changed accordingly (disabled in case of enterprise with an hint about following the manual upgrade procedure).

<img width="930" alt="image" src="https://github.com/owncloud/core/assets/12248713/486f90d7-c071-4799-b3d1-6add919e8519">


## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Database schema changes (next release will require increase of minor version instead of patch)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [ ] Tests only (no source changes)

## Checklist:
- [x] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised
- [x] Changelog item