### PR TITLE
make sure that parameters are a string when string is expected

### DIFF
--- a/apps/dav/lib/Connector/Sabre/ServerFactory.php
+++ b/apps/dav/lib/Connector/Sabre/ServerFactory.php
@@ -138,7 +138,7 @@ class ServerFactory {
 		$config = $this->config;
 
 		$server->on('beforeMethod:PROPFIND', function (Request $request) use ($config) {
-			$depthHeader = strtolower($request->getHeader('depth'));
+			$depthHeader = strtolower($request->getHeader('depth') ?? '');
 
 			if ($depthHeader === 'infinity' && !$config->getSystemValue('dav.propfind.depth_infinity', false)) {
 				throw new PreconditionFailed('Depth infinity not supported');

--- a/changelog/unreleased/40944
+++ b/changelog/unreleased/40944
@@ -1,0 +1,6 @@
+Bugfix: make sure that parameters are a string when string is expected
+
+The code now checks for when variables are null are passed to functions that
+expect a string, and handles that correctly.
+
+https://github.com/owncloud/core/pull/40944

--- a/lib/private/AppFramework/Http/Request.php
+++ b/lib/private/AppFramework/Http/Request.php
@@ -418,7 +418,7 @@ class Request implements \ArrayAccess, \Countable, IRequest {
 		$params = [];
 
 		// 'application/json' must be decoded manually.
-		if (\strpos($this->getHeader('Content-Type'), 'application/json') !== false) {
+		if (\strpos($this->getHeader('Content-Type') ?? '', 'application/json') !== false) {
 			$params = \json_decode(\file_get_contents($this->inputStream), true);
 			if (\is_array($params) && \count($params) > 0) {
 				$this->items['params'] = $params;

--- a/lib/private/Security/Crypto.php
+++ b/lib/private/Security/Crypto.php
@@ -122,7 +122,7 @@ class Crypto implements ICrypto {
 			$password = $this->config->getSystemValue('secret');
 		}
 
-		$parts = \explode('|', $authenticatedCiphertext);
+		$parts = \explode('|', $authenticatedCiphertext ?? '');
 
 		// v2 uses stronger binary random iv
 		if (\sizeof($parts) === 4 && $parts[0] === 'v2') {

--- a/lib/private/Setup/AbstractDatabase.php
+++ b/lib/private/Setup/AbstractDatabase.php
@@ -78,7 +78,7 @@ abstract class AbstractDatabase {
 		$dbUser = $config['dbuser'];
 		$dbPass = $config['dbpass'];
 		$dbName = $config['dbname'];
-		$dbConnectionString = $config['dbconnectionstring'];
+		$dbConnectionString = $config['dbconnectionstring'] ?? '';
 		$dbHost = !empty($config['dbhost']) ? $config['dbhost'] : 'localhost';
 		$dbTablePrefix = isset($config['dbtableprefix']) ? $config['dbtableprefix'] : 'oc_';
 

--- a/lib/private/User/Session.php
+++ b/lib/private/User/Session.php
@@ -1072,7 +1072,11 @@ class Session implements IUserSession, Emitter {
 	public function clearRememberMeTokensForLoggedInUser($targetToken) {
 		$user = $this->getUser();
 		$uid = $user->getUID();
-		$hashedToken = \hash('snefru', $targetToken);
+		if ($targetToken !== null) {
+			$hashedToken = \hash('snefru', $targetToken);
+		} else {
+			$hashedToken = "";
+		}
 
 		$keys = $this->config->getUserKeys($uid, 'login_token');
 		foreach ($keys as $key) {

--- a/lib/private/legacy/helper.php
+++ b/lib/private/legacy/helper.php
@@ -509,7 +509,7 @@ class OC_Helper {
 		if (\in_array($function_name, $disabled)) {
 			return false;
 		}
-		$disabled = \explode(',', $ini->get('suhosin.executor.func.blacklist'));
+		$disabled = \explode(',', $ini->get('suhosin.executor.func.blacklist') ?? '');
 		$disabled = \array_map('trim', $disabled);
 		if (\in_array($function_name, $disabled)) {
 			return false;


### PR DESCRIPTION
## Description
Functions like `explode` `hash` `strpos` `strtolower` expect a string as input. But sometimes the code is passing something that can be `null`. That is normally converted to an empty string on-the-fly by PHP. For the future, it is better to explictly cast to a string where we know this can happen "normally".

## How Has This Been Tested?
CI

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Database schema changes (next release will require increase of minor version instead of patch)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [ ] Tests only (no source changes)

## Checklist:
- [ ] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 
- [ ] Changelog item, see [TEMPLATE](https://github.com/owncloud/core/blob/master/changelog/TEMPLATE)
