### PR TITLE
Upgrading league/mime-type-detection (1.11.0 => 1.12.0)

### DIFF
--- a/changelog/unreleased/PHPdependencies20230404onward
+++ b/changelog/unreleased/PHPdependencies20230404onward
@@ -4,6 +4,7 @@ The following have been updated:
 - doctrine/deprecations (1.0.0 to 1.1.1)
 - egulias/email-validator (3.2.5 to 3.2.6)
 - guzzlehttp/guzzle (7.5.0 to 7.7.0)
+- league/mime-type-detection (1.11.0 to 1.12.0)
 - owncloud/tarstreamer (2.0.0 to 2.1.0)
 - pear/pear-core-minimal (1.10.11 to 1.10.13)
 - phpseclib/phpseclib (3.0.19 to 3.0.21)
@@ -31,3 +32,4 @@ https://github.com/owncloud/core/pull/40849
 https://github.com/owncloud/core/pull/40853
 https://github.com/owncloud/core/pull/40854
 https://github.com/owncloud/core/pull/40867
+https://github.com/owncloud/core/pull/40900

--- a/composer.lock
+++ b/composer.lock
@@ -1683,16 +1683,16 @@
         },
         {
             "name": "league/mime-type-detection",
-            "version": "1.11.0",
+            "version": "1.12.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/thephpleague/mime-type-detection.git",
-                "reference": "ff6248ea87a9f116e78edd6002e39e5128a0d4dd"
+                "reference": "c7f2872fb273bf493811473dafc88d60ae829f48"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/thephpleague/mime-type-detection/zipball/ff6248ea87a9f116e78edd6002e39e5128a0d4dd",
-                "reference": "ff6248ea87a9f116e78edd6002e39e5128a0d4dd",
+                "url": "https://api.github.com/repos/thephpleague/mime-type-detection/zipball/c7f2872fb273bf493811473dafc88d60ae829f48",
+                "reference": "c7f2872fb273bf493811473dafc88d60ae829f48",
                 "shasum": ""
             },
             "require": {
@@ -1723,7 +1723,7 @@
             "description": "Mime-type detection for Flysystem",
             "support": {
                 "issues": "https://github.com/thephpleague/mime-type-detection/issues",
-                "source": "https://github.com/thephpleague/mime-type-detection/tree/1.11.0"
+                "source": "https://github.com/thephpleague/mime-type-detection/tree/1.12.0"
             },
             "funding": [
                 {
@@ -1735,7 +1735,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2022-04-17T13:12:02+00:00"
+            "time": "2023-08-03T07:14:11+00:00"
         },
         {
             "name": "nikic/php-parser",
@@ -6880,16 +6880,16 @@
         },
         {
             "name": "sebastian/global-state",
-            "version": "5.0.5",
+            "version": "5.0.6",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/global-state.git",
-                "reference": "0ca8db5a5fc9c8646244e629625ac486fa286bf2"
+                "reference": "bde739e7565280bda77be70044ac1047bc007e34"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/global-state/zipball/0ca8db5a5fc9c8646244e629625ac486fa286bf2",
-                "reference": "0ca8db5a5fc9c8646244e629625ac486fa286bf2",
+                "url": "https://api.github.com/repos/sebastianbergmann/global-state/zipball/bde739e7565280bda77be70044ac1047bc007e34",
+                "reference": "bde739e7565280bda77be70044ac1047bc007e34",
                 "shasum": ""
             },
             "require": {
@@ -6932,7 +6932,7 @@
             ],
             "support": {
                 "issues": "https://github.com/sebastianbergmann/global-state/issues",
-                "source": "https://github.com/sebastianbergmann/global-state/tree/5.0.5"
+                "source": "https://github.com/sebastianbergmann/global-state/tree/5.0.6"
             },
             "funding": [
                 {
@@ -6940,7 +6940,7 @@
                     "type": "github"
                 }
             ],
-            "time": "2022-02-14T08:28:10+00:00"
+            "time": "2023-08-02T09:26:13+00:00"
         },
         {
             "name": "sebastian/lines-of-code",


### PR DESCRIPTION
## Description
```
Updating dependencies
Lock file operations: 0 installs, 2 updates, 0 removals
  - Upgrading league/mime-type-detection (1.11.0 => 1.12.0)
  - Upgrading sebastian/global-state (5.0.5 => 5.0.6)
Writing lock file
```

https://github.com/thephpleague/mime-type-detection/releases/tag/1.12.0

https://github.com/sebastianbergmann/global-state/releases/tag/5.0.6 (dev dependency only)

Keep the PHP dependencies right up-to-date before making 10.13.0

## How Has This Been Tested?
CI

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Database schema changes (next release will require increase of minor version instead of patch)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [ ] Tests only (no source changes)

## Checklist:
- [ ] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 
- [ ] Changelog item, see [TEMPLATE](https://github.com/owncloud/core/blob/master/changelog/TEMPLATE)
