### PR TITLE
fix: `user:list -a` command now correctly displays user's creation time

### DIFF
--- a/changelog/unreleased/41125
+++ b/changelog/unreleased/41125
@@ -1,0 +1,5 @@
+Bugfix: "user:list -a" occ command now correctly displays user's creation time
+
+Previously, the "user:list -a" occ command was not correctly returning the user's creation time but rather the path to the user's home directory. This has been now fixed.
+
+https://github.com/owncloud/core/pull/41125

--- a/core/Command/User/ListUsers.php
+++ b/core/Command/User/ListUsers.php
@@ -141,7 +141,7 @@ class ListUsers extends Base {
 							break;
 						case 'creationtime':
 							$this->add($row, 'creationTime', $user->getCreationTime(), $useKey);
-							// no break
+							break;
 						case 'home':
 							$this->add($row, 'home', $user->getHome(), $useKey);
 							break;


### PR DESCRIPTION
## Description
The `user:list -a` occ command now correctly displays user's creation time.

## Motivation and Context
User's creation time was not correctly returned when using the `-a` key.

## How Has This Been Tested?
Manually. Before:

```
sudo -u www-data php occ user:list -a creationTime
  - admin: /var/www/html/owncloud10133/data/admin
  - user1: /var/www/html/owncloud10133/data/user1
  - user2: /var/www/html/owncloud10133/data/user2
  - user3: /var/www/html/owncloud10133/data/user3
```

After:

```
sudo -u www-data php occ user:list -a creationTime
  - admin: 1700847050
  - user1: 1700847086
  - user2: 1701083934
  - user3: 1701083990
```

## Types of changes
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Database schema changes (next release will require increase of minor version instead of patch)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [ ] Tests only (no source changes)

## Checklist:
- [X] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised
- [x] Changelog item