### PR TITLE
fix: drop usage of ${}

### DIFF
--- a/apps/dav/appinfo/Migrations/Version20170116170538.php
+++ b/apps/dav/appinfo/Migrations/Version20170116170538.php
@@ -33,8 +33,8 @@ class Version20170116170538 implements ISchemaMigration {
 	 * @param Schema $schema
 	 * @param string $prefix
 	 */
-	private function createPropertiesTable(Schema $schema, $prefix) {
-		$table = $schema->createTable("${prefix}properties");
+	private function createPropertiesTable(Schema $schema, string $prefix): void {
+		$table = $schema->createTable("{$prefix}properties");
 		$table->addColumn('id', 'integer', [
 			'autoincrement' => true,
 			'notnull' => true,
@@ -62,16 +62,16 @@ class Version20170116170538 implements ISchemaMigration {
 	 * @param Schema $schema
 	 * @param array $options
 	 */
-	public function changeSchema(Schema $schema, array $options) {
+	public function changeSchema(Schema $schema, array $options): void {
 		$prefix = $options['tablePrefix'];
 
-		if (!$schema->hasTable("${prefix}properties")) {
+		if (!$schema->hasTable("{$prefix}properties")) {
 			// install
 			$this->createPropertiesTable($schema, $prefix);
 		} else {
 			// We allow fileid column to be nullable on update
 			// otherwise migration will fail for some DB engines
-			$table = $schema->getTable("${prefix}properties");
+			$table = $schema->getTable("{$prefix}properties");
 			if (!$table->hasColumn('fileid')) {
 				$table->addColumn('fileid', 'integer', [
 					'notnull' => false,

--- a/apps/dav/appinfo/Migrations/Version20170202220512.php
+++ b/apps/dav/appinfo/Migrations/Version20170202220512.php
@@ -38,7 +38,7 @@ class Version20170202220512 implements ISchemaMigration {
 	public function changeSchema(Schema $schema, array $options) {
 		$prefix = $options['tablePrefix'];
 
-		$table = $schema->getTable("${prefix}properties");
+		$table = $schema->getTable("{$prefix}properties");
 		if ($table->hasIndex('property_index')) {
 			$table->dropIndex('property_index');
 		}

--- a/apps/dav/appinfo/Migrations/Version20170519091921.php
+++ b/apps/dav/appinfo/Migrations/Version20170519091921.php
@@ -10,7 +10,7 @@ use OCP\Migration\ISchemaMigration;
 class Version20170519091921 implements ISchemaMigration {
 	public function changeSchema(Schema $schema, array $options) {
 		$prefix = $options['tablePrefix'];
-		$table = $schema->getTable("${prefix}cards");
+		$table = $schema->getTable("{$prefix}cards");
 		// Check for existing index spanning these columns
 		foreach ($table->getIndexes() as $index) {
 			// Check if we have a matching index already

--- a/apps/dav/appinfo/Migrations/Version20170711193427.php
+++ b/apps/dav/appinfo/Migrations/Version20170711193427.php
@@ -12,7 +12,7 @@ class Version20170711193427 implements ISchemaMigration {
 	public function changeSchema(Schema $schema, array $options) {
 		$prefix = $options['tablePrefix'];
 
-		if ($schema->hasTable("${prefix}properties")) {
+		if ($schema->hasTable("{$prefix}properties")) {
 			$table = $schema->getTable("{$prefix}properties");
 
 			$idColumn = $table->getColumn('id');

--- a/apps/dav/appinfo/Migrations/Version20170927201245.php
+++ b/apps/dav/appinfo/Migrations/Version20170927201245.php
@@ -37,8 +37,8 @@ class Version20170927201245 implements ISchemaMigration {
 	 */
 	public function changeSchema(Schema $schema, array $options) {
 		$prefix = $options['tablePrefix'];
-		if (!$schema->hasTable("${prefix}dav_properties")) {
-			$table = $schema->createTable("${prefix}dav_properties");
+		if (!$schema->hasTable("{$prefix}dav_properties")) {
+			$table = $schema->createTable("{$prefix}dav_properties");
 			$table->addColumn('id', Type::BIGINT, [
 				'autoincrement' => true,
 				'notnull' => true,

--- a/apps/dav/appinfo/Migrations/Version20180622095921.php
+++ b/apps/dav/appinfo/Migrations/Version20180622095921.php
@@ -8,10 +8,10 @@ use OCP\Migration\ISchemaMigration;
 class Version20180622095921 implements ISchemaMigration {
 	public function changeSchema(Schema $schema, array $options) {
 		$prefix = $options['tablePrefix'];
-		if ($schema->hasTable("${prefix}dav_job_status")) {
+		if ($schema->hasTable("{$prefix}dav_job_status")) {
 			return;
 		}
-		$table = $schema->createTable("${prefix}dav_job_status");
+		$table = $schema->createTable("{$prefix}dav_job_status");
 		$table->addColumn('id', Type::BIGINT, [
 			'autoincrement' => true,
 			'notnull' => true,

--- a/apps/dav/appinfo/Migrations/Version20190823065724.php
+++ b/apps/dav/appinfo/Migrations/Version20190823065724.php
@@ -40,7 +40,7 @@ class Version20190823065724 implements ISchemaMigration {
 	public function changeSchema(Schema $schema, array $options) {
 		$prefix = $options['tablePrefix'];
 
-		$table = $schema->getTable("${prefix}properties");
+		$table = $schema->getTable("{$prefix}properties");
 		$column = $table->getColumn('fileid');
 		/**
 		 * If the fileid column's notnull is set to false then

--- a/apps/dav/appinfo/Migrations/Version20200114181454.php
+++ b/apps/dav/appinfo/Migrations/Version20200114181454.php
@@ -29,7 +29,7 @@ use OCP\Migration\ISchemaMigration;
 class Version20200114181454 implements ISchemaMigration {
 	public function changeSchema(Schema $schema, array $options) {
 		$prefix = $options['tablePrefix'];
-		$table = $schema->getTable("${prefix}cards_properties");
+		$table = $schema->getTable("{$prefix}cards_properties");
 		// Check for existing index spanning these columns
 		foreach ($table->getIndexes() as $index) {
 			// Check if we have a matching index already

--- a/apps/dav/appinfo/Migrations/Version20210714123001.php
+++ b/apps/dav/appinfo/Migrations/Version20210714123001.php
@@ -30,8 +30,8 @@ class Version20210714123001 implements ISchemaMigration {
 	public function changeSchema(Schema $schema, array $options) {
 		$prefix = $options['tablePrefix'];
 
-		if ($schema->hasTable("${prefix}cards_properties")) {
-			$cardsPropertiesTable = $schema->getTable("${prefix}cards_properties");
+		if ($schema->hasTable("{$prefix}cards_properties")) {
+			$cardsPropertiesTable = $schema->getTable("{$prefix}cards_properties");
 
 			$columnNames = ['addressbookid', 'name'];
 			if (!$cardsPropertiesTable->columnsAreIndexed($columnNames)) {

--- a/apps/dav/lib/DAV/Sharing/Backend.php
+++ b/apps/dav/lib/DAV/Sharing/Backend.php
@@ -185,7 +185,7 @@ class Backend {
 		while ($row = $result->fetch()) {
 			$p = $this->principalBackend->getPrincipalByPath($row['principaluri']);
 			$shares[]= [
-				'href' => "principal:${row['principaluri']}",
+				'href' => "principal:{$row['principaluri']}",
 				'commonName' => isset($p['{DAV:}displayname']) ? $p['{DAV:}displayname'] : '',
 				'status' => 1,
 				'readOnly' => $row['access'] == self::ACCESS_READ,

--- a/apps/federatedfilesharing/appinfo/Migrations/Version20170804201253.php
+++ b/apps/federatedfilesharing/appinfo/Migrations/Version20170804201253.php
@@ -11,7 +11,7 @@ class Version20170804201253 implements ISchemaMigration {
 	public function changeSchema(Schema $schema, array $options) {
 		$prefix = $options['tablePrefix'];
 
-		if ($schema->hasTable("${prefix}federated_reshares")) {
+		if ($schema->hasTable("{$prefix}federated_reshares")) {
 			$table = $schema->getTable("{$prefix}federated_reshares");
 
 			$shareIdColumn = $table->getColumn('share_id');

--- a/apps/federatedfilesharing/appinfo/Migrations/Version20190410160725.php
+++ b/apps/federatedfilesharing/appinfo/Migrations/Version20190410160725.php
@@ -30,7 +30,7 @@ class Version20190410160725 implements ISchemaMigration {
 	public function changeSchema(Schema $schema, array $options) {
 		$prefix = $options['tablePrefix'];
 
-		if ($schema->hasTable("${prefix}federated_reshares")) {
+		if ($schema->hasTable("{$prefix}federated_reshares")) {
 			$table = $schema->getTable("{$prefix}federated_reshares");
 			$remoteIdColumn = $table->getColumn('remote_id');
 			if ($remoteIdColumn && $remoteIdColumn->getType()->getName() !== Type::STRING) {

--- a/apps/files_sharing/appinfo/Migrations/Version20170804201253.php
+++ b/apps/files_sharing/appinfo/Migrations/Version20170804201253.php
@@ -11,7 +11,7 @@ class Version20170804201253 implements ISchemaMigration {
 	public function changeSchema(Schema $schema, array $options) {
 		$prefix = $options['tablePrefix'];
 
-		if ($schema->hasTable("${prefix}share_external")) {
+		if ($schema->hasTable("{$prefix}share_external")) {
 			$table = $schema->getTable("{$prefix}share_external");
 
 			$idColumn = $table->getColumn('id');

--- a/apps/files_sharing/appinfo/Migrations/Version20170830112305.php
+++ b/apps/files_sharing/appinfo/Migrations/Version20170830112305.php
@@ -29,8 +29,8 @@ class Version20170830112305 implements ISchemaMigration {
 	public function changeSchema(Schema $schema, array $options) {
 		$prefix = $options['tablePrefix'];
 
-		if ($schema->hasTable("${prefix}share")) {
-			$table = $schema->getTable("${prefix}share");
+		if ($schema->hasTable("{$prefix}share")) {
+			$table = $schema->getTable("{$prefix}share");
 			if (!$table->hasIndex('share_with_index')) {
 				$table->addIndex(['share_with'], 'share_with_index');
 			}

--- a/apps/files_sharing/appinfo/Migrations/Version20171115154900.php
+++ b/apps/files_sharing/appinfo/Migrations/Version20171115154900.php
@@ -29,8 +29,8 @@ class Version20171115154900 implements ISchemaMigration {
 	public function changeSchema(Schema $schema, array $options) {
 		$prefix = $options['tablePrefix'];
 
-		if ($schema->hasTable("${prefix}share")) {
-			$table = $schema->getTable("${prefix}share");
+		if ($schema->hasTable("{$prefix}share")) {
+			$table = $schema->getTable("{$prefix}share");
 			if (!$table->hasIndex('item_source_index')) {
 				$table->addIndex(['item_source'], 'item_source_index');
 			}

--- a/apps/files_sharing/appinfo/Migrations/Version20171215103657.php
+++ b/apps/files_sharing/appinfo/Migrations/Version20171215103657.php
@@ -35,8 +35,8 @@ class Version20171215103657 implements ISchemaMigration {
 
 		$prefix = $options['tablePrefix'];
 
-		if ($schema->hasTable("${prefix}share")) {
-			$table = $schema->getTable("${prefix}share");
+		if ($schema->hasTable("{$prefix}share")) {
+			$table = $schema->getTable("{$prefix}share");
 			if (!$table->hasIndex($indexName)) {
 				$table->addIndex($columns, $indexName);
 			}

--- a/apps/files_sharing/appinfo/Migrations/Version20190426123324.php
+++ b/apps/files_sharing/appinfo/Migrations/Version20190426123324.php
@@ -29,7 +29,7 @@ use OCP\Migration\ISchemaMigration;
 class Version20190426123324 implements ISchemaMigration {
 	public function changeSchema(Schema $schema, array $options) {
 		$prefix = $options['tablePrefix'];
-		if ($schema->hasTable("${prefix}share_external")) {
+		if ($schema->hasTable("{$prefix}share_external")) {
 			$table = $schema->getTable("{$prefix}share_external");
 			$remoteIdColumn = $table->getColumn('remote_id');
 			if ($remoteIdColumn && $remoteIdColumn->getType()->getName() !== Type::STRING) {

--- a/apps/files_sharing/appinfo/Migrations/Version20200504211654.php
+++ b/apps/files_sharing/appinfo/Migrations/Version20200504211654.php
@@ -12,8 +12,8 @@ class Version20200504211654 implements ISchemaMigration {
 	public function changeSchema(Schema $schema, array $options) {
 		$prefix = $options['tablePrefix'];
 
-		if ($schema->hasTable("${prefix}share_external")) {
-			$table = $schema->getTable("${prefix}share_external");
+		if ($schema->hasTable("{$prefix}share_external")) {
+			$table = $schema->getTable("{$prefix}share_external");
 
 			if (!$table->hasColumn('lastscan')) {
 				$table->addColumn(

--- a/apps/files_sharing/appinfo/Migrations/Version20200823121322.php
+++ b/apps/files_sharing/appinfo/Migrations/Version20200823121322.php
@@ -29,7 +29,7 @@ use OCP\Migration\ISchemaMigration;
 class Version20200823121322 implements ISchemaMigration {
 	public function changeSchema(Schema $schema, array $options) {
 		$prefix = $options['tablePrefix'];
-		if ($schema->hasTable("${prefix}share_external")) {
+		if ($schema->hasTable("{$prefix}share_external")) {
 			$table = $schema->getTable("{$prefix}share_external");
 			$nameColumn = $table->getColumn('name');
 			if ($nameColumn && $nameColumn->getLength() !== 255) {

--- a/apps/files_trashbin/appinfo/Migrations/Version20170804201253.php
+++ b/apps/files_trashbin/appinfo/Migrations/Version20170804201253.php
@@ -11,7 +11,7 @@ class Version20170804201253 implements ISchemaMigration {
 	public function changeSchema(Schema $schema, array $options) {
 		$prefix = $options['tablePrefix'];
 
-		if ($schema->hasTable("${prefix}files_trash")) {
+		if ($schema->hasTable("{$prefix}files_trash")) {
 			$table = $schema->getTable("{$prefix}files_trash");
 
 			$idColumn = $table->getColumn('auto_id');

--- a/core/Migrations/Version20170101010100.php
+++ b/core/Migrations/Version20170101010100.php
@@ -31,8 +31,8 @@ class Version20170101010100 implements ISchemaMigration {
 	public function changeSchema(Schema $schema, array $options) {
 		$prefix = $options['tablePrefix'];
 
-		if (!$schema->hasTable("${prefix}addressbookchanges")) {
-			$addressBookChangesTable = $schema->createTable("${prefix}addressbookchanges");
+		if (!$schema->hasTable("{$prefix}addressbookchanges")) {
+			$addressBookChangesTable = $schema->createTable("{$prefix}addressbookchanges");
 
 			$addressBookChangesTable->addColumn(
 				'id',
@@ -83,8 +83,8 @@ class Version20170101010100 implements ISchemaMigration {
 			$addressBookChangesTable->addIndex(['addressbookid', 'synctoken'], 'addressbookid_synctoken');
 		}
 
-		if (!$schema->hasTable("${prefix}addressbooks")) {
-			$addressBooksTable = $schema->createTable("${prefix}addressbooks");
+		if (!$schema->hasTable("{$prefix}addressbooks")) {
+			$addressBooksTable = $schema->createTable("{$prefix}addressbooks");
 
 			$addressBooksTable->addColumn(
 				'id',
@@ -149,8 +149,8 @@ class Version20170101010100 implements ISchemaMigration {
 			$addressBooksTable->addUniqueIndex(['principaluri', 'uri'], 'addressbook_index');
 		}
 
-		if (!$schema->hasTable("${prefix}calendarchanges")) {
-			$calendarChangesTable = $schema->createTable("${prefix}calendarchanges");
+		if (!$schema->hasTable("{$prefix}calendarchanges")) {
+			$calendarChangesTable = $schema->createTable("{$prefix}calendarchanges");
 
 			$calendarChangesTable->addColumn(
 				'id',
@@ -195,8 +195,8 @@ class Version20170101010100 implements ISchemaMigration {
 			$calendarChangesTable->addIndex(['calendarid', 'synctoken'], 'calendarid_synctoken');
 		}
 
-		if (!$schema->hasTable("${prefix}calendarobjects")) {
-			$calendarObjectsTable = $schema->createTable("${prefix}calendarobjects");
+		if (!$schema->hasTable("{$prefix}calendarobjects")) {
+			$calendarObjectsTable = $schema->createTable("{$prefix}calendarobjects");
 
 			$calendarObjectsTable->addColumn(
 				'id',
@@ -307,8 +307,8 @@ class Version20170101010100 implements ISchemaMigration {
 			$calendarObjectsTable->addUniqueIndex(['calendarid', 'uri'], 'calobjects_index');
 		}
 
-		if (!$schema->hasTable("${prefix}calendars")) {
-			$calendarsTable = $schema->createTable("${prefix}calendars");
+		if (!$schema->hasTable("{$prefix}calendars")) {
+			$calendarsTable = $schema->createTable("{$prefix}calendars");
 
 			$calendarsTable->addColumn(
 				'id',
@@ -419,8 +419,8 @@ class Version20170101010100 implements ISchemaMigration {
 			$calendarsTable->addUniqueIndex(['principaluri', 'uri'], 'calendars_index');
 		}
 
-		if (!$schema->hasTable("${prefix}calendarsubscriptions")) {
-			$calendarSubscriptionsTable = $schema->createTable("${prefix}calendarsubscriptions");
+		if (!$schema->hasTable("{$prefix}calendarsubscriptions")) {
+			$calendarSubscriptionsTable = $schema->createTable("{$prefix}calendarsubscriptions");
 
 			$calendarSubscriptionsTable->addColumn(
 				'id',
@@ -542,8 +542,8 @@ class Version20170101010100 implements ISchemaMigration {
 			$calendarSubscriptionsTable->addUniqueIndex(['principaluri', 'uri'], 'calsub_index');
 		}
 
-		if (!$schema->hasTable("${prefix}cards")) {
-			$cardsTable = $schema->createTable("${prefix}cards");
+		if (!$schema->hasTable("{$prefix}cards")) {
+			$cardsTable = $schema->createTable("{$prefix}cards");
 
 			$cardsTable->addColumn(
 				'id',
@@ -613,8 +613,8 @@ class Version20170101010100 implements ISchemaMigration {
 			$cardsTable->setPrimaryKey(['id']);
 		}
 
-		if (!$schema->hasTable("${prefix}cards_properties")) {
-			$cardsPropertiesTable = $schema->createTable("${prefix}cards_properties");
+		if (!$schema->hasTable("{$prefix}cards_properties")) {
+			$cardsPropertiesTable = $schema->createTable("{$prefix}cards_properties");
 
 			$cardsPropertiesTable->addColumn(
 				'id',
@@ -677,8 +677,8 @@ class Version20170101010100 implements ISchemaMigration {
 			$cardsPropertiesTable->addIndex(['cardid'], 'card_contactid_index');
 		}
 
-		if (!$schema->hasTable("${prefix}comments")) {
-			$commentsTable = $schema->createTable("${prefix}comments");
+		if (!$schema->hasTable("{$prefix}comments")) {
+			$commentsTable = $schema->createTable("{$prefix}comments");
 
 			$commentsTable->addColumn(
 				'id',
@@ -797,8 +797,8 @@ class Version20170101010100 implements ISchemaMigration {
 			$commentsTable->addIndex(['parent_id'], 'comments_parent_id_index');
 		}
 
-		if (!$schema->hasTable("${prefix}comments_read_markers")) {
-			$commentsReadMarkersTable = $schema->createTable("${prefix}comments_read_markers");
+		if (!$schema->hasTable("{$prefix}comments_read_markers")) {
+			$commentsReadMarkersTable = $schema->createTable("{$prefix}comments_read_markers");
 
 			$commentsReadMarkersTable->addColumn(
 				'user_id',
@@ -840,8 +840,8 @@ class Version20170101010100 implements ISchemaMigration {
 			$commentsReadMarkersTable->addIndex(['object_type', 'object_id'], 'comments_marker_object_index');
 		}
 
-		if (!$schema->hasTable("${prefix}credentials")) {
-			$credentialsTable = $schema->createTable("${prefix}credentials");
+		if (!$schema->hasTable("{$prefix}credentials")) {
+			$credentialsTable = $schema->createTable("{$prefix}credentials");
 
 			$credentialsTable->addColumn(
 				'user',
@@ -872,8 +872,8 @@ class Version20170101010100 implements ISchemaMigration {
 			$credentialsTable->addIndex(['user'], 'credentials_user');
 		}
 
-		if (!$schema->hasTable("${prefix}dav_shares")) {
-			$davSharesTable = $schema->createTable("${prefix}dav_shares");
+		if (!$schema->hasTable("{$prefix}dav_shares")) {
+			$davSharesTable = $schema->createTable("{$prefix}dav_shares");
 
 			$davSharesTable->addColumn(
 				'id',
@@ -926,8 +926,8 @@ class Version20170101010100 implements ISchemaMigration {
 			$davSharesTable->addUniqueIndex(['principaluri', 'resourceid', 'type'], 'dav_shares_index');
 		}
 
-		if (!$schema->hasTable("${prefix}mounts")) {
-			$mountsTable = $schema->createTable("${prefix}mounts");
+		if (!$schema->hasTable("{$prefix}mounts")) {
+			$mountsTable = $schema->createTable("{$prefix}mounts");
 
 			$mountsTable->addColumn(
 				'id',
@@ -971,8 +971,8 @@ class Version20170101010100 implements ISchemaMigration {
 			$mountsTable->addIndex(['user_id'], 'mounts_user_index');
 		}
 
-		if (!$schema->hasTable("${prefix}schedulingobjects")) {
-			$schedulingObjectsTable = $schema->createTable("${prefix}schedulingobjects");
+		if (!$schema->hasTable("{$prefix}schedulingobjects")) {
+			$schedulingObjectsTable = $schema->createTable("{$prefix}schedulingobjects");
 
 			$schedulingObjectsTable->addColumn(
 				'id',
@@ -1044,8 +1044,8 @@ class Version20170101010100 implements ISchemaMigration {
 			$schedulingObjectsTable->setPrimaryKey(['id']);
 		}
 
-		if (!$schema->hasTable("${prefix}systemtag")) {
-			$systemTagTable = $schema->createTable("${prefix}systemtag");
+		if (!$schema->hasTable("{$prefix}systemtag")) {
+			$systemTagTable = $schema->createTable("{$prefix}systemtag");
 
 			$systemTagTable->addColumn(
 				'id',
@@ -1086,8 +1086,8 @@ class Version20170101010100 implements ISchemaMigration {
 			$systemTagTable->addUniqueIndex(['name', 'visibility', 'editable'], 'tag_ident');
 		}
 
-		if (!$schema->hasTable("${prefix}systemtag_object_mapping")) {
-			$systemTagObjectMappingTable = $schema->createTable("${prefix}systemtag_object_mapping");
+		if (!$schema->hasTable("{$prefix}systemtag_object_mapping")) {
+			$systemTagObjectMappingTable = $schema->createTable("{$prefix}systemtag_object_mapping");
 
 			$systemTagObjectMappingTable->addColumn(
 				'objectid',
@@ -1120,12 +1120,12 @@ class Version20170101010100 implements ISchemaMigration {
 			$systemTagObjectMappingTable->addUniqueIndex(['objecttype', 'objectid', 'systemtagid'], 'mapping');
 		}
 
-		if ($schema->hasTable("${prefix}file_map")) {
-			$schema->dropTable("${prefix}file_map");
+		if ($schema->hasTable("{$prefix}file_map")) {
+			$schema->dropTable("{$prefix}file_map");
 		}
 
-		if ($schema->hasTable("${prefix}filecache")) {
-			$fileCacheTable = $schema->getTable("${prefix}filecache");
+		if ($schema->hasTable("{$prefix}filecache")) {
+			$fileCacheTable = $schema->getTable("{$prefix}filecache");
 
 			if (!$fileCacheTable->hasColumn('checksum')) {
 				$fileCacheTable->addColumn(
@@ -1140,8 +1140,8 @@ class Version20170101010100 implements ISchemaMigration {
 			}
 		}
 
-		if ($schema->hasTable("${prefix}share")) {
-			$shareTable = $schema->getTable("${prefix}share");
+		if ($schema->hasTable("{$prefix}share")) {
+			$shareTable = $schema->getTable("{$prefix}share");
 
 			if (!$shareTable->hasColumn('uid_initiator')) {
 				$shareTable->addColumn(

--- a/core/Migrations/Version20170101215145.php
+++ b/core/Migrations/Version20170101215145.php
@@ -13,8 +13,8 @@ class Version20170101215145 implements ISchemaMigration {
 	public function changeSchema(Schema $schema, array $options) {
 		$prefix = $options['tablePrefix'];
 
-		if (!$schema->hasTable("${prefix}authtoken")) {
-			$authTokenTable = $schema->createTable("${prefix}authtoken");
+		if (!$schema->hasTable("{$prefix}authtoken")) {
+			$authTokenTable = $schema->createTable("{$prefix}authtoken");
 
 			$authTokenTable->addColumn(
 				'id',
@@ -111,8 +111,8 @@ class Version20170101215145 implements ISchemaMigration {
 			$authTokenTable->addUniqueIndex(['token'], 'authtoken_token_index');
 		}
 
-		if (!$schema->hasTable("${prefix}systemtag_group")) {
-			$systemTagGroupTable = $schema->createTable("${prefix}systemtag_group");
+		if (!$schema->hasTable("{$prefix}systemtag_group")) {
+			$systemTagGroupTable = $schema->createTable("{$prefix}systemtag_group");
 
 			$systemTagGroupTable->addColumn(
 				'gid',
@@ -136,8 +136,8 @@ class Version20170101215145 implements ISchemaMigration {
 			$systemTagGroupTable->setPrimaryKey(['gid', 'systemtagid']);
 		}
 
-		if ($schema->hasTable("${prefix}jobs")) {
-			$jobsTable = $schema->getTable("${prefix}jobs");
+		if ($schema->hasTable("{$prefix}jobs")) {
+			$jobsTable = $schema->getTable("{$prefix}jobs");
 
 			if (!$jobsTable->hasColumn('last_checked')) {
 				$jobsTable->addColumn(
@@ -162,8 +162,8 @@ class Version20170101215145 implements ISchemaMigration {
 			}
 		}
 
-		if ($schema->hasTable("${prefix}calendarobjects")) {
-			$calendarObjectsTable = $schema->getTable("${prefix}calendarobjects");
+		if ($schema->hasTable("{$prefix}calendarobjects")) {
+			$calendarObjectsTable = $schema->getTable("{$prefix}calendarobjects");
 
 			if (!$calendarObjectsTable->hasColumn('classification')) {
 				$calendarObjectsTable->addColumn(
@@ -193,8 +193,8 @@ class Version20170101215145 implements ISchemaMigration {
 			}
 		}
 
-		if ($schema->hasTable("${prefix}calendars")) {
-			$calendarsTable = $schema->getTable("${prefix}calendars");
+		if ($schema->hasTable("{$prefix}calendars")) {
+			$calendarsTable = $schema->getTable("{$prefix}calendars");
 
 			if ($calendarsTable->hasColumn('components')) {
 				$components = $calendarsTable->getColumn('components');
@@ -202,8 +202,8 @@ class Version20170101215145 implements ISchemaMigration {
 			}
 		}
 
-		if ($schema->hasTable("${prefix}calendarsubscriptions")) {
-			$calendarSubscriptionsTable = $schema->getTable("${prefix}calendarsubscriptions");
+		if ($schema->hasTable("{$prefix}calendarsubscriptions")) {
+			$calendarSubscriptionsTable = $schema->getTable("{$prefix}calendarsubscriptions");
 
 			if ($calendarSubscriptionsTable->hasColumn('lastmodified')) {
 				$lastModified = $calendarSubscriptionsTable->getColumn('lastmodified');

--- a/core/Migrations/Version20170111103310.php
+++ b/core/Migrations/Version20170111103310.php
@@ -30,8 +30,8 @@ use OCP\Migration\ISchemaMigration;
 class Version20170111103310 implements ISchemaMigration {
 	public function changeSchema(Schema $schema, array $options) {
 		$prefix = $options['tablePrefix'];
-		if (!$schema->hasTable("${prefix}external_mounts")) {
-			$table = $schema->createTable("${prefix}external_mounts");
+		if (!$schema->hasTable("{$prefix}external_mounts")) {
+			$table = $schema->createTable("{$prefix}external_mounts");
 			$table->addColumn('mount_id', 'bigint', [
 				'autoincrement' => true,
 				'notnull' => true,
@@ -62,8 +62,8 @@ class Version20170111103310 implements ISchemaMigration {
 			$table->setPrimaryKey(['mount_id']);
 		}
 
-		if (!$schema->hasTable("${prefix}external_applicable")) {
-			$table = $schema->createTable("${prefix}external_applicable");
+		if (!$schema->hasTable("{$prefix}external_applicable")) {
+			$table = $schema->createTable("{$prefix}external_applicable");
 			$table->addColumn('applicable_id', 'bigint', [
 				'autoincrement' => true,
 				'notnull' => true,
@@ -89,8 +89,8 @@ class Version20170111103310 implements ISchemaMigration {
 			$table->addUniqueIndex(['type', 'value', 'mount_id'], 'applicable_type_value_mount');
 		}
 
-		if (!$schema->hasTable("${prefix}external_config")) {
-			$table = $schema->createTable("${prefix}external_config");
+		if (!$schema->hasTable("{$prefix}external_config")) {
+			$table = $schema->createTable("{$prefix}external_config");
 			$table->addColumn('config_id', 'bigint', [
 				'autoincrement' => true,
 				'notnull' => true,
@@ -114,8 +114,8 @@ class Version20170111103310 implements ISchemaMigration {
 			$table->addUniqueIndex(['mount_id', 'key'], 'config_mount_key');
 		}
 
-		if (!$schema->hasTable("${prefix}external_options")) {
-			$table = $schema->createTable("${prefix}external_options");
+		if (!$schema->hasTable("{$prefix}external_options")) {
+			$table = $schema->createTable("{$prefix}external_options");
 			$table->addColumn('option_id', 'bigint', [
 				'autoincrement' => true,
 				'notnull' => true,

--- a/core/Migrations/Version20170213215145.php
+++ b/core/Migrations/Version20170213215145.php
@@ -11,8 +11,8 @@ use OCP\Migration\ISchemaMigration;
 class Version20170213215145 implements ISchemaMigration {
 	public function changeSchema(Schema $schema, array $options) {
 		$prefix = $options['tablePrefix'];
-		if ($schema->hasTable("${prefix}jobs")) {
-			$table = $schema->getTable("${prefix}jobs");
+		if ($schema->hasTable("{$prefix}jobs")) {
+			$table = $schema->getTable("{$prefix}jobs");
 			if (!$table->hasColumn('execution_duration')) {
 				$table->addColumn('execution_duration', 'integer', [
 					'notnull' => true,

--- a/core/Migrations/Version20170315173825.php
+++ b/core/Migrations/Version20170315173825.php
@@ -29,8 +29,8 @@ use OCP\Migration\ISchemaMigration;
 class Version20170315173825 implements ISchemaMigration {
 	public function changeSchema(Schema $schema, array $options) {
 		$prefix = $options['tablePrefix'];
-		if (!$schema->hasTable("${prefix}share")) {
-			$table = $schema->createTable("${prefix}share");
+		if (!$schema->hasTable("{$prefix}share")) {
+			$table = $schema->createTable("{$prefix}share");
 			$table->addColumn('id', 'integer', [
 				'autoincrement' => true,
 				'notnull' => true,

--- a/core/Migrations/Version20170320173955.php
+++ b/core/Migrations/Version20170320173955.php
@@ -29,7 +29,7 @@ use OCP\Migration\ISchemaMigration;
 class Version20170320173955 implements ISchemaMigration {
 	public function changeSchema(Schema $schema, array $options) {
 		$prefix = $options['tablePrefix'];
-		$table = $schema->getTable("${prefix}share");
+		$table = $schema->getTable("{$prefix}share");
 
 		// Arbitrary name for the share
 		$table->addColumn('share_name', 'string', [

--- a/core/Migrations/Version20170516100103.php
+++ b/core/Migrations/Version20170516100103.php
@@ -32,8 +32,8 @@ use OCP\Migration\ISchemaMigration;
 class Version20170516100103 implements ISchemaMigration {
 	public function changeSchema(Schema $schema, array $options) {
 		$prefix = $options['tablePrefix'];
-		if (!$schema->hasTable("${prefix}account_terms")) {
-			$table = $schema->createTable("${prefix}account_terms");
+		if (!$schema->hasTable("{$prefix}account_terms")) {
+			$table = $schema->createTable("{$prefix}account_terms");
 
 			$table->addColumn('id', Type::BIGINT, [
 				'autoincrement' => true,
@@ -57,8 +57,8 @@ class Version20170516100103 implements ISchemaMigration {
 			$table->addIndex(['term'], 'term_index');
 		}
 
-		if ($schema->hasTable("${prefix}accounts")) {
-			$table = $schema->getTable("${prefix}accounts");
+		if ($schema->hasTable("{$prefix}accounts")) {
+			$table = $schema->getTable("{$prefix}accounts");
 			if (!$table->hasIndex('lower_user_id_index')) {
 				$table->addUniqueIndex(['lower_user_id'], 'lower_user_id_index');
 			}

--- a/core/Migrations/Version20170711191432.php
+++ b/core/Migrations/Version20170711191432.php
@@ -12,7 +12,7 @@ class Version20170711191432 implements ISchemaMigration {
 	public function changeSchema(Schema $schema, array $options) {
 		$prefix = $options['tablePrefix'];
 
-		if ($schema->hasTable("${prefix}share")) {
+		if ($schema->hasTable("{$prefix}share")) {
 			$table = $schema->getTable("{$prefix}share");
 
 			$fileSourceColumn = $table->getColumn('file_source');

--- a/core/Migrations/Version20170804201253.php
+++ b/core/Migrations/Version20170804201253.php
@@ -12,10 +12,10 @@ use OCP\Migration\ISchemaMigration;
 class Version20170804201253 implements ISchemaMigration {
 	public function changeSchema(Schema $schema, array $options) {
 		$prefix = $options['tablePrefix'];
-		$this->updateToBigint($schema, "${prefix}mounts", "root_id");
-		$this->updateToBigint($schema, "${prefix}filecache", "fileid");
-		$this->updateToBigint($schema, "${prefix}filecache", "parent");
-		$this->updateToBigint($schema, "${prefix}vcategory_to_object", "objid");
+		$this->updateToBigint($schema, "{$prefix}mounts", "root_id");
+		$this->updateToBigint($schema, "{$prefix}filecache", "fileid");
+		$this->updateToBigint($schema, "{$prefix}filecache", "parent");
+		$this->updateToBigint($schema, "{$prefix}vcategory_to_object", "objid");
 	}
 
 	/**

--- a/core/Migrations/Version20170928120000.php
+++ b/core/Migrations/Version20170928120000.php
@@ -11,7 +11,7 @@ use OCP\Migration\ISchemaMigration;
 class Version20170928120000 implements ISchemaMigration {
 	public function changeSchema(Schema $schema, array $options) {
 		$prefix = $options['tablePrefix'];
-		$table = $schema->getTable("${prefix}filecache");
+		$table = $schema->getTable("{$prefix}filecache");
 		foreach (['mtime','storage_mtime'] as $column) {
 			if ($table->getColumn($column)->getType()->getName() === Type::INTEGER) {
 				$table->getColumn($column)->setType(Type::getType(Type::BIGINT));

--- a/core/Migrations/Version20181220085457.php
+++ b/core/Migrations/Version20181220085457.php
@@ -32,8 +32,8 @@ class Version20181220085457 implements ISchemaMigration {
 	public function changeSchema(Schema $schema, array $options) {
 		$prefix = $options['tablePrefix'];
 
-		if ($schema->hasTable("${prefix}share")) {
-			$shareTable = $schema->getTable("${prefix}share");
+		if ($schema->hasTable("{$prefix}share")) {
+			$shareTable = $schema->getTable("{$prefix}share");
 
 			if (!$shareTable->hasColumn('attributes')) {
 				$shareTable->addColumn(

--- a/core/Migrations/Version20190125162909.php
+++ b/core/Migrations/Version20190125162909.php
@@ -31,8 +31,8 @@ class Version20190125162909 implements ISchemaMigration {
 	public function changeSchema(Schema $schema, array $options) {
 		$prefix = $options['tablePrefix'];
 
-		if ($schema->hasTable("${prefix}authtoken")) {
-			$authTokenTable = $schema->getTable("${prefix}authtoken");
+		if ($schema->hasTable("{$prefix}authtoken")) {
+			$authTokenTable = $schema->getTable("{$prefix}authtoken");
 
 			$loginNameColumn = $authTokenTable->getColumn('login_name');
 			$loginNameColumn->setLength(255);

--- a/core/Migrations/Version20230105001100.php
+++ b/core/Migrations/Version20230105001100.php
@@ -9,8 +9,8 @@ class Version20230105001100 implements ISchemaMigration {
 	public function changeSchema(Schema $schema, array $options) {
 		$prefix = $options['tablePrefix'];
 
-		if ($schema->hasTable("${prefix}calendars")) {
-			$calendarsTable = $schema->getTable("${prefix}calendars");
+		if ($schema->hasTable("{$prefix}calendars")) {
+			$calendarsTable = $schema->getTable("{$prefix}calendars");
 
 			if ($calendarsTable->hasColumn('components')) {
 				$components = $calendarsTable->getColumn('components');

--- a/core/Migrations/Version20230120101715.php
+++ b/core/Migrations/Version20230120101715.php
@@ -31,7 +31,7 @@ use OCP\Migration\ISchemaMigration;
 class Version20230120101715 implements ISchemaMigration {
 	public function changeSchema(Schema $schema, array $options) {
 		$prefix = $options['tablePrefix'];
-		$accountsTable = $schema->getTable("${prefix}accounts");
+		$accountsTable = $schema->getTable("{$prefix}accounts");
 			  
 		if (!$accountsTable->hasColumn('creation_time')) {
 			$accountsTable->addColumn('creation_time', Type::INTEGER, [

--- a/lib/base.php
+++ b/lib/base.php
@@ -1020,7 +1020,7 @@ class OC {
 			$crashDir = self::$config->getValue('crashdirectory', $dataDir);
 		}
 
-		$filename = "${crashDir}/crash-" . \date('Y-m-d') . '.log';
+		$filename = "{$crashDir}/crash-" . \date('Y-m-d') . '.log';
 
 		$date = \date('c');
 		$currentEntryId = \uniqid(\md5($date), true);

--- a/lib/private/App/AppManager.php
+++ b/lib/private/App/AppManager.php
@@ -414,7 +414,7 @@ class AppManager implements IAppManager {
 		$stat = \stat($path);
 		if ($stat) {
 			// ok, file still exists
-			return "${stat['mtime']}|${stat['ino']}|${stat['dev']}|${stat['size']}";
+			return "{$stat['mtime']}|{$stat['ino']}|{$stat['dev']}|{$stat['size']}";
 		}
 		return null;
 	}

--- a/lib/private/L10N/L10N.php
+++ b/lib/private/L10N/L10N.php
@@ -97,16 +97,16 @@ class L10N implements IL10N {
 	 *
 	 */
 	public function n($text_singular, $text_plural, $count, $parameters = []) {
-		$identifier = "_${text_singular}_::_${text_plural}_";
+		$identifier = "_{$text_singular}_::_{$text_plural}_";
 		if (isset($this->translations[$identifier])) {
 			return (string) new \OC_L10N_String($this, $identifier, $parameters, $count);
-		} else {
-			if ($count === 1) {
-				return (string) new \OC_L10N_String($this, $text_singular, $parameters, $count);
-			} else {
-				return (string) new \OC_L10N_String($this, $text_plural, $parameters, $count);
-			}
 		}
+
+		if ($count === 1) {
+			return (string) new \OC_L10N_String($this, $text_singular, $parameters, $count);
+		}
+
+		return (string) new \OC_L10N_String($this, $text_plural, $parameters, $count);
 	}
 
 	/**

--- a/lib/private/Repair/Apps.php
+++ b/lib/private/Repair/Apps.php
@@ -393,8 +393,8 @@ class Apps implements IRepairStep {
 	 */
 	private function changeSchema(Schema $schema, array $options) {
 		$prefix = $options['tablePrefix'];
-		if ($schema->hasTable("${prefix}jobs")) {
-			$jobsTable = $schema->getTable("${prefix}jobs");
+		if ($schema->hasTable("{$prefix}jobs")) {
+			$jobsTable = $schema->getTable("{$prefix}jobs");
 
 			if (!$jobsTable->hasColumn('last_checked')) {
 				$jobsTable->addColumn(

--- a/lib/private/Security/SignedUrl/Verifier.php
+++ b/lib/private/Security/SignedUrl/Verifier.php
@@ -75,7 +75,7 @@ class Verifier {
 			return false;
 		}
 		$date = new \DateTime($urlDate);
-		$date->add(new \DateInterval("PT${urlExpires}S"));
+		$date->add(new \DateInterval("PT{$urlExpires}S"));
 		if (!($date < $this->now)) {
 			return true;
 		}

--- a/lib/private/Setup/MySQL.php
+++ b/lib/private/Setup/MySQL.php
@@ -68,7 +68,7 @@ class MySQL extends AbstractDatabase {
 			$user = $this->dbUser;
 			//we can't use OC_DB functions here because we need to connect as the administrative user.
 			$characterSet = $this->config->getSystemValue('mysql.utf8mb4', false) ? 'utf8mb4' : 'utf8';
-			$query = "CREATE DATABASE IF NOT EXISTS `$name` CHARACTER SET $characterSet COLLATE ${characterSet}_bin;";
+			$query = "CREATE DATABASE IF NOT EXISTS `$name` CHARACTER SET $characterSet COLLATE {$characterSet}_bin;";
 			$connection->executeUpdate($query);
 		} catch (\Exception $ex) {
 			$this->logger->error('Database creation failed: {error}', [

--- a/tests/acceptance/features/bootstrap/NotificationsCoreContext.php
+++ b/tests/acceptance/features/bootstrap/NotificationsCoreContext.php
@@ -245,7 +245,7 @@ class NotificationsCoreContext implements Context {
 			Assert::assertArrayHasKey(
 				$notification['key'],
 				$response['ocs']['data'],
-				"Could not find notification with key '${notification['key']}' matching '${notification['regex']}', in " . __METHOD__
+				"Could not find notification with key '{$notification['key']}' matching '{$notification['regex']}', in " . __METHOD__
 			);
 			if ($regex) {
 				$value = $this->featureContext->substituteInLineCodes(

--- a/tests/acceptance/features/bootstrap/OccContext.php
+++ b/tests/acceptance/features/bootstrap/OccContext.php
@@ -1918,7 +1918,7 @@ class OccContext implements Context {
 				$createdLocalStorage,
 				"'"
 				. \implode(', ', $createdLocalStorage)
-				. "' does not contain '${expectedStorageEntry['localStorage']}' "
+				. "' does not contain '{$expectedStorageEntry['localStorage']}' "
 				. __METHOD__
 			);
 		}
@@ -1976,7 +1976,7 @@ class OccContext implements Context {
 				$backendTypesEntry['backend-type'],
 				$keys,
 				__METHOD__
-				. " ${backendTypesEntry['backend-type']} is not contained in '"
+				. " {$backendTypesEntry['backend-type']} is not contained in '"
 				. \implode(', ', $keys)
 				. "' but was expected to be."
 			);
@@ -2010,7 +2010,7 @@ class OccContext implements Context {
 				$backendsEntry['backends'],
 				$keys,
 				__METHOD__
-				. " ${backendsEntry['backends']} is not contained in '"
+				. " {$backendsEntry['backends']} is not contained in '"
 				. \implode(', ', $keys)
 				. "' but was expected to be."
 			);
@@ -2044,7 +2044,7 @@ class OccContext implements Context {
 				$backendKeysEntry['backend-keys'],
 				$keys,
 				__METHOD__
-				. " ${backendKeysEntry['backend-keys']} is not contained in '"
+				. " {$backendKeysEntry['backend-keys']} is not contained in '"
 				. \implode(', ', $keys)
 				. "' but was expected to be."
 			);

--- a/tests/acceptance/features/bootstrap/OccUsersGroupsContext.php
+++ b/tests/acceptance/features/bootstrap/OccUsersGroupsContext.php
@@ -604,13 +604,13 @@ class OccUsersGroupsContext implements Context {
 				$row['uid'],
 				$result,
 				__METHOD__
-				. " Failed asserting that key '${row['uid']}' exists"
+				. " Failed asserting that key '{$row['uid']}' exists"
 			);
 			Assert::assertContains(
 				$row['display name'],
 				$result,
 				__METHOD__
-				. " Failed asserting that ${row['display name']} exists"
+				. " Failed asserting that {$row['display name']} exists"
 			);
 		}
 	}
@@ -682,7 +682,7 @@ class OccUsersGroupsContext implements Context {
 				$row['group'],
 				$lastOutputGroups,
 				__METHOD__
-				. " Failed asserting that '${row['group']}' exists in '"
+				. " Failed asserting that '{$row['group']}' exists in '"
 				. \implode(', ', $lastOutputGroups)
 				. "'"
 			);
@@ -778,7 +778,7 @@ class OccUsersGroupsContext implements Context {
 			$noOfUsers,
 			$actualUsers[1],
 			__METHOD__
-			. " Expected number of users to be '$noOfUsers' but got '${actualUsers[1]}'"
+			. " Expected number of users to be '$noOfUsers' but got '{$actualUsers[1]}'"
 		);
 	}
 

--- a/tests/acceptance/features/bootstrap/Sharing.php
+++ b/tests/acceptance/features/bootstrap/Sharing.php
@@ -2914,7 +2914,7 @@ trait Sharing {
 							$expectedElementsArray['path'],
 							(string) $elementResponded->path[0],
 							__METHOD__
-							. " Expected '${expectedElementsArray['path']}' but got '"
+							. " Expected '{$expectedElementsArray['path']}' but got '"
 							. $elementResponded->path[0]
 							. "'"
 						);
@@ -2922,7 +2922,7 @@ trait Sharing {
 							$expectedElementsArray['permissions'],
 							(string) $elementResponded->permissions[0],
 							__METHOD__
-							. " Expected '${expectedElementsArray['permissions']}' but got '"
+							. " Expected '{$expectedElementsArray['permissions']}' but got '"
 							. $elementResponded->permissions[0]
 							. "'"
 						);

--- a/tests/acceptance/features/bootstrap/TagsContext.php
+++ b/tests/acceptance/features/bootstrap/TagsContext.php
@@ -633,7 +633,7 @@ class TagsContext implements Context {
 			$tagData = $this->requestTagByDisplayName($user, $row['name']);
 			if ($tagData === null) {
 				Assert::fail(
-					"tag ${row['name']} is not in propfind answer"
+					"tag {$row['name']} is not in propfind answer"
 				);
 			} else {
 				$this->assertTypeOfTag($tagData, $row['type']);
@@ -1609,7 +1609,7 @@ class TagsContext implements Context {
 			}
 			if ($found === false) {
 				Assert::fail(
-					"tag ${row['name']} is not in propfind answer"
+					"tag {$row['name']} is not in propfind answer"
 				);
 			}
 		}

--- a/tests/lib/DateTimeFormatterTest.php
+++ b/tests/lib/DateTimeFormatterTest.php
@@ -155,8 +155,8 @@ class DateTimeFormatterTest extends TestCase {
 	public function formatDateTimeData() {
 		$narrowNoBreakSpace = "\xE2\x80\xAF";
 		return [
-			[1350129205, null, "October 13, 2012, 11:53:25${narrowNoBreakSpace}AM UTC"],
-			[1350129205, new \DateTimeZone('Europe/Berlin'), "October 13, 2012, 1:53:25${narrowNoBreakSpace}PM GMT+2"],
+			[1350129205, null, "October 13, 2012, 11:53:25{$narrowNoBreakSpace}AM UTC"],
+			[1350129205, new \DateTimeZone('Europe/Berlin'), "October 13, 2012, 1:53:25{$narrowNoBreakSpace}PM GMT+2"],
 		];
 	}
 

--- a/tests/lib/L10N/L10nTest.php
+++ b/tests/lib/L10N/L10nTest.php
@@ -91,27 +91,27 @@ class L10nTest extends TestCase {
 		$narrowNoBreakSpace = "\xE2\x80\xAF";
 		return [
 			// timestamp as string
-			["February 13, 2009, 11:31:30${narrowNoBreakSpace}PM UTC", 'en', 'datetime', '1234567890'],
+			["February 13, 2009, 11:31:30{$narrowNoBreakSpace}PM UTC", 'en', 'datetime', '1234567890'],
 			['13. Februar 2009, 23:31:30 UTC', 'de', 'datetime', '1234567890'],
 			['February 13, 2009', 'en', 'date', '1234567890'],
 			['13. Februar 2009', 'de', 'date', '1234567890'],
-			["11:31:30${narrowNoBreakSpace}PM UTC", 'en', 'time', '1234567890'],
+			["11:31:30{$narrowNoBreakSpace}PM UTC", 'en', 'time', '1234567890'],
 			['23:31:30 UTC', 'de', 'time', '1234567890'],
 
 			// timestamp as int
-			["February 13, 2009, 11:31:30${narrowNoBreakSpace}PM UTC", 'en', 'datetime', 1234567890],
+			["February 13, 2009, 11:31:30{$narrowNoBreakSpace}PM UTC", 'en', 'datetime', 1234567890],
 			['13. Februar 2009, 23:31:30 UTC', 'de', 'datetime', 1234567890],
 			['February 13, 2009', 'en', 'date', 1234567890],
 			['13. Februar 2009', 'de', 'date', 1234567890],
-			["11:31:30${narrowNoBreakSpace}PM UTC", 'en', 'time', 1234567890],
+			["11:31:30{$narrowNoBreakSpace}PM UTC", 'en', 'time', 1234567890],
 			['23:31:30 UTC', 'de', 'time', 1234567890],
 
 			// DateTime object
-			["February 13, 2009, 11:31:30${narrowNoBreakSpace}PM GMT+0", 'en', 'datetime', new DateTime('@1234567890')],
+			["February 13, 2009, 11:31:30{$narrowNoBreakSpace}PM GMT+0", 'en', 'datetime', new DateTime('@1234567890')],
 			['13. Februar 2009, 23:31:30 GMT+0', 'de', 'datetime', new DateTime('@1234567890')],
 			['February 13, 2009', 'en', 'date', new DateTime('@1234567890')],
 			['13. Februar 2009', 'de', 'date', new DateTime('@1234567890')],
-			["11:31:30${narrowNoBreakSpace}PM GMT+0", 'en', 'time', new DateTime('@1234567890')],
+			["11:31:30{$narrowNoBreakSpace}PM GMT+0", 'en', 'time', new DateTime('@1234567890')],
 			['23:31:30 GMT+0', 'de', 'time', new DateTime('@1234567890')],
 
 			// en_GB

--- a/tests/lib/UtilTest.php
+++ b/tests/lib/UtilTest.php
@@ -109,12 +109,12 @@ class UtilTest extends \Test\TestCase {
 	public function formatDateWithTZFromSessionData() {
 		$narrowNoBreakSpace = self::narrowNoBreakSpace;
 		return [
-			[3, "October 13, 2012, 2:53:25${narrowNoBreakSpace}PM GMT+3", 'Etc/GMT-3'],
-			[15, "October 13, 2012, 11:53:25${narrowNoBreakSpace}AM UTC", 'UTC'],
-			[-13, "October 13, 2012, 11:53:25${narrowNoBreakSpace}AM UTC", 'UTC'],
-			[9.5, "October 13, 2012, 9:23:25${narrowNoBreakSpace}PM GMT+9:30", 'Australia/Darwin'],
-			[-4.5, "October 13, 2012, 7:23:25${narrowNoBreakSpace}AM GMT-4:30", 'America/Caracas'],
-			[15.5, "October 13, 2012, 11:53:25${narrowNoBreakSpace}AM UTC", 'UTC'],
+			[3, "October 13, 2012, 2:53:25{$narrowNoBreakSpace}PM GMT+3", 'Etc/GMT-3'],
+			[15, "October 13, 2012, 11:53:25{$narrowNoBreakSpace}AM UTC", 'UTC'],
+			[-13, "October 13, 2012, 11:53:25{$narrowNoBreakSpace}AM UTC", 'UTC'],
+			[9.5, "October 13, 2012, 9:23:25{$narrowNoBreakSpace}PM GMT+9:30", 'Australia/Darwin'],
+			[-4.5, "October 13, 2012, 7:23:25{$narrowNoBreakSpace}AM GMT-4:30", 'America/Caracas'],
+			[15.5, "October 13, 2012, 11:53:25{$narrowNoBreakSpace}AM UTC", 'UTC'],
 		];
 	}
 


### PR DESCRIPTION
## Description
In preparation of php8.2 support - see https://php.watch/versions/8.2/$%7Bvar%7D-string-interpolation-deprecated

## How Has This Been Tested?
- :robot: 

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Database schema changes (next release will require increase of minor version instead of patch)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Technical debt
- [ ] Tests only (no source changes)

## Checklist:
<!-- Tick the checkboxes when done. -->
<!-- Raise documentation ticket in https://github.com/owncloud/documentation -->
- [ ] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 
- [ ] Changelog item, see [TEMPLATE](https://github.com/owncloud/core/blob/master/changelog/TEMPLATE)
