### PR TITLE
Improved wording as it wasn't clear before that users of blocked groups can still be invited in shares

### DIFF
--- a/apps/files_sharing/templates/settings.php
+++ b/apps/files_sharing/templates/settings.php
@@ -27,7 +27,7 @@ script('files_sharing', 'settings');
 		<p><?php p($l->t('Exclude groups from receiving shares')); ?></p>
 		<input name="blacklisted_receiver_groups" class="noautosave" value="<?php p($_['blacklistedReceivers']) ?>" style="width: 400px"/>
 		<br />
-		<em><?php p($l->t('These groups will not be available to share with. Members of the group are not restricted in initiating shares and can receive shares with other groups they are a member of as usual.')); ?></em>
+		<em><?php p($l->t('These groups will not be available to share with. Members of the group are not restricted in initiating shares and receiving personal shares/invitations. Furthermore they can receive shares from other groups they are members of as usual.')); ?></em>
 	</div>
 
 	<p>

--- a/apps/files_sharing/templates/settings.php
+++ b/apps/files_sharing/templates/settings.php
@@ -27,7 +27,7 @@ script('files_sharing', 'settings');
 		<p><?php p($l->t('Exclude groups from receiving shares')); ?></p>
 		<input name="blacklisted_receiver_groups" class="noautosave" value="<?php p($_['blacklistedReceivers']) ?>" style="width: 400px"/>
 		<br />
-		<em><?php p($l->t('These groups will not be available to share with. Members of the group are not restricted in initiating shares and receiving personal shares/invitations. Furthermore they can receive shares from other groups they are members of as usual.')); ?></em>
+		<em><?php p($l->t('These groups will not be available to share with. Members of the group are not restricted in initiating shares and receiving personal shares/invitations. Furthermore they can receive shares addressed to other groups they are members of as usual.')); ?></em>
 	</div>
 
 	<p>


### PR DESCRIPTION
## Description
This PR improves the text for the `Group Sharing Blacklist`

## Motivation and Context
The current wording isn't quite clear that the user of blocked as still receive personal shares. So the blacklist doesn't apply to group members just to the group itself.

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Database schema changes (next release will require increase of minor version instead of patch)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [ ] Tests only (no source changes)

## Checklist:
- [ ] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 
- [ ] Changelog item, see [TEMPLATE](https://github.com/owncloud/core/blob/master/changelog/TEMPLATE)
