### PR TITLE
[tests-only][full-ci] Use of publicWebDAVAPIVersion on publicLocksFileLastSharedFolder function

### DIFF
--- a/tests/acceptance/features/apiWebdavLocks/publicLink.feature
+++ b/tests/acceptance/features/apiWebdavLocks/publicLink.feature
@@ -82,7 +82,7 @@ Feature: persistent-locking in case of a public link
       | new                       | shared     |
       | new                       | exclusive  |
 
-  @smokeTest
+  @smokeTest @issue-40882
   Scenario Outline: Public locking is not supported
     Given user "Alice" has created a public link share of folder "PARENT" with change permission
     When the public locks "/CHILD" in the last public link shared folder using the <public-webdav-api-version> public WebDAV API setting the following properties
@@ -93,5 +93,9 @@ Feature: persistent-locking in case of a public link
       | public-webdav-api-version | lock-scope |
       | old                       | shared     |
       | old                       | exclusive  |
+
+  @skipOnOcV10
+    Examples:
+      | public-webdav-api-version | lock-scope |
       | new                       | shared     |
       | new                       | exclusive  |

--- a/tests/acceptance/features/apiWebdavLocks/publicLink.feature
+++ b/tests/acceptance/features/apiWebdavLocks/publicLink.feature
@@ -94,7 +94,7 @@ Feature: persistent-locking in case of a public link
       | old                       | shared     |
       | old                       | exclusive  |
 
-  @skipOnOcV10
+    @skipOnOcV10
     Examples:
       | public-webdav-api-version | lock-scope |
       | new                       | shared     |

--- a/tests/acceptance/features/apiWebdavLocks/publicLinkOc10Issue40882.feature
+++ b/tests/acceptance/features/apiWebdavLocks/publicLinkOc10Issue40882.feature
@@ -1,16 +1,14 @@
-@api @smokeTest @public_link_share-feature-required @files_sharing-app-required @issue-40882
+@api @smokeTest @public_link_share-feature-required @files_sharing-app-required
 Feature: persistent-locking in case of a public link
 
-  Background:
+
+  Scenario Outline: Public locking is not supported
     Given user "Alice" has been created with default attributes and without skeleton files
     And user "Alice" has created folder "PARENT"
     And user "Alice" has created folder "PARENT/CHILD"
     And user "Alice" has uploaded file "filesForUpload/textfile.txt" to "PARENT/parent.txt"
     And user "Alice" has uploaded file "filesForUpload/textfile.txt" to "PARENT/CHILD/child.txt"
-
- 
-  Scenario Outline: Public locking is not supported
-    Given user "Alice" has created a public link share of folder "PARENT" with change permission
+    And user "Alice" has created a public link share of folder "PARENT" with change permission
     When the public locks "/CHILD" in the last public link shared folder using the <public-webdav-api-version> public WebDAV API setting the following properties
       | lockscope | <lock-scope> |
     Then the HTTP status code should be "403"

--- a/tests/acceptance/features/apiWebdavLocks/publicLinkOc10Issue40882.feature
+++ b/tests/acceptance/features/apiWebdavLocks/publicLinkOc10Issue40882.feature
@@ -1,0 +1,20 @@
+@api @smokeTest @public_link_share-feature-required @files_sharing-app-required @issue-40882
+Feature: persistent-locking in case of a public link
+
+  Background:
+    Given user "Alice" has been created with default attributes and without skeleton files
+    And user "Alice" has created folder "PARENT"
+    And user "Alice" has created folder "PARENT/CHILD"
+    And user "Alice" has uploaded file "filesForUpload/textfile.txt" to "PARENT/parent.txt"
+    And user "Alice" has uploaded file "filesForUpload/textfile.txt" to "PARENT/CHILD/child.txt"
+
+ 
+  Scenario Outline: Public locking is not supported
+    Given user "Alice" has created a public link share of folder "PARENT" with change permission
+    When the public locks "/CHILD" in the last public link shared folder using the <public-webdav-api-version> public WebDAV API setting the following properties
+      | lockscope | <lock-scope> |
+    Then the HTTP status code should be "403"
+    Examples:
+      | public-webdav-api-version | lock-scope |
+      | new                       | shared     |
+      | new                       | exclusive  |

--- a/tests/acceptance/features/bootstrap/WebDavLockingContext.php
+++ b/tests/acceptance/features/bootstrap/WebDavLockingContext.php
@@ -60,12 +60,13 @@ class WebDavLockingContext implements Context {
 		string $file,
 		TableNode $properties,
 		bool $public = false,
-		bool $expectToSucceed = true
+		bool $expectToSucceed = true,
+		string $publicWebDAVAPIVersion = "old"
 	) {
 		$user = $this->featureContext->getActualUsername($user);
 		$baseUrl = $this->featureContext->getBaseUrl();
 		if ($public === true) {
-			$type = "public-files";
+			$type = "public-files-$publicWebDAVAPIVersion";
 			$password = null;
 		} else {
 			$type = "files";
@@ -211,7 +212,8 @@ class WebDavLockingContext implements Context {
 			$file,
 			$properties,
 			true,
-			false
+			false,
+			$publicWebDAVAPIVersion
 		);
 	}
 

--- a/tests/acceptance/features/bootstrap/WebDavLockingContext.php
+++ b/tests/acceptance/features/bootstrap/WebDavLockingContext.php
@@ -52,6 +52,7 @@ class WebDavLockingContext implements Context {
 	 * @param TableNode $properties table with no heading with | property | value |
 	 * @param boolean $public if the file is in a public share or not
 	 * @param boolean $expectToSucceed
+	 * @param string $publicWebDAVAPIVersion
 	 *
 	 * @return void
 	 */


### PR DESCRIPTION
## Description
This PR make the use of publicWebDAVAPIVersion on publicLocksFileLastSharedFolder function as mentioned in https://github.com/owncloud/core/issues/40756
As the changes was made the response code was different for new webdav api path. So new issue was created https://github.com/owncloud/core/issues/40882
So, this pr also has bug demonstration for it.

## Related Issue
https://github.com/owncloud/core/issues/40756

## Motivation and Context
make the use of publicWebDAVAPIVersion on publicLocksFileLastSharedFolder function

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
- test environment:
- locally
- CI

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Database schema changes (next release will require increase of minor version instead of patch)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [X] Tests only (no source changes)

## Checklist:
<!-- Tick the checkboxes when done. -->
<!-- Raise documentation ticket in https://github.com/owncloud/documentation -->
- [X] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 
- [ ] Changelog item, see [TEMPLATE](https://github.com/owncloud/core/blob/master/changelog/TEMPLATE)
