### PR TITLE
feat: in debug mode write sql queries to the log file + add query cou…

### DIFF
--- a/config/config.sample.php
+++ b/config/config.sample.php
@@ -873,6 +873,11 @@ $CONFIG = [
 		'apps' => ['files_mediaviewer'],
 		'logfile' => '/tmp/mediaviewer.log'
 	],
+	[
+		# special sql query logging
+		'apps' => ['core/sql'],
+		'logfile' => __DIR__ . '/../data/sql.jsonl'
+	],
   ],
 
 /**

--- a/lib/kernel.php
+++ b/lib/kernel.php
@@ -551,12 +551,12 @@ class OC {
 		@\ini_set('log_errors', 1);
 
 		if (!\date_default_timezone_set('UTC')) {
-			\OC::$server->getLogger()->error('Could not set timezone to UTC');
-		};
+			self::$server->getLogger()->error('Could not set timezone to UTC');
+		}
 
-		//try to configure php to enable big file uploads.
-		//this doesn´t work always depending on the webserver and php configuration.
-		//Let´s try to overwrite some defaults anyway
+		// try to configure php to enable big file uploads.
+		// this doesn't work always depending on the webserver and php configuration.
+		// Let´s try to overwrite some defaults anyway
 
 		//try to set the maximum execution time to 60min
 		@\set_time_limit(3600);
@@ -685,6 +685,18 @@ class OC {
 			$lockProvider = \OC::$server->getLockingProvider();
 			$lockProvider->releaseAll();
 		});
+		$debug = \OC::$server->getConfig()->getSystemValue('debug', false);
+		if ($debug) {
+			\OC::$server->getShutdownHandler()->register(function () {
+				$queries = \OC::$server->getQueryLogger()->getQueries();
+				\OC::$server->getLogger()->debug("SQL query log", [
+					'app' => 'core/sql',
+					'extraFields' => [
+						'queries' => $queries
+					]
+				]);
+			});
+		}
 
 		// Check whether the sample configuration has been copied
 		if ($systemConfig->getValue('copied_sample_config', false)) {

--- a/lib/kernel.php
+++ b/lib/kernel.php
@@ -64,6 +64,7 @@ require_once 'public/Constants.php';
  * No, we can not put this class in its own file because it is used by
  * OC_autoload!
  */
