### PR TITLE
Bump files app version

### DIFF
--- a/apps/files/appinfo/info.xml
+++ b/apps/files/appinfo/info.xml
@@ -6,7 +6,7 @@
 	<licence>AGPL</licence>
 	<author>Robin Appelman, Vincent Petry</author>
 	<default_enable/>
-	<version>1.5.2</version>
+	<version>1.6.0</version>
 	<types>
 		<filesystem/>
 	</types>

--- a/changelog/unreleased/40878
+++ b/changelog/unreleased/40878
@@ -1,0 +1,5 @@
+Bugfix: Bump files app version
+
+Files app version was not properly increased when the "OCA\Files\BackgroundJob\CleanupPersistentFileLock" and "OCA\Files\BackgroundJob\PreviewCleanupJob" background jobs were originally added. As a result, those two jobs were not correctly inserted into the "oc_jobs" table upon a core upgrade. First time installations are not affected as there jobs are correctly added.
+
+https://github.com/owncloud/core/pull/40878

--- a/tests/Core/Command/Apps/AppsListTest.php
+++ b/tests/Core/Command/Apps/AppsListTest.php
@@ -56,7 +56,7 @@ class AppsListTest extends TestCase {
 
 	public function providesAppIds() {
 		return [
-			[[], "- files:\n    - Version: 1.5"],
+			[[], "- files:\n    - Version: 1.6"],
 			[[], "- dav:\n    - Version: 0.7.0\n    - Path: ".\realpath(__DIR__ . '/../../../../apps/dav')],
 			[['--shipped' => 'true'],  "- dav:\n    - Version: 0.7.0"],
 			[['--shipped' => 'false'], '- comments:'],


### PR DESCRIPTION
## Description
Bump files app version for adding missing background jobs.

## Related Issue
- https://github.com/owncloud/enterprise/issues/5865

## Motivation and Context

Files app version was not properly increased when adding the `OCA\Files\BackgroundJob\CleanupPersistentFileLock` and `OCA\Files\BackgroundJob\PreviewCleanupJob` jobs. As a result, those jobs were not correctly inserted into the `oc_jobs` table upon a core upgrade. First time installations are not affected as there jobs are correctly added.

## How Has This Been Tested?

- Manually increasing the version to `1.6.0` in the app info.xml file and observing the two jobs are inserted into the `oc_jobs` table after running `occ upgrade`.

## Screenshots (if appropriate):

## Types of changes
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Database schema changes (next release will require increase of minor version instead of patch)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [ ] Tests only (no source changes)

## Checklist:
- [X] Code changes
- [x] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised
- [X] Changelog item