### PR TITLE
fix: DAV storage should return false on stat() if connection fails

### DIFF
--- a/changelog/unreleased/40861
+++ b/changelog/unreleased/40861
@@ -1,0 +1,7 @@
+Bugfix: DAV storage should return false on stat() if connection fails
+
+Trying to connect an external WebDAV storage to a non-WebDAV server will now
+fail when trying to initiate the first connection. This prevents connecting
+to an invalid server, and thus prevents problems for users.
+
+https://github.com/owncloud/core/pull/40861

--- a/composer.json
+++ b/composer.json
@@ -65,7 +65,8 @@
         "ext-json": "*",
         "sabre/vobject": "^4.5",
         "dg/composer-cleaner": "^2.2",
-        "firebase/php-jwt": "^6.8"
+        "firebase/php-jwt": "^6.8",
+        "ext-curl": "*"
     },
     "extra": {
         "bamarni-bin": {

--- a/tests/lib/Files/Storage/DavTest.php
+++ b/tests/lib/Files/Storage/DavTest.php
@@ -972,6 +972,17 @@ class DavTest extends TestCase {
 		$this->instance->stat('/some%dir/file%type');
 	}
 
+	/**
+	 */
+	public function testStatPropfindFalse() {
+		$this->davClient->expects($this->once())
+			->method('propfind')
+			->willReturn(false);
+
+		$returnValue = $this->instance->stat('/some%dir/file%type');
+		$this->assertFalse($returnValue);
+	}
+
 	public function mimeTypeDataProvider() {
 		return [
 			[


### PR DESCRIPTION
## Description
DAV::stat() is returning an empty array when the propfind fails. As a result when a non-WebDAV servers can be mounted and cause followup issues for the end user.

## How Has This Been Tested?
- Hook up any other WebDAV server in external storage settings -> green
- Hook up any http server -> red
- (proving the wrong behavior before the patch is only of theoretical nature)

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Database schema changes (next release will require increase of minor version instead of patch)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [ ] Tests only (no source changes)

## Checklist:
<!-- Tick the checkboxes when done. -->
<!-- Raise documentation ticket in https://github.com/owncloud/documentation -->
- [ ] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 
- [ ] Changelog item, see [TEMPLATE](https://github.com/owncloud/core/blob/master/changelog/TEMPLATE)
