### PR TITLE
fix: delete all files from object store when user is deleted

### DIFF
--- a/lib/private/Files/View.php
+++ b/lib/private/Files/View.php
@@ -1446,6 +1446,9 @@ class View {
 		$path = Filesystem::normalizePath($this->fakeRoot . '/' . $path);
 
 		$mount = Filesystem::getMountManager()->find($path);
+		if ($mount === null) {
+			return false;
+		}
 		$storage = $mount->getStorage();
 		$internalPath = $mount->getInternalPath($path);
 		if ($storage) {

--- a/lib/private/User/User.php
+++ b/lib/private/User/User.php
@@ -33,6 +33,8 @@
 namespace OC\User;
 
 use OC\Files\Cache\Storage;
+use OC\Files\ObjectStore\ObjectStoreStorage;
+use OC\Files\View;
 use OC\Group\Manager;
 use OC\Hooks\Emitter;
 use OC_Helper;
@@ -184,7 +186,8 @@ class User implements IUser {
 	}
 
 	/**
-	 * get the display name for the user, if no specific display name is set it will fallback to the user id
+	 * get the display name for the user, if no specific display name is set
+	 * it will fall back to the user id
 	 *
 	 * @return string
 	 */
@@ -285,19 +288,12 @@ class User implements IUser {
 	 *
 	 * @return bool
 	 */
-	public function delete() {
+	public function delete(): bool {
 		if ($this->emitter) {
 			$this->emitter->emit('\OC\User', 'preDelete', [$this]);
 		}
 		// get the home now because it won't return it after user deletion
 		$homePath = $this->getHome();
-		$this->mapper->delete($this->account);
-		$bi = $this->account->getBackendInstance();
-		if ($bi !== null) {
-			$bi->deleteUser($this->account->getUserId());
-		}
-
-		// FIXME: Feels like an hack - suggestions?
 
 		// We have to delete the user from all groups
 		foreach (\OC::$server->getGroupManager()->getUserGroups($this) as $group) {
@@ -311,19 +307,34 @@ class User implements IUser {
 		//Delete external storage or remove user from applicableUsers list
 		\OC::$server->getGlobalStoragesService()->deleteAllForUser($this);
 
-		// Delete user files in /data/
-		if ($homePath !== false) {
-			// FIXME: this operates directly on FS, should use View instead...
-			// also this is not testable/mockable...
-			\OC_Helper::rmdirr($homePath);
+		$view = new View();
+		$fileInfo = $view->getFileInfo("/");
+		if ($fileInfo !== false) {
+			$homeStorage = $fileInfo->getStorage();
+			$isPrimaryObjectStore = $homeStorage->instanceOfStorage(ObjectStoreStorage::class);
+			if ($isPrimaryObjectStore) {
+				/** @var ObjectStoreStorage $homeStorage */
+				/** @phan-suppress-next-line PhanUndeclaredMethod */
+				$homeStorage->removeAllFilesForUser($this);
+			}
 		}
+
+		// Delete user files in /data/
+		\OC_Helper::rmdirr($homePath);
 
 		// Delete the users entry in the storage table
 		Storage::remove('home::' . $this->getUID());
-		Storage::remove('object::user:' . $this->getUID());
 
 		\OC::$server->getCommentsManager()->deleteReferencesOfActor('users', $this->getUID());
 		\OC::$server->getCommentsManager()->deleteReadMarksFromUser($this);
+
+		# finally delete the user and account records
+		# this way the operation can be re-run in case of errors
+		$this->mapper->delete($this->account);
+		$bi = $this->account->getBackendInstance();
+		if ($bi !== null) {
+			$bi->deleteUser($this->account->getUserId());
+		}
 
 		if ($this->emitter) {
 			$this->emitter->emit('\OC\User', 'postDelete', [$this]);

--- a/tests/lib/Files/ObjectStore/ObjectStoreDeleteAllTest.php
+++ b/tests/lib/Files/ObjectStore/ObjectStoreDeleteAllTest.php
@@ -1,0 +1,88 @@
+<?php
+/**
+ * @author Thomas Müller <thomas.mueller@tmit.eu>
+ *
+ * @copyright Copyright (c) 2023, ownCloud GmbH
+ * @license AGPL-3.0
+ *
+ * This code is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License, version 3,
+ * as published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License, version 3,
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>
+ *
+ */
+
+namespace Test\Files\ObjectStore;
+
+use OC\Files\ObjectStore\ObjectStoreStorage;
+use OC\Files\Storage\Wrapper\Wrapper;
+use OCP\Files\File;
+use Test\TestCase;
+use Test\Traits\UserTrait;
+
+/**
+ * Class ObjectStoreDeleteAllTest
+ *
+ * @group DB
+ *
+ * @package Test\Files\ObjectStore
+ */
+class ObjectStoreDeleteAllTest extends TestCase {
+	use UserTrait;
+
+	public function test(): void {
+		$user = $this->createUser('user1');
+
+		$folder = \OC::$server->getUserFolder($user->getUID());
+		$storage = $folder->getStorage();
+		while ($storage instanceof Wrapper) {
+			$storage = $storage->getWrapperStorage();
+		}
+		if (!$storage instanceof ObjectStoreStorage) {
+			$this->markTestSkipped();
+		}
+
+		# add some files and folders
+		$folderFoo = $folder->newFolder('foo');
+		$file1 = $folder->newFile('foo/lorem.txt');
+		$file1->putContent('1234567890');
+		$file2 = $folder->newFile('lorem.txt');
+		$file2->putContent('1234567890');
+
+		# assert objects on storage
+		$this->assertFileOnObjectStore($storage, $file1);
+		$this->assertFileOnObjectStore($storage, $file2);
+
+		# perform delete
+		$storage->removeAllFilesForUser($user);
+
+		# assert no objects on storage
+		$this->assertFileNotOnObjectStore($storage, $file1);
+		$this->assertFileNotOnObjectStore($storage, $file2);
+
+		# assert no records in oc_filecache
+		self::assertFalse($storage->file_exists($folderFoo->getInternalPath()));
+		self::assertFalse($storage->file_exists($file2->getInternalPath()));
+		self::assertFalse($storage->file_exists($file2->getInternalPath()));
+	}
+
+	private function assertFileOnObjectStore($storage, File $file1): void {
+		$stream = $storage->fopen($file1->getInternalPath(), 'r');
+		self::assertNotFalse($stream);
+		$content = stream_get_contents($stream);
+		fclose($stream);
+		self::assertEquals('1234567890', $content);
+	}
+
+	private function assertFileNotOnObjectStore($storage, File $file1): void {
+		$stream = $storage->fopen($file1->getInternalPath(), 'r');
+		self::assertFalse($stream);
+	}
+}


### PR DESCRIPTION
## Description
As soon as a user is deleted files will also be removed from object storage (s3).

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
- test environment:
- test case 1:
- test case 2:
- ...

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Database schema changes (next release will require increase of minor version instead of patch)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [ ] Tests only (no source changes)

## Checklist:
<!-- Tick the checkboxes when done. -->
<!-- Raise documentation ticket in https://github.com/owncloud/documentation -->
- [ ] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 
- [ ] Changelog item, see [TEMPLATE](https://github.com/owncloud/core/blob/master/changelog/TEMPLATE)
