### PR TITLE
Apply code-style changes from php-cs-fixer 3.20

### DIFF
--- a/apps/files/lib/Command/Scan.php
+++ b/apps/files/lib/Command/Scan.php
@@ -221,7 +221,7 @@ class Scan extends Base {
 			$scanner->listen('\OC\Files\Utils\Scanner', 'StorageNotAvailable', function (StorageNotAvailableException $e) use ($output) {
 				$output->writeln("Error while scanning, storage not available (" . $e->getMessage() . ")");
 			});
-		# count only
+			# count only
 		} else {
 			$scanner->listen('\OC\Files\Utils\Scanner', 'scanFile', function () {
 				$this->filesCounter += 1;

--- a/composer.lock
+++ b/composer.lock
@@ -5726,17 +5726,17 @@
             "source": {
                 "type": "git",
                 "url": "https://github.com/Roave/SecurityAdvisories.git",
-                "reference": "237f1821ece806de66072813d8cbe5bdbc8f3117"
+                "reference": "3b77f2101068074f1c98977cc34ef939bbce3d19"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/Roave/SecurityAdvisories/zipball/237f1821ece806de66072813d8cbe5bdbc8f3117",
-                "reference": "237f1821ece806de66072813d8cbe5bdbc8f3117",
+                "url": "https://api.github.com/repos/Roave/SecurityAdvisories/zipball/3b77f2101068074f1c98977cc34ef939bbce3d19",
+                "reference": "3b77f2101068074f1c98977cc34ef939bbce3d19",
                 "shasum": ""
             },
             "conflict": {
                 "3f/pygmentize": "<1.2",
-                "admidio/admidio": "<4.2.8",
+                "admidio/admidio": "<4.2.9",
                 "adodb/adodb-php": "<=5.20.20|>=5.21,<=5.21.3",
                 "aheinze/cockpit": "<=2.2.1",
                 "akaunting/akaunting": "<2.1.13",
@@ -5770,7 +5770,7 @@
                 "baserproject/basercms": "<4.7.5",
                 "bassjobsen/bootstrap-3-typeahead": ">4.0.2",
                 "bigfork/silverstripe-form-capture": ">=3,<3.1.1",
-                "billz/raspap-webgui": "<=2.6.6",
+                "billz/raspap-webgui": "<2.8.9",
                 "bk2k/bootstrap-package": ">=7.1,<7.1.2|>=8,<8.0.8|>=9,<9.0.4|>=9.1,<9.1.3|>=10,<10.0.10|>=11,<11.0.3",
                 "bmarshall511/wordpress_zero_spam": "<5.2.13",
                 "bolt/bolt": "<3.7.2",
@@ -5999,7 +5999,7 @@
                 "modx/revolution": "<= 2.8.3-pl|<2.8",
                 "mojo42/jirafeau": "<4.4",
                 "monolog/monolog": ">=1.8,<1.12",
-                "moodle/moodle": "<4.2-rc.2|= 3.11",
+                "moodle/moodle": "<4.2-rc.2|= 4.2.0|= 3.11",
                 "mustache/mustache": ">=2,<2.14.1",
                 "namshi/jose": "<2.2",
                 "neoan3-apps/template": "<1.1.1",
@@ -6334,7 +6334,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2023-06-22T20:04:46+00:00"
+            "time": "2023-06-28T00:17:41+00:00"
         },
         {
             "name": "sebastian/cli-parser",

--- a/lib/private/App/InfoParser.php
+++ b/lib/private/App/InfoParser.php
@@ -172,7 +172,7 @@ class InfoParser {
 				} else {
 					$array[$element] = $data;
 				}
-			// Just a value
+				// Just a value
 			} else {
 				if ($totalElement > 1) {
 					$array[$element][] = $this->xmlToArray($node);

--- a/lib/private/AppFramework/Http/Request.php
+++ b/lib/private/AppFramework/Http/Request.php
@@ -427,8 +427,8 @@ class Request implements \ArrayAccess, \Countable, IRequest {
 				}
 			}
 
-		// Handle application/x-www-form-urlencoded for methods other than GET
-		// or post correctly
+			// Handle application/x-www-form-urlencoded for methods other than GET
+			// or post correctly
 		} elseif ($this->method !== 'GET'
 				&& $this->method !== 'POST'
 				&& \strpos($this->getHeader('Content-Type'), 'application/x-www-form-urlencoded') !== false) {

--- a/lib/private/Files/Stream/Encryption.php
+++ b/lib/private/Files/Stream/Encryption.php
@@ -298,7 +298,7 @@ class Encryption extends Wrapper {
 				$result .= \substr($this->cache, $blockPosition, $remainingLength);
 				$this->position += $remainingLength;
 				$count = 0;
-			// otherwise remainder of current block is fetched, the block is flushed and the position updated
+				// otherwise remainder of current block is fetched, the block is flushed and the position updated
 			} else {
 				$result .= \substr($this->cache, $blockPosition);
 				$this->flush();
@@ -359,8 +359,8 @@ class Encryption extends Wrapper {
 					$this->position += $remainingLength;
 					$length += $remainingLength;
 					$data = '';
-				// if $data doesn't fit the current block, the fill the current block and reiterate
-				// after the block is filled, it is flushed and $data is updatedxxx
+					// if $data doesn't fit the current block, the fill the current block and reiterate
+					// after the block is filled, it is flushed and $data is updatedxxx
 				} else {
 					$this->cache = \substr($this->cache, 0, $blockPosition) .
 						\substr($data, 0, $this->unencryptedBlockSize - $blockPosition);

--- a/lib/private/Files/View.php
+++ b/lib/private/Files/View.php
@@ -869,14 +869,14 @@ class View {
 						} else {
 							$result = false;
 						}
-					// moving a file/folder within the same mount point
+						// moving a file/folder within the same mount point
 					} elseif ($storage1 === $storage2) {
 						if ($storage1) {
 							$result = $storage1->rename($internalPath1, $internalPath2);
 						} else {
 							$result = false;
 						}
-					// moving a file/folder between storages (from $storage1 to $storage2)
+						// moving a file/folder between storages (from $storage1 to $storage2)
 					} else {
 						$result = $storage2->moveFromStorage($storage1, $internalPath1, $internalPath2);
 					}

--- a/lib/private/Share/Share.php
+++ b/lib/private/Share/Share.php
@@ -1108,9 +1108,9 @@ class Share extends Constants {
 			// delete the item with the expected share_type and owner
 			if ((int)$item['share_type'] === (int)$shareType && $item['uid_owner'] === $currentUser) {
 				$toDelete = $item;
-			// if there is more then one result we don't have to delete the children
-			// but update their parent. For group shares the new parent should always be
-			// the original group share and not the db entry with the unique name
+				// if there is more then one result we don't have to delete the children
+				// but update their parent. For group shares the new parent should always be
+				// the original group share and not the db entry with the unique name
 			} elseif ((int)$item['share_type'] === self::$shareTypeGroupUserUnique) {
 				$newParent = $item['parent'];
 			} else {

--- a/lib/private/legacy/files.php
+++ b/lib/private/legacy/files.php
@@ -80,7 +80,7 @@ class OC_Files {
 				\header('Accept-Ranges: bytes', true);
 				if (\count($rangeArray) > 1) {
 					$type = 'multipart/byteranges; boundary='.self::getBoundary();
-				// no Content-Length header here
+					// no Content-Length header here
 				} else {
 					\header(\sprintf('Content-Range: bytes %d-%d/%d', $rangeArray[0]['from'], $rangeArray[0]['to'], $fileSize), true);
 					OC_Response::setContentLengthHeader($rangeArray[0]['to'] - $rangeArray[0]['from'] + 1);

--- a/vendor-bin/owncloud-codestyle/composer.json
+++ b/vendor-bin/owncloud-codestyle/composer.json
@@ -1,5 +1,5 @@
 {
     "require": {
-      "owncloud/coding-standard": "^4.1"
+      "owncloud/coding-standard": "^4.2"
     }
   }


### PR DESCRIPTION
## Description
php-cs-fixer https://github.com/PHP-CS-Fixer/PHP-CS-Fixer/releases/tag/v3.20.0 was released.
owncloud code style https://github.com/owncloud/coding-standard/releases/tag/4.2.0 was released, updating to this latest php-cs-fixer.

It makes some small changes to indent of comments. This PR applies those changes so that code-style CI will pass.

No changelog needed - this is just changes to indent of comments.

## How Has This Been Tested?
CI

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Database schema changes (next release will require increase of minor version instead of patch)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [ ] Tests only (no source changes)

## Checklist:
- [ ] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 
- [ ] Changelog item, see [TEMPLATE](https://github.com/owncloud/core/blob/master/changelog/TEMPLATE)
