### PR TITLE
Check for existence of creation time when running migrations

### DIFF
--- a/changelog/unreleased/40991
+++ b/changelog/unreleased/40991
@@ -1,0 +1,5 @@
+Bugfix: Check if account creation time exists for migrations
+
+In some rare scenarios it could have happened that the migration responsible for adding the creation time in the oc_accounts table was not correctly inserted into oc_migrations with the consequence that it was reattempted i.e. when upgrading apps, even if the column was already present. This has been now fixed.
+
+https://github.com/owncloud/core/pull/40991

--- a/core/Migrations/Version20230120101715.php
+++ b/core/Migrations/Version20230120101715.php
@@ -32,11 +32,13 @@ class Version20230120101715 implements ISchemaMigration {
 	public function changeSchema(Schema $schema, array $options) {
 		$prefix = $options['tablePrefix'];
 		$accountsTable = $schema->getTable("${prefix}accounts");
-
-		$accountsTable->addColumn('creation_time', Type::INTEGER, [
-				'notnull' => true,
-				'length' => 32,
-				'default' => 0,
-		]);
+			  
+		if (!$table->hasColumn('creation_time')) {
+			$accountsTable->addColumn('creation_time', Type::INTEGER, [
+					'notnull' => true,
+					'length' => 32,
+					'default' => 0,
+			]);
+		}
 	}
 }

--- a/core/Migrations/Version20230120101715.php
+++ b/core/Migrations/Version20230120101715.php
@@ -33,7 +33,7 @@ class Version20230120101715 implements ISchemaMigration {
 		$prefix = $options['tablePrefix'];
 		$accountsTable = $schema->getTable("${prefix}accounts");
 			  
-		if (!$table->hasColumn('creation_time')) {
+		if (!$accountsTable->hasColumn('creation_time')) {
 			$accountsTable->addColumn('creation_time', Type::INTEGER, [
 					'notnull' => true,
 					'length' => 32,


### PR DESCRIPTION
## Description
In some weird scenarios it can happen that the migration responsible for adding the creation time in the oc_accounts table  is not correctly inserted into oc_migrations with the consequence that it is reattempted when i.e. upgrading apps, even if the column is already present.

## Related Issue

- https://github.com/owncloud/enterprise/issues/6036

## Motivation and Context
Make migration more robust.

## How Has This Been Tested?
Manually.

## Types of changes
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Database schema changes (next release will require increase of minor version instead of patch)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [ ] Tests only (no source changes)

## Checklist:
- [X] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised 
- [x] Changelog item
