### PR TITLE
chore(deps): remove unneeded phpstan ignores

### DIFF
--- a/lib/private/Config.php
+++ b/lib/private/Config.php
@@ -250,10 +250,8 @@ class Config {
 				throw new \Exception(\sprintf('Could not acquire a shared lock on the config file %s', $file));
 			}
 
-			/* @phpstan-ignore-next-line */
 			unset($CONFIG);
 			include $file;
-			/* @phpstan-ignore-next-line */
 			if (isset($CONFIG) && \is_array($CONFIG)) {
 				$this->cache = \array_merge($this->cache, $CONFIG);
 			}

--- a/phpstan.neon
+++ b/phpstan.neon
@@ -10,8 +10,6 @@ parameters:
       - %currentWorkingDirectory%/apps/*/composer/*
       - %currentWorkingDirectory%/apps/*/3rdparty/*
   ignoreErrors:
-    - '#Undefined variable: \$OC_[a-zA-Z0-9\\_]+#'
-    - '#Undefined variable: \$vendor#'
     # errors below are to be addressed by own pull requests - non trivial changes required
     - '#Instantiated class OCA\\Encryption\\Crypto\\Crypt not found.#'
     - '#Instantiated class OCA\\Encryption\\Util not found.#'


### PR DESCRIPTION
## Description
A new patch release of phpstan no longer complains about some things. That happened in:
https://github.com/phpstan/phpstan/releases/tag/1.10.48

And just in the last hours there is:
https://github.com/phpstan/phpstan/releases/tag/1.10.49

This PR removes them so that phpstan will pass.

## How Has This Been Tested?
CI

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Database schema changes (next release will require increase of minor version instead of patch)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [ ] Tests only (no source changes)

## Checklist:
- [ ] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 
- [ ] Changelog item, see [TEMPLATE](https://github.com/owncloud/core/blob/master/changelog/TEMPLATE)
