### PR TITLE
Bump sabre/xml (2.2.5 to 2.2.6)

### DIFF
--- a/changelog/unreleased/PHPdependencies20230404onward
+++ b/changelog/unreleased/PHPdependencies20230404onward
@@ -8,7 +8,8 @@ The following have been updated:
 - phpseclib/phpseclib (3.0.19 to 3.0.20)
 - punic/punic (3.8.0 to 3.8.1)
 - sabre/http (5.1.6 to 5.1.7)
-- sabre/url (2.3.2 to 2.3.3)
+- sabre/uri (2.3.2 to 2.3.3)
+- sabre/xml (2.2.5 to 2.2.6)
 
 The following have been updated in apps/files_external/3rdparty:
 - google/apiclient (2.13.1 to 2.13.2)
@@ -26,3 +27,4 @@ https://github.com/owncloud/core/pull/40833
 https://github.com/owncloud/core/pull/40838
 https://github.com/owncloud/core/pull/40839
 https://github.com/owncloud/core/pull/40849
+https://github.com/owncloud/core/pull/40853

--- a/composer.lock
+++ b/composer.lock
@@ -3242,16 +3242,16 @@
         },
         {
             "name": "sabre/xml",
-            "version": "2.2.5",
+            "version": "2.2.6",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sabre-io/xml.git",
-                "reference": "a6af111850e7536d200d9637c34885cd3c77a86c"
+                "reference": "9cde7cdab1e50893cc83b037b40cd47bfde42a2b"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sabre-io/xml/zipball/a6af111850e7536d200d9637c34885cd3c77a86c",
-                "reference": "a6af111850e7536d200d9637c34885cd3c77a86c",
+                "url": "https://api.github.com/repos/sabre-io/xml/zipball/9cde7cdab1e50893cc83b037b40cd47bfde42a2b",
+                "reference": "9cde7cdab1e50893cc83b037b40cd47bfde42a2b",
                 "shasum": ""
             },
             "require": {
@@ -3307,7 +3307,7 @@
                 "issues": "https://github.com/sabre-io/xml/issues",
                 "source": "https://github.com/fruux/sabre-xml"
             },
-            "time": "2021-11-04T06:37:27+00:00"
+            "time": "2023-06-28T12:56:05+00:00"
         },
         {
             "name": "swiftmailer/swiftmailer",


### PR DESCRIPTION
## Description
```
Updating dependencies
Lock file operations: 0 installs, 1 update, 0 removals
  - Upgrading sabre/xml (2.2.5 => 2.2.6)
Writing lock file
```

https://github.com/sabre-io/xml/releases/tag/2.2.6

## How Has This Been Tested?
CI

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Database schema changes (next release will require increase of minor version instead of patch)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [ ] Tests only (no source changes)

## Checklist:
- [ ] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 
- [ ] Changelog item, see [TEMPLATE](https://github.com/owncloud/core/blob/master/changelog/TEMPLATE)
