### PR TITLE
Display and delete invalid background jobs

### DIFF
--- a/changelog/unreleased/40846
+++ b/changelog/unreleased/40846
@@ -1,0 +1,13 @@
+Change: display and delete invalid background jobs
+
+Background jobs can be no longer valid because they are from an old version of
+an app, or from an app that has been disabled. These jobs can now be listed
+with the command:
+
+occ background:queue:status --display-invalid-jobs
+
+And can be deleted with the command:
+
+occ background:queue:delete <Job ID>
+
+https://github.com/owncloud/core/pull/40846

--- a/core/Command/Background/Queue/Delete.php
+++ b/core/Command/Background/Queue/Delete.php
@@ -51,8 +51,7 @@ class Delete extends Command {
 	protected function execute(InputInterface $input, OutputInterface $output): int {
 		$id = $input->getArgument('Job ID');
 
-		$job = $this->jobList->getById($id);
-		if ($job === null) {
+		if (!$this->jobList->jobIdExists($id)) {
 			$output->writeln("Job with ID <$id> is not known.");
 			return 1;
 		}

--- a/lib/public/BackgroundJob/IJobList.php
+++ b/lib/public/BackgroundJob/IJobList.php
@@ -85,6 +85,13 @@ interface IJobList {
 	public function getById($id);
 
 	/**
+	 * @param int $id
+	 * @return bool
+	 * @since 10.13.0
+	 */
+	public function jobIdExists($id);
+
+	/**
 	 * set the job that was last ran to the current time
 	 *
 	 * @param \OCP\BackgroundJob\IJob $job
@@ -129,12 +136,20 @@ interface IJobList {
 	public function setExecutionTime($job, $timeTaken);
 
 	/**
-	 * iterate over all jobs in the queue
+	 * iterate over all valid jobs in the queue
 	 *
 	 * @return void
 	 * @since 10.2.0
 	 */
 	public function listJobs(\Closure $callback);
+
+	/**
+	 * get the details of all invalid jobs in the queue
+	 *
+	 * @return array
+	 * @since 10.13.0
+	 */
+	public function listInvalidJobs();
 
 	/**
 	 * remove a specific job by id

--- a/lib/public/BackgroundJob/IJobList.php
+++ b/lib/public/BackgroundJob/IJobList.php
@@ -138,18 +138,47 @@ interface IJobList {
 	/**
 	 * iterate over all valid jobs in the queue
 	 *
+	 * The callback will be called for each job.
+	 * An IJob object will be passed to the callback.
+	 * The callback should do whatever the caller wants with the IJob.
+	 * For example, generate some output about the job.
+	 *
+	 * The callback should return a boolean.
+	 * If true, then the iteration will continue to the next job.
+	 * If false, then the iteration stops early.
+	 *
+	 * @param \Closure $callback callback(IJob $job):boolean
 	 * @return void
 	 * @since 10.2.0
 	 */
 	public function listJobs(\Closure $callback);
 
 	/**
-	 * get the details of all invalid jobs in the queue
+	 * iterate over all jobs in the queue, including invalid jobs
 	 *
-	 * @return array
+	 * The validJobCallback will be called for each job that has a valid class.
+	 * An IJob object will be passed to the callback.
+	 * The callback should do whatever the caller wants with the IJob.
+	 * For example, generate some output about the job.
+	 *
+	 * The invalidJobCallback will be called for each job that does not have a valid class.
+	 * In this case, it is not possible to construct an IJob object, so an array
+	 * of data about the job will be passed to the callback.
+	 * The array has keys for 'id', 'class', 'argument', 'last_run', 'last_checked',
+	 * 'reserved_at' and 'execution_duration'.
+	 * The callback should do whatever the caller wants with the data about the job.
+	 * For example, generate some output about the job.
+	 *
+	 * Each callback should return a boolean.
+	 * If true, then the iteration will continue to the next job.
+	 * If false, then the iteration stops early.
+	 *
+	 * @param \Closure $validJobCallback callback(IJob $job):boolean
+	 * @param \Closure $invalidJobCallback callback(array $row):boolean
+	 * @return void
 	 * @since 10.13.0
 	 */
-	public function listInvalidJobs();
+	public function listJobsIncludingInvalid(\Closure $validJobCallback, \Closure $invalidJobCallback): void;
 
 	/**
 	 * remove a specific job by id

--- a/tests/Core/Command/Background/Queue/DeleteTest.php
+++ b/tests/Core/Command/Background/Queue/DeleteTest.php
@@ -41,9 +41,9 @@ class DeleteTest extends TestCase {
 		parent::setUp();
 
 		$this->jobList = $this->createMock(IJobList::class);
-		$this->jobList->expects($this->any())->method('getById')
+		$this->jobList->expects($this->any())->method('jobIdExists')
 			->willReturnCallback(function ($id) {
-				return ($id !== '666') ? true : null;
+				return ($id !== '666') ? true : false;
 			});
 
 		$command = new Delete($this->jobList);

--- a/tests/Core/Command/Background/Queue/StatusTest.php
+++ b/tests/Core/Command/Background/Queue/StatusTest.php
@@ -120,4 +120,32 @@ EOS;
 
 		$this->assertStringContainsString($expected, $output);
 	}
+
+	public function testListingInvalidJob() {
+		$this->jobList->expects($this->any())->method('listInvalidJobs')
+			->willReturn([
+				[
+					'id' => '42',
+					'class' => 'OC\BackgroundJob\Legacy\RegularJob',
+					'argument' => '{"k":"v"}',
+					'last_run' => '2023-01-01T00:00:10+00:00',
+					'last_checked' => '2023-06-01T00:00:40+00:00',
+					'reserved_at' => '2023-06-02T00:00:40+00:00',
+					'execution_duration' => 7,
+				]
+			]);
+		$this->commandTester->execute(
+			['--display-invalid-jobs' => null]
+		);
+		$output = $this->commandTester->getDisplay();
+		$expected = <<<EOS
++--------+------------------------------------+---------------+---------------------------+---------------------------+---------------------------+------------------------+
+| Job ID | Job                                | Job Arguments | Last Run                  | Last Checked              | Reserved At               | Execution Duration (s) |
++--------+------------------------------------+---------------+---------------------------+---------------------------+---------------------------+------------------------+
+| 42     | OC\BackgroundJob\Legacy\RegularJob | {"k":"v"}     | 2023-01-01T00:00:10+00:00 | 2023-06-01T00:00:40+00:00 | 2023-06-02T00:00:40+00:00 | 7                      |
++--------+------------------------------------+---------------+---------------------------+---------------------------+---------------------------+------------------------+
+EOS;
+
+		$this->assertStringContainsString($expected, $output);
+	}
 }

--- a/tests/lib/BackgroundJob/JobListTest.php
+++ b/tests/lib/BackgroundJob/JobListTest.php
@@ -129,6 +129,22 @@ class JobListTest extends TestCase {
 	 * @dataProvider argumentProvider
 	 * @param $argument
 	 */
+	public function testJobIdExists($argument) {
+		$this->timeFactory->method('getTime')->willReturn(164419800);
+		$job = new TestJob();
+		$this->instance->add($job, $argument);
+		$jobs = $this->getAllSorted();
+		$addedJob = $jobs[\count($jobs) - 1];
+		$addedJobId = $addedJob->getId();
+		$this->assertTrue($this->instance->jobIdExists($addedJobId));
+		$this->instance->remove($job, $argument);
+		$this->assertFalse($this->instance->jobIdExists($addedJobId));
+	}
+
+	/**
+	 * @dataProvider argumentProvider
+	 * @param $argument
+	 */
 	public function testHas($argument) {
 		$this->timeFactory->method('getTime')->willReturn(164419800);
 		$job = new TestJob();


### PR DESCRIPTION
## Description
If I have background jobs that are from an old version of an app (their associated class no longer exists) or are from an app that is now disabled (and maybe deleted from the server) then `occ background:queue:status` does not show them (the code of that command only reports background jobs where the class of the job can be instantiated). So I can't find out the job id of those invalid jobs.

Even if I have found out the job id, if I try `occ background:queue:delete` with the job id, it tells me the job id is not known, because the code only finds a job id if it has a class that can be instantiated.

It's a PITA.

This PR adds:
`occ background:queue:status --display-invalid-jobs`
so that the user can see the invalid jobs.

And the `occ background:queue:delete` is adjusted so that, if the job id exists then it is deleted (whether or not the job is valid).

## How Has This Been Tested?
TBD

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Database schema changes (next release will require increase of minor version instead of patch)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [ ] Tests only (no source changes)

## Checklist:
- [ ] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 
- [ ] Changelog item, see [TEMPLATE](https://github.com/owncloud/core/blob/master/changelog/TEMPLATE)
