### PR TITLE
Fix error when version_metadata is enabled and there is no quota

### DIFF
--- a/apps/files_versions/lib/Storage.php
+++ b/apps/files_versions/lib/Storage.php
@@ -469,7 +469,7 @@ class Storage {
 
 			if (self::metaEnabled()) {
 				// NOTE: we need to move current file first as in case of interuption lack of this file could cause issues
-				
+
 				// Also move/copy the current version
 				$src = '/files_versions/' . $sourcePath . MetaStorage::CURRENT_FILE_PREFIX . MetaStorage::VERSION_FILE_EXT;
 				$dst = '/files_versions/' . $targetPath . MetaStorage::CURRENT_FILE_PREFIX . MetaStorage::VERSION_FILE_EXT;
@@ -635,7 +635,7 @@ class Storage {
 			if (Filesystem::is_dir($filename) || !Filesystem::file_exists($filename)) {
 				return false;
 			}
-			
+
 			list($uid, $currentFileName) = self::getUidAndFilename($filename);
 
 			// overwrite current file metadata with minor=false to create new major version
@@ -671,7 +671,7 @@ class Storage {
 		if ($dirContent === false) {
 			return $versions;
 		}
-		
+
 		// add historical versions
 		if (\is_resource($dirContent)) {
 			while (($entryName = \readdir($dirContent)) !== false) {
@@ -682,7 +682,7 @@ class Storage {
 						$pathparts = \pathinfo($entryName);
 						$timestamp = \substr($pathparts['extension'], 1);
 						$filename = $pathparts['filename'];
-						
+
 						// ordering key
 						$key = $timestamp . '#' . $filename;
 
@@ -971,15 +971,17 @@ class Storage {
 			// if still not enough free space we rearrange the versions from all files
 			if ($availableSpace <= 0) {
 				$result = self::getFileHelper()->getAllVersions($uid);
-				$allVersions = $result['all'];
+				if ($result) {
+					$allVersions = $result['all'];
 
-				foreach ($result['by_file'] as $versions) {
-					list($toDeleteNew, $size) = self::getExpireList($time, $versions, $availableSpace <= 0);
-					$toDelete = \array_merge($toDelete, $toDeleteNew);
-					$sizeOfDeletedVersions += $size;
+					foreach ($result['by_file'] as $versions) {
+						list($toDeleteNew, $size) = self::getExpireList($time, $versions, $availableSpace <= 0);
+						$toDelete = \array_merge($toDelete, $toDeleteNew);
+						$sizeOfDeletedVersions += $size;
+					}
+					$availableSpace = $availableSpace + $sizeOfDeletedVersions;
+					$versionsSize = $versionsSize - $sizeOfDeletedVersions;
 				}
-				$availableSpace = $availableSpace + $sizeOfDeletedVersions;
-				$versionsSize = $versionsSize - $sizeOfDeletedVersions;
 			}
 
 			// we need to check if we have to remove any empty folder based on the

--- a/changelog/unreleased/40847
+++ b/changelog/unreleased/40847
@@ -1,0 +1,6 @@
+Bugfix: Versions expire job does not error with federated shares
+
+Versions expire job does not error with federated shares when versioning meta-
+data is enabled.
+
+https://github.com/owncloud/core/pull/40847


### PR DESCRIPTION
<!--
Thanks for submitting a change to ownCloud!

This is the bug tracker for the Server component. Find other components at https://github.com/owncloud/core/blob/master/.github/CONTRIBUTING.md#guidelines

For fixing potential security issues please see https://owncloud.com/security/

To make it possible for us to get your change reviewed and merged please carefully fill out the requested information below.

Please note that any kind of change needs first be submitted to the master branch which holds the next version of ownCloud.

Please set the following labels:

- Set label "3 - To review" for review or "2 - Development" if the PR still has open tasks
- Assignment: assign to self
- Milestone: set the same as the ticket this PR fixes, or "development" by default
- Reviewers: pick at least one
-->

## Description
Fix Exception with Files_Version/ExpireJob.php when receiving a federated share and having 'file_storage.save_version_metadata' enabled. 

We fixed by ignoring metadata for fed-shares.

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
- Fixes https://github.com/owncloud/enterprise/issues/5732

## How Has This Been Tested?
:hand: 


## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Database schema changes (next release will require increase of minor version instead of patch)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [ ] Tests only (no source changes)

## Checklist:
<!-- Tick the checkboxes when done. -->
<!-- Raise documentation ticket in https://github.com/owncloud/documentation -->
- [x] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 
- [ ] Changelog item, see [TEMPLATE](https://github.com/owncloud/core/blob/master/changelog/TEMPLATE)
