### PR TITLE
feat: check conventional commits in drone

### DIFF
--- a/.drone.star
+++ b/.drone.star
@@ -552,7 +552,7 @@ def main(ctx):
     return initial + before + coverageTests + afterCoverageTests + nonCoverageTests + stages + after
 
 def initialPipelines(ctx):
-    return dependencies(ctx) + checkStarlark()
+    return dependencies(ctx) + checkStarlark() + checkGitCommit()
 
 def beforePipelines(ctx):
     return codestyle(ctx) + changelog(ctx) + phpstan(ctx) + phan(ctx)
@@ -3030,6 +3030,25 @@ def checkStarlark():
                         "failure",
                     ],
                 },
+            },
+        ],
+        "depends_on": [],
+        "trigger": {
+            "ref": [
+                "refs/pull/**",
+            ],
+        },
+    }]
+
+def checkGitCommit():
+    return [{
+        "kind": "pipeline",
+        "type": "docker",
+        "name": "check-git-commit-messages",
+        "steps": [
+            {
+                "name": "format-check-git-commit",
+                "image": "aevea/commitsar:latest",
             },
         ],
         "depends_on": [],


### PR DESCRIPTION
## Description
We agreed on following https://www.conventionalcommits.org/en/v1.0.0/ 
This drone step will ensure this.


## Screenshots (if appropriate):
### Not compliant
![image](https://github.com/owncloud/core/assets/1005065/ee7d829c-2e08-415f-9cd0-8d74cec63a5f)

### Compliant
![Screenshot from 2023-11-16 10-06-54](https://github.com/owncloud/core/assets/1005065/c509cb57-9d0f-4a83-84cd-7d6b86ae2b56)


## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Database schema changes (next release will require increase of minor version instead of patch)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [ ] Tests only (no source changes)

## Checklist:
<!-- Tick the checkboxes when done. -->
<!-- Raise documentation ticket in https://github.com/owncloud/documentation -->
- [ ] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 
- [ ] Changelog item, see [TEMPLATE](https://github.com/owncloud/core/blob/master/changelog/TEMPLATE)
