### PR TITLE
Update guzzlehttp/promises (2.0.0 => 2.0.1) guzzlehttp/psr7 (2.5.0 => 2.6.0)

### DIFF
--- a/changelog/unreleased/PHPdependencies20230404onward
+++ b/changelog/unreleased/PHPdependencies20230404onward
@@ -4,6 +4,8 @@ The following have been updated:
 - doctrine/deprecations (1.0.0 to 1.1.1)
 - egulias/email-validator (3.2.5 to 3.2.6)
 - guzzlehttp/guzzle (7.5.0 to 7.7.0)
+- guzzlehttp/promises (2.0.0 to 2.0.1)
+- guzzlehttp/psr7 (2.5.0 to 2.6.0)
 - league/mime-type-detection (1.11.0 to 1.12.0)
 - owncloud/tarstreamer (2.0.0 to 2.1.0)
 - pear/pear-core-minimal (1.10.11 to 1.10.13)
@@ -33,3 +35,4 @@ https://github.com/owncloud/core/pull/40853
 https://github.com/owncloud/core/pull/40854
 https://github.com/owncloud/core/pull/40867
 https://github.com/owncloud/core/pull/40900
+https://github.com/owncloud/core/pull/40907

--- a/changelog/unreleased/PHPdependencies20230404onward
+++ b/changelog/unreleased/PHPdependencies20230404onward
@@ -6,7 +6,7 @@ The following have been updated:
 - guzzlehttp/guzzle (7.5.0 to 7.7.0)
 - guzzlehttp/promises (2.0.0 to 2.0.1)
 - guzzlehttp/psr7 (2.5.0 to 2.6.0)
-- league/mime-type-detection (1.11.0 to 1.12.0)
+- league/mime-type-detection (1.11.0 to 1.13.0)
 - owncloud/tarstreamer (2.0.0 to 2.1.0)
 - pear/pear-core-minimal (1.10.11 to 1.10.13)
 - phpseclib/phpseclib (3.0.19 to 3.0.21)

