### PR TITLE
Skip share_folder for guest users

### DIFF
--- a/apps/files_sharing/lib/Helper.php
+++ b/apps/files_sharing/lib/Helper.php
@@ -282,16 +282,16 @@ class Helper {
 		if ($view === null) {
 			$view = Filesystem::getView();
 		}
-		$shareFolder = \OC::$server->getConfig()->getSystemValue('share_folder', '/');
-		$shareFolder = Filesystem::normalizePath($shareFolder);
 		// for guests we default to root as their home storage is read-only
 		$user = User::getUser();
 		$userTypeHelper = new UserTypeHelper();
 		$isGuestUser = $userTypeHelper->isGuestUser($user);
 		if ($isGuestUser) {
 			$shareFolder = '/';
-			return;
+			return "/";
 		}
+		$shareFolder = \OC::$server->getConfig()->getSystemValue('share_folder', '/');
+		$shareFolder = Filesystem::normalizePath($shareFolder);
 		if (!$view->file_exists($shareFolder)) {
 			// if the share folder doesn't exists, create the folder in order
 			// to place the shares inside it. All the parent folders need to

--- a/apps/files_sharing/lib/Helper.php
+++ b/apps/files_sharing/lib/Helper.php
@@ -34,6 +34,7 @@ use OC\Files\Filesystem;
 use OC\Files\View;
 use OCP\Files\NotFoundException;
 use OCP\User;
+use OC\Helper\UserTypeHelper;
 
 class Helper {
 	public static function registerHooks() {
@@ -283,7 +284,14 @@ class Helper {
 		}
 		$shareFolder = \OC::$server->getConfig()->getSystemValue('share_folder', '/');
 		$shareFolder = Filesystem::normalizePath($shareFolder);
-
+		// for guests we default to root as their home storage is read-only
+		$user = User::getUser();
+		$userTypeHelper = new UserTypeHelper();
+		$isGuestUser = $userTypeHelper->isGuestUser($user);
+		if ($isGuestUser) {
+			$shareFolder = '/';
+			return;
+		}
 		if (!$view->file_exists($shareFolder)) {
 			// if the share folder doesn't exists, create the folder in order
 			// to place the shares inside it. All the parent folders need to

--- a/apps/files_sharing/lib/Helper.php
+++ b/apps/files_sharing/lib/Helper.php
@@ -287,7 +287,6 @@ class Helper {
 		$userTypeHelper = new UserTypeHelper();
 		$isGuestUser = $userTypeHelper->isGuestUser($user);
 		if ($isGuestUser) {
-			$shareFolder = '/';
 			return '/';
 		}
 		$shareFolder = \OC::$server->getConfig()->getSystemValue('share_folder', '/');

--- a/apps/files_sharing/lib/Helper.php
+++ b/apps/files_sharing/lib/Helper.php
@@ -288,7 +288,7 @@ class Helper {
 		$isGuestUser = $userTypeHelper->isGuestUser($user);
 		if ($isGuestUser) {
 			$shareFolder = '/';
-			return "/";
+			return '/';
 		}
 		$shareFolder = \OC::$server->getConfig()->getSystemValue('share_folder', '/');
 		$shareFolder = Filesystem::normalizePath($shareFolder);

--- a/changelog/unreleased/40864
+++ b/changelog/unreleased/40864
@@ -1,0 +1,5 @@
+Bugfix: Skip share_folder for guest users
+
+In https://github.com/owncloud/core/pull/40378 we've fixed the case of (not) moving the share target when the backend storage becomes temporary unavailable but we had the collateral effect that guests did not see anymore their received shares as we were forcing the creation of the target which failed for them as their storage is read-only. We now skip the share_folder config.php option for guests and default to root.
+
+https://github.com/owncloud/core/pull/40864

--- a/config/config.sample.php
+++ b/config/config.sample.php
@@ -1512,6 +1512,7 @@ $CONFIG = [
 
 /**
  * Define a default folder for shared files and folders other than root
+ * Please note that this setting is skipped for guests and the root folder will be used for such users.
  */
 'share_folder' => '/',
 


### PR DESCRIPTION
## Description

In https://github.com/owncloud/core/pull/40378 we've fixed the case of (not) moving the share target when the backend storage becomes temporary unavailable but we have now the collateral effect that guests do not see anymore their received shares as we are now forcing the creation of the target which will obviously fail for them as storage is read-only.

We now skip the `share_folder` config.php option for guests and default to root.

## Related issue

https://github.com/owncloud/enterprise/issues/5842

## How Has This Been Tested?
- manually by setting the above mentioned config.php option and verifying that guests can see their received shares at the root folder.

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Database schema changes (next release will require increase of minor version instead of patch)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [ ] Tests only (no source changes)

## Checklist:
- [x] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [x] Documentation ticket raised
- [x] Changelog item