### PR TITLE
[docs-only] add toc to changelog

### DIFF
--- a/changelog/CHANGELOG.tmpl
+++ b/changelog/CHANGELOG.tmpl
@@ -1,7 +1,13 @@
+# Table of Contents
+
+{{ range . -}}
+  * [Changelog for {{ .Version }}](#changelog-for-{{ .Version | replace "." ""}}-{{ .Date -}})
+{{ end -}}
 {{ $allVersions := . }}
 {{- range $index, $changes := . }}{{ with $changes -}}
-Changelog for ownCloud Core [{{ .Version }}] ({{ .Date }})
-=======================================
+{{ if gt (len $allVersions) 1 }}
+# Changelog for ownCloud Core [{{ .Version }}] ({{ .Date }})
+
 The following sections list the changes in ownCloud core {{ .Version }} relevant to
 ownCloud admins and users.
 
@@ -21,14 +27,12 @@ ownCloud admins and users.
 [{{ .Version }}]: https://github.com/owncloud/core/compare/v10.3.1...v{{ .Version }}
 {{- end }}
 
-Summary
--------
+## Summary
 {{ range $entry := .Entries }}{{ with $entry }}
 * {{ .Type }} - {{ .Title }}: [#{{ .PrimaryID }}]({{ .PrimaryURL }})
 {{- end }}{{ end }}
 
-Details
--------
+## Details
 {{ range $entry := .Entries }}{{ with $entry }}
 * {{ .Type }} - {{ .Title }}: [#{{ .PrimaryID }}]({{ .PrimaryURL }})
 {{ range $par := .Paragraphs }}

--- a/changelog/CHANGELOG.tmpl
+++ b/changelog/CHANGELOG.tmpl
@@ -5,7 +5,6 @@
 {{ end -}}
 {{ $allVersions := . }}
 {{- range $index, $changes := . }}{{ with $changes -}}
-{{ if gt (len $allVersions) 1 }}
 # Changelog for ownCloud Core [{{ .Version }}] ({{ .Date }})
 
 The following sections list the changes in ownCloud core {{ .Version }} relevant to


### PR DESCRIPTION
## Description

Adds table of contents to the top of the CHANGELOG.md file.

### Anchor links in markdown are generated from the content of the header according to the following rules:

1. All text is converted to lowercase.
2. All non-word text (e.g., punctuation, HTML) is removed.
3. All spaces are converted to hyphens.
4. Two or more hyphens in a row are converted to one.
5. If a header with the same ID has already been generated, a unique incrementing number is appended, starting at 1.

## Related Issue
- Relates to https://github.com/owncloud/docs/issues/4901
- Changes copied from: https://github.com/owncloud/ocis/pull/7691

