### PR TITLE
Fix settings/templates/users/main.php so that errors are not generated

### DIFF
--- a/changelog/unreleased/40947
+++ b/changelog/unreleased/40947
@@ -1,0 +1,8 @@
+Bugfix: users page generates error logs in owncloud.log
+
+Error logs were being generated in owncloud.log when the admin logged in and
+browsed to the users page. The code that processes the available groups has
+been corrected so that entries are no longer generated.
+
+https://github.com/owncloud/core/pull/40947
+https://github.com/owncloud/core/issues/40946

--- a/settings/templates/users/main.php
+++ b/settings/templates/users/main.php
@@ -20,13 +20,13 @@ style('settings', 'settings');
 $userlistParams = [];
 $allGroups = [];
 foreach ($_["adminGroup"] as $group) {
-	$allGroups[$group['gid']] = [
+	$allGroups[$group['id']] = [
 		'gid' => $group['id'],
 		'name' => $group['name'],
 	];
 }
 foreach ($_["groups"] as $group) {
-	$allGroups[$group['gid']] = [
+	$allGroups[$group['id']] = [
 		'gid' => $group['id'],
 		'name' => $group['name'],
 	];


### PR DESCRIPTION
## Description
Adjust the code for the users page backend so that it does not generate the errors in owncloud.log that are reported in the issue.

## Related Issue
- Fixes #40946 

## How Has This Been Tested?
`rm `data/owncloud.log`
Login as admin to the web UI
Browse to the users page, and it displays the list of groups on the left side - good.
Use the dropdown in the Groups column to add and remove users to/from groups - works.
Refresh the page and check that all the changes are still there - works.
Check the content of `data/owncloud.log` and confirm that it does not contain any errors about `Undefined index: gid` - works, good.

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Database schema changes (next release will require increase of minor version instead of patch)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [ ] Tests only (no source changes)

## Checklist:
- [ ] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 
- [ ] Changelog item, see [TEMPLATE](https://github.com/owncloud/core/blob/master/changelog/TEMPLATE)
