### PR TITLE
fix: remove just uploaded files in case of error - also for storages …

### DIFF
--- a/apps/dav/lib/Connector/Sabre/File.php
+++ b/apps/dav/lib/Connector/Sabre/File.php
@@ -187,9 +187,7 @@ class File extends Node implements IFile, IFileNode {
 			try {
 				$this->changeLock(ILockingProvider::LOCK_EXCLUSIVE);
 			} catch (LockedException $e) {
-				if ($usePartFile) {
-					$partStorage->unlink($internalPartPath);
-				}
+				$this->cleanFailedUpload($partStorage, $internalPartPath);
 				throw new FileLocked($e->getMessage(), $e->getCode(), $e);
 			}
 
@@ -234,9 +232,7 @@ class File extends Node implements IFile, IFileNode {
 				}
 			}
 		} catch (\Exception $e) {
-			if ($usePartFile) {
-				$partStorage->unlink($internalPartPath);
-			}
+			$this->cleanFailedUpload($partStorage, $internalPartPath);
 			$this->convertToSabreException($e);
 		}
 
@@ -255,9 +251,7 @@ class File extends Node implements IFile, IFileNode {
 			try {
 				$this->changeLock(ILockingProvider::LOCK_EXCLUSIVE);
 			} catch (LockedException $e) {
-				if ($usePartFile) {
-					$partStorage->unlink($internalPartPath);
-				}
+				$this->cleanFailedUpload($partStorage, $internalPartPath);
 				throw new FileLocked($e->getMessage(), $e->getCode(), $e);
 			}
 
@@ -633,9 +627,7 @@ class File extends Node implements IFile, IFileNode {
 				}
 				return $etag;
 			} catch (\Exception $e) {
-				if ($partFile !== null) {
-					$targetStorage->unlink($targetInternalPath);
-				}
+				$this->cleanFailedUpload($targetStorage, $targetInternalPath);
 				$this->convertToSabreException($e);
 			}
 		}
@@ -766,5 +758,24 @@ class File extends Node implements IFile, IFileNode {
 	 */
 	public function getNode() {
 		return \OC::$server->getRootFolder()->get($this->getFileInfo()->getPath());
+	}
+
+	private function cleanFailedUpload(Storage $partStorage, $internalPartPath): void {
+		if ($partStorage->file_exists($internalPartPath)) {
+			try {
+				# broken/uncompleted uploaded files shall not go into trash-bin
+				if (class_exists(\OCA\Files_Trashbin\Storage::class)) {
+					\OCA\Files_Trashbin\Storage::$disableTrash = true;
+				}
+				# delete file from storage
+				$partStorage->unlink($internalPartPath);
+				# delete file from cache
+				$partStorage->getCache()->remove($internalPartPath);
+			} finally {
+				if (class_exists(\OCA\Files_Trashbin\Storage::class)) {
+					\OCA\Files_Trashbin\Storage::$disableTrash = false;
+				}
+			}
+		}
 	}
 }

