### PR TITLE
Fix problem with postgresql complaining about a wrong cast

### DIFF
--- a/changelog/unreleased/41051
+++ b/changelog/unreleased/41051
@@ -1,0 +1,14 @@
+Bugfix: Fix potential issue with the PreviewCleanup job in postgresql
+
+One of the filters of the preview cleanup job requires casting a filename,
+which is supposed to contain only digits, to an integer. The expected execution
+of the DB query should have filtered the results so the condition above should
+be true, but the DB's query planner might choose to apply the filters in a
+different way, so we could potentially cast random strings to integer.
+For the case of postgresql, the cast function will cause an error if the string
+can't be casted to an integer (because it has non-digit chars, for example)
+
+This situation is fixed for all the supported DBs, so we don't require the
+query planner to execute the query in any particular way.
+
+https://github.com/owncloud/core/pull/41051


### PR DESCRIPTION
<!--
Thanks for submitting a change to ownCloud!

This is the bug tracker for the Server component. Find other components at https://github.com/owncloud/core/blob/master/.github/CONTRIBUTING.md#guidelines

For fixing potential security issues please see https://owncloud.com/security/

To make it possible for us to get your change reviewed and merged please carefully fill out the requested information below.

Please note that any kind of change needs first be submitted to the master branch which holds the next version of ownCloud.

Please set the following labels:

- Set label "3 - To review" for review or "2 - Development" if the PR still has open tasks
- Assignment: assign to self
- Milestone: set the same as the ticket this PR fixes, or "development" by default
- Reviewers: pick at least one
-->

## Description
The DBs can change the query plan whenever they want. In particular, the second condition, which was expected to be applied second, could be applied first. This means that the `cast` function could be applied to regular filenames instead of the "only digit" ones (which reference to file ids).
For postgresql, this situation causes an error because the `cast` function fails to convert a random string into an integer.

Since the issue depends on the DB's query planner, it could happen that some installations running prosgresql aren't affected. Big installations might not be affected because scanning the whole filecache table should cost higher than running an indexed filter (which might not be true for small installations)

## Related Issue
https://github.com/owncloud/core/issues/41040

## Motivation and Context
We don't have any control over the DB's query planner, so we need to consider that the second condition is applied first even though it might not make sense on average.

## How Has This Been Tested?
Manually tested on some DBs.
Unit tests pass on all the DBs.

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Database schema changes (next release will require increase of minor version instead of patch)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [ ] Tests only (no source changes)

## Checklist:
<!-- Tick the checkboxes when done. -->
<!-- Raise documentation ticket in https://github.com/owncloud/documentation -->
- [x] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 
- [ ] Changelog item, see [TEMPLATE](https://github.com/owncloud/core/blob/master/changelog/TEMPLATE)
