### PR TITLE
fix: drop JavaScript function `tipsy()` in favor of bootstrap tooltip

### DIFF
--- a/apps/federatedfilesharing/js/settings-admin.js
+++ b/apps/federatedfilesharing/js/settings-admin.js
@@ -8,6 +8,4 @@ $(document).ready(function() {
 		var app = (this.id !== 'autoAcceptTrusted') ? 'files_sharing' : 'federatedfilesharing';
 		OC.AppConfig.setValue(app, $(this).attr('name'), value);
 	});
-
-	$('.section .icon-info').tipsy({gravity: 'w'});
 });

--- a/apps/files/js/breadcrumb.js
+++ b/apps/files/js/breadcrumb.js
@@ -248,8 +248,7 @@
 					if (firstHidden) {
 						// set the path of this one as title for the ellipsis
 						this.$el.find('.crumb.ellipsized')
-							.attr('title', $crumb.attr('data-dir'))
-							.tipsy();
+							.tooltip({title: $crumb.attr('data-dir'), placement: 'bottom'});
 						this.$el.find('.ellipsis')
 							.wrap('<a class="ellipsislink" href="' + encodeURI(OC.generateUrl('apps/files/?dir=' + $crumb.attr('data-dir'))) + '"></a>');
 					}

--- a/apps/files/js/file-upload.js
+++ b/apps/files/js/file-upload.js
@@ -1201,7 +1201,7 @@ OC.Uploader.prototype = _.extend({
 				start: function(e) {
 					self.log('start', e, null);
 					//hide the tooltip otherwise it covers the progress bar
-					$('#upload').tipsy('hide');
+					$('#upload').tooltip('hide');
 				},
 				fail: function(e, data) {
 					var upload = self.getUpload(data);
@@ -1370,7 +1370,7 @@ OC.Uploader.prototype = _.extend({
 							+ '</span><span class="mobile">'
 							+ t('files', '...')
 							+ '</span></em>');
-					self.$uploadprogressbar.tipsy({gravity:'n', fade:true, live:true});
+					self.$uploadprogressbar.tooltip();
 					self._showProgressBar();
 					self.trigger('start', e, data);
 				});

--- a/core/js/backgroundjobs.js
+++ b/core/js/backgroundjobs.js
@@ -22,6 +22,4 @@
 // start worker once page has loaded
 $(document).ready(function(){
 	$.get( OC.webroot+'/cron.php' );
-
-	$('.section .icon-info').tipsy({gravity: 'w'});
 });

--- a/core/js/js.js
+++ b/core/js/js.js
@@ -1459,6 +1459,9 @@ function object(o) {
  * Initializes core
  */
 function initCore() {
+	// setup tooltip
+	$('.section .icon-info').tooltip({placement: 'right'});
+
 	/**
 	 * Disable automatic evaluation of responses for $.ajax() functions (and its
 	 * higher-level alternatives like $.get() and $.post()).
@@ -2472,66 +2475,6 @@ jQuery.fn.exists = function () {
  */
 function getScrollBarWidth() {
 	return OC.Util.getScrollBarWidth();
-}
-
-/**
- * jQuery tipsy shim for the bootstrap tooltip
- */
-jQuery.fn.tipsy = function (argument) {
-	console.warn('Deprecation warning: tipsy is deprecated. Use tooltip instead.');
-	if (typeof argument === 'object' && argument !== null) {
-
-		// tipsy defaults
-		var options = {
-			placement: 'bottom',
-			delay: {'show': 0, 'hide': 0},
-			trigger: 'hover',
-			html: false,
-			container: 'body'
-		};
-		if (argument.gravity) {
-			switch (argument.gravity) {
-				case 'n':
-				case 'nw':
-				case 'ne':
-					options.placement = 'bottom';
-					break;
-				case 's':
-				case 'sw':
-				case 'se':
-					options.placement = 'top';
-					break;
-				case 'w':
-					options.placement = 'right';
-					break;
-				case 'e':
-					options.placement = 'left';
-					break;
-			}
-		}
-		if (argument.trigger) {
-			options.trigger = argument.trigger;
-		}
-		if (argument.delayIn) {
-			options.delay["show"] = argument.delayIn;
-		}
-		if (argument.delayOut) {
-			options.delay["hide"] = argument.delayOut;
-		}
-		if (argument.html) {
-			options.html = true;
-		}
-		if (argument.fallback) {
-			options.title = argument.fallback;
-		}
-		// destroy old tooltip in case the title has changed
-		jQuery.fn.tooltip.call(this, 'destroy');
-		jQuery.fn.tooltip.call(this, options);
-	} else {
-		this.tooltip(argument);
-		jQuery.fn.tooltip.call(this, argument);
-	}
-	return this;
 }
 
 jQuery.extend = jQuery.fn.extend = function() {

--- a/core/js/share.js
+++ b/core/js/share.js
@@ -269,7 +269,7 @@ OC.Share = _.extend(OC.Share || {}, {
 			}
 			action.html('<span> ' + message + '</span>').prepend(icon);
 			if (owner || recipients) {
-				action.find('.remoteAddress').tipsy({gravity: 's'});
+				action.find('.remoteAddress').tooltip({placement: 'top'});
 			}
 		}
 		else {

--- a/core/js/singleselect.js
+++ b/core/js/singleselect.js
@@ -2,13 +2,13 @@
 	$.fn.singleSelect = function () {
 		return this.each(function (i, select) {
 			var input = $('<input/>'),
-				gravity = $(select).attr('data-tipsy-gravity'),
+				placement = $(select).attr('data-tooltip-placement'),
 				inputTooltip = $(select).attr('data-inputtitle');
 			if (inputTooltip){
 				input.attr('title', inputTooltip);
 			}
-			if (typeof gravity === 'undefined') {
-				gravity = 'n'
+			if (typeof placement === 'undefined') {
+				placement = 'top'
 			}
 			select = $(select);
 			input.css('position', 'absolute');
@@ -38,10 +38,9 @@
 					// adjust offset, in case the user scrolled
 					input.css(select.offset());
 					input.show();
-					if ($.fn.tipsy){
-						input.tipsy({gravity: gravity, trigger: 'manual'});
-						input.tipsy('show');
-					}
+					input.tooltip({trigger: 'manual', placement: placement});
+					input.tooltip('show');
+
 					select.css('background-color', 'white');
 					input.focus();
 				}
@@ -83,9 +82,7 @@
 
 			input.on('blur', function () {
 				$(this).change();
-				if ($.fn.tipsy){
-					$(this).tipsy('hide');
-				}
+				$(this).tooltip('hide');
 			});
 			input.click(function(ev) {
 				// prevent clicks to close any container

--- a/core/js/tests/specs/shareSpec.js
+++ b/core/js/tests/specs/shareSpec.js
@@ -23,10 +23,10 @@
 describe('OC.Share tests', function() {
 	describe('markFileAsShared', function() {
 		var $file;
-		var tipsyStub;
+		var tooltipStub;
 
 		beforeEach(function() {
-			tipsyStub = sinon.stub($.fn, 'tipsy');
+			tooltipStub = sinon.stub($.fn, 'tooltip');
 			$file = $('<tr><td class="filename"><div class="thumbnail"></div><span class="name">File name</span></td></tr>');
 			$file.find('.filename').append(
 				'<span class="fileactions">' +
@@ -38,7 +38,7 @@ describe('OC.Share tests', function() {
 		});
 		afterEach(function() {
 			$file = null;
-			tipsyStub.restore();
+			tooltipStub.restore();
 		});
 		describe('displaying the share owner', function() {
 			function checkOwner(input, output, title) {
@@ -54,8 +54,8 @@ describe('OC.Share tests', function() {
 				} else {
 					expect($action.find('.remoteAddress').attr('title')).not.toBeDefined();
 				}
-				expect(tipsyStub.calledOnce).toEqual(true);
-				tipsyStub.reset();
+				expect(tooltipStub.calledOnce).toEqual(true);
+				tooltipStub.reset();
 			}
 
 			it('displays the local share owner as is', function() {
@@ -171,8 +171,8 @@ describe('OC.Share tests', function() {
 				} else {
 						expect($action.find('.remoteAddress').attr('title')).not.toBeDefined();
 				}
-				expect(tipsyStub.calledOnce).toEqual(true);
-				tipsyStub.reset();
+				expect(tooltipStub.calledOnce).toEqual(true);
+				tooltipStub.reset();
 			}
 
 			it('displays the local share owner as is', function() {

--- a/settings/js/admin-apps.js
+++ b/settings/js/admin-apps.js
@@ -121,11 +121,11 @@ OC.Settings.Apps = OC.Settings.Apps || {
 					$('#apps-list-empty').removeClass('hidden').find('h2').text(t('settings', 'No apps found for your version'));
 				}
 
-				$('.enable.needs-download').tipsy({fallback: t('settings', 'The app will be downloaded from the app store')});
+				$('.enable.needs-download').tooltip({title: t('settings', 'The app will be downloaded from the app store'), container: 'body'});
 
-				$('.app-level .official').tipsy({fallback: t('settings', 'Official apps are developed by and within the ownCloud community. They offer functionality central to ownCloud and are ready for production use.')});
-				$('.app-level .approved').tipsy({fallback: t('settings', 'Approved apps are developed by trusted developers and have passed a cursory security check. They are actively maintained in an open code repository and their maintainers deem them to be stable for casual to normal use.')});
-				$('.app-level .experimental').tipsy({fallback: t('settings', 'This app is not checked for security issues and is new or known to be unstable. Install at your own risk.')});
+				$('.app-level .official').tooltip({title: t('settings', 'Official apps are developed by and within the ownCloud community. They offer functionality central to ownCloud and are ready for production use.'), container: 'body'});
+				$('.app-level .approved').tooltip({title: t('settings', 'Approved apps are developed by trusted developers and have passed a cursory security check. They are actively maintained in an open code repository and their maintainers deem them to be stable for casual to normal use.'), container: 'body'});
+				$('.app-level .experimental').tooltip({title: t('settings', 'This app is not checked for security issues and is new or known to be unstable. Install at your own risk.'), container: 'body'});
 			},
 			complete: function() {
 				$('#apps-list').removeClass('icon-loading');

--- a/settings/js/certificates.js
+++ b/settings/js/certificates.js
@@ -13,7 +13,7 @@ $(document).ready(function () {
 		return true;
 	});
 
-	$('#sslCertificate tr > td').tipsy({gravity: 'n', live: true});
+	$('#sslCertificate tr > td').tooltip({placement: 'top'});
 
 	$('#rootcert_import').fileupload({
 		pasteZone: null,

--- a/settings/js/panels/backgroundjobs.js
+++ b/settings/js/panels/backgroundjobs.js
@@ -1,6 +1,6 @@
 $(document).ready(function() {
 
-	$('#backgroundjobs span.crondate').tipsy({gravity: 's', live: true});
+	$('#backgroundjobs span.crondate').tooltip({placement: 'top'});
 
 	$('#backgroundjobs input').change(function () {
 		if ($(this).is(':checked')) {

--- a/settings/js/users/users.js
+++ b/settings/js/users/users.js
@@ -774,9 +774,9 @@ $(document).ready(function () {
 		var isRestoreDisabled = UserList.getRestoreDisabled($td) === true;
 		if(isRestoreDisabled) {
 			$tr.addClass('row-warning');
-			// add tipsy if the password change could cause data loss - no recovery enabled
-			$input.tipsy({gravity:'s'});
-			$input.attr('title', t('settings', 'Changing the password will result in data loss, because data recovery is not available for this user'));
+			// add tooltip if the password change could cause data loss - no recovery enabled
+			var title = t('settings', 'Changing the password will result in data loss, because data recovery is not available for this user');
+			$input.tooltip({placement:'bottom', title: title});
 		}
 		$td.find('img').hide();
 		$td.children('span').replaceWith($input);

--- a/settings/templates/panels/admin/backgroundjobs.php
+++ b/settings/templates/panels/admin/backgroundjobs.php
@@ -14,12 +14,12 @@ script('settings', 'panels/backgroundjobs');
 			$absolute_time = OC_Util::formatDate($_['lastcron']);
 			if (\time() - $_['lastcron'] <= 3600): ?>
 				<span class="status success"></span>
-				<span class="crondate" original-title="<?php p($absolute_time);?>">
+				<span class="crondate" title="<?php p($absolute_time);?>">
 					<?php p($l->t("Last cron job execution: %s.", [$relative_time]));?>
 				</span>
 			<?php else: ?>
 				<span class="status error"></span>
-				<span class="crondate" original-title="<?php p($absolute_time);?>">
+				<span class="crondate" title="<?php p($absolute_time);?>">
 					<?php p($l->t("Last cron job execution: %s. Something seems wrong.", [$relative_time]));?>
 				</span>
 			<?php endif;

--- a/settings/templates/users/part.setquota.php
+++ b/settings/templates/users/part.setquota.php
@@ -2,7 +2,9 @@
 	<!-- Default storage -->
 	<span><?php p($l->t('Default Quota'));?></span>
 	<?php if ((bool) $_['isAdmin']): ?>
-		<select id='default_quota' data-inputtitle="<?php p($l->t('Please enter storage quota (ex: "512 MB" or "12 GB")')) ?>" data-tipsy-gravity="s">
+		<select id='default_quota'
+				data-inputtitle="<?php p($l->t('Please enter storage quota (ex: "512 MB" or "12 GB")')) ?>"
+				data-tooltip-placement="top">
 			<option <?php if ($_['default_quota'] === 'none') {
 				print_unescaped('selected="selected"');
 			}?> value='none'>


### PR DESCRIPTION
## Description
jquery tipsy was removed back in 2015 or even earlier - enough time for everybody to migrate to bootstrap tooltip

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
- test environment:
- test case 1:
- test case 2:
- ...

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Database schema changes (next release will require increase of minor version instead of patch)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Technical debt
- [ ] Tests only (no source changes)

## Checklist:
<!-- Tick the checkboxes when done. -->
<!-- Raise documentation ticket in https://github.com/owncloud/documentation -->
- [x] Code changes
- [x] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 
- [ ] Changelog item, see [TEMPLATE](https://github.com/owncloud/core/blob/master/changelog/TEMPLATE)
