### PR TITLE
Use app config to disable background jobs and prevent them from running

### DIFF
--- a/changelog/unreleased/40969
+++ b/changelog/unreleased/40969
@@ -1,0 +1,6 @@
+Enhancement: Allow disabling background jobs
+
+Background jobs can now be disabled so they won't run automatically.
+Those jobs can still be executed manually if needed even if disabled.
+
+https://github.com/owncloud/core/pull/40969

--- a/lib/private/BackgroundJob/JobList.php
+++ b/lib/private/BackgroundJob/JobList.php
@@ -207,6 +207,14 @@ class JobList implements IJobList {
 				// Background job already executed elsewhere, try again.
 				return $this->getNext();
 			}
+
+			// skip jobs marked as disabled
+			$jobs_disabled = \explode(',', $this->config->getAppValue('backgroundjob', 'jobs_disabled', ''));
+			if (\in_array($row['id'], $jobs_disabled, true)) {
+				$this->logger->warning("Background job configuration has the job {$row['id']} as disabled. Skipping it");
+				return $this->getNext();
+			}
+
 			$job = $this->buildJob($row);
 
 			if ($job === null) {


### PR DESCRIPTION
<!--
Thanks for submitting a change to ownCloud!

This is the bug tracker for the Server component. Find other components at https://github.com/owncloud/core/blob/master/.github/CONTRIBUTING.md#guidelines

For fixing potential security issues please see https://owncloud.com/security/

To make it possible for us to get your change reviewed and merged please carefully fill out the requested information below.

Please note that any kind of change needs first be submitted to the master branch which holds the next version of ownCloud.

Please set the following labels:

- Set label "3 - To review" for review or "2 - Development" if the PR still has open tasks
- Assignment: assign to self
- Milestone: set the same as the ticket this PR fixes, or "development" by default
- Reviewers: pick at least one
-->

## Description
Allow background jobs to be disabled via app config.
You can use `occ config:app:set backgroundjob jobs_disabled --value 19,5` to disable the jobs with the id 19 and 5.
The value for the key is a comma-separated list of job ids. The job ids can be checked with `occ background:queue:status`
You can use `occ config:app:delete backgroundjob jobs_disabled` to remove the option set.

Note that this only affects to the cron execution. You can still run the disabled jobs manually with `occ background:queue:execute <jobid>`
Furthermore, a disabled job that tried to run will have the "reserved_at" column filled. This means that you'll have to wait 12 hours for the next attempt to run the job even if it's removed from the disabled list.

## Related Issue
https://github.com/owncloud/enterprise/issues/5978

## Motivation and Context
This is intended to disable jobs that could use too many resources or take a lot of time, without removing them from the list. Note that all the background jobs should run unless there is a problem with them.

## How Has This Been Tested?
In a fresh installation:
1. Setup a disabled job with `occ config:app:set backgroundjob jobs_disabled --value <jobid>`
2. Run `occ system:cron`. A warning log should appear for the job marked as disabled. "reserved_at" column in the DB is filled for the target job id.
3. Run `occ system:cron` again. Disabled job won't run until 12 hours have passed, so no new log message will be shown.

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Database schema changes (next release will require increase of minor version instead of patch)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [ ] Tests only (no source changes)

## Checklist:
<!-- Tick the checkboxes when done. -->
<!-- Raise documentation ticket in https://github.com/owncloud/documentation -->
- [x] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 
- [ ] Changelog item, see [TEMPLATE](https://github.com/owncloud/core/blob/master/changelog/TEMPLATE)