+/** @codeCoverageIgnore */
 class OC {
 	/**
 	 * Associative array for autoloading. classname => filename

--- a/lib/private/Diagnostics/Query.php
+++ b/lib/private/Diagnostics/Query.php
@@ -24,21 +24,21 @@ namespace OC\Diagnostics;
 
 use OCP\Diagnostics\IQuery;
 
-class Query implements IQuery {
-	private $sql;
+class Query implements IQuery, \JsonSerializable {
+	private string $sql;
 
-	private $params;
+	private array $params;
 
-	private $start;
+	private int $start;
 
-	private $end;
+	private int $end;
 
 	/**
 	 * @param string $sql
 	 * @param array $params
 	 * @param int $start
 	 */
-	public function __construct($sql, $params, $start) {
+	public function __construct(string $sql, $params, $start) {
 		$this->sql = $sql;
 		$this->params = $params;
 		$this->start = $start;
@@ -74,5 +74,15 @@ class Query implements IQuery {
 	 */
 	public function getDuration() {
 		return $this->end - $this->start;
+	}
+
+	public function jsonSerialize() {
+		return [
+			'query' => $this->sql,
+			'parameters' => $this->params,
+			'duration' => $this->getDuration(),
+			'start' => $this->start,
+			'end' => $this->end,
+		];
 	}
 }

--- a/lib/private/Diagnostics/QueryLogger.php
+++ b/lib/private/Diagnostics/QueryLogger.php
@@ -25,15 +25,16 @@
 namespace OC\Diagnostics;
 
 use OCP\Diagnostics\IQueryLogger;
+use function microtime;
 
 class QueryLogger implements IQueryLogger {
 	/**
-	 * @var \OC\Diagnostics\Query
+	 * @var Query
 	 */
 	protected $activeQuery;
 
 	/**
-	 * @var \OC\Diagnostics\Query[]
+	 * @var Query[]
 	 */
 	protected $queries = [];
 
@@ -47,7 +48,7 @@ class QueryLogger implements IQueryLogger {
 	 */
 	public function startQuery($sql, array $params = null, array $types = null) {
 		if ($this->activated) {
-			$this->activeQuery = new Query($sql, $params, \microtime(true));
+			$this->activeQuery = new Query($sql, $params ?? [], microtime(true));
 		}
 	}
 
@@ -56,7 +57,7 @@ class QueryLogger implements IQueryLogger {
 	 */
 	public function stopQuery() {
 		if ($this->activated && $this->activeQuery) {
-			$this->activeQuery->end(\microtime(true));
+			$this->activeQuery->end(microtime(true));
 			$this->queries[] = $this->activeQuery;
 			$this->activeQuery = null;
 		}
@@ -74,5 +75,9 @@ class QueryLogger implements IQueryLogger {
 	 */
 	public function activate() {
 		$this->activated = true;
+	}
+
+	public function flush(): void {
+		$this->queries = [];
 	}
 }

--- a/lib/public/Diagnostics/IQueryLogger.php
+++ b/lib/public/Diagnostics/IQueryLogger.php
@@ -71,4 +71,11 @@ interface IQueryLogger extends SQLLogger {
 	 * @since 10.0.0
 	 */
 	public function activate();
+
+	/**
+	 * Clears out the query log
+	 *
+	 * @since 10.14.0
+	 */
+	public function flush(): void;
 }

--- a/tests/lib/AppConfigTest.php
+++ b/tests/lib/AppConfigTest.php
@@ -9,6 +9,7 @@
 
 namespace Test;
 use Symfony\Component\EventDispatcher\GenericEvent;
+use Test\Traits\AssertQueryCountTrait;
 
 /**
  * Class AppConfigTest
@@ -18,6 +19,8 @@ use Symfony\Component\EventDispatcher\GenericEvent;
  * @package Test
  */
 class AppConfigTest extends TestCase {
+	use AssertQueryCountTrait;
+
 	/** @var \OCP\IAppConfig */
 	protected $appConfig;
 
@@ -146,15 +149,17 @@ class AppConfigTest extends TestCase {
 		});
 	}
 
-	public function testGetApps() {
-		$config = new \OC\AppConfig(\OC::$server->getDatabaseConnection());
+	public function testGetApps(): void {
+		$this->assertQueryCountMatches(1, function () {
+			$config = new \OC\AppConfig(\OC::$server->getDatabaseConnection());
 
-		$this->assertEquals([
-			'anotherapp',
-			'someapp',
-			'testapp',
-			'123456',
-		], $config->getApps());
+			$this->assertEquals([
+				'anotherapp',
+				'someapp',
+				'testapp',
+				'123456',
+			], $config->getApps());
+		});
 	}
 
 	public function testGetKeys() {

--- a/tests/lib/Diagnostics/QueryLoggerTest.php
+++ b/tests/lib/Diagnostics/QueryLoggerTest.php
@@ -31,15 +31,15 @@ class QueryLoggerTest extends TestCase {
 	public function setUp(): void {
 		parent::setUp();
 
-		$this->logger = new QueryLogger();
+		$this->logger = new QueryLogger(2444666668888888);
 	}
 
-	public function testQueryLogger() {
+	public function testQueryLogger(): void {
 		// Module is not activated and this should not be logged
 		$this->logger->startQuery("SELECT", ["testuser", "count"], ["string", "int"]);
 		$this->logger->stopQuery();
 		$queries = $this->logger->getQueries();
-		$this->assertCount(0, $queries);
+		self::assertCount(0, $queries);
 
 		// Activate module and log some query
 		$this->logger->activate();
@@ -47,6 +47,18 @@ class QueryLoggerTest extends TestCase {
 		$this->logger->stopQuery();
 
 		$queries = $this->logger->getQueries();
-		$this->assertCount(1, $queries);
+		self::assertCount(1, $queries);
+
+		# assert json serialize
+		self::assertEquals([
+			'query' => 'SELECT',
+			'parameters' => [
+				'testuser',
+				'count'
+			],
+			'duration' => 0,
+			'start' => 2444666668888888,
+			'end' => 2444666668888888
+		], $queries[0]->jsonSerialize());
 	}
 }

--- a/tests/lib/Traits/AssertQueryCountTrait.php
+++ b/tests/lib/Traits/AssertQueryCountTrait.php
@@ -1,0 +1,83 @@
+<?php
+
+namespace Test\Traits;
+
+use Closure;
+use function PHPUnit\Framework\assertEquals;
+use function PHPUnit\Framework\assertGreaterThan;
+use function PHPUnit\Framework\assertLessThan;
+
+trait AssertQueryCountTrait {
+	public function assertNoQueriesExecuted(Closure $closure = null): void {
+		if ($closure) {
+			self::trackQueries();
+
+			$closure();
+		}
+
+		$this->assertQueryCountMatches(0);
+
+		if ($closure) {
+			self::flushQueryLog();
+		}
+	}
+
+	public function assertQueryCountMatches(int $count, Closure $closure = null): void {
+		if ($closure) {
+			self::trackQueries();
+
+			$closure();
+		}
+
+		assertEquals($count, self::getQueryCount());
+
+		if ($closure) {
+			self::flushQueryLog();
+		}
+	}
+
+	public function assertQueryCountLessThan(int $count, Closure $closure = null): void {
+		if ($closure) {
+			self::trackQueries();
+
+			$closure();
+		}
+
+		assertLessThan($count, self::getQueryCount());
+
+		if ($closure) {
+			self::flushQueryLog();
+		}
+	}
+
+	public function assertQueryCountGreaterThan(int $count, Closure $closure = null): void {
+		if ($closure) {
+			self::trackQueries();
+
+			$closure();
+		}
+
+		assertGreaterThan($count, self::getQueryCount());
+
+		if ($closure) {
+			self::flushQueryLog();
+		}
+	}
+
+	public static function trackQueries(): void {
+		self::flushQueryLog();
+		\OC::$server->getQueryLogger()->activate();
+	}
+
+	public static function getQueriesExecuted(): array {
+		return \OC::$server->getQueryLogger()->getQueries();
+	}
+
+	public static function getQueryCount(): int {
+		return \count(self::getQueriesExecuted());
+	}
+
+	private static function flushQueryLog() {
+		\OC::$server->getQueryLogger()->flush();
+	}
+}


### PR DESCRIPTION
…nt asserts got unit testing


## Description
During development and debugging it is quite interesting to see all sql queries per request.
The log messages are written with the app context `core/sql` which allows to redirect them all into a dedicated log file via log conditions (see sample config).
Please also note the file extension `.jsonl` - see https://jsonlines.org/

Output after reformating in IDE:
```
{
  "reqId": "GUIbokakiGBry534CYD0",
  "level": 0,
  "time": "2023-11-10T11:42:08+00:00",
  "remoteAddr": "127.0.0.1",
  "user": "alice",
  "app": "core\/sql",
  "method": "GET",
  "url": "\/index.php\/apps\/files\/?dir=\/&fileid=1929",
  "message": "SQL query log",
  "queries": [
    {
      "query": "SELECT * FROM \"oc_appconfig\"",
      "parameters": [],
      "duration": 0,
      "start": 1699616528,
      "end": 1699616528
    },
    {
      "query": "SELECT * FROM \"oc_accounts\" WHERE \"lower_user_id\" = :dcValue1",
      "parameters": {
        "dcValue1": "alice"
      },
      "duration": 0,
      "start": 1699616528,
      "end": 1699616528
    },
    {
      "query": "SELECT \"appid\", \"configkey\", \"configvalue\" FROM \"oc_preferences\" WHERE \"userid\" = ?",
      "parameters": [
        "alice"
      ],
      "duration": 0,
      "start": 1699616528,
      "end": 1699616528
    },
    {
      "query": "SELECT \"id\", \"uid\", \"login_name\", \"password\", \"name\", \"type\", \"token\", \"last_activity\", \"last_check\" FROM \"oc_authtoken\" WHERE \"token\" = :token",
      "parameters": {
        "token": "d839890fc821667f835ad213e3aa5b9f0ac01d44902f46e1e172ac59608f5514901bbff61619795ee4722dc202b423c5208997a37080aba314e4ec9fe3f23ebf"
      },
      "duration": 0,
      "start": 1699616528,
      "end": 1699616528
    },
    {
      "query": "SELECT \"uid\", \"password\" FROM \"oc_users\" WHERE LOWER(\"uid\") = LOWER(?)",
      "parameters": [
        "alice"
      ],
      "duration": 0,
      "start": 1699616528,
      "end": 1699616528
    },
    {
      "query": "SELECT * FROM \"oc_accounts\" WHERE \"lower_user_id\" = :dcValue1",
      "parameters": {
        "dcValue1": "alice"
      },
      "duration": 0,
      "start": 1699616528,
      "end": 1699616528
    },
    {
      "query": "SELECT \"uid\", \"displayname\" FROM \"oc_users\" WHERE LOWER(\"uid\") = LOWER(?)",
      "parameters": [
        "alice"
      ],
      "duration": 0,
      "start": 1699616528,
      "end": 1699616528
    },
    {
      "query": "UPDATE \"oc_authtoken\" SET \"last_check\" = ? WHERE \"id\" = ?",
      "parameters": {
        "1": 1699616528,
        "2": 23
      },
      "duration": 0,
      "start": 1699616528,
      "end": 1699616528
    },
    {
      "query": "UPDATE \"oc_authtoken\" SET \"last_check\" = ?,\"last_activity\" = ? WHERE \"id\" = ?",
      "parameters": {
        "1": 1699616528,
        "2": 1699616528,
        "3": 23
      },
      "duration": 0,
      "start": 1699616528,
      "end": 1699616528
    },
    {
      "query": "SELECT \"id\", \"uid\", \"login_name\", \"password\", \"name\", \"type\", \"token\", \"last_activity\", \"last_check\" FROM \"oc_authtoken\" WHERE \"token\" = :token",
      "parameters": {
        "token": "d839890fc821667f835ad213e3aa5b9f0ac01d44902f46e1e172ac59608f5514901bbff61619795ee4722dc202b423c5208997a37080aba314e4ec9fe3f23ebf"
      },
      "duration": 0,
      "start": 1699616528,
      "end": 1699616528
    },
    {
      "query": "SELECT \"id\", \"uid\", \"login_name\", \"password\", \"name\", \"type\", \"token\", \"last_activity\", \"last_check\" FROM \"oc_authtoken\" WHERE \"token\" = :token",
      "parameters": {
        "token": "d839890fc821667f835ad213e3aa5b9f0ac01d44902f46e1e172ac59608f5514901bbff61619795ee4722dc202b423c5208997a37080aba314e4ec9fe3f23ebf"
      },
      "duration": 0,
      "start": 1699616528,
      "end": 1699616528
    },
    {
      "query": "SELECT \"id\", \"uid\", \"login_name\", \"password\", \"name\", \"type\", \"token\", \"last_activity\", \"last_check\" FROM \"oc_authtoken\" WHERE \"token\" = :token",
      "parameters": {
        "token": "d839890fc821667f835ad213e3aa5b9f0ac01d44902f46e1e172ac59608f5514901bbff61619795ee4722dc202b423c5208997a37080aba314e4ec9fe3f23ebf"
      },
      "duration": 0,
      "start": 1699616528,
      "end": 1699616528
    },
    {
      "query": "SELECT * FROM \"oc_storages\" WHERE \"id\" = ?",
      "parameters": [
        "fd254efe6f858be769bc8b1c471d946c"
      ],
      "duration": 0,
      "start": 1699616528,
      "end": 1699616528
    },
    {
      "query": "SELECT \"fileid\" FROM \"oc_filecache\" WHERE \"storage\" = ? AND \"path_hash\" = ?",
      "parameters": [
        583,
        "d41d8cd98f00b204e9800998ecf8427e"
      ],
      "duration": 0,
      "start": 1699616528,
      "end": 1699616528
    },
    {
      "query": "SELECT * FROM \"oc_storages\" WHERE \"id\" = ?",
      "parameters": [
        "home::alice"
      ],
      "duration": 0,
      "start": 1699616528,
      "end": 1699616528
    },
    {
      "query": "SELECT \"fileid\" FROM \"oc_filecache\" WHERE \"storage\" = ? AND \"path_hash\" = ?",
      "parameters": [
        584,
        "d41d8cd98f00b204e9800998ecf8427e"
      ],
      "duration": 0,
      "start": 1699616528,
      "end": 1699616528
    },
    {
      "query": "SELECT \"storage_id\", \"root_id\", \"user_id\", \"mount_point\" FROM \"oc_mounts\" WHERE \"user_id\" = ? ORDER BY \"storage_id\" ASC",
      "parameters": {
        "1": "alice"
      },
      "duration": 0,
      "start": 1699616528,
      "end": 1699616528
    },
    {
      "query": "SELECT \"gid\" FROM \"oc_groups\" WHERE \"gid\" = :dcValue1",
      "parameters": {
        "dcValue1": "admin"
      },
      "duration": 0,
      "start": 1699616528,
      "end": 1699616528
    },
    {
      "query": "SELECT \"uid\" FROM \"oc_group_user\" WHERE (\"gid\" = :dcValue1) AND (\"uid\" = :dcValue2)",
      "parameters": {
        "dcValue1": "admin",
        "dcValue2": "alice"
      },
      "duration": 0,
      "start": 1699616528,
      "end": 1699616528
    },
    {
      "query": "SELECT \"fileid\", \"storage\", \"path\", \"parent\", \"name\", \"mimetype\", \"mimepart\", \"size\", \"mtime\",\n\t\t\t\t\t   \"storage_mtime\", \"encrypted\", \"etag\", \"permissions\", \"checksum\"\n\t\t\t\tFROM \"oc_filecache\" WHERE \"storage\" = ? AND \"path_hash\" = ?",
      "parameters": [
        584,
        "45b963397aa40d4a0063e0d85e4fe7a1"
      ],
      "duration": 0,
      "start": 1699616528,
      "end": 1699616528
    },
    {
      "query": "SELECT \"fileid\", \"storage\", \"path\", \"parent\", \"name\", \"mimetype\", \"mimepart\", \"size\", \"mtime\",\n\t\t\t\t\t   \"storage_mtime\", \"encrypted\", \"etag\", \"permissions\", \"checksum\"\n\t\t\t\tFROM \"oc_filecache\" WHERE \"storage\" = ? AND \"path_hash\" = ?",
      "parameters": [
        584,
        "45b963397aa40d4a0063e0d85e4fe7a1"
      ],
      "duration": 0,
      "start": 1699616528,
      "end": 1699616528
    },
    {
      "query": "SELECT \"fileid\", \"storage\", \"path\", \"parent\", \"name\", \"mimetype\", \"mimepart\", \"size\", \"mtime\",\n\t\t\t\t\t   \"storage_mtime\", \"encrypted\", \"etag\", \"permissions\", \"checksum\"\n\t\t\t\tFROM \"oc_filecache\" WHERE \"storage\" = ? AND \"path_hash\" = ?",
      "parameters": [
        584,
        "45b963397aa40d4a0063e0d85e4fe7a1"
      ],
      "duration": 0,
      "start": 1699616528,
      "end": 1699616528
    }
  ]
}
```


Finally this PR introduces asserts for query count for unit testing:
https://github.com/owncloud/core/blob/1649787803d7572733023a767a355a5a4e77fb0b/tests/lib/AppConfigTest.php#L153-L162

## Motivation and Context
Make ownCloud even greater! :rofl: 

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Database schema changes (next release will require increase of minor version instead of patch)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [ ] Tests only (no source changes)

## Checklist:
<!-- Tick the checkboxes when done. -->
<!-- Raise documentation ticket in https://github.com/owncloud/documentation -->
- [x] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 
- [ ] Changelog item, see [TEMPLATE](https://github.com/owncloud/core/blob/master/changelog/TEMPLATE)
