### PR TITLE
feat: show alert about ioc scanner to all customers on upgrade

### DIFF
--- a/changelog/unreleased/41137
+++ b/changelog/unreleased/41137
@@ -1,0 +1,6 @@
+Change: Display IoC-Scanner Prompt
+
+Prompt the admins of licensed instances to run the IoC-Scanner. The Prompt
+appears in the admin menu and after an upgrade on the CLI.
+
+https://github.com/owncloud/core/pull/41137

--- a/core/templates/ioc.warning.php
+++ b/core/templates/ioc.warning.php
@@ -1,0 +1,37 @@
+<h1 style="color: red; font-size: 30px; margin-bottom: 10px;">Critical Alert</h1>
+<h2>Urgent Security Advisory for All ownCloud Operators:</h2>
+<h2 style="color: red">Immediate Action Required</h2>
+
+<div class="infogroup bold" style="margin-bottom: 15px">ownCloud Security Update and System Scan Tool</div>
+
+<div class="infogroup bold" style="margin-bottom: 15px">In response to recent, high-severity security
+	vulnerabilities, ownCloud has developed an essential system scan tool. This
+	tool is designed to determine whether your systems have been compromised by
+	vulnerabilities addressed in our latest updates.
+</div>
+
+<div class="infogroup bold" style="margin-bottom: 15px">Immediate Action Required</div>
+
+<ol style="text-align: left; margin-left: 30px; font-size: 15px">
+	<li style="margin-bottom: 15px"><b>Download the Script:</b> Access the
+		critical security script at <a href="https://cloud.owncloud.com/s/WwZGSJYsKigcj10" target="_blank" rel="noopener noreferrer" style="text-decoration: underline">ownCloud Security Script</a>.
+	</li>
+
+	<li style="margin-bottom: 15px"><b>Root Access Needed:</b> The script
+		requires root access to analyze log files effectively. Ensure you have
+		the necessary permissions before proceeding.
+	</li>
+
+	<li style="margin-bottom: 15px"><b>Detailed Information and
+			Documentation:</b> For comprehensive instructions and details about
+		the script, visit <a href="https://cloud.owncloud.com/s/WwZGSJYsKigcj10" target="_blank" rel="noopener noreferrer" style="text-decoration: underline">ownCloud Script Documentation</a>.
+	</li>
+
+</ol>
+<br>
+<div class="infogroup bold" style="margin-bottom: 15px">You MUST execute the above security measures.
+	Failure to implement these security measures could lead to severe
+	consequences, including significant data loss, privacy violations, and legal
+	repercussions. This is not merely a preventive step but a necessary action
+	to safeguard your organization.
+</div>

--- a/core/templates/update.admin.php
+++ b/core/templates/update.admin.php
@@ -1,3 +1,11 @@
+
+<?php $license = \OC::$server->query(\OC\License\LicenseFetcher::class)->getOwncloudLicense();
+if ($license !== null) {
+	?>
+<div class="update">
+<?php include_once('ioc.warning.php'); ?>
+</div>
+<?php } ?>
 <div class="update" data-productname="<?php p($_['productName']) ?>" data-version="<?php p($_['version']) ?>">
 	<div class="updateOverview">
 		<?php if ($_['isAppsOnlyUpgrade']) {

--- a/settings/templates/panels/admin/securitywarning.php
+++ b/settings/templates/panels/admin/securitywarning.php
@@ -7,6 +7,17 @@
 script('core', 'setupchecks');
 script('settings', 'panels/setupchecks');
 ?>
+
+<?php
+$license = \OC::$server->query(\OC\License\LicenseFetcher::class)->getOwncloudLicense();
+$ioc_exec_confirmation = \OC::$server->getConfig()->getSystemValue('indicators-of-compromise-scanner.confirmation', false);
+if ($license !== null && $ioc_exec_confirmation !== 'EXECUTED_ON_ALL_NODES') {
+	?>
+	<div id="security-warning" class="section">
+		<?php include_once(__DIR__ . '/../../../../core/templates/ioc.warning.php'); ?>
+	</div>
+<?php } ?>
+
 <div id="security-warning" class="section">
 	<h2 class="app-name"><?php p($l->t('Security & setup warnings'));?></h2>
 	<ul>


### PR DESCRIPTION
## Description
Display ioc scanner instructions to all customers before upgrade (console as well as web updater) and in admin settings.
Community users will be take care of in future versions ... :crying_cat_face: 

## How Has This Been Tested?
### Display message in upgrade 
- add license key (even an outdated is fine)
- force upgrade by manually incrementing the version in version.php
- run occ up
- run upgrade in browser

### Display alert in admin section
- add license key (even an outdated is fine)
- login as admin
- go to admin settings

## Screenshots (if appropriate):
![Screenshot from 2023-12-11 17-55-09](https://github.com/owncloud/core/assets/1005065/e0180e81-92f6-4818-8cd3-8be53553f640)
![Screenshot from 2023-12-12 11-53-36](https://github.com/owncloud/core/assets/1005065/2511284a-67c0-4249-be89-2d6d5df222c9)
![image](https://github.com/owncloud/core/assets/1005065/3ed9872e-7a09-4a58-9369-868b7b40c5aa)



## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Database schema changes (next release will require increase of minor version instead of patch)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [ ] Tests only (no source changes)

## Checklist:
<!-- Tick the checkboxes when done. -->
<!-- Raise documentation ticket in https://github.com/owncloud/documentation -->
- [ ] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 
- [ ] Changelog item, see [TEMPLATE](https://github.com/owncloud/core/blob/master/changelog/TEMPLATE)
