### PR TITLE
fix: 2fa check on controllers which are annotated as `@PublicPage` an…

### DIFF
--- a/changelog/unreleased/41123
+++ b/changelog/unreleased/41123
@@ -1,0 +1,3 @@
+Bugfix: check 2FA on controllers which are accessible publicly and authenticated
+
+https://github.com/owncloud/core/pull/41123


### PR DESCRIPTION
…d also used authenticated


## Description
Some controllers define methods which are publicly accessible and accessible for authenticated users the same time.
e.g. https://github.com/owncloud/files_texteditor/blob/3b00b6ea0b4d89bc91c5fdd68d459337f079399f/controller/filehandlingcontroller.php#L105

In such situations the 2fa handling was bypassed because of the `@PublicPage` annotation.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Database schema changes (next release will require increase of minor version instead of patch)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [ ] Tests only (no source changes)

## Checklist:
<!-- Tick the checkboxes when done. -->
<!-- Raise documentation ticket in https://github.com/owncloud/documentation -->
- [x] Code changes
- [x] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 
- [ ] Changelog item, see [TEMPLATE](https://github.com/owncloud/core/blob/master/changelog/TEMPLATE)
