### PR TITLE
fix: right after loading windows.oc_user is stored in OC._user

### DIFF
--- a/changelog/unreleased/41054
+++ b/changelog/unreleased/41054
@@ -1,0 +1,7 @@
+Bugfix: Store user information in explicit variable
+
+Before user information was stored in the browser global object. In some rare
+cases browsers seem to loose data stored in the global object. This is fixed now.
+
+https://github.com/owncloud/core/pull/41054
+https://github.com/owncloud/enterprise/issues/5873

--- a/core/js/js.js
+++ b/core/js/js.js
@@ -74,6 +74,8 @@ var OC = {
 	 */
 	_capabilities: window.oc_capabilities || null,
 
+	_user: window.oc_user || null,
+
 	appswebroots: (typeof oc_appswebroots !== 'undefined') ? oc_appswebroots : false,
 	/**
 	 * Currently logged in user or null if none
@@ -321,7 +323,7 @@ var OC = {
 	 * @since 9.0.0
 	 */
 	getCurrentUser: function () {
-		if (!_.isUndefined(window.oc_user)) {
+		if (OC._user !== null) {
 			return oc_user;
 		}
 		return {


### PR DESCRIPTION
## Description
Instead of using `window.oc_user` it's value is stored as `OC._user`

This should prevent to loose this information on Safari where variables in window.* get lost

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
- Fixes <issue_link>

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
- test environment:
- test case 1:
- test case 2:
- ...

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Database schema changes (next release will require increase of minor version instead of patch)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [ ] Tests only (no source changes)

## Checklist:
<!-- Tick the checkboxes when done. -->
<!-- Raise documentation ticket in https://github.com/owncloud/documentation -->
- [x] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 
- [ ] Changelog item, see [TEMPLATE](https://github.com/owncloud/core/blob/master/changelog/TEMPLATE)