--- a/composer.lock
+++ b/composer.lock
@@ -1746,26 +1746,26 @@
         },
         {
             "name": "league/mime-type-detection",
-            "version": "1.12.0",
+            "version": "1.13.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/thephpleague/mime-type-detection.git",
-                "reference": "c7f2872fb273bf493811473dafc88d60ae829f48"
+                "reference": "a6dfb1194a2946fcdc1f38219445234f65b35c96"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/thephpleague/mime-type-detection/zipball/c7f2872fb273bf493811473dafc88d60ae829f48",
-                "reference": "c7f2872fb273bf493811473dafc88d60ae829f48",
+                "url": "https://api.github.com/repos/thephpleague/mime-type-detection/zipball/a6dfb1194a2946fcdc1f38219445234f65b35c96",
+                "reference": "a6dfb1194a2946fcdc1f38219445234f65b35c96",
                 "shasum": ""
             },
             "require": {
                 "ext-fileinfo": "*",
-                "php": "^7.2 || ^8.0"
+                "php": "^7.4 || ^8.0"
             },
             "require-dev": {
                 "friendsofphp/php-cs-fixer": "^3.2",
                 "phpstan/phpstan": "^0.12.68",
-                "phpunit/phpunit": "^8.5.8 || ^9.3"
+                "phpunit/phpunit": "^8.5.8 || ^9.3 || ^10.0"
             },
             "type": "library",
             "autoload": {
@@ -1786,7 +1786,7 @@
             "description": "Mime-type detection for Flysystem",
             "support": {
                 "issues": "https://github.com/thephpleague/mime-type-detection/issues",
-                "source": "https://github.com/thephpleague/mime-type-detection/tree/1.12.0"
+                "source": "https://github.com/thephpleague/mime-type-detection/tree/1.13.0"
             },
             "funding": [
                 {
@@ -1798,7 +1798,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2023-08-03T07:14:11+00:00"
+            "time": "2023-08-05T12:09:49+00:00"
         },
         {
             "name": "nikic/php-parser",

--- a/composer.lock
+++ b/composer.lock
@@ -960,16 +960,16 @@
         },
         {
             "name": "guzzlehttp/promises",
-            "version": "2.0.0",
+            "version": "2.0.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/guzzle/promises.git",
-                "reference": "3a494dc7dc1d7d12e511890177ae2d0e6c107da6"
+                "reference": "111166291a0f8130081195ac4556a5587d7f1b5d"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/guzzle/promises/zipball/3a494dc7dc1d7d12e511890177ae2d0e6c107da6",
-                "reference": "3a494dc7dc1d7d12e511890177ae2d0e6c107da6",
+                "url": "https://api.github.com/repos/guzzle/promises/zipball/111166291a0f8130081195ac4556a5587d7f1b5d",
+                "reference": "111166291a0f8130081195ac4556a5587d7f1b5d",
                 "shasum": ""
             },
             "require": {
@@ -1023,7 +1023,7 @@
             ],
             "support": {
                 "issues": "https://github.com/guzzle/promises/issues",
-                "source": "https://github.com/guzzle/promises/tree/2.0.0"
+                "source": "https://github.com/guzzle/promises/tree/2.0.1"
             },
             "funding": [
                 {
@@ -1039,20 +1039,20 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2023-05-21T13:50:22+00:00"
+            "time": "2023-08-03T15:11:55+00:00"
         },
         {
             "name": "guzzlehttp/psr7",
-            "version": "2.5.0",
+            "version": "2.6.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/guzzle/psr7.git",
-                "reference": "b635f279edd83fc275f822a1188157ffea568ff6"
+                "reference": "8bd7c33a0734ae1c5d074360512beb716bef3f77"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/guzzle/psr7/zipball/b635f279edd83fc275f822a1188157ffea568ff6",
-                "reference": "b635f279edd83fc275f822a1188157ffea568ff6",
+                "url": "https://api.github.com/repos/guzzle/psr7/zipball/8bd7c33a0734ae1c5d074360512beb716bef3f77",
+                "reference": "8bd7c33a0734ae1c5d074360512beb716bef3f77",
                 "shasum": ""
             },
             "require": {
@@ -1139,7 +1139,7 @@
             ],
             "support": {
                 "issues": "https://github.com/guzzle/psr7/issues",
-                "source": "https://github.com/guzzle/psr7/tree/2.5.0"
+                "source": "https://github.com/guzzle/psr7/tree/2.6.0"
             },
             "funding": [
                 {
@@ -1155,7 +1155,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2023-04-17T16:11:26+00:00"
+            "time": "2023-08-03T15:06:02+00:00"
         },
         {
             "name": "icewind/streams",


### PR DESCRIPTION
## Description
Keep dependencies up-to-date:
```
Updating dependencies
Lock file operations: 0 installs, 2 updates, 0 removals
  - Upgrading guzzlehttp/promises (2.0.0 => 2.0.1)
  - Upgrading guzzlehttp/psr7 (2.5.0 => 2.6.0)
Writing lock file
```

https://github.com/guzzle/promises/releases/tag/2.0.1
https://github.com/guzzle/psr7/releases/tag/2.6.0

And:
```
Updating dependencies
Lock file operations: 0 installs, 1 update, 0 removals
  - Upgrading league/mime-type-detection (1.12.0 => 1.13.0)
Writing lock file
```

https://github.com/thephpleague/mime-type-detection/releases/tag/1.13.0


## How Has This Been Tested?
CI

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Database schema changes (next release will require increase of minor version instead of patch)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [ ] Tests only (no source changes)

## Checklist:
- [ ] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 
- [ ] Changelog item, see [TEMPLATE](https://github.com/owncloud/core/blob/master/changelog/TEMPLATE)
