### PR TITLE
Fix handling of logger calls in lib/private/Log.php

### DIFF
--- a/changelog/unreleased/40844
+++ b/changelog/unreleased/40844
@@ -1,0 +1,5 @@
+Bugfix: verbose command output
+
+Verbose command output of the background:queue:execute is now displayed.
+
+https://github.com/owncloud/core/pull/40844

--- a/lib/private/Log.php
+++ b/lib/private/Log.php
@@ -400,6 +400,8 @@ class Log implements ILogger {
 				\call_user_func([$logger, 'write'], $app, $formattedMessage, $level, $logConditionFile);
 			} elseif (\is_callable([$logger, 'log'])) {
 				\call_user_func([$logger, 'log'], $level, $formattedMessage, $context);
+			} else {
+				throw new \Exception("No logger method available. Trying to log message '$formattedMessage'.");
 			}
 		}
 

--- a/lib/private/Log.php
+++ b/lib/private/Log.php
@@ -393,11 +393,13 @@ class Log implements ILogger {
 
 		if ($level >= $minLevel) {
 			$logger = $this->logger;
-			// check if logger supports extra fields
+			// check if logger supports extra fields, and which method is available
 			if (!empty($extraFields) && \is_callable([$logger, 'writeExtra'])) {
 				\call_user_func([$logger, 'writeExtra'], $app, $formattedMessage, $level, $logConditionFile, $extraFields);
-			} else {
+			} elseif (\is_callable([$logger, 'write'])) {
 				\call_user_func([$logger, 'write'], $app, $formattedMessage, $level, $logConditionFile);
+			} elseif (\is_callable([$logger, 'log'])) {
+				\call_user_func([$logger, 'log'], $level, $formattedMessage, $context);
 			}
 		}
 

--- a/tests/acceptance/config/behat.yml
+++ b/tests/acceptance/config/behat.yml
@@ -709,6 +709,7 @@ default:
       contexts:
         - FeatureContext: *common_feature_context_params
         - OccContext:
+        - LoggingContext:
 
     cliCreateLocalStorage:
       paths:

--- a/tests/acceptance/features/bootstrap/OccContext.php
+++ b/tests/acceptance/features/bootstrap/OccContext.php
@@ -510,6 +510,22 @@ class OccContext implements Context {
 	 * @return void
 	 * @throws Exception
 	 */
+	public function executeLastBackgroundJobUsingTheOccCommand(string $job):void {
+		$match = $this->getLastJobIdForJob($job);
+		if ($match === false) {
+			throw new Exception("Couldn't find jobId for given job: $job");
+		}
+		$this->invokingTheCommand(
+			"background:queue:execute --accept-warning --force -vvv $match"
+		);
+	}
+
+	/**
+	 * @param string $job
+	 *
+	 * @return void
+	 * @throws Exception
+	 */
 	public function deleteLastBackgroundJobUsingTheOccCommand(string $job):void {
 		$match = $this->getLastJobIdForJob($job);
 		if ($match === false) {
@@ -2889,6 +2905,18 @@ class OccContext implements Context {
 	 */
 	public function theAdministratorGetsAllTheJobsInTheBackgroundQueueUsingTheOccCommand():void {
 		$this->getAllJobsInBackgroundQueueUsingOccCommand();
+	}
+
+	/**
+	 * @When the administrator executes the last background job :job using the occ command
+	 *
+	 * @param string $job
+	 *
+	 * @return void
+	 * @throws Exception
+	 */
+	public function theAdministratorExecutesLastBackgroundJobUsingTheOccCommand(string $job):void {
+		$this->executeLastBackgroundJobUsingTheOccCommand($job);
 	}
 
 	/**

--- a/tests/acceptance/features/cliBackground/backgroundQueue.feature
+++ b/tests/acceptance/features/cliBackground/backgroundQueue.feature
@@ -1,8 +1,8 @@
 @cli @files_trashbin-app-required @files_sharing-app-required @skipOnLDAP
 Feature: get status, delete and execute jobs in background queue
   As an admin
-  I want to be able to see, delete and execute the jobs in background queue
-  So that I have control over background job queue
+  I want to be able to see, delete and execute jobs in the background queue
+  So that I have control over the background job queue
 
 
   Scenario: get the list of jobs in background queue
@@ -24,9 +24,23 @@ Feature: get status, delete and execute jobs in background queue
       | OC\Authentication\Token\DefaultTokenCleanupJob     |
 
 
-  Scenario: delete one of the job in background queue
+  Scenario: delete one of the jobs in the background queue
     Given user "Alice" has been created with default attributes and small skeleton files
     And user "Alice" has deleted file "/textfile0.txt"
     When the administrator deletes the last background job "OC\Command\CommandJob" using the occ command
     Then the command should have been successful
     And the last deleted background job "OC\Command\CommandJob" should not be listed in the background jobs queue
+
+
+  Scenario: execute one of the jobs in the background queue
+    Given user "Alice" has been created with default attributes and small skeleton files
+    And user "Alice" has deleted file "/textfile0.txt"
+    And the owncloud log level has been set to debug
+    When the administrator executes the last background job "OCA\Files\BackgroundJob\ScanFiles" using the occ command
+    Then the command should have been successful
+    And the command output should contain the text "Found job: OCA\Files\BackgroundJob\ScanFiles with ID"
+    And the command output should contain the text "Forcing run, resetting last run value to 0"
+    And the command output should contain the text "Running job..."
+    And the command output should contain the text "Started background job of class : OCA\Files\BackgroundJob\ScanFiles with arguments :"
+    And the command output should contain the text "Finished background job"
+    And the command output should contain the text "this job is an instance of class : OCA\Files\BackgroundJob\ScanFiles with arguments :"


### PR DESCRIPTION
## Description
Try to run a background job with verbose output.
Before this PR:
```
phil@phil-Inspiron-5468:~/git/owncloud/core$ git checkout master
Switched to branch 'master'
Your branch is up to date with 'origin/master'.
phil@phil-Inspiron-5468:~/git/owncloud/core$ php occ background:queue:execute --force -vvv 23
This command is for maintenance and support purposes. 
This will run the specified background job now. Regular scheduled runs of the job will
continue to happen at their scheduled times. 
If you still want to use this command please confirm the usage by entering: yes
yes
Found job: OCA\Files_Antivirus\Cron\Task with ID 23
Forcing run, resetting last run value to 0
Running job...
Finished in 0 seconds
phil@phil-Inspiron-5468:~/git/owncloud/core$ cat data/owncloud.log 
{"reqId":"HH4bi7VV9j1x0S8cKJkM","level":3,"time":"2023-06-20T07:56:37+00:00","remoteAddr":"","user":"--","app":"PHP","method":"--","url":"--","message":"call_user_func() expects parameter 1 to be a valid callback, class 'OC\\Log\\CommandLogger' does not have a method 'write' at \/home\/phil\/git\/owncloud\/core\/lib\/private\/Log.php#400"}
{"reqId":"HH4bi7VV9j1x0S8cKJkM","level":3,"time":"2023-06-20T07:56:37+00:00","remoteAddr":"","user":"--","app":"PHP","method":"--","url":"--","message":"call_user_func() expects parameter 1 to be a valid callback, class 'OC\\Log\\CommandLogger' does not have a method 'write' at \/home\/phil\/git\/owncloud\/core\/lib\/private\/Log.php#400"}
{"reqId":"HH4bi7VV9j1x0S8cKJkM","level":3,"time":"2023-06-20T07:56:37+00:00","remoteAddr":"","user":"--","app":"PHP","method":"--","url":"--","message":"call_user_func() expects parameter 1 to be a valid callback, class 'OC\\Log\\CommandLogger' does not have a method 'write' at \/home\/phil\/git\/owncloud\/core\/lib\/private\/Log.php#400"}
```

Errors are logged to `owncloud.log` and the verbose output is not displayed.

After this PR:
```
phil@phil-Inspiron-5468:~/git/owncloud/core$ git checkout log-with-CommandLogger
Switched to branch 'log-with-CommandLogger'
Your branch is up to date with 'origin/log-with-CommandLogger'.
phil@phil-Inspiron-5468:~/git/owncloud/core$ rm data/owncloud.log 
phil@phil-Inspiron-5468:~/git/owncloud/core$ php occ background:queue:execute --force -vvv 23
This command is for maintenance and support purposes. 
This will run the specified background job now. Regular scheduled runs of the job will
continue to happen at their scheduled times. 
If you still want to use this command please confirm the usage by entering: yes
yes
Found job: OCA\Files_Antivirus\Cron\Task with ID 23
Forcing run, resetting last run value to 0
Running job...
Running job with id 23 and class OCA\Files_Antivirus\Cron\Task. Last run 0 and interval 900
Started background job of class : OCA\Files_Antivirus\Cron\Task with arguments : 
Finished background job, the job took : 0 seconds, this job is an instance of class : OCA\Files_Antivirus\Cron\Task with arguments : 
Finished in 0 seconds
phil@phil-Inspiron-5468:~/git/owncloud/core$ cat data/owncloud.log 
```

The verbose output is displayed and no errors are written to `owncloud.log`

Some things pass a real `OCP\ILogger` class to the "old" `lib/private/Log.php`

`OCP\ILogger` does not have methods `writeExtra` or `write`, so it fails when trying to call `write`

This PR adds more logic so that it calls the `log` method if that exists.
This should be backward-compatible with whatever currently calls `lib/private/Log.php` and has `writeExtra` and `write` methods.


## Related Issue
I noticed this because I was looking at https://github.com/owncloud/files_antivirus/issues/378

## How Has This Been Tested?
See fixed command output above.

Added an acceptance test for the `background:queue:execute` command (there was not one yet)

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Database schema changes (next release will require increase of minor version instead of patch)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [ ] Tests only (no source changes)

## Checklist:
- [x] Code changes
- [ ] Unit tests added
- [x] Acceptance tests added
- [ ] Documentation ticket raised: <link> 
- [ ] Changelog item, see [TEMPLATE](https://github.com/owncloud/core/blob/master/changelog/TEMPLATE)
