### PR TITLE
ci: add more commit message words to updateDocsWhiteList

### DIFF
--- a/.github/config.yml
+++ b/.github/config.yml
@@ -6,6 +6,14 @@ updateDocsComment: >
 
 updateDocsWhiteList:
   - Tests-only
+  - "build:"
+  - "build("
+  - "ci:"
+  - "ci("
+  - "docs:"
+  - "docs("
+  - "test:"
+  - "test("
 
 updateDocsTargetFiles:
   - changelog/unreleased/


### PR DESCRIPTION
## Description
https://www.conventionalcommits.org/en/v1.0.0/#specification

We know that a changelog is not compulsory (usually not needed) for PRs that only have docs, tests, build and ci changes.
Whitelist those so the bot does not put a message about missing changelog.

## How Has This Been Tested?
CI

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Database schema changes (next release will require increase of minor version instead of patch)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [ ] Tests only (no source changes)

## Checklist:
- [ ] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 
- [ ] Changelog item, see [TEMPLATE](https://github.com/owncloud/core/blob/master/changelog/TEMPLATE)
