### PR TITLE
FR display a theme while maintenance mode is active

### DIFF
--- a/config/config.sample.php
+++ b/config/config.sample.php
@@ -1135,6 +1135,17 @@ $CONFIG = [
 'maintenance' => false,
 
 /**
+ * Enable a theme while maintenance mode is active.
+ * Typically, no apps will be loaded while maintenance mode is active.
+ * This also applies to themes since they are essentially apps.
+ * You can specify the name of the theme to enable it,
+ * or use an empty string ('') to disable it.
+ * Additionally, you have the option to specify a different theme than
+ * the one you have currently enabled.
+ */
+'maintenance.theme' => '',
+
+/**
  * Enable or disable `single user mode`
  * When set to `true`, the ownCloud instance will be unavailable for all users
  * who are not in the `admin` group.

--- a/lib/kernel.php
+++ b/lib/kernel.php
@@ -300,6 +300,9 @@ class OC {
 			&& OC::$SUBURI != '/core/ajax/update.php'
 			&& !$isOccControllerRequested
 		) {
+			// load the maintenance theme if any
+			\OC_App::loadMaintenanceTheme();
+
 			// send http status 503
 			\http_response_code(503);
 			\header('Status: 503 Service Temporarily Unavailable');

--- a/lib/private/Route/Router.php
+++ b/lib/private/Route/Router.php
@@ -272,8 +272,12 @@ class Router implements IRouter {
 			$this->loadRoutes($app);
 		} elseif (\substr($url, 0, 6) === '/core/' or \substr($url, 0, 10) === '/settings/') {
 			\OC::$REQUESTEDAPP = $url;
-			if (!\OC::$server->getConfig()->getSystemValue('maintenance', false) && !Util::needUpgrade()) {
-				\OC_App::loadApps();
+			if (!Util::needUpgrade()) {
+				if (!\OC::$server->getConfig()->getSystemValue('maintenance', false)) {
+					\OC_App::loadApps();
+				} else {
+					\OC_App::loadMaintenanceTheme();
+				}
 			}
 			$this->loadRoutes('core');
 		} else {

--- a/lib/private/legacy/app.php
+++ b/lib/private/legacy/app.php
@@ -86,6 +86,25 @@ class OC_App {
 	}
 
 	/**
+	 * Loads a theme in maintenance mode if one has been set in the config.php at 'maintenance.theme'
+	 *
+	 * @return bool
+	 */
+	public static function loadMaintenanceTheme() {
+		$theme = \OC::$server->getConfig()->getSystemValue('maintenance.theme', null);
+		if ($theme === null || $theme === '') {
+			return false;
+		}
+
+		if (!self::isType($theme, ['theme'])) {
+			return false;
+		}
+
+		self::loadApp($theme, false);
+		return true;
+	}
+
+	/**
 	 * loads all apps
 	 *
 	 * @param string[] | string | null $types
@@ -101,9 +120,11 @@ class OC_App {
 		if (\is_array($types) && !\array_diff($types, self::$loadedTypes)) {
 			return true;
 		}
+
 		if (\OC::$server->getSystemConfig()->getValue('maintenance', false)) {
 			return false;
 		}
+
 		// Load the enabled apps here
 		$apps = self::getEnabledApps();
 


### PR DESCRIPTION
<!--
Thanks for submitting a change to ownCloud!

This is the bug tracker for the Server component. Find other components at https://github.com/owncloud/core/blob/master/.github/CONTRIBUTING.md#guidelines

For fixing potential security issues please see https://owncloud.com/security/

To make it possible for us to get your change reviewed and merged please carefully fill out the requested information below.

Please note that any kind of change needs first be submitted to the master branch which holds the next version of ownCloud.

Please set the following labels:

- Set label "3 - To review" for review or "2 - Development" if the PR still has open tasks
- Assignment: assign to self
- Milestone: set the same as the ticket this PR fixes, or "development" by default
- Reviewers: pick at least one
-->

## Description
<!--- Describe your changes in detail -->
This pull request enables our users to utilize a theme while maintenance mode is active, whether it's the currently loaded theme or a different one.
## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
I consider this feature a 'nice-to-have,' especially since a recent customer requested it. It ensures that the Web UI always displays branding when available.

I made a change to an 'if' statement in the Router.php file that I believed was unnecessary, but I still marked it as a 'Breaking change' because I'm not a PHP developer, and this file seemed significant to me.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
- Baremetal oC 10.13.1

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Database schema changes (next release will require increase of minor version instead of patch)
- [x] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [ ] Tests only (no source changes)

## Checklist:
<!-- Tick the checkboxes when done. -->
<!-- Raise documentation ticket in https://github.com/owncloud/documentation -->
- [x] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 
- [ ] Changelog item, see [TEMPLATE](https://github.com/owncloud/core/blob/master/changelog/TEMPLATE)
