### PR TITLE
[tests-only] Add test step to set the system skeleton for a scenario

### DIFF
--- a/tests/acceptance/features/bootstrap/Provisioning.php
+++ b/tests/acceptance/features/bootstrap/Provisioning.php
@@ -58,6 +58,13 @@ trait Provisioning {
 	];
 
 	/**
+	 * Path to the skeleton directory before a test changed it.
+	 *
+	 * @var string
+	 */
+	private ?string $originalSkeletonPath = null;
+
+	/**
 	 * Check if this is the admin group. That group is always a local group in
 	 * ownCloud10, even if other groups come from LDAP.
 	 *
@@ -496,6 +503,18 @@ trait Provisioning {
 	 */
 	public function theseUsersHaveBeenCreatedWithoutSkeletonFiles(TableNode $table, string $doNotInitialize):void {
 		$this->theseUsersHaveBeenCreated("", "", $doNotInitialize, $table);
+	}
+
+	/**
+	 * @Given /^the administrator has set the system skeleton to (tiny|small|large)\s?skeleton files$/
+	 *
+	 * @param string $skeletonType
+	 *
+	 * @return void
+	 * @throws Exception
+	 */
+	public function theAdministratorHasSetTheSkeletonTo(string $skeletonType):void {
+		$this->originalSkeletonPath = $this->setSkeletonDirByType($skeletonType);
 	}
 
 	/**
@@ -5308,6 +5327,9 @@ trait Provisioning {
 		}
 		$this->cleanupDatabaseUsers();
 		$this->cleanupDatabaseGroups();
+		if ($this->originalSkeletonPath !== null) {
+			$this->setSkeletonDir($this->originalSkeletonPath);
+		}
 	}
 
 	/**


### PR DESCRIPTION
## Description
Tests that use "skeleton files" currently just switch the skeleton dir, create the user, and switch the skeleton dir back (or remove the skeleton dir setting).

In some cases we want the skeleton dir to be in effect for the whole scenario. We need this in the data_exporter app tests. When we import a user, we need to be able to have the system-wide skeleton dir set in the scenario before we do the import. That will let us test what happens when there is a skeleton dir defined and we are importing users. This was noticed because of issue https://github.com/owncloud/data_exporter/issues/234 - and I want to write test scenarios that confirm the fix for the issue.

IMO it will be good to have this test step definition in core, then any oC10 app can make use of it as needed.


## How Has This Been Tested?
Developing test scenarios for data_exporter app.

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Database schema changes (next release will require increase of minor version instead of patch)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [x] Tests only (no source changes)

## Checklist:
- [ ] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 
- [ ] Changelog item, see [TEMPLATE](https://github.com/owncloud/core/blob/master/changelog/TEMPLATE)
