### PR TITLE
fix: reduce sql queries in Share::getUsersSharingFile()

### DIFF
--- a/lib/private/Diagnostics/Query.php
+++ b/lib/private/Diagnostics/Query.php
@@ -76,6 +76,23 @@ class Query implements IQuery, \JsonSerializable {
 		return $this->end - $this->start;
 	}
 
+	public function getFullSql(): string {
+		$s = preg_replace('/\s\s+/', ' ', $this->sql);
+		foreach ($this->params as $i => $param) {
+			$param = json_encode($param);
+			# NOTE: this might not result in a perfect sql query because ? must not be a placeholder
+			# nevertheless for analysis purpose this is a good enough approach
+			$pos = strpos($s, '?');
+			if ($pos !== false) {
+				$s = substr_replace($s, $param, $pos, \strlen('?'));
+			} else {
+				$s = str_replace(":$i", $param, $s);
+			}
+		}
+
+		return $s;
+	}
+
 	public function jsonSerialize() {
 		return [
 			'query' => $this->sql,

--- a/lib/public/IDBConnection.php
+++ b/lib/public/IDBConnection.php
@@ -57,7 +57,7 @@ interface IDBConnection {
 	 * @param string $sql the sql query with ? placeholder for params
 	 * @param int $limit the maximum number of rows
 	 * @param int $offset from which row we want to start
-	 * @return \Doctrine\DBAL\Driver\Statement The prepared statement.
+	 * @return \Doctrine\DBAL\Statement The prepared statement.
 	 * @since 6.0.0
 	 */
 	public function prepare($sql, $limit=null, $offset=null);

--- a/tests/lib/Share/GetUsersSharingFileTest.php
+++ b/tests/lib/Share/GetUsersSharingFileTest.php
@@ -1,8 +1,9 @@
 <?php
 
-namespace lib\Share;
+namespace Test\Share;
 
 use OC;
+use OCP\Files\Node;
 use OC\Share\Constants;
 use OC\Share\Share;
 use OC\User\NoUserException;
@@ -14,6 +15,7 @@ use OCP\IUser;
 use OCP\Share\Exceptions\GenericShareException;
 use OCP\Share\IShare;
 use Test\TestCase;
+use Test\Traits\AssertQueryCountTrait;
 use Test\Traits\GroupTrait;
 use Test\Traits\UserTrait;
 use function PHPUnit\Framework\assertEquals;
@@ -22,7 +24,7 @@ use function PHPUnit\Framework\assertEquals;
  * @group DB
  */
 class GetUsersSharingFileTest extends TestCase {
-	use UserTrait, GroupTrait;
+	use UserTrait, GroupTrait, AssertQueryCountTrait;
 
 	/**
 	 * @throws GenericShareException
@@ -42,7 +44,7 @@ class GetUsersSharingFileTest extends TestCase {
 	/**
 	 * @throws GenericShareException
 	 */
-	private static function shareWithUser(File $file, IUser $user, IUser $owner): IShare {
+	private static function shareWithUser(Node $file, IUser $user, IUser $owner): IShare {
 		$sm = OC::$server->getShareManager();
 		$share = $sm->newShare();
 		$share->setSharedBy($owner->getUID());
@@ -50,6 +52,20 @@ class GetUsersSharingFileTest extends TestCase {
 		$share->setNode($file);
 		$share->setShareType(Constants::SHARE_TYPE_USER);
 		$share->setPermissions(OCConstants::PERMISSION_ALL);
+
+		return $sm->createShare($share);
+	}
+
+	/**
+	 * @throws GenericShareException
+	 */
+	private static function shareByLink(File $file, IUser $owner): IShare {
+		$sm = OC::$server->getShareManager();
+		$share = $sm->newShare();
+		$share->setSharedBy($owner->getUID());
+		$share->setNode($file);
+		$share->setShareType(Constants::SHARE_TYPE_LINK);
+		$share->setPermissions(OCConstants::PERMISSION_READ);
 
 		return $sm->createShare($share);
 	}
@@ -69,15 +85,17 @@ class GetUsersSharingFileTest extends TestCase {
 		self::loginAsUser($alice->getUID());
 		$aliceFolder = OC::$server->getUserFolder($alice->getUID());
 		$file = self::createFileWithContent($aliceFolder, 'welcome.txt', 'loram ipsum');
-		$share = self::shareWithGroup($file, $group, $alice);
+		self::shareWithGroup($file, $group, $alice);
 
 		# test
+		self::trackQueries();
 		$result = Share::getUsersSharingFile('welcome.txt', $alice->getUID());
 		assertEquals([
 			'users' => ['alice', 'bob'],
 			'public' => false,
 			'remote' => false
 		], $result);
+		$this->assertQueryCountLessThan(9);
 	}
 
 	/**
@@ -96,16 +114,18 @@ class GetUsersSharingFileTest extends TestCase {
 		$share = self::shareWithUser($file, $bob, $alice);
 
 		# test accepted
+		self::trackQueries();
 		$result = Share::getUsersSharingFile('welcome.txt', $alice->getUID());
 		assertEquals([
 			'users' => ['bob'],
 			'public' => false,
 			'remote' => false
 		], $result);
+		$this->assertQueryCountMatches(7);
 
-		# tst rejected
+		# test rejected
 		$share->setState(Constants::STATE_REJECTED);
-		\OC::$server->getShareManager()->updateShare($share);
+		OC::$server->getShareManager()->updateShare($share);
 
 		$result = Share::getUsersSharingFile('welcome.txt', $alice->getUID());
 		assertEquals([
@@ -113,5 +133,102 @@ class GetUsersSharingFileTest extends TestCase {
 			'public' => false,
 			'remote' => false
 		], $result);
+	}
+
+	/**
+	 * @throws NotPermittedException
+	 * @throws NoUserException
+	 * @throws GenericShareException
+	 */
+	public function testPublicLink(): void {
+		# setup
+		$alice = $this->createUser('alice');
+
+		self::loginAsUser($alice->getUID());
+		$aliceFolder = OC::$server->getUserFolder($alice->getUID());
+		$file = self::createFileWithContent($aliceFolder, 'welcome.txt', 'loram ipsum');
+		self::shareByLink($file, $alice);
+
+		# test
+		self::trackQueries();
+		$result = Share::getUsersSharingFile('welcome.txt', $alice->getUID());
+		assertEquals([
+			'users' => [],
+			'public' => true,
+			'remote' => false
+		], $result);
+		$this->assertQueryCountMatches(7);
+	}
+
+	/**
+	 * @throws NotPermittedException
+	 * @throws NoUserException
+	 * @throws GenericShareException
+	 */
+	public function testRecursive() : void {
+		# setup
+		$alice = $this->createUser('alice');
+		$bob = $this->createUser('bob');
+
+		self::loginAsUser($alice->getUID());
+		$aliceFolder = OC::$server->getUserFolder($alice->getUID());
+		$fooFolder = $aliceFolder->newFolder('foo');
+		self::createFileWithContent($fooFolder, 'welcome.txt', 'loram ipsum');
+		self::shareWithUser($fooFolder, $bob, $alice);
+
+		# test recursive
+		$result = Share::getUsersSharingFile('foo/welcome.txt', $alice->getUID());
+		assertEquals([
+			'users' => ['bob'],
+			'public' => false,
+			'remote' => false
+		], $result);
+
+		# test recursive
+		self::trackQueries();
+		$result = Share::getUsersSharingFile('foo/welcome.txt', $alice->getUID(), false, false, false);
+		assertEquals([
+			'users' => [],
+			'public' => false,
+			'remote' => false
+		], $result);
+		$this->assertQueryCountMatches(4);
+	}
+
+	/**
+	 * @throws NotPermittedException
+	 * @throws NoUserException
+	 * @throws GenericShareException
+	 */
+	public function testIncludeOwner() : void {
+		self::assertTrue(Share::isEnabled());
+		# setup
+		$alice = $this->createUser('alice');
+		$bob = $this->createUser('bob');
+
+		self::loginAsUser($alice->getUID());
+		$aliceFolder = OC::$server->getUserFolder($alice->getUID());
+		$fooFolder = $aliceFolder->newFolder('foo');
+		self::createFileWithContent($fooFolder, 'welcome.txt', 'loram ipsum');
+		self::shareWithUser($fooFolder, $bob, $alice);
+
+		self::trackQueries();
+		$result = Share::getUsersSharingFile('foo/welcome.txt', $alice->getUID(), true, true);
+		assertEquals([
+			'bob' => '/foo/welcome.txt',
+			'alice' => '/foo/welcome.txt',
+		], $result);
+		# in some cases there is an additional query required because Cache::$path_cache is not holding the path in question
+		$this->assertQueryCountLessThan(11);
+
+		# let's see how bob is doing ....
+		self::loginAsUser($bob->getUID());
+		self::trackQueries();
+		$result = Share::getUsersSharingFile('foo/welcome.txt', $bob->getUID(), true, true);
+		assertEquals([
+			'bob' => '/foo/welcome.txt',
+		], $result);
+		# in some cases there is an additional query required because Cache::$path_cache is not holding the path in question
+		$this->assertQueryCountLessThan(11);
 	}
 }

--- a/tests/lib/Traits/AssertQueryCountTrait.php
+++ b/tests/lib/Traits/AssertQueryCountTrait.php
@@ -3,6 +3,7 @@
 namespace Test\Traits;
 
 use Closure;
+use OC\Diagnostics\Query;
 use function PHPUnit\Framework\assertEquals;
 use function PHPUnit\Framework\assertGreaterThan;
 use function PHPUnit\Framework\assertLessThan;
@@ -33,7 +34,7 @@ trait AssertQueryCountTrait {
 		}
 
 		self::ensureTacking();
-		assertEquals($count, self::getQueryCount());
+		assertEquals($count, self::getQueryCount(), self::buildAssertMessage());
 
 		if ($closure) {
 			self::flushQueryLog();
@@ -48,7 +49,7 @@ trait AssertQueryCountTrait {
 		}
 
 		self::ensureTacking();
-		assertLessThan($count, self::getQueryCount());
+		assertLessThan($count, self::getQueryCount(), self::buildAssertMessage());
 
 		if ($closure) {
 			self::flushQueryLog();
@@ -63,7 +64,7 @@ trait AssertQueryCountTrait {
 		}
 
 		self::ensureTacking();
-		assertGreaterThan($count, self::getQueryCount());
+		assertGreaterThan($count, self::getQueryCount(), self::buildAssertMessage());
 
 		if ($closure) {
 			self::flushQueryLog();
@@ -80,6 +81,11 @@ trait AssertQueryCountTrait {
 		return \OC::$server->getQueryLogger()->getQueries();
 	}
 
+	public static function getQueriesExecutedHumanReadable(): array {
+		$queries = self::getQueriesExecuted();
+		return array_map(static fn (Query $q) => $q->getFullSql(), $queries);
+	}
+
 	public static function getQueryCount(): int {
 		return \count(self::getQueriesExecuted());
 	}
@@ -90,5 +96,9 @@ trait AssertQueryCountTrait {
 
 	private static function ensureTacking(): void {
 		assertTrue(self::$trackingStarted, "SQl query tracking not enabled.");
+	}
+
+	private static function buildAssertMessage(): string {
+		return "Recorded queries: " . PHP_EOL . implode(PHP_EOL, self::getQueriesExecutedHumanReadable());
 	}
 }


### PR DESCRIPTION
## Description
Save the :ringed_planet:  - save CPU, network, memory, energy :dancers: 

Number of queries of `Share::getUsersSharingFile()` has been reduced from 17+ to 8

## Motivation and Context
Be smart on sql queries

## How Has This Been Tested?
- :robot: 

## Screenshots (if appropriate):
![image](https://github.com/owncloud/core/assets/1005065/2555f3d1-3667-4b95-8921-2102cc0b447d)

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Database schema changes (next release will require increase of minor version instead of patch)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Technical debt
- [ ] Tests only (no source changes)

## Checklist:
<!-- Tick the checkboxes when done. -->
<!-- Raise documentation ticket in https://github.com/owncloud/documentation -->
- [x] Code changes
- [x] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 
- [ ] Changelog item, see [TEMPLATE](https://github.com/owncloud/core/blob/master/changelog/TEMPLATE)
