### PR TITLE
[tests-only] [full-ci] Use pgSQL 10.21 in CI

### DIFF
--- a/.drone.star
+++ b/.drone.star
@@ -90,7 +90,7 @@ config = {
                 "mysql:5.7",
                 "mysql:8.0",
                 "postgres:9.4",
-                "postgres:10.20",
+                "postgres:10.21",
             ],
         },
         "slowDatabases": {
@@ -345,7 +345,7 @@ config = {
             "dbServices": [
                 "sqlite",
                 "mysql:8.0",
-                "postgres:10.20",
+                "postgres:10.21",
             ],
         },
         "cliExternalStorage": {
@@ -1371,7 +1371,7 @@ def phpTests(ctx, testType, withCoverage):
             "mysql:5.7",
             "mysql:8.0",
             "postgres:9.4",
-            "postgres:10.20",
+            "postgres:10.21",
         ],
         "coverage": True,
         "includeKeyInMatrixName": False,
@@ -1406,7 +1406,7 @@ def phpTests(ctx, testType, withCoverage):
             "mysql:5.7",
             "mysql:8.0",
             "postgres:9.4",
-            "postgres:10.20",
+            "postgres:10.21",
             "oracle",
         ],
         "coverage": True,


### PR DESCRIPTION
## Description
Use the latest release of pgSQL 10 in CI. That will ensure that everything works for production systems that are keeping up with pgSQL10 releases. There does not seem to be a docker image for 10.22 or 10.23 so this updates to 10.21

https://www.postgresql.org/docs/release/10.21

## How Has This Been Tested?
CI

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Database schema changes (next release will require increase of minor version instead of patch)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [x] Tests only (no source changes)

## Checklist:
- [ ] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 
- [ ] Changelog item, see [TEMPLATE](https://github.com/owncloud/core/blob/master/changelog/TEMPLATE)
