### PR TITLE
fix: properly convert file id with instance postfix to pure id

### DIFF
--- a/changelog/unreleased/40958
+++ b/changelog/unreleased/40958
@@ -1,0 +1,6 @@
+Bugfix: Remove instance id postfix from file id
+
+On the App Registry endpoints file ids can hold the instance id which needs to
+be removed.
+
+https://github.com/owncloud/core/pull/40958

--- a/core/Controller/AppRegistryController.php
+++ b/core/Controller/AppRegistryController.php
@@ -203,7 +203,7 @@ class AppRegistryController extends Controller {
 			], 404);
 		}
 
-		$uri = $this->buildWebUri($app_info, $file_id);
+		$uri = $this->buildWebUri($app_info, $fileId);
 		if ($uri === null) {
 			return new DataResponse([
 				"code" => "RESOURCE_NOT_FOUND",

--- a/tests/Core/Controller/AppRegistryControllerTest.php
+++ b/tests/Core/Controller/AppRegistryControllerTest.php
@@ -84,7 +84,7 @@ class AppRegistryControllerTest extends TestCase {
 
 		$controller = new AppRegistryController('core', $request, $appManager, $rootFolder, $generator, $config, $logger);
 
-		$result = $controller->openWithWeb(123, 'draw.io');
+		$result = $controller->openWithWeb('123ocxxxxx', 'draw.io');
 		$data = $result->getData();
 		self::assertCount(1, $data);
 		self::assertEquals('https://example.cloud/index.php/apps/drawio/editor/123', $data['uri']);


### PR DESCRIPTION
## Description
<!--- Describe your changes in detail -->

## Related Issue
- Fixes https://github.com/owncloud/enterprise/issues/5994

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
- test environment:
- test case 1:
- test case 2:
- ...

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Database schema changes (next release will require increase of minor version instead of patch)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [ ] Tests only (no source changes)

## Checklist:
<!-- Tick the checkboxes when done. -->
<!-- Raise documentation ticket in https://github.com/owncloud/documentation -->
- [ ] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 
- [ ] Changelog item, see [TEMPLATE](https://github.com/owncloud/core/blob/master/changelog/TEMPLATE)
