### PR TITLE
[tests-only] Skip changed repair step test on recently released oC10 versions

### DIFF
--- a/tests/acceptance/features/cliMain/maintenance.feature
+++ b/tests/acceptance/features/cliMain/maintenance.feature
@@ -5,7 +5,7 @@ Feature: Maintenance command
   I want to be able to maintain and repair my ownCloud installation
   So that I can run ownCloud smoothly
 
-
+  @skipOnOcV10.12 @skipOnOcV10.13.0 @skipOnOcV10.13.1
   Scenario: Repair steps should be listed correctly
     When the administrator list the repair steps using the occ command
     Then the command should have been successful


### PR DESCRIPTION
## Description
This test was adjusted in PR #40996 so we know that it will pass on oC10 core master, but not when run against existing releases such as 10.12 120.13.0 and 10.13.1. So skip it in those cases.

## Related Issue
- Fixes https://github.com/owncloud/user_ldap/issues/805

## How Has This Been Tested?
CI

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Database schema changes (next release will require increase of minor version instead of patch)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [ ] Tests only (no source changes)

## Checklist:
- [ ] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 
- [ ] Changelog item, see [TEMPLATE](https://github.com/owncloud/core/blob/master/changelog/TEMPLATE)
