### PR TITLE
fix: remove preceding and trailing whitespace from config

### DIFF
--- a/changelog/unreleased/40950
+++ b/changelog/unreleased/40950
@@ -1,0 +1,6 @@
+Bugfix: Remove Preceding and Trailing White Space from Config
+
+Create recursive function to remove white space during the writing of the config/config.php file. This will remove white space from nested array values as well (hence the recursive function).
+
+https://github.com/owncloud/core/issues/33294
+https://github.com/owncloud/core/pull/40950

--- a/lib/private/Config.php
+++ b/lib/private/Config.php
@@ -42,7 +42,6 @@ use OCP\Events\EventEmitterTrait;
  * configuration file of ownCloud.
  */
 class Config {
-
 	use EventEmitterTrait;
 	public const ENV_PREFIX = 'OC_';
 

--- a/lib/private/Config.php
+++ b/lib/private/Config.php
@@ -153,7 +153,25 @@ class Config {
 		return true;
 	}
 
-	/**
+    /**
+     * This function removes leading and preceding whitespace from string
+     *
+     * @param mixed $arr data
+     * @return string | array Remove whitespace from data
+     */
+    protected function stripWhitespace($arr) {
+        if(is_array($arr)) {
+            foreach($arr as $key => $element) {
+                $arr[$key] = $this->stripWhitespace($element);
+            }
+        } else {
+            $arr = trim($arr);
+        }
+        return $arr;
+    }
+
+
+    /**
 	 * This function sets the value
 	 *
 	 * @param string $key key
@@ -168,7 +186,7 @@ class Config {
 					$afterArray['oldvalue'] = $this->cache[$key];
 				}
 				// Add change
-				$this->cache[$key] = $value;
+				$this->cache[$key] = $this->stripWhitespace($value);
 				return true;
 			}
 

--- a/lib/private/Config.php
+++ b/lib/private/Config.php
@@ -34,6 +34,7 @@
  */
 
 namespace OC;
+
 use OCP\Events\EventEmitterTrait;
 
 /**
@@ -41,25 +42,36 @@ use OCP\Events\EventEmitterTrait;
  * configuration file of ownCloud.
  */
 class Config {
+
 	use EventEmitterTrait;
 	public const ENV_PREFIX = 'OC_';
 
-	/** @var array Associative array ($key => $value) */
+	/**
+	 * @var array Associative array ($key => $value)
+	 */
 	protected $cache = [];
-	/** @var string */
+	/**
+	 * @var string
+	 */
 	protected $configDir;
-	/** @var string */
+	/**
+	 * @var string
+	 */
 	protected $configFilePath;
-	/** @var string */
+	/**
+	 * @var string
+	 */
 	protected $configFileName;
 
 	/**
 	 * @param string $configDir Path to the config dir, needs to end with '/'
 	 * @param string $fileName (Optional) Name of the config file. Defaults to config.php
+	 *
+	 * @throws \Exception
 	 */
 	public function __construct($configDir, $fileName = 'config.php') {
 		$this->configDir = $configDir;
-		$this->configFilePath = $this->configDir.$fileName;
+		$this->configFilePath = $this->configDir . $fileName;
 		$this->configFileName = $fileName;
 		$this->readData();
 	}
@@ -76,14 +88,13 @@ class Config {
 	}
 
 	/**
-	 * Returns a config value
-	 *
-	 * gets its value from an `OC_` prefixed environment variable
+	 * Returns a config value gets its value from an `OC_` prefixed environment variable
 	 * if it doesn't exist from config.php
 	 * if this doesn't exist either, it will return the given `$default`
 	 *
 	 * @param string $key key
 	 * @param mixed $default = null default value
+	 *
 	 * @return mixed the value or $default
 	 */
 	public function getValue($key, $default = null) {
@@ -104,6 +115,8 @@ class Config {
 	 *
 	 * @param array $configs Associative array with `key => value` pairs
 	 *                       If value is null, the config key will be deleted
+	 *
+	 * @throws \Exception Config file not found
 	 */
 	public function setValues(array $configs) {
 		if ($this->isReadOnly()) {
@@ -129,6 +142,8 @@ class Config {
 	 *
 	 * @param string $key key
 	 * @param mixed $value value
+	 *
+	 * @throws \Exception Config file not found
 	 */
 	public function setValue($key, $value) {
 		/**
@@ -153,53 +168,63 @@ class Config {
 		return true;
 	}
 
-    /**
-     * This function removes leading and preceding whitespace from string
-     *
-     * @param mixed $arr data
-     * @return string | array Remove whitespace from data
-     */
-    protected function stripWhitespace($arr) {
-        if(is_array($arr)) {
-            foreach($arr as $key => $element) {
-                $arr[$key] = $this->stripWhitespace($element);
-            }
-        } else {
-            $arr = trim($arr);
-        }
-        return $arr;
-    }
+	/**
+	 * This function removes leading and preceding whitespace from string
+	 *
+	 * @param mixed $arr data
+	 *
+	 * @return string | array Remove whitespace from data
+	 */
+	protected function stripWhitespace($arr) {
+		if (\is_array($arr)) {
+			foreach ($arr as $key => $element) {
+				$arr[$key] = $this->stripWhitespace($element);
+			}
+		} else {
+			$arr = trim($arr);
+		}
+		return $arr;
+	}
 
-
-    /**
+	/**
 	 * This function sets the value
 	 *
 	 * @param string $key key
 	 * @param mixed $value value
+	 *
 	 * @return bool True if the file needs to be updated, false otherwise
 	 */
 	protected function set($key, $value) {
-		return $this->emittingCall(function (&$afterArray) use (&$key, &$value) {
-			if (!isset($this->cache[$key]) || $this->cache[$key] !== $value) {
-				if (isset($this->cache[$key])) {
-					$afterArray['update'] = true;
-					$afterArray['oldvalue'] = $this->cache[$key];
+		return $this->emittingCall(
+			function (&$afterArray) use (&$key, &$value) {
+				if (!isset($this->cache[$key]) || $this->cache[$key] !== $value) {
+					if (isset($this->cache[$key])) {
+						$afterArray['update'] = true;
+						$afterArray['oldvalue'] = $this->cache[$key];
+					}
+					// Add change
+					$this->cache[$key] = $this->stripWhitespace($value);
+					return true;
 				}
-				// Add change
-				$this->cache[$key] = $this->stripWhitespace($value);
-				return true;
-			}
 
-			return false;
-		}, [
+				return false;
+			},
+			[
 			'before' => ['key' => $key, 'value' => $value],
 			'after' => ['key' => $key, 'value' => $value, 'update' => false, 'oldvalue' => null]
-		], 'config', 'setvalue');
+			],
+			'config',
+			'setvalue'
+		);
 	}
 
 	/**
 	 * Removes a key from the config and removes it from config.php if required
+	 *
 	 * @param string $key
+	 *
+	 * @return bool True if delete is successful
+	 * @throws \Exception If file is readonly
 	 */
 	public function deleteKey($key) {
 		if ($this->isReadOnly()) {
@@ -217,21 +242,27 @@ class Config {
 	 * This function removes a key from the config
 	 *
 	 * @param string $key
+	 *
 	 * @return bool True if the file needs to be updated, false otherwise
 	 */
 	protected function delete($key) {
-		return $this->emittingCall(function (&$afterArray) use (&$key) {
-			if (isset($this->cache[$key])) {
-				$afterArray['value'] = $this->cache[$key];
-				// Delete key from cache
-				unset($this->cache[$key]);
-				return true;
-			}
-			return false;
-		}, [
+		return $this->emittingCall(
+			function (&$afterArray) use (&$key) {
+				if (isset($this->cache[$key])) {
+					$afterArray['value'] = $this->cache[$key];
+					// Delete key from cache
+					unset($this->cache[$key]);
+					return true;
+				}
+				return false;
+			},
+			[
 			'before' => ['key' => $key, 'value' => null],
 			'after' => ['key' => $key, 'value' => null]
-		], 'config', 'deletevalue');
+			],
+			'config',
+			'deletevalue'
+		);
 	}
 
 	/**
@@ -246,7 +277,7 @@ class Config {
 		$configFiles = [$this->configFilePath];
 
 		// Add all files in the config dir ending with the same file name
-		$extra = \glob($this->configDir.'*.'.$this->configFileName);
+		$extra = \glob($this->configDir . '*.' . $this->configFileName);
 		if (\is_array($extra)) {
 			\natsort($extra);
 			$configFiles = \array_merge($configFiles, $extra);
@@ -255,9 +286,10 @@ class Config {
 		// Include file and merge config
 		foreach ($configFiles as $file) {
 			$filePointer = \file_exists($file) ? \fopen($file, 'r') : false;
-			if ($file === $this->configFilePath &&
-				$filePointer === false &&
-				@!\file_exists($this->configFilePath)) {
+			if ($file === $this->configFilePath
+				&& $filePointer === false
+				&& @!\file_exists($this->configFilePath)
+			) {
 				// Opening the main config might not be possible, e.g. if the wrong
 				// permissions are set (likely on a new installation)
 				continue;
@@ -311,7 +343,7 @@ class Config {
 			throw new HintException(
 				"Can't write into config directory!",
 				'This can usually be fixed by '
-				.'<a href="' . $url . '" target="_blank" rel="noreferrer">giving the webserver write access to the config directory</a>.'
+				. '<a href="' . $url . '" target="_blank" rel="noreferrer">giving the webserver write access to the config directory</a>.'
 			);
 		}
 
@@ -334,6 +366,11 @@ class Config {
 		}
 	}
 
+	/**
+	 * Check if file is read-only
+	 *
+	 * @return false|mixed
+	 */
 	public function isReadOnly() {
 		if (!$this->getValue('installed', false)) {
 			return false;

--- a/tests/lib/ConfigTest.php
+++ b/tests/lib/ConfigTest.php
@@ -17,10 +17,10 @@ use Symfony\Component\EventDispatcher\GenericEvent;
  * @package Test
  */
 class ConfigTest extends TestCase {
-	public const TESTCONTENT = '<?php $CONFIG=array("foo"=>"bar", "beers" => array("Appenzeller", "Guinness", "Kölsch"), "alcohol_free" => false);';
+	public const TESTCONTENT = '<?php $CONFIG=array("no"=>"whitespace", "foo"=>"bar", "beers" => array("Appenzeller", "Guinness", "Kölsch"), "alcohol_free" => false);';
 
 	/** @var array */
-	private $initialConfig = ['foo' => 'bar', 'beers' => ['Appenzeller', 'Guinness', 'Kölsch'], 'alcohol_free' => false];
+	private $initialConfig = ['no' => 'whitespace', 'foo' => 'bar', 'beers' => ['Appenzeller', 'Guinness', 'Kölsch'], 'alcohol_free' => false];
 	/** @var string */
 	private $configFile;
 	/** @var \OC\Config */
@@ -43,7 +43,7 @@ class ConfigTest extends TestCase {
 	}
 
 	public function testGetKeys() {
-		$expectedConfig = ['foo', 'beers', 'alcohol_free'];
+		$expectedConfig = ['no', 'foo', 'beers', 'alcohol_free'];
 		$this->assertSame($expectedConfig, $this->config->getKeys());
 	}
 
@@ -69,11 +69,13 @@ class ConfigTest extends TestCase {
 
 	public function testSetValue() {
 		$this->config->setValue('foo', 'moo');
+		$this->config->setValue('no', ' whitespace ');
 		$expectedConfig = $this->initialConfig;
 		$expectedConfig['foo'] = 'moo';
+		$expectedConfig['no'] = 'whitespace';
 		$this->checkConfigMatchesExpected($expectedConfig);
 
-		$expected = "<?php\n\$CONFIG = array (\n  'foo' => 'moo',\n  'beers' => \n  array (\n    0 => 'Appenzeller',\n  " .
+		$expected = "<?php\n\$CONFIG = array (\n  'no' => 'whitespace',\n  'foo' => 'moo',\n  'beers' => \n  array (\n    0 => 'Appenzeller',\n  " .
 			"  1 => 'Guinness',\n    2 => 'Kölsch',\n  ),\n  'alcohol_free' => false,\n);\n";
 		$this->assertStringEqualsFile($this->configFile, $expected);
 
@@ -110,7 +112,7 @@ class ConfigTest extends TestCase {
 		$this->assertArrayHasKey('update', $calledAfterSetValue[1]);
 		$this->assertArrayHasKey('oldvalue', $calledAfterSetValue[1]);
 
-		$expected = "<?php\n\$CONFIG = array (\n  'foo' => 'moo',\n  'beers' => \n  array (\n    0 => 'Appenzeller',\n  " .
+		$expected = "<?php\n\$CONFIG = array (\n  'no' => 'whitespace',\n  'foo' => 'moo',\n  'beers' => \n  array (\n    0 => 'Appenzeller',\n  " .
 			"  1 => 'Guinness',\n    2 => 'Kölsch',\n  ),\n  'alcohol_free' => false,\n  'bar' => 'red',\n  'apps' => \n " .
 			" array (\n    0 => 'files',\n    1 => 'gallery',\n  ),\n);\n";
 		$this->assertStringEqualsFile($this->configFile, $expected);
@@ -170,7 +172,7 @@ class ConfigTest extends TestCase {
 		$this->assertArrayHasKey('oldvalue', $calledAfterUpdate[1]);
 		$this->assertEquals('bar', $calledAfterUpdate[1]->getArgument('oldvalue'));
 
-		$expected = "<?php\n\$CONFIG = array (\n  'foo' => 'moo',\n  'beers' => \n  array (\n    0 => 'Appenzeller',\n  " .
+		$expected = "<?php\n\$CONFIG = array (\n  'no' => 'whitespace',\n  'foo' => 'moo',\n  'beers' => \n  array (\n    0 => 'Appenzeller',\n  " .
 			"  1 => 'Guinness',\n    2 => 'Kölsch',\n  ),\n);\n";
 		$this->assertStringEqualsFile($this->configFile, $expected);
 
@@ -237,7 +239,7 @@ class ConfigTest extends TestCase {
 		$this->assertArrayHasKey('key', $calledBeforeDeleteValue[1]);
 		$this->assertArrayHasKey('key', $calledAfterDeleteValue[1]);
 
-		$expected = "<?php\n\$CONFIG = array (\n  'beers' => \n  array (\n    0 => 'Appenzeller',\n  " .
+		$expected = "<?php\n\$CONFIG = array (\n  'no' => 'whitespace',\n  'beers' => \n  array (\n    0 => 'Appenzeller',\n  " .
 			"  1 => 'Guinness',\n    2 => 'Kölsch',\n  ),\n  'alcohol_free' => false,\n);\n";
 		$this->assertStringEqualsFile($this->configFile, $expected);
 	}
@@ -257,7 +259,7 @@ class ConfigTest extends TestCase {
 
 		// Write a new value to the config
 		$this->config->setValue('CoolWebsites', ['demo.owncloud.com', 'owncloud.com', 'owncloud.com']);
-		$expected = "<?php\n\$CONFIG = array (\n  'foo' => 'bar',\n  'beers' => \n  array (\n    0 => 'Appenzeller',\n  " .
+		$expected = "<?php\n\$CONFIG = array (\n  'no' => 'whitespace',\n  'foo' => 'bar',\n  'beers' => \n  array (\n    0 => 'Appenzeller',\n  " .
 			"  1 => 'Guinness',\n    2 => 'Kölsch',\n  ),\n  'alcohol_free' => false,\n  'php53' => 'totallyOutdated',\n  'CoolWebsites' => \n  array (\n  " .
 			"  0 => 'demo.owncloud.com',\n    1 => 'owncloud.com',\n    2 => 'owncloud.com',\n  ),\n);\n";
 		$this->assertStringEqualsFile($this->configFile, $expected);

--- a/tests/lib/ConfigTest.php
+++ b/tests/lib/ConfigTest.php
@@ -1,6 +1,8 @@
 <?php
 /**
  * Copyright (c) 2013 Bart Visscher <bartv@thisnet.nl>
+ *
+ * @author Bart Visscher <bartv@thisnet.nl>
  * This file is licensed under the Affero General Public License version 3 or
  * later.
  * See the COPYING-README file.
@@ -19,20 +21,28 @@ use Symfony\Component\EventDispatcher\GenericEvent;
 class ConfigTest extends TestCase {
 	public const TESTCONTENT = '<?php $CONFIG=array("no"=>"whitespace", "foo"=>"bar", "beers" => array("Appenzeller", "Guinness", "Kölsch"), "alcohol_free" => false);';
 
-	/** @var array */
+	/**
+	 * @var array
+	 */
 	private $initialConfig = ['no' => 'whitespace', 'foo' => 'bar', 'beers' => ['Appenzeller', 'Guinness', 'Kölsch'], 'alcohol_free' => false];
-	/** @var string */
+	/**
+	 * @var string
+	 */
 	private $configFile;
-	/** @var \OC\Config */
+	/**
+	 * @var \OC\Config
+	 */
 	private $config;
-	/** @var string */
+	/**
+	 * @var string
+	 */
 	private $randomTmpDir;
 
 	protected function setUp(): void {
 		parent::setUp();
 
 		$this->randomTmpDir = \OC::$server->getTempManager()->getTemporaryFolder();
-		$this->configFile = $this->randomTmpDir.'testconfig.php';
+		$this->configFile = $this->randomTmpDir . 'testconfig.php';
 		\file_put_contents($this->configFile, self::TESTCONTENT);
 		$this->config = new \OC\Config($this->randomTmpDir, 'testconfig.php');
 	}
@@ -123,10 +133,12 @@ class ConfigTest extends TestCase {
 
 		// Changing configs to existing values and deleting nonexistent configs
 		// should not rewrite the config.php
-		$this->config->setValues([
+		$this->config->setValues(
+			[
 			'foo'			=> 'bar',
 			'not_exists'	=> null,
-		]);
+			]
+		);
 
 		$this->checkConfigMatchesExpected($this->initialConfig);
 		$this->assertStringEqualsFile($this->configFile, self::TESTCONTENT);
@@ -147,10 +159,12 @@ class ConfigTest extends TestCase {
 				$calledAfterUpdate[] = $event;
 			}
 		);
-		$this->config->setValues([
+		$this->config->setValues(
+			[
 			'foo'			=> 'moo',
 			'alcohol_free'	=> null,
-		]);
+			]
+		);
 		$expectedConfig = $this->initialConfig;
 		$expectedConfig['foo'] = 'moo';
 		unset($expectedConfig['alcohol_free']);
@@ -193,9 +207,11 @@ class ConfigTest extends TestCase {
 			}
 		);
 
-		$this->config->setValues([
+		$this->config->setValues(
+			[
 			'foo' => null
-		]);
+			]
+		);
 		$this->assertInstanceOf(GenericEvent::class, $calledBeforeDelete[1]);
 		$this->assertInstanceOf(GenericEvent::class, $calledAfterDelete[1]);
 		$this->assertEquals('config.beforedeletevalue', $calledBeforeDelete[0]);
@@ -247,7 +263,7 @@ class ConfigTest extends TestCase {
 	public function testConfigMerge() {
 		// Create additional config
 		$additionalConfig = '<?php $CONFIG=array("php53"=>"totallyOutdated");';
-		$additionalConfigPath = $this->randomTmpDir.'additionalConfig.testconfig.php';
+		$additionalConfigPath = $this->randomTmpDir . 'additionalConfig.testconfig.php';
 		\file_put_contents($additionalConfigPath, $additionalConfig);
 
 		// Reinstantiate the config to force a read-in of the additional configs


### PR DESCRIPTION
<!--
Thanks for submitting a change to ownCloud!

This is the bug tracker for the Server component. Find other components at https://github.com/owncloud/core/blob/master/.github/CONTRIBUTING.md#guidelines

For fixing potential security issues please see https://owncloud.com/security/

To make it possible for us to get your change reviewed and merged please carefully fill out the requested information below.

Please note that any kind of change needs first be submitted to the master branch which holds the next version of ownCloud.

Please set the following labels:

- Set label "3 - To review" for review or "2 - Development" if the PR still has open tasks
- Assignment: assign to self
- Milestone: set the same as the ticket this PR fixes, or "development" by default
- Reviewers: pick at least one
-->

## Description
<!--- Describe your changes in detail -->
Create recursive function to remove white space during the writing of the `config/config.php` file. This will remove white space from nested array values as well (hence the recursive function). 

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
- Fixes  #33294

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
Solves issues with the SMTP server input where if there were white spaces preceding or succeeding the input the connection would error out. Creates a better user experience for the user as sometimes you may not see that you entered a white space either before or after an input.


## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
### test environment:
- **OS**: Ubuntu 22.04 LTS
- **Database**: PostgreSQL 14
- **Web Server**: Apache2

### Testing Procedure
- Modified PHPUnit `testSetValue()` test to add white space and the beginning and end of a value and then make sure that the output does not include white space. 


## Screenshots (if appropriate):
![image](https://github.com/owncloud/core/assets/12134329/72829315-4c04-4378-accf-80e93aca00d0)
SMTP server address with preceding and succeeding spaces.


![image](https://github.com/owncloud/core/assets/12134329/b5cd6a5c-2f6f-48c1-8e4b-a3173f7bdd07)
Saved value in `config/config.php` that has preceding and succeeding white spaces removed.


## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Database schema changes (next release will require increase of minor version instead of patch)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [ ] Tests only (no source changes)

## Checklist:
<!-- Tick the checkboxes when done. -->
<!-- Raise documentation ticket in https://github.com/owncloud/documentation -->
- [x] Code changes
- [x] Unit tests added
- [x] Acceptance tests added
- [ ] Documentation ticket raised: <link> 
- [ ] Changelog item, see [TEMPLATE](https://github.com/owncloud/core/blob/master/changelog/TEMPLATE)
