### PR TITLE
[10.13] Fix sharing search length for 10.13.0

### DIFF
--- a/apps/files_sharing/lib/Controller/ShareesController.php
+++ b/apps/files_sharing/lib/Controller/ShareesController.php
@@ -382,6 +382,13 @@ class ShareesController extends OCSController {
 	 * @return void
 	 */
 	protected function getRemote($search) {
+		$this->result['remotes'] = $this->result['exact']['remotes'] = $users = [];
+
+		if (\strlen(\trim($search)) === 0 && $this->userSearch->getSearchMinLength() > 0) {
+			$this->result['remotes'] = [];
+			return;
+		}
+
 		$pluginClass = $this->config->getSystemValue('sharing.remoteShareesSearch');
 		if ($pluginClass !== '') {
 			$this->result['remotes'] = [];

--- a/changelog/10.13.0_2023-07-27/40885
+++ b/changelog/10.13.0_2023-07-27/40885
@@ -1,0 +1,8 @@
+Bugfix: Apply same restrictions for all the shares
+
+Remote shares will have the same restrictions as user and group shares.
+This means that the in order for a remote user to show up as sharee,
+the search term length must be greater than the minimum configured,
+otherwise only exact matches will be shown.
+
+https://github.com/owncloud/core/pull/40885


### PR DESCRIPTION
## Description
Minimum search length will be applied to all shares (user, group and remote)

Note: this is the code from PR #40885 but targeted to the 10.13.0 release branch.

## Related Issue
https://github.com/owncloud/enterprise/issues/5833

## Motivation and Context

## How Has This Been Tested?
Manually tested with federation. No remote will be shown if the search length is lower than the minimum allowed. Only exact matches will be shown if the search term is below the minimum char length

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Database schema changes (next release will require increase of minor version instead of patch)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [ ] Tests only (no source changes)

## Checklist:
- [x] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 
- [ ] Changelog item, see [TEMPLATE](https://github.com/owncloud/core/blob/master/changelog/TEMPLATE)
