### PR TITLE
fix: user can only delete own external storage

### DIFF
--- a/apps/files_external/lib/Controller/UserStoragesController.php
+++ b/apps/files_external/lib/Controller/UserStoragesController.php
@@ -29,7 +29,6 @@ use OCP\AppFramework\Http;
 use OCP\AppFramework\Http\DataResponse;
 use OCP\Files\External\Auth\AuthMechanism;
 use OCP\Files\External\IStorageConfig;
-use OCP\Files\External\Lib\Backend\Backend;
 use OCP\Files\External\NotFoundException;
 use OCP\Files\External\Service\IUserStoragesService;
 use OCP\IL10N;
@@ -75,10 +74,8 @@ class UserStoragesController extends StoragesController {
 	}
 
 	protected function manipulateStorageConfig(IStorageConfig $storage) {
-		/** @var AuthMechanism */
 		$authMechanism = $storage->getAuthMechanism();
 		$authMechanism->manipulateStorageConfig($storage, $this->userSession->getUser());
-		/** @var Backend */
 		$backend = $storage->getBackend();
 		$backend->manipulateStorageConfig($storage, $this->userSession->getUser());
 	}

--- a/changelog/unreleased/41092
+++ b/changelog/unreleased/41092
@@ -1,0 +1,3 @@
+Bugfix: Users can only delete their own external storage configurations
+
+https://github.com/owncloud/core/pull/41092

--- a/lib/private/Files/External/Service/DBConfigService.php
+++ b/lib/private/Files/External/Service/DBConfigService.php
@@ -73,9 +73,9 @@ class DBConfigService {
 		$mounts = $this->getMountsFromQuery($query);
 		if (\count($mounts) > 0) {
 			return $mounts[0];
-		} else {
-			return null;
 		}
+
+		return null;
 	}
 
 	/**
@@ -424,6 +424,20 @@ class DBConfigService {
 				return \json_decode($option);
 			}, $options);
 		}, $optionsMap);
+	}
+
+	public function getPersonalMountById(int $mountId, string $userId): ?array {
+		$builder = $this->connection->getQueryBuilder();
+		$query = $this->getForQuery($builder, self::APPLICABLE_TYPE_USER, $userId);
+		$query->andWhere($builder->expr()->eq('m.type', $builder->expr()->literal(self::MOUNT_TYPE_PERSONAl, IQueryBuilder::PARAM_INT)));
+		$query->andWhere($builder->expr()->eq('m.mount_id', $builder->createNamedParameter($mountId, IQueryBuilder::PARAM_INT)));
+
+		$mounts = $this->getMountsFromQuery($query);
+		if (\count($mounts) > 0) {
+			return $mounts[0];
+		}
+
+		return null;
 	}
 
 	/**

--- a/lib/private/Files/External/Service/UserStoragesService.php
+++ b/lib/private/Files/External/Service/UserStoragesService.php
@@ -178,4 +178,13 @@ class UserStoragesService extends StoragesService implements IUserStoragesServic
 		}
 		return $result;
 	}
+
+	public function removeStorage($id) {
+		$mount = $this->dbConfig->getPersonalMountById($id, $this->getUser()->getUID());
+		if (!\is_array($mount)) {
+			throw new NotFoundException('Storage with id "' . $id . '" not found');
+		}
+
+		parent::removeStorage($id);
+	}
 }


### PR DESCRIPTION
## Description
Ensure that users can only delete their own external storage configurations.

## How Has This Been Tested?
- :robot: 

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Database schema changes (next release will require increase of minor version instead of patch)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [ ] Tests only (no source changes)

## Checklist:
<!-- Tick the checkboxes when done. -->
<!-- Raise documentation ticket in https://github.com/owncloud/documentation -->
- [x] Code changes
- [x] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 
- [ ] Changelog item, see [TEMPLATE](https://github.com/owncloud/core/blob/master/changelog/TEMPLATE)