--- a/apps/dav/tests/unit/Upload/FailedUploadTest.php
+++ b/apps/dav/tests/unit/Upload/FailedUploadTest.php
@@ -1,0 +1,73 @@
+<?php
+/**
+ * @author Thomas Müller <thomas.mueller@tmit.eu>
+ *
+ * @copyright Copyright (c) 2023, ownCloud GmbH
+ * @license AGPL-3.0
+ *
+ * This code is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License, version 3,
+ * as published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License, version 3,
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>
+ *
+ */
+namespace OCA\DAV\Tests\unit\Upload;
+
+use OC\Files\FileInfo;
+use OC\Files\View;
+use OCA\DAV\Connector\Sabre\File;
+use OCP\Lock\ILockingProvider;
+use Sabre\DAV\Exception\BadRequest;
+use Test\TestCase;
+use Test\Traits\UserTrait;
+
+/**
+ * @group DB
+ */
+class FailedUploadTest extends TestCase {
+	use UserTrait;
+
+	public function test(): void {
+		# init
+		$user = $this->createUser('user');
+		$folder = \OC::$server->getUserFolder($user->getUID());
+
+		# fake request
+		$_SERVER['CONTENT_LENGTH'] = 12;
+		$_SERVER['REQUEST_METHOD'] = 'PUT';
+		unset($_SERVER['HTTP_OC_CHUNKED']);
+
+		# perform the request
+		$path = '/test.txt';
+		$info = new FileInfo("user/files/$path", null, null, [], null);
+		$view = new View();
+		$file = new File($view, $info);
+		$file->acquireLock(ILockingProvider::LOCK_SHARED);
+		$stream = fopen('data://text/plain,' . '123456', 'rb');
+		try {
+			$file->put($stream);
+		} catch (BadRequest $e) {
+			self::assertEquals('expected filesize 12 got 6', $e->getMessage());
+		}
+
+		# assert file does not exist
+		self::assertFalse($folder->nodeExists($path));
+		# ensure folder can ge listed
+		$children = $folder->getDirectoryListing();
+		self::assertCount(0, $children);
+
+		# assert there is no file on disk
+		$internalPath = $folder->getInternalPath();
+		self::assertFalse($folder->getStorage()->file_exists($internalPath.'/test.txt'));
+
+		# assert file is not in cache
+		self::assertFalse($folder->getStorage()->getCache()->inCache($internalPath.'/test.txt'));
+	}
+}

--- a/apps/files/js/file-upload.js
+++ b/apps/files/js/file-upload.js
@@ -1296,8 +1296,9 @@ OC.Uploader.prototype = _.extend({
 						var message = '';
 						if (upload) {
 							var response = upload.getResponse();
-							message = response.message;
+							message = t('files', 'Failed to upload the file "{fileName}": {error}', {fileName: upload.getFileName(), error: response.message});
 						}
+
 						OC.Notification.show(message || data.errorThrown, {type: 'error'});
 					}
 

--- a/apps/files_trashbin/lib/Storage.php
+++ b/apps/files_trashbin/lib/Storage.php
@@ -39,9 +39,12 @@ class Storage extends Wrapper {
 	/**
 	 * Disable trash logic
 	 *
+	 * NOTE: this public for a very specific purpose to handle broken uploads.
+	 * Don't touch this property unless you know what this is doing! :dancers:
+	 *
 	 * @var bool
 	 */
-	private static $disableTrash = false;
+	public static $disableTrash = false;
 
 	/** @var  IUserManager */
 	private $userManager;

--- a/changelog/unreleased/40892
+++ b/changelog/unreleased/40892
@@ -1,0 +1,5 @@
+Bugfix: Cleanup storage and database after failed files uploads
+
+Storage and database is cleaned up of any remaining items in case a files upload fails.
+
+https://github.com/owncloud/core/pull/40892


### PR DESCRIPTION
…which do not support part files

## Description
Storage which does not support part files (external storage and s3) can leave broken files in the user space.
This change cleans up these broken files.

Alternative approach to #40891 - which is breaking apis too badly ...

## Related Issue
- https://github.com/owncloud/enterprise/issues/5903

## How Has This Been Tested?
One has to force a failure during upload - e.g. adding one byte to the expected size at https://github.com/owncloud/core/blob/20da6a8554a86d6fb4864c5ef3ddbbc729d33139/apps/dav/lib/Connector/Sabre/File.php#L229

- have trash enabled
- have encryption enabled
- to test with posix storage
- to test with s3 storage
- to test with different external storage
- to test with and without chunking (smaller and greater 10MB

1. Upload file
2. see the error message on the browser
3. assert that the file is not on storage
4. assert that the file is not in DB

## Screenshots (if appropriate):
![image](https://github.com/owncloud/core/assets/1005065/968f94d9-558a-48d3-b215-3d4bfe22c756)


## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Database schema changes (next release will require increase of minor version instead of patch)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [ ] Tests only (no source changes)

## Checklist:
<!-- Tick the checkboxes when done. -->
<!-- Raise documentation ticket in https://github.com/owncloud/documentation -->
- [ ] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 
- [ ] Changelog item, see [TEMPLATE](https://github.com/owncloud/core/blob/master/changelog/TEMPLATE)
