### PR TITLE
[tests-only] Skip cleanup shared files preview test on recently released oc10 versions

### DIFF
--- a/tests/acceptance/features/cliTrashbin/previewsCleanup.feature
+++ b/tests/acceptance/features/cliTrashbin/previewsCleanup.feature
@@ -63,7 +63,7 @@ Feature: orphaned previews can be deleted
     Then the command should have been successful
     And the command output should contain the text '4 orphaned previews deleted'
 
-
+  @skipOnOcV10.12 @skipOnOcV10.13.0 @skipOnOcV10.13.1
   Scenario: the previews from shared files are cleaned up
     Given user "Brian" has been created with default attributes and without skeleton files
     And user "Brian" has uploaded file with content "text file zero" to "/textfile0.txt"


### PR DESCRIPTION
## Description
This test was adjusted in PR https://github.com/owncloud/core/pull/40974 so we know that it will pass on oC10 core master, but not when run against existing releases such as 10.12 120.13.0 and 10.13.1. So skip it in those cases.

Failed in user_ldap: https://drone.owncloud.com/owncloud/user_ldap/4724/113/15

## Related Issue

## How Has This Been Tested?


## Screenshots (if appropriate):

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Database schema changes (next release will require increase of minor version instead of patch)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [x] Tests only (no source changes)

## Checklist:
- [ ] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 
- [ ] Changelog item, see [TEMPLATE](https://github.com/owncloud/core/blob/master/changelog/TEMPLATE)
