### PR TITLE
feat: implement App Registry 

### DIFF
--- a/core/Application.php
+++ b/core/Application.php
@@ -30,6 +30,7 @@ namespace OC\Core;
 
 use OC\AppFramework\Utility\SimpleContainer;
 use OC\AppFramework\Utility\TimeFactory;
+use OC\Core\Controller\AppRegistryController;
 use OC\Core\Controller\AvatarController;
 use OC\Core\Controller\CloudController;
 use OC\Core\Controller\CronController;
@@ -64,10 +65,23 @@ class Application extends App {
 		parent::__construct('core', $urlParams);
 
 		$container = $this->getContainer();
+		$server = $container->getServer();
 
 		/**
 		 * Controllers
 		 */
+		$container->registerService('AppRegistryController', static function (SimpleContainer $c) use ($server) {
+			return new AppRegistryController(
+				$c->query('AppName'),
+				$server->getRequest(),
+				$server->getAppManager(),
+				$server->query('LazyRootFolder'),
+				$server->getURLGenerator(),
+				$server->getConfig(),
+				$server->getLogger()
+			);
+		});
+
 		$container->registerService('LostController', static function (SimpleContainer $c) {
 			return new LostController(
 				$c->query('AppName'),

--- a/core/Controller/AppRegistryController.php
+++ b/core/Controller/AppRegistryController.php
@@ -298,7 +298,7 @@ class AppRegistryController extends Controller {
 		]);
 		foreach ($clientRules as $client => $rule) {
 			if (strpos($userAgent, $rule) !== false) {
-				return str_replace('https://', $schema[$client], $userAgent);
+				return str_replace('https://', $schema[$client], $uri);
 			}
 		}
 

--- a/core/Controller/AppRegistryController.php
+++ b/core/Controller/AppRegistryController.php
@@ -1,0 +1,270 @@
+<?php
+/**
+ * @author Thomas Müller <thomas.mueller@tmit.eu>
+ *
+ * @copyright Copyright (c) 2023, ownCloud GmbH
+ * @license AGPL-3.0
+ *
+ * This code is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License, version 3,
+ * as published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License, version 3,
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>
+ *
+ */
+
+namespace OC\Core\Controller;
+
+use OCP\App\IAppManager;
+use OCP\AppFramework\Controller;
+use OCP\AppFramework\Http\DataResponse;
+use OCP\Files\IRootFolder;
+use OCP\Files\Node;
+use OCP\IConfig;
+use OCP\ILogger;
+use OCP\IRequest;
+use OCP\IURLGenerator;
+
+class AppRegistryController extends Controller {
+	private const MIME_PDF = "application/pdf";
+	private const MIME_DOCX = 'application/vnd.openxmlformats-officedocument.wordprocessingml.document';
+	private const MIME_ODT = "application/vnd.oasis.opendocument.text";
+	private const MIME_XLSX = "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet";
+	private const MIME_DRAWIO = 'application/x-drawio';
+
+	private IAppManager $appManager;
+	private IRootFolder $rootFolder;
+	private IURLGenerator $generator;
+	private ILogger $logger;
+	private IConfig $config;
+
+	public function __construct(
+		$appName,
+		IRequest $request,
+		IAppManager $appManager,
+		IRootFolder $rootFolder,
+		IURLGenerator $generator,
+		IConfig $config,
+		ILogger $logger
+	) {
+		parent::__construct($appName, $request);
+		$this->appManager = $appManager;
+		$this->rootFolder = $rootFolder;
+		$this->generator = $generator;
+		$this->logger = $logger;
+		$this->config = $config;
+	}
+
+	private static array $apps = [
+		'Collabora' => [
+			"oc_app_name" => 'richdocuments',
+			"icon" => "https://www.collaboraoffice.com/wp-content/uploads/2019/01/CP-icon.png",
+			"mime-types" => [self::MIME_PDF, self::MIME_ODT]
+		],
+		'OnlyOffice' => [
+			"oc_app_name" => 'onlyoffice',
+			"icon" => "https://www.pikpng.com/pngl/m/343-3435764_onlyoffice-desktop-editors-onlyoffice-logo-clipart.png",
+			"mime-types" => [self::MIME_PDF, self::MIME_ODT, self::MIME_XLSX]
+		],
+		'MS Office' => [
+			"oc_app_name" => 'wopi',
+			"icon" => "https://www.pikpng.com/pngl/m/343-3435764_onlyoffice-desktop-editors-onlyoffice-logo-clipart.png",
+			"mime-types" => [self::MIME_ODT, self::MIME_XLSX, self::MIME_DOCX]
+		],
+		'draw.io' => [
+			"oc_app_name" => 'drawio',
+			"icon" => "https://avatars.githubusercontent.com/u/1769238?s=200&v=4",
+			"mime-types" => [self::MIME_DRAWIO]
+		],
+	];
+
+	private static array $mimes = [
+		self::MIME_PDF => [
+			"ext" => "pdf",
+			"name" => "PDF",
+		],
+		self::MIME_DRAWIO => [
+			"ext" => "drawio",
+			"name" => "draw.io (diagrams.net)",
+		],
+		self::MIME_ODT => [
+			"ext" => "odt",
+			"name" => "OpenDocument",
+			"description" => "OpenDocument text document",
+		],
+		self::MIME_XLSX => [
+			"ext" => "xlsx",
+			"name" => "Microsoft Excel",
+		],
+		self::MIME_DOCX => [
+			"ext" => "docx",
+			"name" => "Microsoft Word",
+		]
+	];
+
+	private static function buildMimeType(string $mimetype): array {
+		$d = self::$mimes[$mimetype];
+
+		return [
+			"mime_type" => $mimetype,
+			"app_providers" => [],
+			"ext" => $d['ext'],
+			"name" => $d['name'],
+			"description" => $d['description'] ?? $d['name'] . ' document'
+		];
+	}
+
+	/**
+	 * @NoAdminRequired
+	 * @NoCSRFRequired
+	 * @CORS
+	 */
+	public function list(): array {
+		$mimeTypes = [];
+
+		foreach (self::$apps as $app_name => $app_info) {
+			if ($this->appManager->isEnabledForUser($app_info['oc_app_name'])) {
+				foreach ($app_info['mime-types'] as $mimetype) {
+					# init new mime
+					if (($mimeTypes[$mimetype] ?? null) === null) {
+						$mimeTypes[$mimetype] = self::buildMimeType($mimetype);
+					}
+					# add app to mime
+					$mimeTypes[$mimetype]['app_providers'][] = [
+						"name" => $app_name,
+						"icon" => $app_info['icon']
+					];
+				}
+			}
+		}
+
+		return [
+			"mime-types" => array_values($mimeTypes)
+		];
+	}
+
+	/**
+	 * @NoAdminRequired
+	 * @NoCSRFRequired
+	 * @CORS
+	 */
+	public function openWithWeb(?string $file_id, ?string $app_name): DataResponse {
+		$userAgent = $this->request->getHeader('User-Agent') ?? '-';
+		$this->logger->info("openWithWeb($file_id, $app_name) - $userAgent");
+		$fileId = $this->extractFileId($file_id);
+		$nodes = $this->rootFolder->getById($fileId, true);
+		if (\count($nodes) !== 1) {
+			return new DataResponse([
+				"code" => "INVALID_PARAMETER",
+				"message" => "invalid file ID"
+			], 404);
+		}
+
+		if ($app_name === null) {
+			$app_name = $this->getDefaultApp($nodes[0]);
+			if ($app_name === null) {
+				return new DataResponse([
+					"code" => "INVALID_PARAMETER",
+					"message" => "error: no default app defined"
+				], 404);
+			}
+		}
+		$app_info = self::$apps[$app_name] ?? null;
+		if ($app_info === null || !$this->appManager->isEnabledForUser($app_info['oc_app_name'])) {
+			return new DataResponse([
+				"code" => "RESOURCE_NOT_FOUND",
+				"message" => "error: not found: app '$app_name' not found"
+			], 404);
+		}
+
+		$uri = $this->buildWebUri($app_info, $file_id);
+		if ($uri === null) {
+			return new DataResponse([
+				"code" => "RESOURCE_NOT_FOUND",
+				"message" => "error: cannot build uri"
+			], 404);
+		}
+
+		return new DataResponse([
+			'uri' => $uri]);
+	}
+
+	private function buildWebUri(array $app_info, string $fileId): ?string {
+		# TODO: alternative idea: use a string in $app_info de
+		$uri = null;
+		$app_name = $app_info['oc_app_name'];
+		# https://github.com/ONLYOFFICE/onlyoffice-owncloud/blob/2afca075249f24d857f0b3097d565f5129e88d17/appinfo/routes.php#LL27C47-L27C53
+		if ($app_name === 'onlyoffice') {
+			$uri = $this->generator->linkToRouteAbsolute('onlyoffice.editor.index', [
+				'fileId' => $fileId
+			]);
+		}
+		# https://github.com/owncloud/richdocuments/blob/5adc1dd3a0ab39918b2c3f7a3c62f3231f216cb6/appinfo/routes.php#L26
+		if ($app_name === 'richdocuments') {
+			$uri =  $this->generator->linkToRouteAbsolute('richdocuments.document.index', [
+				'fileId' => $fileId
+			]);
+		}
+		# https://github.com/owncloud/wopi/blob/f24b081d8bc1ac89b73ae211636cb4194d0cf0a8/appinfo/routes.php#LL22C15-L22C26
+		if ($app_name === 'wopi') {
+			$uri =  $this->generator->linkToRouteAbsolute('wopi.page.Office', [
+				'_action' => 'edit',
+				'fileId' => $fileId
+			]);
+		}
+		# https://github.com/owncloud/drawio/blob/b460be2e6606c4222db415aa1c750ae10ea8e74c/appinfo/routes.php#L31
+		if ($app_name === 'drawio') {
+			$uri =  $this->generator->linkToRouteAbsolute('drawio.page.editor', [
+				'fileid' => $fileId
+			]);
+		}
+		if ($uri === null) {
+			return null;
+		}
+
+		$userAgent = $this->request->getHeader('User-Agent') ?? '-';
+		$clientRules = $this->config->getSystemValue('client.detection' , [
+			'ios' => 'ownCloudApp/'
+		]);
+		$schema = $this->config->getSystemValue('app-registry.uri-schema', [
+			'ios' => 'https://'
+		]);
+		foreach ($clientRules as $client => $rule) {
+			if (strpos($userAgent, $rule) !== false) {
+				return str_replace('https://', $schema[$client], $userAgent);
+			}
+		}
+
+		return $uri;
+	}
+
+	private function getDefaultApp(Node $node): ?string {
+		# get mime from file and see which of the enabled apps matches
+		foreach (self::$apps as $app_name => $app_info) {
+			if ($this->appManager->isEnabledForUser($app_name)) {
+				if (\in_array($node->getMimetype(), $app_info['mime-types'], true)) {
+					return $app_name;
+				}
+			}
+		}
+
+		return null;
+	}
+
+	private function extractFileId(?string $file_id): ?int {
+		if ($file_id === null) {
+			return null;
+		}
+
+		# TODO: remove instanceid?
+		# 		$instance_id = \OC::$server->getConfig()->getSystemValue('instanceid');
+
+		return (int)$file_id;
+	}
+}

--- a/core/Controller/AppRegistryController.php
+++ b/core/Controller/AppRegistryController.php
@@ -220,7 +220,6 @@ class AppRegistryController extends Controller {
 			], 400);
 		}
 
-
 		$parent_container_id = $this->extractFileId($parent_container_id);
 		$nodes = $this->rootFolder->getById($parent_container_id, true);
 		if (\count($nodes) !== 1) {
@@ -291,7 +290,7 @@ class AppRegistryController extends Controller {
 		}
 
 		$userAgent = $this->request->getHeader('User-Agent') ?? '-';
-		$clientRules = $this->config->getSystemValue('client.detection' , [
+		$clientRules = $this->config->getSystemValue('client.detection', [
 			'ios' => 'ownCloudApp/'
 		]);
 		$schema = $this->config->getSystemValue('app-registry.uri-schema', [
@@ -309,7 +308,8 @@ class AppRegistryController extends Controller {
 	private function getDefaultApp(string $mimeType): ?string {
 		# get mime from file and see which of the enabled apps matches
 		foreach (self::$apps as $app_name => $app_info) {
-			if ($this->appManager->isEnabledForUser($app_name)) {
+			$oc_app_name = $app_info['oc_app_name'];
+			if ($this->appManager->isEnabledForUser($oc_app_name)) {
 				if (\in_array($mimeType, $app_info['mime-types'], true)) {
 					return $app_name;
 				}

--- a/core/Controller/AppRegistryController.php
+++ b/core/Controller/AppRegistryController.php
@@ -26,7 +26,6 @@ use OCP\AppFramework\Controller;
 use OCP\AppFramework\Http\DataResponse;
 use OCP\Files\Folder;
 use OCP\Files\IRootFolder;
-use OCP\Files\Node;
 use OCP\Files\NotPermittedException;
 use OCP\IConfig;
 use OCP\ILogger;
@@ -142,6 +141,8 @@ class AppRegistryController extends Controller {
 						"name" => $app_name,
 						"icon" => $app_info['icon']
 					];
+					# add default_application
+					$mimeTypes[$mimetype]['default_application'] = $this->getDefaultApp($mimetype);
 				}
 			}
 		}
@@ -169,7 +170,7 @@ class AppRegistryController extends Controller {
 		}
 
 		if ($app_name === null) {
-			$app_name = $this->getDefaultApp($nodes[0]);
+			$app_name = $this->getDefaultApp($nodes[0]->getMimetype());
 			if ($app_name === null) {
 				return new DataResponse([
 					"code" => "INVALID_PARAMETER",
@@ -305,11 +306,11 @@ class AppRegistryController extends Controller {
 		return $uri;
 	}
 
-	private function getDefaultApp(Node $node): ?string {
+	private function getDefaultApp(string $mimeType): ?string {
 		# get mime from file and see which of the enabled apps matches
 		foreach (self::$apps as $app_name => $app_info) {
 			if ($this->appManager->isEnabledForUser($app_name)) {
-				if (\in_array($node->getMimetype(), $app_info['mime-types'], true)) {
+				if (\in_array($mimeType, $app_info['mime-types'], true)) {
 					return $app_name;
 				}
 			}

--- a/core/routes.php
+++ b/core/routes.php
@@ -56,6 +56,9 @@ $application->registerRoutes($this, [
 		['name' => 'License#setNewLicense', 'url' => '/license/license', 'verb' => 'POST'],
 		['name' => 'License#removeLicense', 'url' => '/license/license', 'verb' => 'DELETE'],
 		['name' => 'License#getLicenseMessage', 'url' => '/license/licenseMessage', 'verb' => 'GET'],
+		// OCIS app registry - https://owncloud.dev/services/app-registry/apps/
+		['root' => '', 'name' => 'AppRegistry#list', 'url' => '/app/list', 'verb' => 'GET'],
+		['root' => '', 'name' => 'AppRegistry#openWithWeb', 'url' => '/app/open-with-web', 'verb' => 'POST'],
 	],
 	'ocs' => [
 		['root' => '/cloud', 'name' => 'Cloud#getCapabilities', 'url' => '/capabilities', 'verb' => 'GET'],

--- a/core/routes.php
+++ b/core/routes.php
@@ -59,6 +59,7 @@ $application->registerRoutes($this, [
 		// OCIS app registry - https://owncloud.dev/services/app-registry/apps/
 		['root' => '', 'name' => 'AppRegistry#list', 'url' => '/app/list', 'verb' => 'GET'],
 		['root' => '', 'name' => 'AppRegistry#openWithWeb', 'url' => '/app/open-with-web', 'verb' => 'POST'],
+		['root' => '', 'name' => 'AppRegistry#new', 'url' => '/app/new', 'verb' => 'POST'],
 	],
 	'ocs' => [
 		['root' => '/cloud', 'name' => 'Cloud#getCapabilities', 'url' => '/capabilities', 'verb' => 'GET'],

--- a/lib/private/Authentication/Token/DefaultTokenProvider.php
+++ b/lib/private/Authentication/Token/DefaultTokenProvider.php
@@ -112,10 +112,6 @@ class DefaultTokenProvider implements IProvider {
 		if (!($token instanceof DefaultToken)) {
 			throw new InvalidTokenException();
 		}
-		$this->logger->debug(
-			'updating token {tokenId}, last check is now {now}',
-			['app' => __METHOD__, 'tokenId' => $token->getId(), 'now' => $token->getLastCheck()]
-		);
 		$this->mapper->update($token);
 	}
 
@@ -166,10 +162,6 @@ class DefaultTokenProvider implements IProvider {
 		try {
 			return $this->mapper->getToken($this->hashToken($tokenId));
 		} catch (DoesNotExistException $ex) {
-			$this->logger->debug(
-				'token {token} does not exist',
-				['app'=>__METHOD__, 'token' => $this->hashToken($tokenId) ]
-			);
 			throw new InvalidTokenException();
 		}
 	}

--- a/lib/private/OCS/CoreCapabilities.php
+++ b/lib/private/OCS/CoreCapabilities.php
@@ -60,7 +60,7 @@ class CoreCapabilities implements ICapability {
 					"apps_url" => $this->generator->linkToRoute("core.AppRegistry.list"),
 					# "open_url" => $this->generator->linkToRoute("core.AppRegistry.open"),
 					"open_web_url" => $this->generator->linkToRoute("core.AppRegistry.openWithWeb"),
-					# "new_url" => $this->generator->linkToRoute("core.AppRegistry.new")
+					"new_url" => $this->generator->linkToRoute("core.AppRegistry.new")
 				]]
 			]
 		];

--- a/lib/private/OCS/CoreCapabilities.php
+++ b/lib/private/OCS/CoreCapabilities.php
@@ -24,6 +24,7 @@ namespace OC\OCS;
 
 use OCP\Capabilities\ICapability;
 use OCP\IConfig;
+use OCP\IURLGenerator;
 use OCP\Util;
 
 /**
@@ -32,22 +33,18 @@ use OCP\Util;
  * @package OC\OCS
  */
 class CoreCapabilities implements ICapability {
-	/** @var IConfig */
-	private $config;
+	private IConfig $config;
+	private IURLGenerator $generator;
 
-	/**
-	 * @param IConfig $config
-	 */
-	public function __construct(IConfig $config) {
+	public function __construct(IConfig $config, IURLGenerator $generator) {
 		$this->config = $config;
+		$this->generator = $generator;
 	}
 
 	/**
 	 * Return this classes capabilities
-	 *
-	 * @return array
 	 */
-	public function getCapabilities() {
+	public function getCapabilities(): array {
 		return [
 			'core' => [
 				// pollinterval is an integer number of milliseconds
@@ -55,6 +52,16 @@ class CoreCapabilities implements ICapability {
 				'webdav-root' => $this->config->getSystemValue('webdav-root', 'remote.php/webdav'),
 				'status' => Util::getStatusInfo(true),
 				'support-url-signing' => true,
+			],
+			'files' => [
+				"app_providers" => [[
+					"enabled" => true,
+					"version" => "1.1.0",
+					"apps_url" => $this->generator->linkToRoute("core.AppRegistry.list"),
+					# "open_url" => $this->generator->linkToRoute("core.AppRegistry.open"),
+					"open_web_url" => $this->generator->linkToRoute("core.AppRegistry.openWithWeb"),
+					# "new_url" => $this->generator->linkToRoute("core.AppRegistry.new")
+				]]
 			]
 		];
 	}

--- a/lib/private/Server.php
+++ b/lib/private/Server.php
@@ -788,7 +788,7 @@ class Server extends ServerContainer implements IServerContainer, IServiceLoader
 		$this->registerService('CapabilitiesManager', function (Server $c) {
 			$manager = new \OC\CapabilitiesManager();
 			$manager->registerCapability(function () use ($c) {
-				return new \OC\OCS\CoreCapabilities($c->getConfig());
+				return new \OC\OCS\CoreCapabilities($c->getConfig(), $c->getURLGenerator());
 			});
 			return $manager;
 		});

--- a/resources/config/mimetypemapping.dist.json
+++ b/resources/config/mimetypemapping.dist.json
@@ -39,6 +39,7 @@
 	"docx": ["application/vnd.openxmlformats-officedocument.wordprocessingml.document"],
 	"dot": ["application/msword"],
 	"dotx": ["application/vnd.openxmlformats-officedocument.wordprocessingml.template"],
+	"drawio": ["application/x-drawio"],
 	"dv": ["video/dv"],
 	"eml": ["message/rfc822"],
 	"eot": ["application/vnd.ms-fontobject"],

--- a/tests/Core/Controller/AppRegistryControllerTest.php
+++ b/tests/Core/Controller/AppRegistryControllerTest.php
@@ -1,0 +1,88 @@
+<?php
+/**
+ * @author Thomas Müller <thomas.mueller@tmit.eu>
+ *
+ * @copyright Copyright (c) 2023, ownCloud GmbH
+ * @license AGPL-3.0
+ *
+ * This code is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License, version 3,
+ * as published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License, version 3,
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>
+ *
+ */
+
+namespace Core\Controller;
+
+use OC\Core\Controller\AppRegistryController;
+use OC\Files\Node\File;
+use OCP\App\IAppManager;
+use OCP\Files\IRootFolder;
+use OCP\IConfig;
+use OCP\ILogger;
+use OCP\IRequest;
+use OCP\IURLGenerator;
+use Test\TestCase;
+
+class AppRegistryControllerTest extends TestCase {
+	public function testList(): void {
+		$request = $this->createMock(IRequest::class);
+		$appManager = $this->createMock(IAppManager::class);
+		$rootFolder = $this->createMock(IRootFolder::class);
+		$generator = $this->createMock(IURLGenerator::class);
+		$logger = $this->createMock(ILogger::class);
+		$config = $this->createMock(IConfig::class);
+
+		$appManager->method('isEnabledForUser')->willReturn(true);
+
+		$controller = new AppRegistryController('core', $request, $appManager, $rootFolder, $generator, $config, $logger);
+
+		$result = $controller->list();
+		$data = $result['mime-types'];
+		self::assertCount(5, $data);
+		self::assertEquals('application/pdf', $data[0]['mime_type']);
+		self::assertEquals('application/vnd.oasis.opendocument.text', $data[1]['mime_type']);
+		self::assertEquals('application/vnd.openxmlformats-officedocument.spreadsheetml.sheet', $data[2]['mime_type']);
+		self::assertEquals('application/vnd.openxmlformats-officedocument.wordprocessingml.document', $data[3]['mime_type']);
+		self::assertEquals('application/x-drawio', $data[4]['mime_type']);
+	}
+
+	public function testOpenWithWeb(): void {
+		$request = $this->createMock(IRequest::class);
+		$appManager = $this->createMock(IAppManager::class);
+		$rootFolder = $this->createMock(IRootFolder::class);
+		$generator = $this->createMock(IURLGenerator::class);
+		$config = $this->createMock(IConfig::class);
+		$logger = $this->createMock(ILogger::class);
+
+		$drawio_node = $this->createMock(File::class);
+
+		$appManager->method('isEnabledForUser')->willReturn(true);
+		$rootFolder->method('getById')->willReturnCallback(function ($file_id) use ($drawio_node) {
+			if ($file_id === 123) {
+				return [$drawio_node];
+			}
+
+			return [];
+		});
+		$generator->method('linkToRouteAbsolute')->willReturn('https://example.cloud/index.php/apps/drawio/editor/123');
+		$request->method('getHeader')->willReturn('ownCloud iOS');
+		$config->method('getSystemValue')->willReturnCallback(function ($key, $default) {
+			return $default;
+		});
+
+		$controller = new AppRegistryController('core', $request, $appManager, $rootFolder, $generator, $config, $logger);
+
+		$result = $controller->openWithWeb(123, 'draw.io');
+		$data = $result->getData();
+		self::assertCount(1, $data);
+		self::assertEquals('https://example.cloud/index.php/apps/drawio/editor/123', $data['uri']);
+	}
+}

--- a/tests/Core/Controller/AppRegistryControllerTest.php
+++ b/tests/Core/Controller/AppRegistryControllerTest.php
@@ -21,6 +21,7 @@
 
 namespace Core\Controller;
 
+use Generator;
 use OC\Core\Controller\AppRegistryController;
 use OC\Files\Node\File;
 use OCP\App\IAppManager;
@@ -74,7 +75,7 @@ class AppRegistryControllerTest extends TestCase {
 			return [];
 		});
 		$generator->method('linkToRouteAbsolute')->willReturn('https://example.cloud/index.php/apps/drawio/editor/123');
-		$request->method('getHeader')->willReturn('ownCloud iOS');
+		$request->method('getHeader')->willReturn('ownCloudApp/12.0.2');
 		$config->method('getSystemValue')->willReturnCallback(function ($key, $default) {
 			return $default;
 		});

--- a/tests/Core/Controller/AppRegistryControllerTest.php
+++ b/tests/Core/Controller/AppRegistryControllerTest.php
@@ -21,7 +21,6 @@
 
 namespace Core\Controller;
 
-use Generator;
 use OC\Core\Controller\AppRegistryController;
 use OC\Files\Node\File;
 use OCP\App\IAppManager;
@@ -48,12 +47,15 @@ class AppRegistryControllerTest extends TestCase {
 
 		$result = $controller->list();
 		$data = $result['mime-types'];
-		self::assertCount(5, $data);
+		self::assertCount(8, $data);
 		self::assertEquals('application/pdf', $data[0]['mime_type']);
 		self::assertEquals('application/vnd.oasis.opendocument.text', $data[1]['mime_type']);
-		self::assertEquals('application/vnd.openxmlformats-officedocument.spreadsheetml.sheet', $data[2]['mime_type']);
-		self::assertEquals('application/vnd.openxmlformats-officedocument.wordprocessingml.document', $data[3]['mime_type']);
-		self::assertEquals('application/x-drawio', $data[4]['mime_type']);
+		self::assertEquals('application/vnd.oasis.opendocument.presentation', $data[2]['mime_type']);
+		self::assertEquals('application/vnd.oasis.opendocument.spreadsheet', $data[3]['mime_type']);
+		self::assertEquals('application/vnd.openxmlformats-officedocument.spreadsheetml.sheet', $data[4]['mime_type']);
+		self::assertEquals('application/vnd.openxmlformats-officedocument.wordprocessingml.document', $data[5]['mime_type']);
+		self::assertEquals('application/vnd.openxmlformats-officedocument.presentationml.presentation', $data[6]['mime_type']);
+		self::assertEquals('application/x-drawio', $data[7]['mime_type']);
 	}
 
 	public function testOpenWithWeb(): void {


### PR DESCRIPTION
## Description
Implements https://owncloud.dev/services/app-registry/apps/

## How Has This Been Tested?
- connect to a server running this PR via ios 12.0.3+ or desktop client 4.0+
- install only office, ms office and/or collabora
- upload a supported file format to the server (depending on the installed office apps)
- open the file ios or the context menu in desktop file manager
- see an option to open the file in the app "Open in MS Office"
- browser to the oc server will open and open the file in the app

## Screenshots (if appropriate):
![Screenshot from 2023-07-05 15-00-39](https://github.com/owncloud/core/assets/1005065/29051c49-f272-4016-8d09-6d30e494913b)


## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Database schema changes (next release will require increase of minor version instead of patch)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [ ] Tests only (no source changes)

## Checklist:
<!-- Tick the checkboxes when done. -->
<!-- Raise documentation ticket in https://github.com/owncloud/documentation -->
- [ ] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 
- [ ] Changelog item, see [TEMPLATE](https://github.com/owncloud/core/blob/master/changelog/TEMPLATE)
