### PR TITLE
fix: proper error handling when deleting users/groups is failing

### DIFF
--- a/changelog/unreleased/41077
+++ b/changelog/unreleased/41077
@@ -1,0 +1,4 @@
+Bugfix: Proper error handling when deleting users or groups
+
+https://github.com/owncloud/core/pull/41077
+https://github.com/owncloud/core/pull/41075

--- a/settings/js/users/groups.js
+++ b/settings/js/users/groups.js
@@ -6,6 +6,7 @@
  */
 
 var GroupList;
+var GroupDeleteHandler;
 
 (function () {
 	GroupList = {
@@ -287,12 +288,7 @@ var GroupList;
 		initDeleteHandling: function () {
 			//set up handler
 			GroupDeleteHandler = new DeleteHandler('/settings/users/groups', 'groupname',
-				GroupList.hide, GroupList.remove);
-
-			var msg = escapeHTML(t('settings', 'deleted {groupName}', {groupName: '%oid'})) + '<span class="undo">' +
-				escapeHTML(t('settings', 'undo')) + '</span>';
-			GroupDeleteHandler.setNotification(OC.Notification, 'deletegroup', msg,
-				GroupList.remove);
+				GroupList.hide, GroupList.remove, GroupList.show);
 
 			//when to mark user for delete
 			this.$userGroupList.on('click', '.delete', function () {

--- a/settings/js/users/users.js
+++ b/settings/js/users/users.js
@@ -349,14 +349,7 @@ var UserList = {
 	initDeleteHandling: function() {
 		//set up handler
 		UserDeleteHandler = new DeleteHandler('/settings/users/users', 'username',
-											UserList.markRemove, UserList.remove);
-
-		//configure undo
-		OC.Notification.hide();
-		var msg = escapeHTML(t('settings', 'deleted {userName}', {userName: '%oid'})) + '<span class="undo">' +
-			escapeHTML(t('settings', 'undo')) + '</span>';
-		UserDeleteHandler.setNotification(OC.Notification, 'deleteuser', msg,
-										UserList.undoRemove);
+											UserList.markRemove, UserList.remove, UserList.undoRemove);
 
 		//when to mark user for delete
 		$userListBody.on('click', '.delete', function () {

--- a/settings/tests/js/users/deleteHandlerSpec.js
+++ b/settings/tests/js/users/deleteHandlerSpec.js
@@ -28,9 +28,7 @@ describe('DeleteHandler tests', function() {
 	var undoCallback;
 
 	function init(markCallback, removeCallback, undoCallback) {
-		var handler = new DeleteHandler('dummyendpoint.php', 'paramid', markCallback, removeCallback);
-		handler.setNotification(OC.Notification, 'dataid', 'removed %oid entry', undoCallback);
-		return handler;
+		return new DeleteHandler('dummyendpoint.php', 'paramid', markCallback, removeCallback, undoCallback);
 	}
 
 	beforeEach(function() {


### PR DESCRIPTION
## Description
In case of an error when deleting a user or a group no proper feedback was given to the user.

Bonus: fix undo on groups

## Related Issue
- Fixes #41075 

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
- test environment:
- test case 1:
- test case 2:
- ...

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Database schema changes (next release will require increase of minor version instead of patch)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [ ] Tests only (no source changes)

## Checklist:
<!-- Tick the checkboxes when done. -->
<!-- Raise documentation ticket in https://github.com/owncloud/documentation -->
- [x] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 
- [x] Changelog item, see [TEMPLATE](https://github.com/owncloud/core/blob/master/changelog/TEMPLATE)
