### PR TITLE
[tests-only][full-ci] refactor acceptance test code to store response data related to public shares on single store

### DIFF
--- a/tests/acceptance/features/bootstrap/FeatureContext.php
+++ b/tests/acceptance/features/bootstrap/FeatureContext.php
@@ -3073,7 +3073,7 @@ class FeatureContext extends BehatVariablesContext {
 				"code" => "%last_public_share_token%",
 				"function" => [
 					$this,
-					"getLastPublicShareToken"
+					"getLastCreatedPublicShareToken"
 				],
 				"parameter" => []
 			]

--- a/tests/acceptance/features/bootstrap/PublicWebDavContext.php
+++ b/tests/acceptance/features/bootstrap/PublicWebDavContext.php
@@ -50,7 +50,7 @@ class PublicWebDavContext implements Context {
 			// accessing it as a public link using the "new" public webDAV API
 			// the client needs to provide the public link share token followed
 			// by just the name of the file - not the full path.
-			$fullPath = $this->featureContext->getLastPublicSharePath();
+			$fullPath = (string) $this->featureContext->getLastCreatedPublicShare()->path;
 			$fullPathParts = \explode("/", $fullPath);
 			$path = \end($fullPathParts);
 		} else {
@@ -75,7 +75,7 @@ class PublicWebDavContext implements Context {
 	 */
 	public function downloadPublicFileWithRangeAndPassword(string $range, string $password, string $publicWebDAVAPIVersion):void {
 		if ($publicWebDAVAPIVersion === "new") {
-			$path = $this->featureContext->getLastPublicShareData()->data->file_target;
+			$path = (string) $this->featureContext->getLastCreatedPublicShare()->file_target;
 		} else {
 			$path = "";
 		}
@@ -120,7 +120,7 @@ class PublicWebDavContext implements Context {
 	 * @return void
 	 */
 	public function deleteFileFromPublicShare(string $fileName, string $publicWebDAVAPIVersion, string $password = ""):void {
-		$token = $this->featureContext->getLastPublicShareToken();
+		$token = $this->featureContext->getLastCreatedPublicShareToken();
 		$davPath = WebDavHelper::getDavPath(
 			$token,
 			0,
@@ -171,7 +171,7 @@ class PublicWebDavContext implements Context {
 	 * @return void
 	 */
 	public function renameFileFromPublicShare(string $fileName, string $toFileName, string $publicWebDAVAPIVersion, ?string $password = ""):void {
-		$token = $this->featureContext->getLastPublicShareToken();
+		$token = $this->featureContext->getLastCreatedPublicShareToken();
 		$davPath = WebDavHelper::getDavPath(
 			$token,
 			0,
@@ -289,7 +289,7 @@ class PublicWebDavContext implements Context {
 	):void {
 		$path = \ltrim($path, "/");
 		$password = $this->featureContext->getActualPassword($password);
-		$token = $this->featureContext->getLastPublicShareToken();
+		$token = $this->featureContext->getLastCreatedPublicShareToken();
 		$davPath = WebDavHelper::getDavPath(
 			$token,
 			0,
@@ -394,7 +394,7 @@ class PublicWebDavContext implements Context {
 	 * @return void
 	 */
 	public function thePublicCopiesFileUsingTheWebDAVApi(string $source, string $destination, string $publicWebDAVAPIVersion):void {
-		$token = $this->featureContext->getLastPublicShareToken();
+		$token = $this->featureContext->getLastCreatedPublicShareToken();
 		$davPath = WebDavHelper::getDavPath(
 			$token,
 			0,
@@ -1101,7 +1101,7 @@ class PublicWebDavContext implements Context {
 	):void {
 		$filename = "";
 		if ($publicWebDAVAPIVersion === "new") {
-			$filename = (string)$this->featureContext->getLastPublicShareData()->data[0]->file_target;
+			$filename = (string)$this->featureContext->getLastCreatedPublicShare()->file_target;
 			$techPreviewHadToBeEnabled = $this->occContext->enableDAVTechPreview();
 		} else {
 			$techPreviewHadToBeEnabled = false;
@@ -1286,7 +1286,7 @@ class PublicWebDavContext implements Context {
 		$should = ($shouldOrNot !== "not");
 		if ($publicWebDAVAPIVersion === "new") {
 			$techPreviewHadToBeEnabled = $this->occContext->enableDAVTechPreview();
-			$path = $this->featureContext->getLastPublicSharePath();
+			$path = (string) $this->featureContext->getLastCreatedPublicShare()->path;
 		} else {
 			$techPreviewHadToBeEnabled = false;
 			$path = "";
@@ -1369,7 +1369,7 @@ class PublicWebDavContext implements Context {
 		string $destination,
 		string $password
 	):void {
-		$token = $this->featureContext->getLastPublicShareToken();
+		$token = $this->featureContext->getLastCreatedPublicShareToken();
 		$davPath = WebDavHelper::getDavPath(
 			$token,
 			0,
@@ -1461,7 +1461,7 @@ class PublicWebDavContext implements Context {
 		string $fileName,
 		string $mtime
 	):void {
-		$token = $this->featureContext->getLastPublicShareToken();
+		$token = $this->featureContext->getLastCreatedPublicShareToken();
 		$baseUrl = $this->featureContext->getBaseUrl();
 
 		Assert::assertEquals(
@@ -1488,7 +1488,7 @@ class PublicWebDavContext implements Context {
 		string $fileName,
 		string $mtime
 	):void {
-		$token = $this->featureContext->getLastPublicShareToken();
+		$token = $this->featureContext->getLastCreatedPublicShareToken();
 		$baseUrl = $this->featureContext->getBaseUrl();
 		Assert::assertNotEquals(
 			$mtime,
@@ -1522,7 +1522,7 @@ class PublicWebDavContext implements Context {
 		string $publicWebDAVAPIVersion = "old"
 	):void {
 		$password = $this->featureContext->getActualPassword($password);
-		$token = $this->featureContext->getLastPublicShareToken();
+		$token = $this->featureContext->getLastCreatedPublicShareToken();
 		$davPath = WebDavHelper::getDavPath(
 			$token,
 			0,
@@ -1626,7 +1626,7 @@ class PublicWebDavContext implements Context {
 		} else {
 			$body = null;
 		}
-		$token = $this->featureContext->getLastPublicShareToken();
+		$token = $this->featureContext->getLastCreatedPublicShareToken();
 		$davPath = WebDavHelper::getDavPath(
 			null,
 			null,

--- a/tests/acceptance/features/bootstrap/Sharing.php
+++ b/tests/acceptance/features/bootstrap/Sharing.php
@@ -43,6 +43,9 @@ trait Sharing {
 	 */
 	private array $createdUserGroupShares = [];
 
+	private ?string $userWhoCreatedLastShare = null;
+	private ?int $savedShareId = null;
+
 	private ?string $userWhoCreatedLastPublicShare = null;
 
 	/**
@@ -83,6 +86,10 @@ trait Sharing {
 		'attributes', 'permissions', 'share_with', 'share_with_displayname', 'share_with_additional_info'
 	];
 
+	/**
+	 * @var array
+	 */
+	private array $createdPublicShares = [];
 	/*
 	 * Contains information about the public links that have been created with the webUI.
 	 * Each entry in the array has a "name", "url" and "path".
@@ -101,43 +108,24 @@ trait Sharing {
 	/**
 	 * @return string
 	 */
-	public function getLastCreatedPublicLinkUrl():string {
-		$lastCreatedLink = $this->getLastCreatedPublicLink();
-		return $lastCreatedLink["url"];
-	}
-
-	/**
-	 * @return string
-	 */
-	public function getLastCreatedPublicLinkPath():string {
-		$lastCreatedLink = $this->getLastCreatedPublicLink();
-		return $lastCreatedLink["path"];
-	}
-
-	/**
-	 * @return string
-	 */
-	public function getLastCreatedPublicLinkToken():string {
-		$lastCreatedLinkUrl = $this->getLastCreatedPublicLinkUrl();
-		// The token is the last part of the URL, delimited by "/"
-		$urlParts = \explode("/", $lastCreatedLinkUrl);
-		return \end($urlParts);
+	public function getLastCreatedPublicShareToken():string {
+		return (string)$this->getLastCreatedPublicShare()->token;
 	}
 
 	/**
 	 * @return SimpleXMLElement|null
 	 */
-	public function getLastPublicShareData():?SimpleXMLElement {
-		return $this->lastPublicShareData;
+	public function getLastCreatedPublicShare():?SimpleXMLElement {
+		return \end($this->createdPublicShares);
 	}
 
 	/**
-	 * @param SimpleXMLElement $responseXml
+	 * @param SimpleXMLElement $shareData
 	 *
 	 * @return void
 	 */
-	public function setLastPublicShareData(SimpleXMLElement $responseXml): void {
-		$this->lastPublicShareData = $responseXml;
+	public function addToCreatedPublicShares(SimpleXMLElement $shareData): void {
+		$this->createdPublicShares[] = $shareData;
 	}
 
 	/**
@@ -159,6 +147,17 @@ trait Sharing {
 
 	/**
 	 * @return SimpleXMLElement
+	 * @throws Exception
+	 */
+	public function getLastShareData():SimpleXMLElement {
+		return $this->getLastShareDataForUser($this->userWhoCreatedLastShare);
+	}
+
+	/**
+	 * @param string|null $user
+	 *
+	 * @return SimpleXMLElement
+	 * @throws Exception
 	 */
 	public function getLastCreatedUserGroupShare(): SimpleXMLElement {
 		return \end($this->createdUserGroupShares);
@@ -167,10 +166,8 @@ trait Sharing {
 	/**
 	 * @return void
 	 */
-	public function resetLastPublicShareData():void {
-		$this->lastPublicShareData = null;
-		$this->lastPublicShareId = null;
-		$this->userWhoCreatedLastPublicShare = null;
+	public function emptyCreatedPublicShares():void {
+		$this->createdPublicShares = [];
 	}
 
 	/**
@@ -901,7 +898,7 @@ trait Sharing {
 		$user = $this->getActualUsername($user);
 
 		if ($updateLastPublicLink) {
-			$share_id = $this->getLastPublicLinkShareId();
+			$share_id = (string) $this->getLastCreatedPublicShare()->id;
 		} else {
 			if ($shareOwner === null) {
 				$share_id = $this->getLastCreatedUserGroupShareId();
@@ -1026,17 +1023,6 @@ trait Sharing {
 	}
 
 	/**
-	 * @param string $name
-	 * @param string $url
-	 * @param string $path
-	 *
-	 * @return void
-	 */
-	public function addToListOfCreatedPublicLinks(string $name, string $url, string $path = ""):void {
-		$this->createdPublicLinks[] = ["name" => $name, "url" => $url, "path" => $path];
-	}
-
-	/**
 	 * @param string $user
 	 * @param string|null $path
 	 * @param string|null $shareType
@@ -1096,29 +1082,23 @@ trait Sharing {
 			|| (($httpStatusCode === 200) && ($this->ocsContext->getOCSResponseStatusCode($this->response) > 299))
 		) {
 			if ($shareType === 'public_link') {
-				$this->resetLastPublicShareData();
+				$this->emptyCreatedPublicShares();
 			} else {
 				$this->emptyCreatedUserGroupShares($userActual);
 			}
 		} else {
-			if ($shareType === 'public_link') {
-				$this->setLastPublicShareData($this->getResponseXml(null, __METHOD__));
-				$this->setLastPublicLinkShareId((string)$this->lastPublicShareData->data[0]->id);
-				$this->setUserWhoCreatedLastPublicShare($user);
-				if (isset($this->lastPublicShareData->data)) {
-					$linkName = (string)$this->lastPublicShareData->data[0]->name;
-					$linkUrl = (string)$this->lastPublicShareData->data[0]->url;
-					$this->addToListOfCreatedPublicLinks($linkName, $linkUrl, $path);
-				}
-			} else {
-				$response = $this->getResponseXml(null, __METHOD__);
-				if (isset($response->data)) {
+			$response = $this->getResponseXml(null, __METHOD__);
+			if (isset($response->data)) {
+				$shareData = $response->data;
+				if ($shareType === 'public_link') {
+					$this->addToCreatedPublicShares($shareData);
+				} else {
 					$sharer = (string)$response->data->uid_owner;
 					$this->addToCreatedUserGroupShares($sharer, $response->data);
 				}
 			}
-			$this->localLastShareTime = \microtime(true);
 		}
+		$this->localLastShareTime = \microtime(true);
 	}
 
 	/**
@@ -1951,7 +1931,7 @@ trait Sharing {
 	public function deleteLastShareUsingSharingApi(string $user, string $sharer = null, bool $deleteLastPublicLink = false):void {
 		$user = $this->getActualUsername($user);
 		if ($deleteLastPublicLink) {
-			$shareId = $this->getLastPublicLinkShareId();
+			$shareId = (string) $this->getLastCreatedPublicShare()->id;
 		} else {
 			if ($sharer === null) {
 				$shareId = $this->getLastCreatedUserGroupShareId();
@@ -2060,7 +2040,7 @@ trait Sharing {
 	 * @throws Exception
 	 */
 	public function theUserGetsInfoOfLastPublicLinkShareUsingTheSharingApi():void {
-		$this->userGetsInfoOfLastPublicLinkShareUsingTheSharingApi($this->getUserWhoCreatedLastPublicShare());
+		$this->userGetsInfoOfLastPublicLinkShareUsingTheSharingApi((string) $this->getLastCreatedPublicShare()->uid_owner);
 	}
 
 	/**
@@ -2074,8 +2054,8 @@ trait Sharing {
 	 * @throws Exception
 	 */
 	public function userGetsInfoOfLastPublicLinkShareUsingTheSharingApi(string $user, ?string $language = null):void {
-		if ($this->lastPublicShareId !== null) {
-			$shareId = $this->lastPublicShareId;
+		if ($this->getLastCreatedPublicShare()->id !== null) {
+			$shareId = (string) $this->getLastCreatedPublicShare()->id;
 		} else {
 			throw new Exception(
 				__METHOD__ . " last public link share data was not found"
@@ -2124,6 +2104,46 @@ trait Sharing {
 		TableNode $table
 	):void {
 		$this->asLastShareInfoAboutUserSharingWithUserShouldInclude($sharer, $sharer, $sharee, $table);
+	}
+
+	/**
+	 * Sets the id of the last shared file
+	 *
+	 * @param string $user
+	 * @param string $shareId
+	 *
+	 * @return void
+	 */
+	public function setLastShareIdOf(string $user, string $shareId):void {
+		$this->lastShareIdByUser[$user] = $shareId;
+		$this->userWhoCreatedLastShare = $user;
+	}
+
+	/**
+	 * Retrieves the id of the last shared file
+	 *
+	 * @return string|null
+	 */
+	public function getLastShareId():?string {
+		return $this->getLastShareIdForUser($this->userWhoCreatedLastShare);
+	}
+
+	/**
+	 * @param string $user
+	 *
+	 * @return string|null
+	 */
+	public function getLastShareIdForUser(string $user):?string {
+		if ($user === "") {
+			throw new Exception(
+				__METHOD__ . " user not specified. Probably no user or group shares have been created yet in the test scenario."
+			);
+		}
+		if (isset($this->lastShareIdByUser[$user])) {
+			return $this->lastShareIdByUser[$user];
+		} else {
+			throw new Exception(__METHOD__ . " last share id for user '$user' was not found");
+		}
 	}
 
 	/**
@@ -2457,7 +2477,7 @@ trait Sharing {
 	):void {
 		$user = $this->getActualUsername($user);
 		$this->verifyTableNodeRows($body, [], $this->shareResponseFields);
-		$this->getShareData($user, (string)$this->getLastPublicLinkShareId());
+		$this->getShareData($user, (string)$this->getLastCreatedPublicShare()->id);
 		$this->theHTTPStatusCodeShouldBe(
 			200,
 			"Error getting info of last public link share for user $user"
@@ -2592,7 +2612,7 @@ trait Sharing {
 	 * @throws Exception
 	 */
 	public function checkLastPublicLinkShareIDIsNotIncluded():void {
-		$shareId = $this->getLastPublicLinkShareId();
+		$shareId = (string) $this->getLastCreatedPublicShare()->id;
 		if ($this->isFieldInResponse('id', $shareId, false)) {
 			Assert::fail(
 				"Public link share id $shareId has been found in response"
@@ -3578,73 +3598,6 @@ trait Sharing {
 	}
 
 	/**
-	 * The tests can create public link shares with the API or with the webUI.
-	 * If lastPublicShareData is null, then there have not been any created with the API,
-	 * so look for details of a public link share created with the webUI.
-	 *
-	 * @return string authorization token
-	 */
-	public function getLastPublicShareToken():string {
-		if ($this->lastPublicShareData === null) {
-			return $this->getLastCreatedPublicLinkToken();
-		} else {
-			if (\count($this->lastPublicShareData->data->element) > 0) {
-				return (string)$this->lastPublicShareData->data[0]->token;
-			}
-
-			return (string)$this->lastPublicShareData->data->token;
-		}
-	}
-
-	/**
-	 * Returns the attribute values from the last public link share data
-	 *
-	 * @param $attr - attribute name to get
-	 *
-	 * @return string
-	 * @throws Exception
-	 */
-	public function getLastPublicShareAttribute(string $attr): string {
-		if ($this->lastPublicShareData === null) {
-			throw new Exception(__METHOD__ . "No public share data available.");
-		}
-		if (!\in_array($attr, $this->shareResponseFields)) {
-			throw new Exception(
-				__METHOD__ . " attribute $attr is not in the list of allowed attributes"
-			);
-		}
-		if (\count($this->lastPublicShareData->data->element) > 0) {
-			if (!isset($this->lastPublicShareData->data[0]->$attr)) {
-				throw new Exception(__METHOD__ . " No attribute $attr available in the last share data.");
-			}
-			return (string)$this->lastPublicShareData->data[0]->{$attr};
-		}
-
-		if (!isset($this->lastPublicShareData->data->$attr)) {
-			throw new Exception(__METHOD__ . " No attribute $attr available in the last share data.");
-		}
-
-		return (string)$this->lastPublicShareData->data->{$attr};
-	}
-
-	/**
-	 * @return string path of file that was shared (relevant when a single file has been shared)
-	 */
-	public function getLastPublicSharePath():string {
-		if ($this->lastPublicShareData === null) {
-			// There have not been any public links created with the API
-			// so get the path of the last public link created with the webUI
-			return $this->getLastCreatedPublicLinkPath();
-		} else {
-			if (\count($this->lastPublicShareData->data->element) > 0) {
-				return (string)$this->lastPublicShareData->data[0]->path;
-			}
-
-			return (string)$this->lastPublicShareData->data->path;
-		}
-	}
-
-	/**
 	 * Send request for preview of a file in a public link
 	 *
 	 * @param string $fileName
@@ -3671,8 +3624,7 @@ trait Sharing {
 	 * @return void
 	 */
 	public function thePublicAccessesThePreviewOfTheSharedFileUsingTheSharingApi(string $path):void {
-		$shareData = $this->getLastPublicShareData();
-		$token = (string) $shareData->data->token;
+		$token = $this->getLastCreatedPublicShareToken();
 		$this->getPublicPreviewOfFile($path, $token);
 		$this->pushToLastStatusCodesArrays();
 	}
@@ -3693,8 +3645,7 @@ trait Sharing {
 		$this->emptyLastHTTPStatusCodesArray();
 		$this->emptyLastOCSStatusCodesArray();
 		foreach ($paths as $path) {
-			$shareData = $this->getLastPublicShareData();
-			$token = (string) $shareData->data->token;
+			$token = $this->getLastCreatedPublicShareToken();
 			$this->getPublicPreviewOfFile($path["path"], $token);
 			$this->pushToLastStatusCodesArrays();
 		}
@@ -3715,12 +3666,12 @@ trait Sharing {
 		$user = $this->getActualUsername($user);
 		$userPassword = $this->getPasswordForUser($user);
 
-		$shareData = $this->getLastPublicShareData();
-		$owner = (string) $shareData->data->uid_owner;
-		$name = $this->encodePath((string) $shareData->data->file_target);
+		$shareData = $this->getLastCreatedPublicShare();
+		$owner = (string) $shareData->uid_owner;
+		$name = $this->encodePath((string) $shareData->file_target);
 		$name = \trim($name, "/");
-		$ownerDisplayName = (string) $shareData->data->displayname_owner;
-		$token = (string) $shareData->data->token;
+		$ownerDisplayName = (string) $shareData->displayname_owner;
+		$token = (string) $shareData->token;
 
 		if (\strtolower($shareServer) == "remote") {
 			$remote = $this->getRemoteBaseUrl();
@@ -3863,7 +3814,7 @@ trait Sharing {
 	 * @throws GuzzleException
 	 */
 	public function expireLastCreatedPublicLinkShare():void {
-		$shareId = $this->getLastPublicLinkShareId();
+		$shareId = (string) $this->getLastCreatedPublicShare()->id;
 		$this->expireShare($shareId);
 	}
 

--- a/tests/acceptance/features/bootstrap/Sharing.php
+++ b/tests/acceptance/features/bootstrap/Sharing.php
@@ -43,24 +43,6 @@ trait Sharing {
 	 */
 	private array $createdUserGroupShares = [];
 
-	private ?string $userWhoCreatedLastShare = null;
-	private ?int $savedShareId = null;
-
-	private ?string $userWhoCreatedLastPublicShare = null;
-
-	/**
-	 * Contains the API response to the last public link share that was created
-	 * by the test-runner using the Sharing API.
-	 * Shares created on the webUI do not have an entry.
-	 */
-	private ?SimpleXMLElement $lastPublicShareData = null;
-
-	/**
-	 * Contains the share id of the last public link share that was created by
-	 * the test-runner, either using the Sharing API or on the web UI.
-	 */
-	private ?string $lastPublicShareId = null;
-
 	private ?float $localLastShareTime = null;
 
 	/**
@@ -90,20 +72,6 @@ trait Sharing {
 	 * @var array
 	 */
 	private array $createdPublicShares = [];
-	/*
-	 * Contains information about the public links that have been created with the webUI.
-	 * Each entry in the array has a "name", "url" and "path".
-	 */
-	private array $createdPublicLinks = [];
-
-	/**
-	 * The end (last) entry will itself be an array with keys "name", "url" and "path"
-	 *
-	 * @return array
-	 */
-	public function getLastCreatedPublicLink():array {
-		return \end($this->createdPublicLinks);
-	}
 
 	/**
 	 * @return string
@@ -147,17 +115,6 @@ trait Sharing {
 
 	/**
 	 * @return SimpleXMLElement
-	 * @throws Exception
-	 */
-	public function getLastShareData():SimpleXMLElement {
-		return $this->getLastShareDataForUser($this->userWhoCreatedLastShare);
-	}
-
-	/**
-	 * @param string|null $user
-	 *
-	 * @return SimpleXMLElement
-	 * @throws Exception
 	 */
 	public function getLastCreatedUserGroupShare(): SimpleXMLElement {
 		return \end($this->createdUserGroupShares);
@@ -2104,86 +2061,6 @@ trait Sharing {
 		TableNode $table
 	):void {
 		$this->asLastShareInfoAboutUserSharingWithUserShouldInclude($sharer, $sharer, $sharee, $table);
-	}
-
-	/**
-	 * Sets the id of the last shared file
-	 *
-	 * @param string $user
-	 * @param string $shareId
-	 *
-	 * @return void
-	 */
-	public function setLastShareIdOf(string $user, string $shareId):void {
-		$this->lastShareIdByUser[$user] = $shareId;
-		$this->userWhoCreatedLastShare = $user;
-	}
-
-	/**
-	 * Retrieves the id of the last shared file
-	 *
-	 * @return string|null
-	 */
-	public function getLastShareId():?string {
-		return $this->getLastShareIdForUser($this->userWhoCreatedLastShare);
-	}
-
-	/**
-	 * @param string $user
-	 *
-	 * @return string|null
-	 */
-	public function getLastShareIdForUser(string $user):?string {
-		if ($user === "") {
-			throw new Exception(
-				__METHOD__ . " user not specified. Probably no user or group shares have been created yet in the test scenario."
-			);
-		}
-		if (isset($this->lastShareIdByUser[$user])) {
-			return $this->lastShareIdByUser[$user];
-		} else {
-			throw new Exception(__METHOD__ . " last share id for user '$user' was not found");
-		}
-	}
-
-	/**
-	 * Sets the id of the last public link shared file
-	 *
-	 * @param string $shareId
-	 *
-	 * @return void
-	 */
-	public function setLastPublicLinkShareId(string $shareId):void {
-		$this->lastPublicShareId = $shareId;
-	}
-
-	/**
-	 * Retrieves the id of the last public link shared file
-	 *
-	 * @return string|null
-	 */
-	public function getLastPublicLinkShareId():?string {
-		return $this->lastPublicShareId;
-	}
-
-	/**
-	 * Sets the user who created the last public link share
-	 *
-	 * @param string $user
-	 *
-	 * @return void
-	 */
-	public function setUserWhoCreatedLastPublicShare(string $user):void {
-		$this->userWhoCreatedLastPublicShare = $user;
-	}
-
-	/**
-	 * Gets the user who created the last public link share
-	 *
-	 * @return string|null
-	 */
-	public function getUserWhoCreatedLastPublicShare():?string {
-		return $this->userWhoCreatedLastPublicShare;
 	}
 
 	/**

--- a/tests/acceptance/features/bootstrap/WebDav.php
+++ b/tests/acceptance/features/bootstrap/WebDav.php
@@ -1568,7 +1568,7 @@ trait WebDav {
 	 * @throws Exception
 	 */
 	public function publicGetsSizeOfLastSharedPublicLinkUsingTheWebdavApi():void {
-		$tokenArray = $this->getLastPublicShareData()->data->token;
+		$tokenArray = $this->getLastCreatedPublicShare()->token;
 		$token = (string)$tokenArray[0];
 		$url = $this->getBaseUrl() . "/remote.php/dav/public-files/$token";
 		$this->response = HttpRequestHelper::sendRequest(
@@ -5113,7 +5113,7 @@ trait WebDav {
 	 * @throws Exception
 	 */
 	public function theLastPublicDavResponseShouldContainTheseNodes(TableNode $table):void {
-		$user = $this->getLastPublicShareToken();
+		$user = $this->getLastCreatedPublicShareToken();
 		$this->verifyTableNodeColumns($table, ["name"]);
 		$type = $this->usingOldDavPath ? "public-files" : "public-files-new";
 		foreach ($table->getHash() as $row) {
@@ -5132,7 +5132,7 @@ trait WebDav {
 	 * @throws Exception
 	 */
 	public function theLastPublicDavResponseShouldNotContainTheseNodes(TableNode $table):void {
-		$user = $this->getLastPublicShareToken();
+		$user = $this->getLastCreatedPublicShareToken();
 		$this->verifyTableNodeColumns($table, ["name"]);
 		$type = $this->usingOldDavPath ? "public-files" : "public-files-new";
 		foreach ($table->getHash() as $row) {
@@ -5151,7 +5151,7 @@ trait WebDav {
 	 * @throws Exception
 	 */
 	public function thePublicListsTheResourcesInTheLastCreatedPublicLinkWithDepthUsingTheWebdavApi(string $depth):void {
-		$user = $this->getLastPublicShareToken();
+		$user = $this->getLastCreatedPublicShareToken();
 		$response = $this->listFolder(
 			$user,
 			'/',

--- a/tests/acceptance/features/bootstrap/WebDavLockingContext.php
+++ b/tests/acceptance/features/bootstrap/WebDavLockingContext.php
@@ -150,7 +150,7 @@ class WebDavLockingContext implements Context {
 	 */
 	public function publicHasLockedLastSharedFile(TableNode $properties) {
 		$this->lockFile(
-			$this->featureContext->getLastPublicShareToken(),
+			$this->featureContext->getLastCreatedPublicShareToken(),
 			"/",
 			$properties,
 			true
@@ -166,7 +166,7 @@ class WebDavLockingContext implements Context {
 	 */
 	public function publicLocksLastSharedFile(TableNode $properties) {
 		$this->lockFile(
-			$this->featureContext->getLastPublicShareToken(),
+			$this->featureContext->getLastCreatedPublicShareToken(),
 			"/",
 			$properties,
 			true,
@@ -187,7 +187,7 @@ class WebDavLockingContext implements Context {
 		TableNode $properties
 	) {
 		$this->lockFile(
-			$this->featureContext->getLastPublicShareToken(),
+			$this->featureContext->getLastCreatedPublicShareToken(),
 			$file,
 			$properties,
 			true
@@ -209,7 +209,7 @@ class WebDavLockingContext implements Context {
 		TableNode $properties
 	) {
 		$this->lockFile(
-			$this->featureContext->getLastPublicShareToken(),
+			$this->featureContext->getLastCreatedPublicShareToken(),
 			$file,
 			$properties,
 			true,
@@ -271,7 +271,7 @@ class WebDavLockingContext implements Context {
 		string $itemToUnlock,
 		string $itemToUseLockOf
 	) {
-		$lockOwner = $this->featureContext->getLastPublicShareToken();
+		$lockOwner = $this->featureContext->getLastCreatedPublicShareToken();
 		$this->unlockItemWithLastLockOfUserAndItemUsingWebDavAPI(
 			$user,
 			$itemToUnlock,
@@ -422,7 +422,7 @@ class WebDavLockingContext implements Context {
 		string $lockOwner,
 		string $itemToUseLockOf
 	) {
-		$user = $this->featureContext->getLastPublicShareToken();
+		$user = $this->featureContext->getLastCreatedPublicShareToken();
 		$this->unlockItemWithLastLockOfUserAndItemUsingWebDavAPI(
 			$user,
 			$itemToUnlock,
@@ -440,7 +440,7 @@ class WebDavLockingContext implements Context {
 	 * @return void
 	 */
 	public function unlockItemAsPublicUsingWebDavAPI(string $itemToUnlock) {
-		$user = $this->featureContext->getLastPublicShareToken();
+		$user = $this->featureContext->getLastCreatedPublicShareToken();
 		$this->unlockItemWithLastLockOfUserAndItemUsingWebDavAPI(
 			$user,
 			$itemToUnlock,
@@ -595,7 +595,7 @@ class WebDavLockingContext implements Context {
 		string $itemToUseLockOf,
 		string $publicWebDAVAPIVersion
 	) {
-		$lockOwner = $this->featureContext->getLastPublicShareToken();
+		$lockOwner = $this->featureContext->getLastCreatedPublicShareToken();
 		$this->publicUploadFileSendingLockTokenOfUser(
 			$filename,
 			$content,

--- a/tests/acceptance/features/bootstrap/WebDavPropertiesContext.php
+++ b/tests/acceptance/features/bootstrap/WebDavPropertiesContext.php
@@ -293,7 +293,7 @@ class WebDavPropertiesContext implements Context {
 	 * @throws Exception
 	 */
 	public function publicGetsThePropertiesOfFolder(string $path, TableNode $propertiesTable):void {
-		$user = $this->featureContext->getLastPublicShareToken();
+		$user = $this->featureContext->getLastCreatedPublicShareToken();
 		$properties = null;
 		if ($propertiesTable instanceof TableNode) {
 			foreach ($propertiesTable->getRows() as $row) {
@@ -866,7 +866,7 @@ class WebDavPropertiesContext implements Context {
 				[
 					"code" => "%public_token%",
 					"function" =>
-					[$this->featureContext, "getLastPublicShareToken"],
+					[$this->featureContext, "getLastCreatedPublicShareToken"],
 					"parameter" => []
 				],
 			]

--- a/tests/acceptance/features/bootstrap/WebUIFilesContext.php
+++ b/tests/acceptance/features/bootstrap/WebUIFilesContext.php
@@ -2660,7 +2660,7 @@ class WebUIFilesContext extends RawMinkContext implements Context {
 	 * @return void
 	 */
 	public function publicLinkWithLastShareTokenShouldBeListedAsShareReceiverViaOnTheWebUI(string $item):void {
-		$token = $this->featureContext->getLastPublicShareToken();
+		$token = $this->featureContext->getLastCreatedPublicShareToken();
 		$sharingDialog = $this->filesPage->getSharingDialog();
 		$shareTreeItem = $sharingDialog->getShareTreeItem("public link", $token, $item);
 		Assert::assertTrue(

--- a/tests/acceptance/features/bootstrap/WebUISharingContext.php
+++ b/tests/acceptance/features/bootstrap/WebUISharingContext.php
@@ -635,7 +635,7 @@ class WebUISharingContext extends RawMinkContext implements Context {
 		$this->publicShareTab->waitForAjaxCallsToStartAndFinish($session);
 
 		$linkUrl = $this->publicShareTab->getLinkUrl($newName);
-		$shareData = new SimpleXMLElement("<empty></empty>");
+		$shareData = new SimpleXMLElement("<element />");
 		$shareData->addChild('url', $linkUrl);
 		$this->featureContext->addToCreatedPublicShares($shareData);
 	}
@@ -688,8 +688,10 @@ class WebUISharingContext extends RawMinkContext implements Context {
 		$this->publicShareTab->editLink($session, $name, null, null, $newPassword);
 		$this->publicShareTab->waitForAjaxCallsToStartAndFinish($session);
 
-		$shareData = $this->featureContext->getListOfShares($this->featureContext->getCurrentUser());
-		$this->featureContext->addToCreatedPublicShares($this->featureContext->getResponseXml($shareData, __METHOD__)->data[0]->element);
+		$linkUrl = $this->publicShareTab->getLinkUrl($name);
+		$shareData = new SimpleXMLElement("<element />");
+		$shareData->addChild('url', $linkUrl);
+		$this->featureContext->addToCreatedPublicShares($shareData);
 	}
 
 	/**
@@ -706,8 +708,10 @@ class WebUISharingContext extends RawMinkContext implements Context {
 		$this->publicShareTab->editLink($session, $name, null, $newPermission);
 		$this->publicShareTab->waitForAjaxCallsToStartAndFinish($session);
 
-		$shareData = $this->featureContext->getListOfShares($this->featureContext->getCurrentUser());
-		$this->featureContext->addToCreatedPublicShares($this->featureContext->getResponseXml($shareData, __METHOD__)->data[0]->element);
+		$linkUrl = $this->publicShareTab->getLinkUrl($name);
+		$shareData = new SimpleXMLElement("<element />");
+		$shareData->addChild('url', $linkUrl);
+		$this->featureContext->addToCreatedPublicShares($shareData);
 	}
 
 	/**
@@ -809,11 +813,14 @@ class WebUISharingContext extends RawMinkContext implements Context {
 	 * @return void
 	 */
 	public function createsThePublicLinkUsingTheWebUI():void {
+		$linkName = $this->publicSharingPopup->getLinkName();
 		$this->publicSharingPopup->save();
 		$this->publicSharingPopup->waitForAjaxCallsToStartAndFinish($this->getSession());
 
-		$shareData = $this->featureContext->getListOfShares($this->featureContext->getCurrentUser());
-		$this->featureContext->addToCreatedPublicShares($this->featureContext->getResponseXml($shareData, __METHOD__)->data[0]->element);
+		$linkUrl = $this->publicShareTab->getLinkUrl($linkName);
+		$shareData = new SimpleXMLElement("<element />");
+		$shareData->addChild('url', $linkUrl);
+		$this->featureContext->addToCreatedPublicShares($shareData);
 	}
 
 	/**
@@ -840,9 +847,12 @@ class WebUISharingContext extends RawMinkContext implements Context {
 	public function theUserCreatesAReadOnlyPublicLinkForFolderUsingTheQuickActionButton(string $name):void {
 		$this->createReadOnlyPublicShareLinkUsingQuickAction($name);
 		$this->theUserOpensTheShareDialogForFileFolder($name);
-		$this->sharingDialog->openPublicShareTab($this->getSession());
-		$currentUser = $this->featureContext->getCurrentUser();
-		$shareData = $this->featureContext->getShares($currentUser, $name);
+		$linkTab = $this->sharingDialog->openPublicShareTab($this->getSession());
+		$linkName = $linkTab->getNameOfFirstPublicLink($this->getSession());
+		$linkUrl = $linkTab->getLinkUrl($linkName);
+		$shareData = new SimpleXMLElement("<element />");
+		$shareData->addChild('url', $linkUrl);
+		$shareData->addChild('name', $linkName);
 		$this->featureContext->addToCreatedPublicShares($shareData);
 	}
 

--- a/tests/acceptance/features/lib/PublicLinkFilesPage.php
+++ b/tests/acceptance/features/lib/PublicLinkFilesPage.php
@@ -369,11 +369,10 @@ class PublicLinkFilesPage extends FilesPageBasic {
 	 * @return void
 	 */
 	public function openPublicShareAuthenticateUrl(array $createdPublicLinks, string $baseUrl): void {
-		$lastCreatedLink = $createdPublicLinks;
 		$path = \str_replace(
 			$baseUrl,
 			"",
-			$lastCreatedLink['url']
+			$createdPublicLinks['url']
 		);
 		$this->setPagePath($path . '/authenticate');
 		$this->open();


### PR DESCRIPTION
<!--
Thanks for submitting a change to ownCloud!

This is the bug tracker for the oCIS component. Find other components at https://github.com/owncloud/core/blob/master/.github/CONTRIBUTING.md#guidelines

For fixing potential security issues please see https://owncloud.org/security/

To make it possible for us to get your change reviewed and merged please carefully fill out the requested information below.

Please note that any kind of change needs first be submitted to the master branch which holds the next version of oCIS.

Please set the following labels:

- Set label "Status:Needs-Review" for review or "Status:In-Progress" if the PR still has open tasks.
- Assignment: assign to self
- Reviewers: pick at least one
-->

## Description
Currently, response details of the public shares are stored in different variables like `$userWhoCreatedLastPublicShare`, `$lastPublicShareData`, `$lastPublicShareId`, etc. Instead of using different stores to store these data, all this can be stored in a single store, and needed information can be retrieved from it where required. This PR implements the storing of all the information of the created user shares in a single place `$createdPublicShares` and the important data are retrieved from it when the public share data are required


## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
-  Closes https://github.com/owncloud/core/issues/40285#issuecomment-1653003369

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [x] Tests only (no source changes)

## Checklist:
<!-- Tick the checkboxes when done. -->
<!-- Raise documentation ticket in owncloud.github.io/ -->
- [ ] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 
