### PR TITLE
test: Patchwork\PHP\Shim\Normalizer is no longer used - we rely on php-intl

### DIFF
--- a/tests/lib/Files/Cache/CacheTest.php
+++ b/tests/lib/Files/Cache/CacheTest.php
@@ -503,60 +503,9 @@ class CacheTest extends TestCase {
 	}
 
 	/**
-	 * this test show the bug resulting if we have no normalizer installed
-	 */
-	public function testWithoutNormalizer() {
-		// folder name "Schön" with U+00F6 (normalized)
-		$folderWith00F6 = "\x53\x63\x68\xc3\xb6\x6e";
-
-		// folder name "Schön" with U+0308 (un-normalized)
-		$folderWith0308 = "\x53\x63\x68\x6f\xcc\x88\x6e";
-
-		/**
-		 * @var Cache | \PHPUnit\Framework\MockObject\MockObject $cacheMock
-		 */
-		$cacheMock = $this->getMockBuilder('\OC\Files\Cache\Cache')
-			->setMethods(['normalize'])
-			->setConstructorArgs([$this->storage])
-			->getMock();
-
-		$cacheMock->expects($this->any())
-			->method('normalize')
-			->will($this->returnArgument(0));
-
-		$data = ['size' => 100, 'mtime' => 50, 'mimetype' => 'httpd/unix-directory'];
-
-		// put root folder
-		$this->assertFalse($cacheMock->get('folder'));
-		$this->assertGreaterThan(0, $cacheMock->put('folder', $data));
-
-		// put un-normalized folder
-		$this->assertFalse($cacheMock->get('folder/' . $folderWith0308));
-		$this->assertGreaterThan(0, $cacheMock->put('folder/' . $folderWith0308, $data));
-
-		// get un-normalized folder by name
-		$unNormalizedFolderName = $cacheMock->get('folder/' . $folderWith0308);
-
-		// check if database layer normalized the folder name (this should not happen)
-		$this->assertEquals($folderWith0308, $unNormalizedFolderName['name']);
-
-		// put normalized folder
-		$this->assertFalse($cacheMock->get('folder/' . $folderWith00F6));
-		$this->assertGreaterThan(0, $cacheMock->put('folder/' . $folderWith00F6, $data));
-
-		// this is our bug, we have two different hashes with the same name (Schön)
-		$this->assertCount(2, $cacheMock->getFolderContents('folder'));
-	}
-
-	/**
 	 * this test shows that there is no bug if we use the normalizer
 	 */
-	public function testWithNormalizer() {
-		if (!\class_exists('Patchwork\PHP\Shim\Normalizer')) {
-			$this->markTestSkipped('The 3rdparty Normalizer extension is not available.');
-			return;
-		}
-
+	public function testWithNormalizer(): void {
 		// folder name "Schön" with U+00F6 (normalized)
 		$folderWith00F6 = "\x53\x63\x68\xc3\xb6\x6e";
 

--- a/tests/lib/Files/FilesystemTest.php
+++ b/tests/lib/Files/FilesystemTest.php
@@ -347,11 +347,7 @@ class FilesystemTest extends TestCase {
 		$this->assertSame($expected, Filesystem::isForbiddenFileOrDir($path, $regex));
 	}
 
-	public function testNormalizePathUTF8() {
-		if (!\class_exists('Patchwork\PHP\Shim\Normalizer')) {
-			$this->markTestSkipped('UTF8 normalizer Patchwork was not found');
-		}
-
+	public function testNormalizePathUTF8(): void {
 		$this->assertEquals("/foo/bar\xC3\xBC", Filesystem::normalizePath("/foo/baru\xCC\x88"));
 		$this->assertEquals("/foo/bar\xC3\xBC", Filesystem::normalizePath("\\foo\\baru\xCC\x88"));
 	}


### PR DESCRIPTION
## Description
left over from https://github.com/owncloud/core/pull/38286

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
- Fixes <issue_link>

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
- test environment:
- test case 1:
- test case 2:
- ...

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Database schema changes (next release will require increase of minor version instead of patch)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [ ] Tests only (no source changes)

## Checklist:
<!-- Tick the checkboxes when done. -->
<!-- Raise documentation ticket in https://github.com/owncloud/documentation -->
- [ ] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 
- [ ] Changelog item, see [TEMPLATE](https://github.com/owncloud/core/blob/master/changelog/TEMPLATE)
