### PR TITLE
Don't mount shares with failed underlying storages

### DIFF
--- a/apps/files_sharing/lib/MountProvider.php
+++ b/apps/files_sharing/lib/MountProvider.php
@@ -82,7 +82,7 @@ class MountProvider implements IMountProvider {
 		$mounts = [];
 		foreach ($superShares as $share) {
 			try {
-				$mounts[] = new SharedMount(
+				$shareMount = new SharedMount(
 					'\OCA\Files_Sharing\SharedStorage',
 					$mounts,
 					[
@@ -94,6 +94,13 @@ class MountProvider implements IMountProvider {
 					],
 					$storageFactory
 				);
+
+				$shareStorage = $shareMount->getStorage();
+				if ($shareStorage !== null && $shareStorage->getPermissions('') !== 0) {
+					// permissions = 0 implies that the underlying storage
+					// being shared isn't valid
+					$mounts[] = $shareMount;
+				}
 			} catch (\Exception $e) {
 				$this->logger->logException($e);
 				$this->logger->error('Error while trying to create shared mount');

--- a/changelog/unreleased/41014
+++ b/changelog/unreleased/41014
@@ -1,0 +1,12 @@
+Bugfix: Do not mount shared storage which are failing
+
+Some mounts use a shared storage, which points to a different storage.
+If the underlying storage is removed, the share mount was still being
+present as if the underlying storage could still be accessed. This was
+causing problems with the `occ files:remove-storage --show-candidates`
+command because the removed storage wasn't shown as possible candidate.
+
+Now, that share storage won't be mounted, and the underlying storage
+will be detected as a candidate to be removed with the command above.
+
+https://github.com/owncloud/core/pull/41014


### PR DESCRIPTION
<!--
Thanks for submitting a change to ownCloud!

This is the bug tracker for the Server component. Find other components at https://github.com/owncloud/core/blob/master/.github/CONTRIBUTING.md#guidelines

For fixing potential security issues please see https://owncloud.com/security/

To make it possible for us to get your change reviewed and merged please carefully fill out the requested information below.

Please note that any kind of change needs first be submitted to the master branch which holds the next version of ownCloud.

Please set the following labels:

- Set label "3 - To review" for review or "2 - Development" if the PR still has open tasks
- Assignment: assign to self
- Milestone: set the same as the ticket this PR fixes, or "development" by default
- Reviewers: pick at least one
-->

## Description
Share mounts with failed underlying storages won't be mounted. A common cause of such failure is the underlying storage has been removed or the sharer has been deleted.
This should help the `occ files:remove-storage --show-candidates` command to detect additional storages that should be removed.

## Related Issue
https://github.com/owncloud/enterprise/issues/6063

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?
Manually tested.
1. Setup a external storage and allow sharing in it
2. Share the external storage with another user
3. Check the new user can access to the storage through the share
4. Remove the external storage
5. The new user can't access to the share
6. The `occ files:remove-storage --show-candidates` now shows the external storage

Step 5 might be required in order for ownCloud to notice the unavailable storage.

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Database schema changes (next release will require increase of minor version instead of patch)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [ ] Tests only (no source changes)

## Checklist:
<!-- Tick the checkboxes when done. -->
<!-- Raise documentation ticket in https://github.com/owncloud/documentation -->
- [x] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 
- [ ] Changelog item, see [TEMPLATE](https://github.com/owncloud/core/blob/master/changelog/TEMPLATE)
