### PR TITLE
Fix usort callback functions to return integers

### DIFF
--- a/changelog/unreleased/40945
+++ b/changelog/unreleased/40945
@@ -1,0 +1,6 @@
+Bugfix: fix usort callback functions to return integers
+
+Calls to the PHP usort function have been refactored so that the callback
+function used always correctly returns an integer.
+
+https://github.com/owncloud/core/pull/40945

--- a/core/Command/App/CheckCode.php
+++ b/core/Command/App/CheckCode.php
@@ -110,7 +110,7 @@ class CheckCode extends Command {
 				$output->writeln(" {$count} errors");
 			}
 			\usort($errors, function ($a, $b) {
-				return $a['line'] >$b['line'];
+				return $a['line'] - $b['line'];
 			});
 
 			foreach ($errors as $p) {

--- a/lib/private/DB/MigrationService.php
+++ b/lib/private/DB/MigrationService.php
@@ -195,7 +195,7 @@ class MigrationService {
 
 		$files = \array_keys(\iterator_to_array($iterator));
 		\uasort($files, function ($a, $b) {
-			return (\basename($a) < \basename($b)) ? -1 : 1;
+			return \strcmp(\basename($a), \basename($b));
 		});
 
 		$migrations = [];

--- a/lib/private/Preview/TXT.php
+++ b/lib/private/Preview/TXT.php
@@ -146,7 +146,7 @@ class TXT implements IProvider2 {
 			if ($a === $b) {
 				return 0;
 			}
-			return ($a < $b) ? 1 : -1;
+			return ($b - $a);
 		});
 		// Information is ordered by counted chars, from highest number of counted chars to lowest.
 		foreach ($countInfo as $key => $value) {

--- a/lib/private/Settings/SettingsManager.php
+++ b/lib/private/Settings/SettingsManager.php
@@ -475,14 +475,15 @@ class SettingsManager implements ISettingsManager {
 
 	/**
 	 * Sort the array of ISettings or ISections by their priority attribute
-	 * @param array $objects (ISections of ISettings)
+	 * A lower priority number means that the item should appear first.
+	 * @param array $objects (ISections or ISettings)
 	 * @return array
 	 */
 	protected function sortOrder($objects) {
 		\usort($objects, function ($a, $b) {
 			/** @var ISection | ISettings $a */
 			/** @var ISection | ISettings $b */
-			return $a->getPriority() < $b->getPriority();
+			return $b->getPriority() - $a->getPriority();
 		});
 		return $objects;
 	}

--- a/tests/lib/Files/Cache/CacheTest.php
+++ b/tests/lib/Files/Cache/CacheTest.php
@@ -366,7 +366,7 @@ class CacheTest extends TestCase {
 		$this->assertCount(2, $results);
 
 		\usort($results, function ($value1, $value2) {
-			return $value1['name'] >= $value2['name'];
+			return \strcmp($value1['name'], $value2['name']);
 		});
 
 		$this->assertEquals('folder', $results[0]['name']);
@@ -382,7 +382,7 @@ class CacheTest extends TestCase {
 		$this->assertCount(3, $results);
 
 		\usort($results, function ($value1, $value2) {
-			return $value1['name'] >= $value2['name'];
+			return \strcmp($value1['name'], $value2['name']);
 		});
 
 		$this->assertEquals('folder', $results[0]['name']);


### PR DESCRIPTION
## Description
The callback function to `usort` is supposed to return an `int`
https://www.php.net/manual/en/function.usort.php
The comparison function must return an integer less than, equal to, or greater than zero if the first argument is considered to be respectively less than, equal to, or greater than the second. 
`callback([mixed](https://www.php.net/manual/en/language.types.declarations.php#language.types.declarations.mixed) $a, [mixed](https://www.php.net/manual/en/language.types.declarations.php#language.types.declarations.mixed) $b): int`

Fix `usort` calls in core so that they do return an `int`. Some of them were returning boolean true/false.

I don't think that there is any real behavior change. Returning `true` is just like returning `1` and so in reality the sorter will make the same decision in this case. Returning `false` is just like returning `0` - so the sorter will think that the items have the same sort "priority", but actually it might be the case that `-1` should have been returned. So items might end up out-of-order.

https://www.php.net/manual/en/function.usort.php

## How Has This Been Tested?
CI

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Database schema changes (next release will require increase of minor version instead of patch)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [ ] Tests only (no source changes)

## Checklist:
- [ ] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 
- [ ] Changelog item, see [TEMPLATE](https://github.com/owncloud/core/blob/master/changelog/TEMPLATE)
