### PR TITLE
Fix occ commands in case of enforce_2fa

### DIFF
--- a/changelog/unreleased/41128
+++ b/changelog/unreleased/41128
@@ -1,0 +1,5 @@
+Bugfix: Fix "twofactorauth:*" occ commands in case 2FA is globally enforced
+
+Previously, the "twofactorauth:*" occ commands did not work correctly in case 2FA was globally enforced. This has been now fixed.
+
+https://github.com/owncloud/core/pull/41128

--- a/lib/private/Authentication/TwoFactorAuth/Manager.php
+++ b/lib/private/Authentication/TwoFactorAuth/Manager.php
@@ -80,7 +80,7 @@ class Manager {
 	 * @return boolean
 	 */
 	public function isTwoFactorAuthenticated(IUser $user) {
-                $twoFactorEnabled = ((int) $this->config->getUserValue($user->getUID(), 'core', 'two_factor_auth_disabled', 0)) === 0;
+		$twoFactorEnabled = ((int) $this->config->getUserValue($user->getUID(), 'core', 'two_factor_auth_disabled', 0)) === 0;
 		if ($this->isTwoFactorEnforcedForUser($user) && $twoFactorEnabled) {
 			return \count($this->getProviders($user)) > 0;
 		}

--- a/lib/private/Authentication/TwoFactorAuth/Manager.php
+++ b/lib/private/Authentication/TwoFactorAuth/Manager.php
@@ -80,10 +80,10 @@ class Manager {
 	 * @return boolean
 	 */
 	public function isTwoFactorAuthenticated(IUser $user) {
-		if ($this->isTwoFactorEnforcedForUser($user)) {
+                $twoFactorEnabled = ((int) $this->config->getUserValue($user->getUID(), 'core', 'two_factor_auth_disabled', 0)) === 0;
+		if ($this->isTwoFactorEnforcedForUser($user) && $twoFactorEnabled) {
 			return \count($this->getProviders($user)) > 0;
 		}
-		$twoFactorEnabled = ((int) $this->config->getUserValue($user->getUID(), 'core', 'two_factor_auth_disabled', 0)) === 0;
 		return $twoFactorEnabled && \count($this->getProviders($user)) > 0;
 	}
 


### PR DESCRIPTION
## Description
Fix `twofactorauth:*` occ commands in case 2FA is globally enforced.

## Related Issue
- https://github.com/owncloud/enterprise/issues/6252

## Motivation and Context
Currently, the `twofactorauth:*` occ commands do not work correctly when 2FA is globally enforced. This means, in case an user loses his device, the only possibility for an oC admin to restore his access is either to impersonate the user (not always possible) and disable TOTP over his settings page or manually edit the DB.

## How Has This Been Tested?
Manually, by running the `twofactorauth:disable` and `twofactorauth:enable` occ commands and be sure 2FA is set accordingly.

## Types of changes
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Database schema changes (next release will require increase of minor version instead of patch)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [ ] Tests only (no source changes)

## Checklist:
- [X] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised
- [X] Changelog item
