### PR TITLE
fix: validate comment verb length

### DIFF
--- a/changelog/unreleased/40965
+++ b/changelog/unreleased/40965
@@ -1,0 +1,5 @@
+Bugfix: Validate comment verb length
+
+User input validation of comment verb
+
+https://github.com/owncloud/core/pull/40965

--- a/lib/private/Comments/Comment.php
+++ b/lib/private/Comments/Comment.php
@@ -27,7 +27,7 @@ use OCP\Comments\IllegalIDChangeException;
 use OCP\Comments\MessageTooLongException;
 
 class Comment implements IComment {
-	protected $data = [
+	protected array $data = [
 		'id'              => '',
 		'parentId'        => '0',
 		'topmostParentId' => '0',
@@ -45,7 +45,7 @@ class Comment implements IComment {
 	/**
 	 * Comment constructor.
 	 *
-	 * @param [] $data	optional, array with keys according to column names from
+	 * @param array|null $data	optional, array with keys according to column names from
 	 * 					the comments database scheme
 	 */
 	public function __construct(array $data = null) {
@@ -193,7 +193,7 @@ class Comment implements IComment {
 			throw new \InvalidArgumentException('String expected.');
 		}
 		$message = \trim($message);
-		if (\mb_strlen($message, 'UTF-8') > IComment::MAX_MESSAGE_LENGTH) {
+		if (\strlen($message) > IComment::MAX_MESSAGE_LENGTH) {
 			throw new MessageTooLongException('Comment message must not exceed ' . IComment::MAX_MESSAGE_LENGTH . ' characters');
 		}
 		$this->data['message'] = $message;
@@ -221,6 +221,11 @@ class Comment implements IComment {
 		if (!\is_string($verb) || !\trim($verb)) {
 			throw new \InvalidArgumentException('Non-empty String expected.');
 		}
+		$verb = \trim($verb);
+		if (\strlen($verb) > IComment::MAX_VERB_LENGTH) {
+			throw new \InvalidArgumentException('Comment verb must not exceed ' . IComment::MAX_VERB_LENGTH . ' characters');
+		}
+
 		$this->data['verb'] = \trim($verb);
 		return $this;
 	}

--- a/lib/public/Comments/IComment.php
+++ b/lib/public/Comments/IComment.php
@@ -31,6 +31,7 @@ namespace OCP\Comments;
  */
 interface IComment {
 	public const MAX_MESSAGE_LENGTH = 1000;
+	public const MAX_VERB_LENGTH = 64;
 
 	/**
 	 * returns the ID of the comment

--- a/tests/lib/Comments/CommentTest.php
+++ b/tests/lib/Comments/CommentTest.php
@@ -69,6 +69,7 @@ class CommentTest extends TestCase {
 			['Message', true],
 			['Verb', true],
 			['Verb', ''],
+			['Verb', str_repeat('x', IComment::MAX_VERB_LENGTH + 1)],
 			['ChildrenCount', true],
 		];
 	}


### PR DESCRIPTION
## Description
The comment verb is user input and needs validation in length.

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
- Fixes <issue_link>

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
- test environment:
- test case 1:
- test case 2:
- ...

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Database schema changes (next release will require increase of minor version instead of patch)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [ ] Tests only (no source changes)

## Checklist:
<!-- Tick the checkboxes when done. -->
<!-- Raise documentation ticket in https://github.com/owncloud/documentation -->
- [ ] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 
- [ ] Changelog item, see [TEMPLATE](https://github.com/owncloud/core/blob/master/changelog/TEMPLATE)
