### PR TITLE
[tests-only][full-ci] Add scrollInToView method to scroll elements into view

### DIFF
--- a/tests/acceptance/features/lib/OwncloudPage.php
+++ b/tests/acceptance/features/lib/OwncloudPage.php
@@ -24,6 +24,8 @@
 namespace Page;
 
 use Behat\Mink\Element\NodeElement;
+use Behat\Mink\Exception\DriverException;
+use Behat\Mink\Exception\UnsupportedDriverActionException;
 use Behat\Mink\Session;
 use Exception;
 use InvalidArgumentException;
@@ -487,6 +489,21 @@ class OwncloudPage extends Page {
 	public function scrollToPosition(string $jQuerySelector, $position, Session $session): void {
 		$session->executeScript(
 			'jQuery("' . $jQuerySelector . '").scrollTop(' . $position . ');'
+		);
+	}
+
+	/**
+	 * scrolls to a position in a specified element
+	 *
+	 * @param string $jQuerySelector e.g. "#app-content"
+	 *
+	 * @return void
+	 * @throws DriverException
+	 * @throws UnsupportedDriverActionException
+	 */
+	public function scrollInToView(string $jQuerySelector): void {
+		$this->getDriver()->executeScript(
+			'jQuery("' . $jQuerySelector . '").get(0).scrollIntoView();'
 		);
 	}
 


### PR DESCRIPTION
## Description
This PR adds test code to scroll into certain selectors before performing some action in behat ui test.

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
- https://github.com/owncloud/firewall/issues/749
- https://github.com/owncloud/QA/issues/814

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
- locally

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Database schema changes (next release will require increase of minor version instead of patch)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [x] Tests only (no source changes)

## Checklist:
<!-- Tick the checkboxes when done. -->
<!-- Raise documentation ticket in https://github.com/owncloud/documentation -->
- [ ] Code changes
- [ ] Unit tests added
- [x] Acceptance tests added
- [ ] Documentation ticket raised: <link> 
- [ ] Changelog item, see [TEMPLATE](https://github.com/owncloud/core/blob/master/changelog/TEMPLATE)
