### PR TITLE
fix: drop code related to php version 7.3 and ealier

### DIFF
--- a/lib/private/Session/CryptoWrapper.php
+++ b/lib/private/Session/CryptoWrapper.php
@@ -69,7 +69,6 @@ class CryptoWrapper {
 	private $timeFactory;
 
 	/**
-	 * @param IConfig $config
 	 * @param ICrypto $crypto
 	 * @param ISecureRandom $random
 	 * @param IRequest $request
@@ -93,7 +92,7 @@ class CryptoWrapper {
 	 * If the target cookie hasn't been received from the request, a cookie containing the passphrase
 	 * will also be sent to the browser for the future.
 	 */
-	public function sendCookie(IConfig $config) {
+	public function sendCookie(IConfig $config): void {
 		if ($this->request->getCookie(self::COOKIE_NAME) !== null) {
 			// just set the passphrase, don't send it to the browser.
 			$this->passphrase = $this->request->getCookie(self::COOKIE_NAME);
@@ -118,7 +117,7 @@ class CryptoWrapper {
 	/**
 	 * Refresh the cookie expiration time
 	 */
-	public function refreshCookie(IConfig $config, $expire = null) {
+	public function refreshCookie(IConfig $config, $expire = null): void {
 		if ($this->request->getCookie(self::COOKIE_NAME) === null) {
 			return;
 		}
@@ -137,7 +136,7 @@ class CryptoWrapper {
 	/**
 	 * Try to delete the cookie
 	 */
-	public function deleteCookie() {
+	public function deleteCookie(): void {
 		// FIXME: Required for CI
 		if (!\defined('PHPUNIT_RUN')) {
 			$options = [
@@ -152,7 +151,7 @@ class CryptoWrapper {
 		}
 	}
 
-	private function prepareOptions(IConfig $config) {
+	private function prepareOptions(IConfig $config): array {
 		$secureCookie = $this->request->getServerProtocol() === 'https';
 		$webRoot = \OC::$WEBROOT;
 		if ($webRoot === '') {
@@ -177,19 +176,11 @@ class CryptoWrapper {
 		];
 	}
 
-	private function sendCookieToBrowser($value, $options) {
-		if (\version_compare(PHP_VERSION, '7.3.0') === -1) {
-			\setcookie(self::COOKIE_NAME, $value, $options['expires'], $options['path'], $options['domain'], $options['secure'], $options['httpOnly']);
-		} else {
-			\setcookie(self::COOKIE_NAME, $value, $options);
-		}
+	private function sendCookieToBrowser(string $value, array $options): void {
+		\setcookie(self::COOKIE_NAME, $value, $options);
 	}
 
-	/**
-	 * @param ISession $session
-	 * @return ISession
-	 */
-	public function wrapSession(ISession $session) {
+	public function wrapSession(ISession $session): CryptoSessionData {
 		if (!($session instanceof CryptoSessionData)) {
 			return new CryptoSessionData($session, $this->crypto, $this->passphrase);
 		}

--- a/lib/private/Session/Internal.php
+++ b/lib/private/Session/Internal.php
@@ -144,14 +144,14 @@ class Internal extends Session {
 	 * @param string $errorString
 	 * @throws \ErrorException
 	 */
-	public function trapError($errorNumber, $errorString) {
+	public function trapError($errorNumber, $errorString): void {
 		throw new \ErrorException($errorString);
 	}
 
 	/**
 	 * @throws \Exception
 	 */
-	private function validateSession() {
+	private function validateSession(): void {
 		if ($this->sessionClosed) {
 			throw new SessionNotAvailableException('Session has been closed - no further changes to the session are allowed');
 		}
@@ -173,27 +173,16 @@ class Internal extends Session {
 			//try to set the session lifetime
 			$sessionLifeTime = self::getSessionLifeTime();
 			@\ini_set('session.gc_maxlifetime', (string)$sessionLifeTime);
-
-			if (\version_compare(PHP_VERSION, '7.3.0') !== -1) {
-				$samesite = \OC::$server->getConfig()->getSystemValue('http.cookie.samesite', 'Strict');
-				\ini_set('session.cookie_samesite', $samesite);
-			}
 		}
 		\session_start();
 	}
 
-	/**
-	 * @return string
-	 */
-	private static function getSessionLifeTime() {
+	private static function getSessionLifeTime(): string {
 		return \OC::$server->getConfig()->getSystemValue('session_lifetime', 60 * 20);
 	}
 
-	private function getServerProtocol() {
-		$method = null;
-		if (isset($_SERVER['REQUEST_METHOD'])) {
-			$method = $_SERVER['REQUEST_METHOD'];
-		}
+	private function getServerProtocol(): string {
+		$method = $_SERVER['REQUEST_METHOD'] ?? null;
 		$req = new Request(
 			[
 				'get' => $_GET,

--- a/settings/Application.php
+++ b/settings/Application.php
@@ -172,7 +172,6 @@ class Application extends App {
 				$c->query('Config'),
 				$c->query('ClientService'),
 				$c->query('URLGenerator'),
-				$c->query('Util'),
 				$c->query('L10N'),
 				$c->query('Checker')
 			);

--- a/settings/Controller/CheckSetupController.php
+++ b/settings/Controller/CheckSetupController.php
@@ -27,9 +27,9 @@
 namespace OC\Settings\Controller;
 
 use GuzzleHttp\Exception\ClientException;
-use OC\AppFramework\Http;
 use OC\IntegrityCheck\Checker;
 use OCP\AppFramework\Controller;
+use OCP\AppFramework\Http;
 use OCP\AppFramework\Http\DataDisplayResponse;
 use OCP\AppFramework\Http\DataResponse;
 use OCP\AppFramework\Http\RedirectResponse;
@@ -47,8 +47,6 @@ class CheckSetupController extends Controller {
 	private $config;
 	/** @var IClientService */
 	private $clientService;
-	/** @var \OC_Util */
-	private $util;
 	/** @var IURLGenerator */
 	private $urlGenerator;
 	/** @var IL10N */
@@ -58,13 +56,6 @@ class CheckSetupController extends Controller {
 
 	/**
 	 * @param string $AppName
-	 * @param IRequest $request
-	 * @param IConfig $config
-	 * @param IClientService $clientService
-	 * @param IURLGenerator $urlGenerator
-	 * @param \OC_Util $util
-	 * @param IL10N $l10n
-	 * @param Checker $checker
 	 */
 	public function __construct(
 		$AppName,
@@ -72,14 +63,12 @@ class CheckSetupController extends Controller {
 		IConfig $config,
 		IClientService $clientService,
 		IURLGenerator $urlGenerator,
-		\OC_Util $util,
 		IL10N $l10n,
 		Checker $checker
 	) {
 		parent::__construct($AppName, $request);
 		$this->config = $config;
 		$this->clientService = $clientService;
-		$this->util = $util;
 		$this->urlGenerator = $urlGenerator;
 		$this->l10n = $l10n;
 		$this->checker = $checker;
@@ -87,9 +76,8 @@ class CheckSetupController extends Controller {
 
 	/**
 	 * Checks if the ownCloud server can connect to the internet using HTTPS and HTTP
-	 * @return bool
 	 */
-	private function isInternetConnectionWorking() {
+	private function isInternetConnectionWorking(): bool {
 		if ($this->config->getSystemValue('has_internet_connection', true) === false) {
 			return false;
 		}
@@ -106,18 +94,15 @@ class CheckSetupController extends Controller {
 
 	/**
 	 * Checks whether a local memcache is installed or not
-	 * @return bool
 	 */
-	private function isMemcacheConfigured() {
+	private function isMemcacheConfigured(): bool {
 		return $this->config->getSystemValue('memcache.local', null) !== null;
 	}
 
 	/**
 	 * Whether /dev/urandom is available to the PHP controller
-	 *
-	 * @return bool
 	 */
-	private function isUrandomAvailable() {
+	private function isUrandomAvailable(): bool {
 		if (@\file_exists('/dev/urandom')) {
 			$file = \fopen('/dev/urandom', 'rb');
 			if ($file) {
@@ -131,10 +116,8 @@ class CheckSetupController extends Controller {
 
 	/**
 	 * Public for the sake of unit-testing
-	 *
-	 * @return array
 	 */
-	protected function getCurlVersion() {
+	protected function getCurlVersion(): array {
 		return \curl_version();
 	}
 
@@ -146,11 +129,12 @@ class CheckSetupController extends Controller {
 	 * @link https://github.com/owncloud/core/issues/17446#issuecomment-122877546
 	 * @link https://bugzilla.redhat.com/show_bug.cgi?id=1241172
 	 * @return string
+	 * @throws \Exception
 	 */
-	private function isUsedTlsLibOutdated() {
+	private function isUsedTlsLibOutdated(): string {
 		// Don't run check when:
 		// 1. Server has `has_internet_connection` set to false
-		// 2. AppStore AND S2S is disabled
+		// 2. App Store AND S2S is disabled
 		if (!$this->config->getSystemValue('has_internet_connection', true)) {
 			return '';
 		}
@@ -199,10 +183,8 @@ class CheckSetupController extends Controller {
 	/**
 	 * Whether the php version is still supported (at time of release)
 	 * according to: https://secure.php.net/supported-versions.php
-	 *
-	 * @return array
 	 */
-	private function isPhpSupported() {
+	private function isPhpSupported(): array {
 		$eol = $this->isEndOfLive();
 
 		return ['eol' => $eol, 'version' => PHP_VERSION];
@@ -213,11 +195,11 @@ class CheckSetupController extends Controller {
 	 *
 	 * @return bool
 	 */
-	private function forwardedForHeadersWorking() {
+	private function forwardedForHeadersWorking(): bool {
 		$trustedProxies = $this->config->getSystemValue('trusted_proxies', []);
 		$remoteAddress = $this->request->getRemoteAddress();
 
-		if (\is_array($trustedProxies) && \in_array($remoteAddress, $trustedProxies)) {
+		if (\is_array($trustedProxies) && \in_array($remoteAddress, $trustedProxies, true)) {
 			return false;
 		}
 
@@ -228,10 +210,8 @@ class CheckSetupController extends Controller {
 	/**
 	 * Checks if the correct memcache module for PHP is installed. Only
 	 * fails if memcached is configured and the working module is not installed.
-	 *
-	 * @return bool
 	 */
-	private function isCorrectMemcachedPHPModuleInstalled() {
+	private function isCorrectMemcachedPHPModuleInstalled(): bool {
 		if ($this->config->getSystemValue('memcache.distributed', null) !== '\OC\Memcache\Memcached') {
 			return true;
 		}
@@ -245,7 +225,7 @@ class CheckSetupController extends Controller {
 	/**
 	 * @return RedirectResponse
 	 */
-	public function rescanFailedIntegrityCheck() {
+	public function rescanFailedIntegrityCheck(): RedirectResponse {
 		$this->checker->runInstanceVerification();
 		return new RedirectResponse(
 			$this->urlGenerator->linkToRoute('settings.SettingsPage.getAdmin')
@@ -254,9 +234,8 @@ class CheckSetupController extends Controller {
 
 	/**
 	 * @NoCSRFRequired
-	 * @return DataResponse | DataDisplayResponse
 	 */
-	public function getFailedIntegrityCheckFiles() {
+	public function getFailedIntegrityCheckFiles(): DataDisplayResponse {
 		if (!$this->checker->isCodeCheckEnforced()) {
 			return new DataDisplayResponse('Integrity checker has been disabled. Integrity cannot be verified.');
 		}
@@ -283,7 +262,7 @@ Results
 							$formattedTextResponse .= "\t\t- $key\n";
 						}
 					} else {
-						foreach ($result as $key => $results) {
+						foreach ($result as $results) {
 							$formattedTextResponse .= "\t\t- $results\n";
 						}
 					}
@@ -299,21 +278,19 @@ Raw output
 			$formattedTextResponse = 'No errors have been found.';
 		}
 
-		$response = new DataDisplayResponse(
+		return new DataDisplayResponse(
 			$formattedTextResponse,
 			Http::STATUS_OK,
 			[
 				'Content-Type' => 'text/plain',
 			]
 		);
-
-		return $response;
 	}
 
 	/**
-	 * @return DataResponse
+	 * @throws \Exception
 	 */
-	public function check() {
+	public function check(): DataResponse {
 		return new DataResponse(
 			[
 				'serverHasInternetConnection' => $this->isInternetConnectionWorking(),
@@ -333,18 +310,10 @@ Raw output
 		);
 	}
 
-	/**
-	 * @return bool
-	 */
-	protected function isEndOfLive() {
-		$eol = false;
-
+	protected function isEndOfLive(): bool {
 		// PHP 5.4 is EOL on 14 Sep 2015
 		// PHP 5.5 is EOL on 21 Jul 2016
-		if (\version_compare(PHP_VERSION, '5.6.0') === -1) {
-			$eol = true;
-			return $eol;
-		}
-		return $eol;
+		# PHP 7.4 is EOL as well - but we support it via distributions
+		return \version_compare(PHP_VERSION, '7.3.0') === -1;
 	}
 }

--- a/tests/Settings/Controller/CheckSetupControllerTest.php
+++ b/tests/Settings/Controller/CheckSetupControllerTest.php
@@ -24,7 +24,6 @@ namespace Tests\Settings\Controller;
 use GuzzleHttp\Exception\ClientException;
 use OC\IntegrityCheck\Checker;
 use OC\Settings\Controller\CheckSetupController;
-use OC_Util;
 use OCP\AppFramework\Http;
 use OCP\AppFramework\Http\DataDisplayResponse;
 use OCP\AppFramework\Http\DataResponse;
@@ -52,8 +51,6 @@ class CheckSetupControllerTest extends TestCase {
 	private $clientService;
 	/** @var IURLGenerator | \PHPUnit\Framework\MockObject\MockObject */
 	private $urlGenerator;
-	/** @var OC_Util */
-	private $util;
 	/** @var IL10N | \PHPUnit\Framework\MockObject\MockObject */
 	private $l10n;
 	/** @var Checker | \PHPUnit\Framework\MockObject\MockObject */
@@ -66,21 +63,17 @@ class CheckSetupControllerTest extends TestCase {
 			->disableOriginalConstructor()->getMock();
 		$this->config = $this->getMockBuilder('\OCP\IConfig')
 			->disableOriginalConstructor()->getMock();
-		$this->config = $this->getMockBuilder('\OCP\IConfig')
-			->disableOriginalConstructor()->getMock();
 		$this->clientService = $this->getMockBuilder('\OCP\Http\Client\IClientService')
-			->disableOriginalConstructor()->getMock();
-		$this->util = $this->getMockBuilder('\OC_Util')
 			->disableOriginalConstructor()->getMock();
 		$this->urlGenerator = $this->getMockBuilder('\OCP\IURLGenerator')
 			->disableOriginalConstructor()->getMock();
 		$this->l10n = $this->getMockBuilder('\OCP\IL10N')
 			->disableOriginalConstructor()->getMock();
-		$this->l10n->expects($this->any())
+		$this->l10n
 			->method('t')
-			->will($this->returnCallback(function ($message, array $replace) {
+			->willReturnCallback(function ($message, array $replace) {
 				return \vsprintf($message, $replace);
-			}));
+			});
 		$this->checker = $this->getMockBuilder('\OC\IntegrityCheck\Checker')
 				->disableOriginalConstructor()->getMock();
 		$this->checkSetupController = $this->getMockBuilder('\OC\Settings\Controller\CheckSetupController')
@@ -90,7 +83,6 @@ class CheckSetupControllerTest extends TestCase {
 				$this->config,
 				$this->clientService,
 				$this->urlGenerator,
-				$this->util,
 				$this->l10n,
 				$this->checker,
 				])
@@ -101,7 +93,7 @@ class CheckSetupControllerTest extends TestCase {
 		$this->config->expects($this->once())
 			->method('getSystemValue')
 			->with('has_internet_connection', true)
-			->will($this->returnValue(false));
+			->willReturn(false);
 
 		$this->assertFalse(
 			self::invokePrivate(
@@ -115,7 +107,7 @@ class CheckSetupControllerTest extends TestCase {
 		$this->config->expects($this->once())
 			->method('getSystemValue')
 			->with('has_internet_connection', true)
-			->will($this->returnValue(true));
+			->willReturn(true);
 
 		$client = $this->getMockBuilder('\OCP\Http\Client\IClient')
 			->disableOriginalConstructor()->getMock();
@@ -129,7 +121,7 @@ class CheckSetupControllerTest extends TestCase {
 
 		$this->clientService->expects($this->once())
 			->method('newClient')
-			->will($this->returnValue($client));
+			->willReturn($client);
 
 		$this->assertTrue(
 			self::invokePrivate(
@@ -143,7 +135,7 @@ class CheckSetupControllerTest extends TestCase {
 		$this->config->expects($this->once())
 			->method('getSystemValue')
 			->with('has_internet_connection', true)
-			->will($this->returnValue(true));
+			->willReturn(true);
 
 		$client = $this->getMockBuilder('\OCP\Http\Client\IClient')
 			->disableOriginalConstructor()->getMock();
@@ -155,7 +147,7 @@ class CheckSetupControllerTest extends TestCase {
 
 		$this->clientService->expects($this->once())
 			->method('newClient')
-			->will($this->returnValue($client));
+			->willReturn($client);
 
 		$this->assertFalse(
 			self::invokePrivate(
@@ -169,7 +161,7 @@ class CheckSetupControllerTest extends TestCase {
 		$this->config->expects($this->once())
 			->method('getSystemValue')
 			->with('has_internet_connection', true)
-			->will($this->returnValue(true));
+			->willReturn(true);
 
 		$client = $this->getMockBuilder('\OCP\Http\Client\IClient')
 			->disableOriginalConstructor()->getMock();
@@ -187,7 +179,7 @@ class CheckSetupControllerTest extends TestCase {
 
 		$this->clientService->expects($this->once())
 			->method('newClient')
-			->will($this->returnValue($client));
+			->willReturn($client);
 
 		$this->assertFalse(
 			self::invokePrivate(
@@ -201,7 +193,7 @@ class CheckSetupControllerTest extends TestCase {
 		$this->config->expects($this->once())
 			->method('getSystemValue')
 			->with('memcache.local', null)
-			->will($this->returnValue(null));
+			->willReturn(null);
 
 		$this->assertFalse(
 			self::invokePrivate(
@@ -215,7 +207,7 @@ class CheckSetupControllerTest extends TestCase {
 		$this->config->expects($this->once())
 			->method('getSystemValue')
 			->with('memcache.local', null)
-			->will($this->returnValue('SomeProvider'));
+			->willReturn('SomeProvider');
 
 		$this->assertTrue(
 			self::invokePrivate(
@@ -325,7 +317,7 @@ class CheckSetupControllerTest extends TestCase {
 
 		$this->clientService->expects($this->once())
 			->method('newClient')
-			->will($this->returnValue($client));
+			->willReturn($client);
 		$this->urlGenerator
 			->expects($this->any())
 			->method('linkToDocs')
@@ -376,7 +368,6 @@ class CheckSetupControllerTest extends TestCase {
 				$this->config,
 				$this->clientService,
 				$this->urlGenerator,
-				$this->util,
 				$this->l10n,
 				$this->checker
 			])
@@ -388,77 +379,77 @@ class CheckSetupControllerTest extends TestCase {
 	public function testIsUsedTlsLibOutdatedWithAnotherLibrary() {
 		$this->config->expects($this->any())
 			->method('getSystemValue')
-			->will($this->returnValue(true));
+			->willReturn(true);
 		$this->checkSetupController
 			->expects($this->once())
 			->method('getCurlVersion')
-			->will($this->returnValue(['ssl_version' => 'SSLlib']));
+			->willReturn(['ssl_version' => 'SSLlib']);
 		$this->assertSame('', self::invokePrivate($this->checkSetupController, 'isUsedTlsLibOutdated'));
 	}
 
 	public function testIsUsedTlsLibOutdatedWithMisbehavingCurl() {
 		$this->config->expects($this->any())
 			->method('getSystemValue')
-			->will($this->returnValue(true));
+			->willReturn(true);
 		$this->checkSetupController
 			->expects($this->once())
 			->method('getCurlVersion')
-			->will($this->returnValue([]));
+			->willReturn([]);
 		$this->assertSame('', self::invokePrivate($this->checkSetupController, 'isUsedTlsLibOutdated'));
 	}
 
 	public function testIsUsedTlsLibOutdatedWithOlderOpenSsl() {
 		$this->config->expects($this->any())
 			->method('getSystemValue')
-			->will($this->returnValue(true));
+			->willReturn(true);
 		$this->checkSetupController
 			->expects($this->once())
 			->method('getCurlVersion')
-			->will($this->returnValue(['ssl_version' => 'OpenSSL/1.0.1c']));
+			->willReturn(['ssl_version' => 'OpenSSL/1.0.1c']);
 		$this->assertSame('cURL is using an outdated OpenSSL version (OpenSSL/1.0.1c). Please update your operating system or features such as installing and updating apps via the market or Federated Cloud Sharing will not work reliably.', self::invokePrivate($this->checkSetupController, 'isUsedTlsLibOutdated'));
 	}
 
 	public function testIsUsedTlsLibOutdatedWithOlderOpenSsl1() {
 		$this->config->expects($this->any())
 			->method('getSystemValue')
-			->will($this->returnValue(true));
+			->willReturn(true);
 		$this->checkSetupController
 			->expects($this->once())
 			->method('getCurlVersion')
-			->will($this->returnValue(['ssl_version' => 'OpenSSL/1.0.2a']));
+			->willReturn(['ssl_version' => 'OpenSSL/1.0.2a']);
 		$this->assertSame('cURL is using an outdated OpenSSL version (OpenSSL/1.0.2a). Please update your operating system or features such as installing and updating apps via the market or Federated Cloud Sharing will not work reliably.', self::invokePrivate($this->checkSetupController, 'isUsedTlsLibOutdated'));
 	}
 
 	public function testIsUsedTlsLibOutdatedWithMatchingOpenSslVersion() {
 		$this->config->expects($this->any())
 			->method('getSystemValue')
-			->will($this->returnValue(true));
+			->willReturn(true);
 		$this->checkSetupController
 			->expects($this->once())
 			->method('getCurlVersion')
-			->will($this->returnValue(['ssl_version' => 'OpenSSL/1.0.1d']));
+			->willReturn(['ssl_version' => 'OpenSSL/1.0.1d']);
 		$this->assertSame('', self::invokePrivate($this->checkSetupController, 'isUsedTlsLibOutdated'));
 	}
 
 	public function testIsUsedTlsLibOutdatedWithMatchingOpenSslVersion1() {
 		$this->config->expects($this->any())
 			->method('getSystemValue')
-			->will($this->returnValue(true));
+			->willReturn(true);
 		$this->checkSetupController
 			->expects($this->once())
 			->method('getCurlVersion')
-			->will($this->returnValue(['ssl_version' => 'OpenSSL/1.0.2b']));
+			->willReturn(['ssl_version' => 'OpenSSL/1.0.2b']);
 		$this->assertSame('', self::invokePrivate($this->checkSetupController, 'isUsedTlsLibOutdated'));
 	}
 
 	public function testIsBuggyNss400() {
 		$this->config->expects($this->any())
 			->method('getSystemValue')
-			->will($this->returnValue(true));
+			->willReturn(true);
 		$this->checkSetupController
 			->expects($this->once())
 			->method('getCurlVersion')
-			->will($this->returnValue(['ssl_version' => 'NSS/1.0.2b']));
+			->willReturn(['ssl_version' => 'NSS/1.0.2b']);
 		$client = $this->getMockBuilder('\OCP\Http\Client\IClient')
 			->disableOriginalConstructor()->getMock();
 		/** @var ClientException | \PHPUnit\Framework\MockObject\MockObject $exception */
@@ -468,10 +459,10 @@ class CheckSetupControllerTest extends TestCase {
 			->disableOriginalConstructor()->getMock();
 		$response->expects($this->once())
 			->method('getStatusCode')
-			->will($this->returnValue(400));
+			->willReturn(400);
 		$exception->expects($this->once())
 			->method('getResponse')
-			->will($this->returnValue($response));
+			->willReturn($response);
 
 		$client
 			->expects($this->once())
@@ -481,7 +472,7 @@ class CheckSetupControllerTest extends TestCase {
 
 		$this->clientService->expects($this->once())
 			->method('newClient')
-			->will($this->returnValue($client));
+			->willReturn($client);
 
 		$this->assertSame('cURL is using an outdated NSS version (NSS/1.0.2b). Please update your operating system or features such as installing and updating apps via the market or Federated Cloud Sharing will not work reliably.', self::invokePrivate($this->checkSetupController, 'isUsedTlsLibOutdated'));
 	}
@@ -489,11 +480,11 @@ class CheckSetupControllerTest extends TestCase {
 	public function testIsBuggyNss200() {
 		$this->config->expects($this->any())
 			->method('getSystemValue')
-			->will($this->returnValue(true));
+			->willReturn(true);
 		$this->checkSetupController
 			->expects($this->once())
 			->method('getCurlVersion')
-			->will($this->returnValue(['ssl_version' => 'NSS/1.0.2b']));
+			->willReturn(['ssl_version' => 'NSS/1.0.2b']);
 		$client = $this->getMockBuilder('\OCP\Http\Client\IClient')
 			->disableOriginalConstructor()->getMock();
 		/** @var ClientException | \PHPUnit\Framework\MockObject\MockObject $exception */
@@ -503,10 +494,10 @@ class CheckSetupControllerTest extends TestCase {
 			->disableOriginalConstructor()->getMock();
 		$response->expects($this->once())
 			->method('getStatusCode')
-			->will($this->returnValue(200));
+			->willReturn(200);
 		$exception->expects($this->once())
 			->method('getResponse')
-			->will($this->returnValue($response));
+			->willReturn($response);
 
 		$client
 			->expects($this->once())
@@ -516,7 +507,7 @@ class CheckSetupControllerTest extends TestCase {
 
 		$this->clientService->expects($this->once())
 			->method('newClient')
-			->will($this->returnValue($client));
+			->willReturn($client);
 
 		$this->assertSame('', self::invokePrivate($this->checkSetupController, 'isUsedTlsLibOutdated'));
 	}
@@ -526,7 +517,7 @@ class CheckSetupControllerTest extends TestCase {
 			->expects($this->once())
 			->method('getSystemValue')
 			->with('has_internet_connection', true)
-			->will($this->returnValue(false));
+			->willReturn(false);
 		$this->assertSame('', self::invokePrivate($this->checkSetupController, 'isUsedTlsLibOutdated'));
 	}
 
@@ -535,7 +526,7 @@ class CheckSetupControllerTest extends TestCase {
 			->expects($this->once())
 			->method('getSystemValue')
 			->with('has_internet_connection', true)
-			->will($this->returnValue(true));
+			->willReturn(true);
 		$this->config
 			->expects($this->once())
 			->method('getAppValue')
@@ -545,7 +536,7 @@ class CheckSetupControllerTest extends TestCase {
 		$this->checkSetupController
 			->expects($this->once())
 			->method('getCurlVersion')
-			->will($this->returnValue([]));
+			->willReturn([]);
 		$this->assertSame('', self::invokePrivate($this->checkSetupController, 'isUsedTlsLibOutdated'));
 	}
 
@@ -553,7 +544,7 @@ class CheckSetupControllerTest extends TestCase {
 		$this->config
 			->method('getSystemValue')
 			->with('has_internet_connection', true)
-			->will($this->returnValue(true));
+			->willReturn(true);
 		$this->config
 			->expects($this->exactly(2))
 			->method('getAppValue')
@@ -569,7 +560,7 @@ class CheckSetupControllerTest extends TestCase {
 		$this->checkSetupController
 			->expects($this->never())
 			->method('getCurlVersion')
-			->will($this->returnValue([]));
+			->willReturn([]);
 		$this->assertSame('', self::invokePrivate($this->checkSetupController, 'isUsedTlsLibOutdated'));
 	}
 
@@ -581,7 +572,7 @@ class CheckSetupControllerTest extends TestCase {
 			->expects($this->once())
 			->method('linkToRoute')
 			->with('settings.SettingsPage.getAdmin')
-			->will($this->returnValue('/admin'));
+			->willReturn('/admin');
 
 		$expected = new RedirectResponse('/admin');
 		$this->assertEquals($expected, $this->checkSetupController->rescanFailedIntegrityCheck());
@@ -605,7 +596,7 @@ class CheckSetupControllerTest extends TestCase {
 		$this->checker
 			->expects($this->once())
 			->method('getResults')
-			->will($this->returnValue([]));
+			->willReturn([]);
 
 		$expected = new DataDisplayResponse(
 			'No errors have been found.',
@@ -625,7 +616,7 @@ class CheckSetupControllerTest extends TestCase {
 		$this->checker
 				->expects($this->once())
 				->method('getResults')
-				->will($this->returnValue(['core' => ['EXTRA_FILE' => ['/testfile' => []], 'INVALID_HASH' => ['/.idea/workspace.xml' => ['expected' => 'f1c5e2630d784bc9cb02d5a28f55d6f24d06dae2a0fee685f3c2521b050955d9d452769f61454c9ddfa9c308146ade10546cfa829794448eaffbc9a04a29d216', 'current' => 'ce08bf30bcbb879a18b49239a9bec6b8702f52452f88a9d32142cad8d2494d5735e6bfa0d8642b2762c62ca5be49f9bf4ec231d4a230559d4f3e2c471d3ea094',], '/lib/private/integritycheck/checker.php' => ['expected' => 'c5a03bacae8dedf8b239997901ba1fffd2fe51271d13a00cc4b34b09cca5176397a89fc27381cbb1f72855fa18b69b6f87d7d5685c3b45aee373b09be54742ea', 'current' => '88a3a92c11db91dec1ac3be0e1c87f862c95ba6ffaaaa3f2c3b8f682187c66f07af3a3b557a868342ef4a271218fe1c1e300c478e6c156c5955ed53c40d06585',], '/settings/controller/checksetupcontroller.php' => ['expected' => '3e1de26ce93c7bfe0ede7c19cb6c93cadc010340225b375607a7178812e9de163179b0dc33809f451e01f491d93f6f5aaca7929685d21594cccf8bda732327c4', 'current' => '09563164f9904a837f9ca0b5f626db56c838e5098e0ccc1d8b935f68fa03a25c5ec6f6b2d9e44a868e8b85764dafd1605522b4af8db0ae269d73432e9a01e63a',],],], 'bookmarks' => ['EXCEPTION' => ['class' => 'OC\\IntegrityCheck\\Exceptions\\InvalidSignatureException', 'message' => 'Signature data not found.',],], 'dav' => ['EXCEPTION' => ['class' => 'OC\\IntegrityCheck\\Exceptions\\InvalidSignatureException', 'message' => 'Signature data not found.',],], 'encryption' => ['EXCEPTION' => ['class' => 'OC\\IntegrityCheck\\Exceptions\\InvalidSignatureException', 'message' => 'Signature data not found.',],], 'external' => ['EXCEPTION' => ['class' => 'OC\\IntegrityCheck\\Exceptions\\InvalidSignatureException', 'message' => 'Signature data not found.',],], 'federation' => ['EXCEPTION' => ['class' => 'OC\\IntegrityCheck\\Exceptions\\InvalidSignatureException', 'message' => 'Signature data not found.',],], 'files' => ['EXCEPTION' => ['class' => 'OC\\IntegrityCheck\\Exceptions\\InvalidSignatureException', 'message' => 'Signature data not found.',],], 'files_antivirus' => ['EXCEPTION' => ['class' => 'OC\\IntegrityCheck\\Exceptions\\InvalidSignatureException', 'message' => 'Signature data not found.',],], 'files_drop' => ['EXCEPTION' => ['class' => 'OC\\IntegrityCheck\\Exceptions\\InvalidSignatureException', 'message' => 'Signature data not found.',],], 'files_external' => ['EXCEPTION' => ['class' => 'OC\\IntegrityCheck\\Exceptions\\InvalidSignatureException', 'message' => 'Signature data not found.',],], 'files_pdfviewer' => ['EXCEPTION' => ['class' => 'OC\\IntegrityCheck\\Exceptions\\InvalidSignatureException', 'message' => 'Signature data not found.',],], 'files_sharing' => ['EXCEPTION' => ['class' => 'OC\\IntegrityCheck\\Exceptions\\InvalidSignatureException', 'message' => 'Signature data not found.',],], 'files_trashbin' => ['EXCEPTION' => ['class' => 'OC\\IntegrityCheck\\Exceptions\\InvalidSignatureException', 'message' => 'Signature data not found.',],], 'files_versions' => ['EXCEPTION' => ['class' => 'OC\\IntegrityCheck\\Exceptions\\InvalidSignatureException', 'message' => 'Signature data not found.',],], 'files_videoviewer' => ['EXCEPTION' => ['class' => 'OC\\IntegrityCheck\\Exceptions\\InvalidSignatureException', 'message' => 'Signature data not found.',],], 'firstrunwizard' => ['EXCEPTION' => ['class' => 'OC\\IntegrityCheck\\Exceptions\\InvalidSignatureException', 'message' => 'Signature data not found.',],], 'gitsmart' => ['EXCEPTION' => ['class' => 'OC\\IntegrityCheck\\Exceptions\\InvalidSignatureException', 'message' => 'Signature data not found.',],], 'logreader' => ['EXCEPTION' => ['class' => 'OC\\IntegrityCheck\\Exceptions\\InvalidSignatureException', 'message' => 'Signature could not get verified.',],], 'password_policy' => ['EXCEPTION' => ['class' => 'OC\\IntegrityCheck\\Exceptions\\InvalidSignatureException', 'message' => 'Signature data not found.',],], 'provisioning_api' => ['EXCEPTION' => ['class' => 'OC\\IntegrityCheck\\Exceptions\\InvalidSignatureException', 'message' => 'Signature data not found.',],], 'sketch' => ['EXCEPTION' => ['class' => 'OC\\IntegrityCheck\\Exceptions\\InvalidSignatureException', 'message' => 'Signature data not found.',],], 'threatblock' => ['EXCEPTION' => ['class' => 'OC\\IntegrityCheck\\Exceptions\\InvalidSignatureException', 'message' => 'Signature data not found.',],], 'two_factor_auth' => ['EXCEPTION' => ['class' => 'OC\\IntegrityCheck\\Exceptions\\InvalidSignatureException', 'message' => 'Signature data not found.',],], 'user_ldap' => ['EXCEPTION' => ['class' => 'OC\\IntegrityCheck\\Exceptions\\InvalidSignatureException', 'message' => 'Signature data not found.',],], 'user_shibboleth' => ['EXCEPTION' => ['class' => 'OC\\IntegrityCheck\\Exceptions\\InvalidSignatureException', 'message' => 'Signature data not found.',],],]));
+				->willReturn(['core' => ['EXTRA_FILE' => ['/testfile' => []], 'INVALID_HASH' => ['/.idea/workspace.xml' => ['expected' => 'f1c5e2630d784bc9cb02d5a28f55d6f24d06dae2a0fee685f3c2521b050955d9d452769f61454c9ddfa9c308146ade10546cfa829794448eaffbc9a04a29d216', 'current' => 'ce08bf30bcbb879a18b49239a9bec6b8702f52452f88a9d32142cad8d2494d5735e6bfa0d8642b2762c62ca5be49f9bf4ec231d4a230559d4f3e2c471d3ea094',], '/lib/private/integritycheck/checker.php' => ['expected' => 'c5a03bacae8dedf8b239997901ba1fffd2fe51271d13a00cc4b34b09cca5176397a89fc27381cbb1f72855fa18b69b6f87d7d5685c3b45aee373b09be54742ea', 'current' => '88a3a92c11db91dec1ac3be0e1c87f862c95ba6ffaaaa3f2c3b8f682187c66f07af3a3b557a868342ef4a271218fe1c1e300c478e6c156c5955ed53c40d06585',], '/settings/controller/checksetupcontroller.php' => ['expected' => '3e1de26ce93c7bfe0ede7c19cb6c93cadc010340225b375607a7178812e9de163179b0dc33809f451e01f491d93f6f5aaca7929685d21594cccf8bda732327c4', 'current' => '09563164f9904a837f9ca0b5f626db56c838e5098e0ccc1d8b935f68fa03a25c5ec6f6b2d9e44a868e8b85764dafd1605522b4af8db0ae269d73432e9a01e63a',],],], 'bookmarks' => ['EXCEPTION' => ['class' => 'OC\\IntegrityCheck\\Exceptions\\InvalidSignatureException', 'message' => 'Signature data not found.',],], 'dav' => ['EXCEPTION' => ['class' => 'OC\\IntegrityCheck\\Exceptions\\InvalidSignatureException', 'message' => 'Signature data not found.',],], 'encryption' => ['EXCEPTION' => ['class' => 'OC\\IntegrityCheck\\Exceptions\\InvalidSignatureException', 'message' => 'Signature data not found.',],], 'external' => ['EXCEPTION' => ['class' => 'OC\\IntegrityCheck\\Exceptions\\InvalidSignatureException', 'message' => 'Signature data not found.',],], 'federation' => ['EXCEPTION' => ['class' => 'OC\\IntegrityCheck\\Exceptions\\InvalidSignatureException', 'message' => 'Signature data not found.',],], 'files' => ['EXCEPTION' => ['class' => 'OC\\IntegrityCheck\\Exceptions\\InvalidSignatureException', 'message' => 'Signature data not found.',],], 'files_antivirus' => ['EXCEPTION' => ['class' => 'OC\\IntegrityCheck\\Exceptions\\InvalidSignatureException', 'message' => 'Signature data not found.',],], 'files_drop' => ['EXCEPTION' => ['class' => 'OC\\IntegrityCheck\\Exceptions\\InvalidSignatureException', 'message' => 'Signature data not found.',],], 'files_external' => ['EXCEPTION' => ['class' => 'OC\\IntegrityCheck\\Exceptions\\InvalidSignatureException', 'message' => 'Signature data not found.',],], 'files_pdfviewer' => ['EXCEPTION' => ['class' => 'OC\\IntegrityCheck\\Exceptions\\InvalidSignatureException', 'message' => 'Signature data not found.',],], 'files_sharing' => ['EXCEPTION' => ['class' => 'OC\\IntegrityCheck\\Exceptions\\InvalidSignatureException', 'message' => 'Signature data not found.',],], 'files_trashbin' => ['EXCEPTION' => ['class' => 'OC\\IntegrityCheck\\Exceptions\\InvalidSignatureException', 'message' => 'Signature data not found.',],], 'files_versions' => ['EXCEPTION' => ['class' => 'OC\\IntegrityCheck\\Exceptions\\InvalidSignatureException', 'message' => 'Signature data not found.',],], 'files_videoviewer' => ['EXCEPTION' => ['class' => 'OC\\IntegrityCheck\\Exceptions\\InvalidSignatureException', 'message' => 'Signature data not found.',],], 'firstrunwizard' => ['EXCEPTION' => ['class' => 'OC\\IntegrityCheck\\Exceptions\\InvalidSignatureException', 'message' => 'Signature data not found.',],], 'gitsmart' => ['EXCEPTION' => ['class' => 'OC\\IntegrityCheck\\Exceptions\\InvalidSignatureException', 'message' => 'Signature data not found.',],], 'logreader' => ['EXCEPTION' => ['class' => 'OC\\IntegrityCheck\\Exceptions\\InvalidSignatureException', 'message' => 'Signature could not get verified.',],], 'password_policy' => ['EXCEPTION' => ['class' => 'OC\\IntegrityCheck\\Exceptions\\InvalidSignatureException', 'message' => 'Signature data not found.',],], 'provisioning_api' => ['EXCEPTION' => ['class' => 'OC\\IntegrityCheck\\Exceptions\\InvalidSignatureException', 'message' => 'Signature data not found.',],], 'sketch' => ['EXCEPTION' => ['class' => 'OC\\IntegrityCheck\\Exceptions\\InvalidSignatureException', 'message' => 'Signature data not found.',],], 'threatblock' => ['EXCEPTION' => ['class' => 'OC\\IntegrityCheck\\Exceptions\\InvalidSignatureException', 'message' => 'Signature data not found.',],], 'two_factor_auth' => ['EXCEPTION' => ['class' => 'OC\\IntegrityCheck\\Exceptions\\InvalidSignatureException', 'message' => 'Signature data not found.',],], 'user_ldap' => ['EXCEPTION' => ['class' => 'OC\\IntegrityCheck\\Exceptions\\InvalidSignatureException', 'message' => 'Signature data not found.',],], 'user_shibboleth' => ['EXCEPTION' => ['class' => 'OC\\IntegrityCheck\\Exceptions\\InvalidSignatureException', 'message' => 'Signature data not found.',],],]);
 
 		$expected = new DataDisplayResponse(
 			'Technical information


### PR DESCRIPTION
## Description
Dropping any code yoga applied due to php 7.3 and earlier ....

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
- test environment:
- test case 1:
- test case 2:
- ...

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Database schema changes (next release will require increase of minor version instead of patch)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [ ] Tests only (no source changes)

## Checklist:
<!-- Tick the checkboxes when done. -->
<!-- Raise documentation ticket in https://github.com/owncloud/documentation -->
- [x] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 
- [ ] Changelog item, see [TEMPLATE](https://github.com/owncloud/core/blob/master/changelog/TEMPLATE)
