### PR TITLE
Fix spelling of namespaceMap

### DIFF
--- a/apps/dav/lib/Connector/Sabre/SharesPlugin.php
+++ b/apps/dav/lib/Connector/Sabre/SharesPlugin.php
@@ -92,7 +92,7 @@ class SharesPlugin extends \Sabre\DAV\ServerPlugin {
 	 * @param \Sabre\DAV\Server $server
 	 */
 	public function initialize(\Sabre\DAV\Server $server) {
-		$server->xml->namespacesMap[self::NS_OWNCLOUD] = 'oc';
+		$server->xml->namespaceMap[self::NS_OWNCLOUD] = 'oc';
 		$server->xml->elementMap[self::SHARETYPES_PROPERTYNAME] = 'OCA\\DAV\\Connector\\Sabre\\ShareTypeList';
 		$server->protectedProperties[] = self::SHARETYPES_PROPERTYNAME;
 

--- a/apps/dav/lib/Connector/Sabre/TagsPlugin.php
+++ b/apps/dav/lib/Connector/Sabre/TagsPlugin.php
@@ -106,7 +106,7 @@ class TagsPlugin extends \Sabre\DAV\ServerPlugin {
 	 * @return void
 	 */
 	public function initialize(\Sabre\DAV\Server $server) {
-		$server->xml->namespacesMap[self::NS_OWNCLOUD] = 'oc';
+		$server->xml->namespaceMap[self::NS_OWNCLOUD] = 'oc';
 		$server->xml->elementMap[self::TAGS_PROPERTYNAME] = 'OCA\\DAV\\Connector\\Sabre\\TagList';
 
 		$this->server = $server;

--- a/changelog/unreleased/40943
+++ b/changelog/unreleased/40943
@@ -1,0 +1,5 @@
+Bugfix: fix namespace map setting
+
+The namespace map setting has been corrected for shares and tags.
+
+https://github.com/owncloud/core/pull/40943


### PR DESCRIPTION
## Description
When trying to login, and using PHP 8, I see in `data/owncloud.log`
```
{"reqId":"l9hXAPcOXzVrL00eKrhJ","level":3,"time":"2023-08-25T08:06:01+00:00","remoteAddr":"192.168.0.12","user":"joan","app":"PHP","method":"PROPFIND","url":"\/remote.php\/dav\/files\/joan\/","message":"Creation of dynamic property Sabre\\DAV\\Xml\\Service::$namespacesMap is deprecated at \/home\/phil\/git\/owncloud\/core\/apps\/dav\/lib\/Connector\/Sabre\/TagsPlugin.php#109"}
```

That is because the name of the property is not `namespacesMap`, it is `namespaceMap`.

The typo has been around for a long time in these 2 files - `SharesPlugin.php` and `TagsPlugin.php`
For example, see https://github.com/owncloud/core/pull/20931/files
It is correct in `apps/dav/lib/Connector/Sabre/FilesPlugin.php`

This PR  fixes the typos.

I wonder what behavior this will fix?

## How Has This Been Tested?
CI

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Database schema changes (next release will require increase of minor version instead of patch)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [ ] Tests only (no source changes)

## Checklist:
- [ ] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 
- [ ] Changelog item, see [TEMPLATE](https://github.com/owncloud/core/blob/master/changelog/TEMPLATE)
