### PR TITLE
fix: file list visual fixes on expirations date and decuplicate elements on shared files

### DIFF
--- a/apps/files/js/filelist.js
+++ b/apps/files/js/filelist.js
@@ -397,6 +397,8 @@
 			this.$el.find('#dir').val('');
 			// remove summary
 			this.$el.find('tfoot tr.summary').remove();
+			// detach click event handler, this ensures that older _onClickFile events won't be triggered
+			this.$fileList.off('click');
 			this.$fileList.empty();
 			// remove events attached to the $el
 			this.$el.off('show', this._onResize);

--- a/apps/files_sharing/js/sharedfilelist.js
+++ b/apps/files_sharing/js/sharedfilelist.js
@@ -93,7 +93,7 @@
 			// add row with expiration date for link only shares - influenced by _createRow of filelist
 			if (this._linksOnly) {
 				var expirationTimestamp = 0;
-				if(fileData.shares && fileData.shares[0].expiration !== null) {
+				if(fileData.shares && (fileData.shares[0].expiration !== null || fileData.shares[0].expiration !== 0)) {
 					expirationTimestamp = moment(fileData.shares[0].expiration).endOf('day').valueOf();
 				}
 				$tr.attr('data-expiration', expirationTimestamp);

--- a/apps/files_sharing/js/sharedfilelist.js
+++ b/apps/files_sharing/js/sharedfilelist.js
@@ -93,7 +93,7 @@
 			// add row with expiration date for link only shares - influenced by _createRow of filelist
 			if (this._linksOnly) {
 				var expirationTimestamp = 0;
-				if(fileData.shares && (fileData.shares[0].expiration !== null || fileData.shares[0].expiration !== 0)) {
+				if(fileData.shares && fileData.shares[0].expiration !== null && fileData.shares[0].expiration !== 0) {
 					expirationTimestamp = moment(fileData.shares[0].expiration).endOf('day').valueOf();
 				}
 				$tr.attr('data-expiration', expirationTimestamp);

--- a/apps/files_sharing/js/sharedfilelist.js
+++ b/apps/files_sharing/js/sharedfilelist.js
@@ -93,6 +93,13 @@
 			// add row with expiration date for link only shares - influenced by _createRow of filelist
 			if (this._linksOnly) {
 				var expirationTimestamp = 0;
+				/**
+    				 * The endpoint returns 'null' for the expiration if none has been set.
+				 * In this context, we also need to check for a value of '0'. 
+    				 * This is important because after the element gets updated from JavaScript events, the data will be fetched from the jQuery data attributes, rather than from the endpoint. 
+				 * A few lines down in the code, you can find the statement '$tr.attr('data-expiration', expirationTimestamp);,' which will set the value to '0' if no expiration has been previously set. 
+    				 * Therefore, we need to account for these two different conditions.
+				 */
 				if(fileData.shares && fileData.shares[0].expiration !== null && fileData.shares[0].expiration !== 0) {
 					expirationTimestamp = moment(fileData.shares[0].expiration).endOf('day').valueOf();
 				}

--- a/changelog/unreleased/41056
+++ b/changelog/unreleased/41056
@@ -1,0 +1,9 @@
+Bugfix: Fix expiration date and eliminate duplicate entries in file list
+
+We've addressed two visual issues in the web ui file list. 
+Firstly, the problem where the start of the epoch was mistakenly displayed as an expiration date in the shared file list
+has been resolved.
+Secondly, we've tackled the pesky bug causing duplicate entries to appear when switching between shared tabs and
+clicking on a file list entry.
+
+https://github.com/owncloud/core/pull/41056


### PR DESCRIPTION
## Description
This PR fixes 2 issues:
1. Duplicate file elements in shared file list caused by an event not beeing cleared
2. Weird expiration date 

## Related Issue
https://github.com/owncloud/core/issues/41055

## Motivation and Context
Visual issues that could be missleading

## How Has This Been Tested?
Not extensively tested, only with Brave and Chrome on oC 10.13.2.

## Screenshots (if appropriate):
Issue: 
![Bildschirmaufnahme-2023-10-20-um-18 13 44](https://github.com/owncloud/core/assets/51854305/12f680bb-0ee1-4624-8f46-a77532330adf)

Fixed:
![Bildschirmaufnahme-2023-10-20-um-18 33 34](https://github.com/owncloud/core/assets/51854305/c0106599-fbf1-49ea-8e05-5a334610dd72)


## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Database schema changes (next release will require increase of minor version instead of patch)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [ ] Tests only (no source changes)

## Checklist:
<!-- Tick the checkboxes when done. -->
<!-- Raise documentation ticket in https://github.com/owncloud/documentation -->
- [X] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 
- [ ] Changelog item, see [TEMPLATE](https://github.com/owncloud/core/blob/master/changelog/TEMPLATE)
