### PR TITLE
Fix log exceptions for mp3 preview

### DIFF
--- a/changelog/unreleased/41153
+++ b/changelog/unreleased/41153
@@ -1,0 +1,5 @@
+Bugfix: Fix log exceptions for mp3 preview
+
+This change fixes log exceptions when previews for mp3 files are being created
+
+https://github.com/owncloud/core/pull/41153

--- a/lib/private/Preview/MP3.php
+++ b/lib/private/Preview/MP3.php
@@ -88,17 +88,9 @@ class MP3 implements IProvider2 {
 		}
 
 		$stream = \fopen($icon, 'r');
-		$content = \stream_get_contents($stream);
-		\fclose($stream);
-
-		$svg = new \Imagick();
-		$svg->setBackgroundColor(new \ImagickPixel('transparent'));
-		$svg->setResolution(1200, 1200);
-		$svg->readImageBlob($content);
-		$svg->setImageFormat('png32');
-
 		$image = new \OC_Image();
-		$image->loadFromData($svg);
+		$image->loadFromFileHandle($stream);
+		\fclose($stream);
 		return $image->valid() ? $image : false;
 	}
 

--- a/lib/private/Preview/MP3.php
+++ b/lib/private/Preview/MP3.php
@@ -87,8 +87,18 @@ class MP3 implements IProvider2 {
 			return false;
 		}
 
+		$stream = \fopen($icon, 'r');
+		$content = \stream_get_contents($stream);
+		\fclose($stream);
+
+		$svg = new \Imagick();
+		$svg->setBackgroundColor(new \ImagickPixel('transparent'));
+		$svg->setResolution(1200, 1200);
+		$svg->readImageBlob($content);
+		$svg->setImageFormat('png32');
+
 		$image = new \OC_Image();
-		$image->loadFromFile($icon);
+		$image->loadFromData($svg);
 		return $image->valid() ? $image : false;
 	}
 


### PR DESCRIPTION
## Description
Fix log exceptions for mp3 preview

## Related Issue
- https://github.com/owncloud/core/pull/39084
- https://github.com/owncloud/core/issues/34900
- https://github.com/owncloud/enterprise/issues/3550

## Motivation and Context
Currently, log exceptions are generated when previews for MP3 files are being created, like:

```
{"reqId":"8q3EycderbaJ2eO5Hyc9","level":3,"time":"2024-01-04T21:19:44+00:00","remoteAddr":"xx.x.xxx.xxx","user":"admin","app":"PHP","method":"GET","url":"\/owncloud10134\/remote.php\/dav\/files\/admin\/file_example_MP3_1MG.mp3?c=faaf02aa4049f8cd054e634034dcdb58&x=64&y=64&forceIcon=0&preview=1","message":"file_get_contents(\/var\/www\/html\/owncloud10134\/data\/admin\/files\/var\/www\/html\/owncloud10134\/core\/img\/filetypes\/audio.svg): failed to open stream: No such file or directory at \/var\/www\/html\/owncloud10134\/lib\/private\/Files\/Storage\/Local.php#227"}
{"reqId":"8q3EycderbaJ2eO5Hyc9","level":3,"time":"2024-01-04T21:19:44+00:00","remoteAddr":"xx.xx.xxx.xxx","user":"admin","app":"PHP","method":"GET","url":"\/owncloud10134\/remote.php\/dav\/files\/admin\/file_example_MP3_1MG.mp3?c=faaf02aa4049f8cd054e634034dcdb58&x=64&y=64&forceIcon=0&preview=1","message":"imagecreatefromstring(): Empty string or invalid image at \/var\/www\/html\/owncloud10134\/lib\/private\/legacy\/image.php#702"}
 ```

## How Has This Been Tested?
- Manually, by making sure that such exceptions are no longer logged.
 
## Types of changes
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Database schema changes (next release will require increase of minor version instead of patch)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [ ] Tests only (no source changes)

## Checklist:
- [X] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised
- [x] Changelog item