### PR TITLE
Allow subadmins to read app config values

### DIFF
--- a/changelog/unreleased/40961
+++ b/changelog/unreleased/40961
@@ -1,0 +1,8 @@
+Bugfix: Allow subadmins to read app config values
+
+Previously, subadmins couldn't read app config values. This caused problems
+in the users page for subadmins because some of the functionalities of the
+page were depending on the config values that the subadmins couldn't read.
+Those problems are now solved.
+
+https://github.com/owncloud/core/pull/40961

--- a/core/js/config.js
+++ b/core/js/config.js
@@ -8,51 +8,62 @@
  * @namespace
  */
 OC.AppConfig={
-	url:OC.filePath('core','ajax','appconfig.php'),
-	getCall:function(action,data,callback){
-		data.action=action;
-		$.getJSON(OC.AppConfig.url,data,function(result){
-			if(result.status==='success'){
-				if(callback){
-					callback(result.data);
-				}
+	url:OC.generateUrl('/settings/appconfig'),
+	getValue:function(app,key,defaultValue,callback){
+		if (defaultValue === undefined || defaultValue === null) {
+			$.ajax({
+				url: `${OC.AppConfig.url}/${app}/${key}`,
+				success: callback
+			});
+		} else {
+			$.ajax({
+				url: `${OC.AppConfig.url}/${app}/${key}?default=${defaultValue}`,
+				success: callback
+			});
+		}
+	},
+	setValue:function(app,key,value){
+		return $.ajax({
+			url: OC.AppConfig.url,
+			type: 'PUT',
+			data: {
+				app: app,
+				key: key,
+				value: value
 			}
 		});
 	},
-	postCall:function(action,data,callback){
-		data.action=action;
-		return $.post(OC.AppConfig.url,data,function(result){
-			if(result.status==='success'){
-				if(callback){
-					callback(result.data);
-				}
-			}
-		},'json');
-	},
-	getValue:function(app,key,defaultValue,callback){
-		if(typeof defaultValue=='function'){
-			callback=defaultValue;
-			defaultValue=null;
-		}
-		OC.AppConfig.getCall('getValue',{app:app,key:key,defaultValue:defaultValue},callback);
-	},
-	setValue:function(app,key,value){
-		return OC.AppConfig.postCall('setValue',{app:app,key:key,value:value});
-	},
 	getApps:function(callback){
-		OC.AppConfig.getCall('getApps',{},callback);
+		$.ajax({
+			url: OC.AppConfig.url,
+			success: callback
+		});
 	},
 	getKeys:function(app,callback){
-		OC.AppConfig.getCall('getKeys',{app:app},callback);
+		$.ajax({
+			url: `${OC.AppConfig.url}/${app}`,
+			success: callback
+		});
 	},
 	hasKey:function(app,key,callback){
-		OC.AppConfig.getCall('hasKey',{app:app,key:key},callback);
+		$.ajax({
+			url: `${OC.AppConfig.url}/${app}/${key}`,
+			success: function(data) {
+				callback(data !== null);
+			}
+		});
 	},
 	deleteKey:function(app,key){
-		OC.AppConfig.postCall('deleteKey',{app:app,key:key});
+		$.ajax({
+			url: `${OC.AppConfig.url}/${app}/${key}`,
+			type: 'DELETE'
+		});
 	},
 	deleteApp:function(app){
-		OC.AppConfig.postCall('deleteApp',{app:app});
+		$.ajax({
+			url: `${OC.AppConfig.url}/${app}`,
+			type: 'DELETE'
+		});
 	}
 };
 //TODO OC.Preferences

--- a/settings/Application.php
+++ b/settings/Application.php
@@ -35,6 +35,7 @@ use OC\Server;
 use OC\AppFramework\Utility\TimeFactory;
 use OC\Settings\Controller\CorsController;
 use OC\Settings\Controller\SettingsPageController;
+use OC\Settings\Controller\AppConfigController;
 use OC\Settings\Controller\AppSettingsController;
 use OC\Settings\Controller\AuthSettingsController;
 use OC\Settings\Controller\CertificateController;
@@ -185,6 +186,13 @@ class Application extends App {
 				$c->query('URLGenerator'),
 				$c->query('Config'),
 				$c->query('L10N')
+			);
+		});
+		$container->registerService('AppConfigController', function (IContainer $c) {
+			return new AppConfigController(
+				$c->query('AppName'),
+				$c->query('Request'),
+				$c->query('ServerContainer')->getAppConfig()
 			);
 		});
 

--- a/settings/Controller/AppConfigController.php
+++ b/settings/Controller/AppConfigController.php
@@ -23,7 +23,6 @@ use OCP\IAppConfig;
 use OCP\IRequest;
 use OCP\AppFramework\Controller;
 use OCP\AppFramework\Http;
-use OCP\AppFramework\Http\DataResponse;
 use OCP\AppFramework\Http\JSONResponse;
 
 /**

--- a/settings/Controller/AppConfigController.php
+++ b/settings/Controller/AppConfigController.php
@@ -1,0 +1,129 @@
+<?php
+/**
+ * @copyright Copyright (c) 2023, ownCloud GmbH
+ * @license AGPL-3.0
+ *
+ * This code is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License, version 3,
+ * as published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License, version 3,
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>
+ *
+ */
+
+namespace OC\Settings\Controller;
+
+use OCP\IAppConfig;
+use OCP\IRequest;
+use OCP\AppFramework\Controller;
+use OCP\AppFramework\Http;
+use OCP\AppFramework\Http\DataResponse;
+use OCP\AppFramework\Http\JSONResponse;
+
+/**
+ * The code is mostly copied from core/ajax/appconfig.php
+ * Read methods (getApps, getKeys and getValue) are available to subadmins,
+ * which wasn't possible with the core/ajax/appconfig.php file. The rest of
+ * the methods require admin privileges.
+ * Note that the "hasKey" method is missing. You can do the same in a lot of
+ * cases by trying to get the value of the key.
+ *
+ * @package OC\Settings\Controller
+ */
+class AppConfigController extends Controller {
+	/** @var IAppConfig */
+	private $appConfig;
+
+	/**
+	 * @param string $appName
+	 * @param IRequest $request
+	 * @param IAppConfig $appConfig
+	 */
+	public function __construct(
+		$appName,
+		IRequest $request,
+		IAppConfig $appConfig
+	) {
+		parent::__construct($appName, $request);
+		$this->appConfig = $appConfig;
+	}
+
+	/**
+	 * @NoAdminRequired
+	 *
+	 * Get the list of apps
+	 */
+	public function getApps() {
+		return new JSONResponse($this->appConfig->getApps());
+	}
+
+	/**
+	 * @NoAdminRequired
+	 *
+	 * Get the list of keys for that particular app
+	 * @param string $app
+	 */
+	public function getKeys($app) {
+		return new JSONResponse($this->appConfig->getKeys($app));
+	}
+
+	/**
+	 * @NoAdminRequired
+	 *
+	 * Get the value of the key for that app, or the default value provided
+	 * if it's missing.
+	 * @param string $app
+	 * @param string $key
+	 * @param string $default
+	 */
+	public function getValue($app, $key, $default = null) {
+		return new JSONResponse($this->appConfig->getValue($app, $key, $default));
+	}
+
+	/**
+	 * Set the value for the target key in the app. If no value is provided,
+	 * the request will fail.
+	 * @param string $app
+	 * @param string $key
+	 * @param string $value
+	 */
+	public function setValue($app, $key, $value) {
+		if (!isset($app, $key, $value)) {
+			return new JSONResponse([], Http::STATUS_BAD_REQUEST);
+		} else {
+			return new JSONResponse($this->appConfig->setValue($app, $key, $value));
+		}
+	}
+
+	/**
+	 * Delete the key from the app
+	 * @param string $app
+	 * @param string $key
+	 */
+	public function deleteKey($app, $key) {
+		if (!isset($app, $key)) {
+			return new JSONResponse([], Http::STATUS_BAD_REQUEST);
+		} else {
+			return new JSONResponse($this->appConfig->deleteKey($app, $key));
+		}
+	}
+
+	/**
+	 * Delete the app from the appconfig. Note that this just deletes the stored
+	 * keys in the appconfig. It won't touch the app in any other way
+	 * @param string $app
+	 */
+	public function deleteApp($app) {
+		if (!isset($app)) {
+			return new JSONResponse([], Http::STATUS_BAD_REQUEST);
+		} else {
+			return new JSONResponse($this->appConfig->deleteApp($app));
+		}
+	}
+}

--- a/settings/routes.php
+++ b/settings/routes.php
@@ -73,6 +73,12 @@ $application->registerRoutes($this, [
 		['name' => 'Users#resendInvitation', 'url' => '/resend/invitation/{userId}', 'verb' => 'POST'],
 		['name' => 'Users#setPassword', 'url' => '/setpassword/{token}/{userId}', 'verb' => 'POST'],
 		['name' => 'Groups#getAssignableAndRemovableGroups', 'url' => '/settings/groups/available', 'verb' => 'GET'],
+		['name' => 'AppConfig#getApps', 'url' => '/settings/appconfig', 'verb' => 'GET'],
+		['name' => 'AppConfig#getKeys', 'url' => '/settings/appconfig/{app}', 'verb' => 'GET'],
+		['name' => 'AppConfig#getValue', 'url' => '/settings/appconfig/{app}/{key}', 'verb' => 'GET'],
+		['name' => 'AppConfig#setValue', 'url' => '/settings/appconfig/{app?}/{key?}', 'verb' => 'PUT'], // optional params can be sent in the request body
+		['name' => 'AppConfig#deleteKey', 'url' => '/settings/appconfig/{app?}/{key?}', 'verb' => 'DELETE'], // optional params can be sent in the request body
+		['name' => 'AppConfig#deleteApp', 'url' => '/settings/appconfig/{app?}', 'verb' => 'DELETE'], // optional params can be sent in the request body
 	]
 ]);
 

--- a/tests/Settings/Controller/AppConfigControllerTest.php
+++ b/tests/Settings/Controller/AppConfigControllerTest.php
@@ -1,0 +1,153 @@
+<?php
+/**
+ * @copyright Copyright (c) 2023, ownCloud GmbH
+ * @license AGPL-3.0
+ *
+ * This code is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License, version 3,
+ * as published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License, version 3,
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>
+ *
+ */
+
+namespace Tests\Settings\Controller;
+
+use OC\Settings\Controller\AppConfigController;
+use OCP\IRequest;
+use OCP\IAppConfig;
+use OCP\AppFramework\Http;
+use OCP\AppFramework\Http\JSONResponse;
+use Test\TestCase;
+
+/**
+ * Class AppSettingsControllerTest
+ *
+ * @package Tests\Settings\Controller
+ */
+class AppConfigControllerTest extends TestCase {
+	/** @var IAppConfig */
+	private $appConfig;
+	/** @var AppConfigController */
+	private $appConfigController;
+
+	public function setUp(): void {
+		parent::setUp();
+
+		$this->appConfig = $this->createMock(IAppConfig::class);
+		$this->request = $this->createMock(IRequest::class);
+		$this->appConfigController = new AppConfigController('settings', $this->request, $this->appConfig);
+	}
+
+	public function testGetApps() {
+		$this->appConfig->method('getApps')->willReturn(['appId1', 'appId2']);
+
+		$expected = new JSONResponse(['appId1', 'appId2']);
+		$this->assertEquals($expected->getData(), $this->appConfigController->getApps()->getData());
+	}
+
+	public function testGetKeys() {
+		$this->appConfig->method('getKeys')
+			->with('appId001')
+			->willReturn(['key1', 'key2']);
+
+		$expected = new JSONResponse(['key1', 'key2']);
+		$this->assertEquals($expected->getData(), $this->appConfigController->getKeys('appId001')->getData());
+	}
+
+	public function testGetValue() {
+		$this->appConfig->method('getValue')
+			->with('appId001', 'key1', null)
+			->willReturn('valueOfKey1');
+
+		$expected = new JSONResponse('valueOfKey1');
+		$this->assertEquals($expected->getData(), $this->appConfigController->getValue('appId001', 'key1', null)->getData());
+	}
+
+	public function testSetValue() {
+		$this->appConfig->method('setValue')
+			->with('appId003', 'key3', 'value3')
+			->willReturn(true);
+
+		$expected = new JSONResponse(true);
+		$response = $this->appConfigController->setValue('appId003', 'key3', 'value3');
+		$this->assertEquals($expected->getData(), $response->getData());
+		$this->assertSame(Http::STATUS_OK, $response->getStatus());
+	}
+
+	public function setValueProvider() {
+		return [
+			[null, null, null],
+			['appId1', null, null],
+			['appId1', 'key1', null],
+		];
+	}
+
+	/**
+	 * @dataProvider setValueProvider
+	 */
+	public function testSetValueWrong($app, $key, $value) {
+		$this->appConfig->expects($this->never())
+			->method('setValue');
+
+		$response = $this->appConfigController->setValue($app, $key, $value);
+		$this->assertEquals([], $response->getData());
+		$this->assertSame(Http::STATUS_BAD_REQUEST, $response->getStatus());
+	}
+
+	public function testDeleteKey() {
+		$this->appConfig->method('deleteKey')
+			->with('appId003', 'key3')
+			->willReturn(true);
+
+		$expected = new JSONResponse(true);
+		$response = $this->appConfigController->deleteKey('appId003', 'key3');
+		$this->assertEquals($expected->getData(), $response->getData());
+		$this->assertSame(Http::STATUS_OK, $response->getStatus());
+	}
+
+	public function deleteKeyProvider() {
+		return [
+			[null, null],
+			['appId1', null, null],
+		];
+	}
+
+	/**
+	 * @dataProvider deleteKeyProvider
+	 */
+	public function testdeleteKeyWrong($app, $key) {
+		$this->appConfig->expects($this->never())
+			->method('deleteKey');
+
+		$response = $this->appConfigController->deleteKey($app, $key);
+		$this->assertEquals([], $response->getData());
+		$this->assertSame(Http::STATUS_BAD_REQUEST, $response->getStatus());
+	}
+
+	public function testDeleteApp() {
+		$this->appConfig->method('deleteApp')
+			->with('appId003')
+			->willReturn(true);
+
+		$expected = new JSONResponse(true);
+		$response = $this->appConfigController->deleteApp('appId003');
+		$this->assertEquals($expected->getData(), $response->getData());
+		$this->assertSame(Http::STATUS_OK, $response->getStatus());
+	}
+
+	public function testdeleteAppWrong() {
+		$this->appConfig->expects($this->never())
+			->method('deleteApp');
+
+		$response = $this->appConfigController->deleteApp(null);
+		$this->assertEquals([], $response->getData());
+		$this->assertSame(Http::STATUS_BAD_REQUEST, $response->getStatus());
+	}
+}

--- a/tests/acceptance/features/bootstrap/WebUIUsersContext.php
+++ b/tests/acceptance/features/bootstrap/WebUIUsersContext.php
@@ -237,7 +237,7 @@ class WebUIUsersContext extends RawMinkContext implements Context {
 	}
 
 	/**
-	 * @Then /^the (?:subadmin|administrator) should (not|)\s?be able\s? to see password field in new user form on the webUI$/
+	 * @Then /^the (?:subadmin|administrator) should (not|)\s?be able\s? to see the password field in the new user form on the webUI$/
 	 *
 	 * @param string $shouldOrNot
 	 *
@@ -262,7 +262,7 @@ class WebUIUsersContext extends RawMinkContext implements Context {
 	}
 
 	/**
-	 * @Then /^the (?:subadmin|administrator) should (not|)\s?be able\s? to see email field in new user form on the webUI$/
+	 * @Then /^the (?:subadmin|administrator) should (not|)\s?be able\s? to see the email field in the new user form on the webUI$/
 	 *
 	 * @param string $shouldOrNot
 	 *

--- a/tests/acceptance/features/webUISettingsMenu/settingsMenu.feature
+++ b/tests/acceptance/features/webUISettingsMenu/settingsMenu.feature
@@ -127,5 +127,5 @@ Feature: add users
     And the administrator has logged out of the webUI
     And user "Alice" has logged in using the webUI
     When the user browses to the users page
-    Then the subadmin should be able to see password field in new user form on the webUI
-    But the subadmin should not be able to see email field in new user form on the webUI
+    Then the subadmin should be able to see the password field in the new user form on the webUI
+    But the subadmin should not be able to see the email field in the new user form on the webUI

--- a/tests/acceptance/features/webUISettingsMenu/settingsMenu.feature
+++ b/tests/acceptance/features/webUISettingsMenu/settingsMenu.feature
@@ -118,7 +118,7 @@ Feature: add users
       | Brian    |
 
   @issue-34652
-  Scenario: subadmin should be able to see password and email field
+  Scenario: subadmin should be able to see the password field but not the email field
     Given group "grp1" has been created
     And user "Alice" has been added to group "grp1"
     And user "Brian" has been added to group "grp1"
@@ -127,5 +127,5 @@ Feature: add users
     And the administrator has logged out of the webUI
     And user "Alice" has logged in using the webUI
     When the user browses to the users page
-    Then the subadmin should be able to see email field in new user form on the webUI
-    And the subadmin should be able to see password field in new user form on the webUI
+    Then the subadmin should be able to see password field in new user form on the webUI
+    But the subadmin should not be able to see email field in new user form on the webUI


### PR DESCRIPTION
<!--
Thanks for submitting a change to ownCloud!

This is the bug tracker for the Server component. Find other components at https://github.com/owncloud/core/blob/master/.github/CONTRIBUTING.md#guidelines

For fixing potential security issues please see https://owncloud.com/security/

To make it possible for us to get your change reviewed and merged please carefully fill out the requested information below.

Please note that any kind of change needs first be submitted to the master branch which holds the next version of ownCloud.

Please set the following labels:

- Set label "3 - To review" for review or "2 - Development" if the PR still has open tasks
- Assignment: assign to self
- Milestone: set the same as the ticket this PR fixes, or "development" by default
- Reviewers: pick at least one
-->

## Description
Create a new `AppConfigController` aiming to deprecate the old "core/ajax/apppconfig.php" file. The functions in the "core/js/config.js" file will use the new controller.

Some additional notes:
* Parameters for the GET requests ("getApps", "getKeys", "getValue" and "hasKey") will be sent as part of the url, so they're be visible to anyone
* Parameters for PUT and DELETE requests ("setValue", "deleteKey" and "deleteApp") can be sent both in the url or in the body
* For now, only the parameters of the "setValue" will be sent in the body

In addition, the "getApps", "getKeys" and "getValue" will be available to subadmins ("hasKey" will rely on the "getValue" method in the server, so it will also be available)

## Related Issue
https://github.com/owncloud/enterprise/issues/5981

## Motivation and Context
Some of the functionality wasn't working for subadmins because they couldn't read the app config.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
- test environment:
- test case 1:
- test case 2:
- ...

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Database schema changes (next release will require increase of minor version instead of patch)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [ ] Tests only (no source changes)

## Checklist:
<!-- Tick the checkboxes when done. -->
<!-- Raise documentation ticket in https://github.com/owncloud/documentation -->
- [x] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 
- [ ] Changelog item, see [TEMPLATE](https://github.com/owncloud/core/blob/master/changelog/TEMPLATE)
