### PR TITLE
feat: add input validation to AppFramework controller

### DIFF
--- a/lib/private/AppFramework/DependencyInjection/DIContainer.php
+++ b/lib/private/AppFramework/DependencyInjection/DIContainer.php
@@ -34,6 +34,7 @@ use OC;
 use OC\AppFramework\Http;
 use OC\AppFramework\Http\Dispatcher;
 use OC\AppFramework\Http\Output;
+use OC\AppFramework\Middleware\InputValidationMiddleware;
 use OC\AppFramework\Middleware\MiddlewareDispatcher;
 use OC\AppFramework\Middleware\Security\CORSMiddleware;
 use OC\AppFramework\Middleware\Security\SecurityMiddleware;
@@ -399,6 +400,7 @@ class DIContainer extends SimpleContainer implements IAppContainer {
 			$dispatcher->registerMiddleware($c['SecurityMiddleware']);
 			$dispatcher->registerMiddleware($c['TwoFactorMiddleware']);
 			$dispatcher->registerMiddleware($c->query(AccountModuleMiddleware::class));
+			$dispatcher->registerMiddleware($c->query(InputValidationMiddleware::class));
 
 			foreach ($middleWares as $middleWare) {
 				$dispatcher->registerMiddleware($c[$middleWare]);

--- a/lib/private/AppFramework/Middleware/InputValidationMiddleware.php
+++ b/lib/private/AppFramework/Middleware/InputValidationMiddleware.php
@@ -1,0 +1,60 @@
+<?php
+/**
+ * @author Morris Jobke <hey@morrisjobke.de>
+ * @author Roeland Jago Douma <rullzer@users.noreply.github.com>
+ * @author Thomas Müller <thomas.mueller@tmit.eu>
+ *
+ * @copyright Copyright (c) 2018, ownCloud GmbH
+ * @license AGPL-3.0
+ *
+ * This code is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License, version 3,
+ * as published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License, version 3,
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>
+ *
+ */
+
+namespace OC\AppFramework\Middleware;
+
+use OCP\AppFramework\Http;
+use OCP\AppFramework\Http\JSONResponse;
+use OCP\AppFramework\ValidationException;
+use OCP\AppFramework\Middleware;
+use OCP\IL10N;
+
+class InputValidationMiddleware extends Middleware {
+	private IL10N $l10n;
+
+	public function __construct(
+		IL10N $l10n
+	) {
+		$this->l10n = $l10n;
+	}
+
+	public function afterException($controller, $methodName, \Exception $exception) {
+		if ($exception instanceof ValidationException) {
+			$message = $this->l10n->t('The given data was invalid.');
+			return new JSONResponse(
+				[
+					# some frontend elements are expecting .status and .data.message
+					'status' => 'error',
+					'data' => [
+						'message' => $message,
+					],
+					# .message should be enough for and cases
+					'message' => $message,
+				],
+				Http::STATUS_UNPROCESSABLE_ENTITY
+			);
+		}
+
+		throw $exception;
+	}
+}

--- a/lib/private/Share20/DefaultShareProvider.php
+++ b/lib/private/Share20/DefaultShareProvider.php
@@ -398,6 +398,8 @@ class DefaultShareProvider implements IShareProvider {
 			}
 
 			if (!$group->inGroup($user)) {
+				$u = $user === null ? "No longer known user: $recipient" : $user->getUID();
+				\OC::$server->getLogger()->error("DefaultShareProvider: $u not in group " . $group->getGID());
 				throw new ProviderException('Recipient not in receiving group');
 			}
 

--- a/lib/public/AppFramework/Controller.php
+++ b/lib/public/AppFramework/Controller.php
@@ -42,6 +42,8 @@ use OCP\IRequest;
  * @since 6.0.0
  */
 abstract class Controller {
+	use ControllerValidationTrait;
+
 	/**
 	 * app name
 	 * @var string

--- a/lib/public/AppFramework/ControllerValidationTrait.php
+++ b/lib/public/AppFramework/ControllerValidationTrait.php
@@ -1,0 +1,33 @@
+<?php
+
+namespace OCP\AppFramework;
+
+use OC\AppFramework\Http;
+use OCP\AppFramework\Http\DataResponse;
+
+trait ControllerValidationTrait {
+	/**
+	 * @since 10.14.0
+	 * @throws ValidationException
+	 */
+	protected function validateString(string $string, int $max): void {
+		if (\strlen($string) > $max) {
+			throw new ValidationException();
+		}
+	}
+
+	/**
+	 * @since 10.14.0
+	 * @throws ValidationException
+	 */
+	protected function validateEMail(string $email, bool $allowEmpty = false): ?DataResponse {
+		if ($allowEmpty && $email === '') {
+			return null;
+		}
+		$mailer = \OC::$server->getMailer();
+		if ($email !== '' && !$mailer->validateMailAddress($email)) {
+			throw new ValidationException();
+		}
+		return null;
+	}
+}

--- a/lib/public/AppFramework/ValidationException.php
+++ b/lib/public/AppFramework/ValidationException.php
@@ -1,0 +1,12 @@
+<?php
+
+namespace OCP\AppFramework;
+
+/**
+ * Class ValidationException
+ *
+ * @package OCP\AppFramework
+ * @since 10.14.0
+ */
+class ValidationException extends \Exception {
+}

--- a/settings/js/panels/profile.js
+++ b/settings/js/panels/profile.js
@@ -48,6 +48,8 @@ function changeDisplayName () {
 				$('#newdisplayname').val(data.data.displayName);
 			}
 			OC.msg.finishedSaving('#displaynameform .msg', data);
+		}).fail(function(result){
+			OC.msg.finishedSaving('#displaynameform .msg', result.responseJSON);
 		});
 	}
 }

