### PR TITLE
fix: account terms can be removed if they differ with the ones stored

### DIFF
--- a/changelog/unreleased/41120
+++ b/changelog/unreleased/41120
@@ -1,0 +1,8 @@
+Bugfix: account terms can be removed if they differ with the ones stored
+
+Search terms for the account can now be removed from the DB if they differ
+with the ones stored in the DB.
+This can happen with the user_ldap app, when user search attributes are
+removed from the connection configuration in the LDAP wizard.
+
+https://github.com/owncloud/core/pull/41120

--- a/lib/private/User/Account.php
+++ b/lib/private/User/Account.php
@@ -106,7 +106,7 @@ class Account extends Entity {
 	 * @param string[] $terms
 	 */
 	public function setSearchTerms(array $terms) {
-		if (\array_diff($terms, $this->terms)) {
+		if (!empty(\array_diff($terms, $this->terms)) || !empty(\array_diff($this->terms, $terms))) {
 			$this->terms = $terms;
 			$this->_termsChanged = true;
 		}


### PR DESCRIPTION
<!--
Thanks for submitting a change to ownCloud!

This is the bug tracker for the Server component. Find other components at https://github.com/owncloud/core/blob/master/.github/CONTRIBUTING.md#guidelines

For fixing potential security issues please see https://owncloud.com/security/

To make it possible for us to get your change reviewed and merged please carefully fill out the requested information below.

Please note that any kind of change needs first be submitted to the master branch which holds the next version of ownCloud.

Please set the following labels:

- Set label "3 - To review" for review or "2 - Development" if the PR still has open tasks
- Assignment: assign to self
- Milestone: set the same as the ticket this PR fixes, or "development" by default
- Reviewers: pick at least one
-->

## Description
Search terms for the accounts were only updated if new terms were present. However, if terms were removed, we weren't updating the terms.

## Related Issue
No opened issue

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?
1. Install and configure the user_ldap app (consider default configuration)
2. Sync the ldap users
3. Change the "user search attributes" in the ldap wizard and add some attributes (at least 2)
4. Sync the ldap users again. Note that terms are populated in the "oc_account_terms" table
5. Remove one of the attributes in the "user search attributes"
6. Sync the ldap users

Without this patch, the "oc_account_terms" won't change, so the removed attribute can still be searched. With the patch, the table is updated

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Database schema changes (next release will require increase of minor version instead of patch)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [ ] Tests only (no source changes)

## Checklist:
<!-- Tick the checkboxes when done. -->
<!-- Raise documentation ticket in https://github.com/owncloud/documentation -->
- [x] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 
- [x] Changelog item, see [TEMPLATE](https://github.com/owncloud/core/blob/master/changelog/TEMPLATE)