--- a/tests/lib/AppFramework/Http/DispatcherValidationExceptionTest.php
+++ b/tests/lib/AppFramework/Http/DispatcherValidationExceptionTest.php
@@ -1,0 +1,62 @@
+<?php
+
+/**
+ * ownCloud - App Framework
+ *
+ * @author Bernhard Posselt
+ * @copyright Copyright (c) 2012 Bernhard Posselt <dev@bernhard-posselt.com>
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU AFFERO GENERAL PUBLIC LICENSE
+ * License as published by the Free Software Foundation; either
+ * version 3 of the License, or any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU AFFERO GENERAL PUBLIC LICENSE for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public
+ * License along with this library.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+namespace Test\AppFramework\Http;
+
+use OC;
+use OC\AppFramework\Http\Request;
+use OCP\AppFramework\Controller;
+use OCP\AppFramework\ValidationException;
+use Test\TestCase;
+
+/**
+ * @group DB
+ */
+class DispatcherValidationExceptionTest extends TestCase {
+	public function testHandlingValidationException(): void {
+		$request = new Request(
+			[
+				'server' => [
+					'SERVER_PROTOCOL' => 'HTTP',
+				],
+			],
+		);
+		$this->overwriteService('Request', $request);
+		$dispatcher = OC::$server->getAppContainer('app')->query('Dispatcher');
+
+		$controller = new class('app', $request) extends Controller {
+			/**
+			 * @PublicPage
+			 * @NoCSRFRequired
+			 */
+			public function doesNotValidate() {
+				throw new ValidationException();
+			}
+		};
+
+		$response = $dispatcher->dispatch($controller, 'doesNotValidate');
+
+		self::assertEquals('HTTP/1.1 422 Unprocessable Entity', $response[0]);
+		self::assertEquals('{"message":"The given data was invalid."}', $response[3]);
+	}
+}


### PR DESCRIPTION
## Description
Instead of adding various input validation checks to each and every controller the base controller provides methods to allow:
- string max length validation
- email address validation
(more to come as needed)


## Motivation and Context
Better DX to build more stable controllers

## How Has This Been Tested?
- :robot: 


## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Database schema changes (next release will require increase of minor version instead of patch)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [ ] Tests only (no source changes)

## Checklist:
<!-- Tick the checkboxes when done. -->
<!-- Raise documentation ticket in https://github.com/owncloud/documentation -->
- [x] Code changes
- [x] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 
- [ ] Changelog item, see [TEMPLATE](https://github.com/owncloud/core/blob/master/changelog/TEMPLATE)
