### PR TITLE
refactor: set id for oc_file_locks to bigint

### DIFF
--- a/changelog/unreleased/41158
+++ b/changelog/unreleased/41158
@@ -1,0 +1,3 @@
+Bugfix: set oc_file_locks.id to bigint
+
+https://github.com/owncloud/core/pull/41158

--- a/core/Migrations/Version20240112140951.php
+++ b/core/Migrations/Version20240112140951.php
@@ -1,0 +1,25 @@
+<?php
+namespace OC\Migrations;
+
+use Doctrine\DBAL\Schema\Schema;
+use Doctrine\DBAL\Types\Type;
+use OCP\Migration\ISchemaMigration;
+
+/**
+ * Updates id column type in the file_locks table from integer to bigint
+ */
+class Version20240112140951 implements ISchemaMigration {
+	public function changeSchema(Schema $schema, array $options) {
+		$prefix = $options['tablePrefix'];
+
+		if ($schema->hasTable("{$prefix}file_locks")) {
+			$table = $schema->getTable("{$prefix}file_locks");
+
+			$idColumn = $table->getColumn('id');
+			if ($idColumn) {
+				$idColumn->setType(Type::getType(Type::BIGINT));
+				$idColumn->setOptions(['length' => 20]);
+			}
+		}
+	}
+}


### PR DESCRIPTION
## Description
Set the id column for the `oc_file_locks` table to bigint

## Related Issue
- Fixes https://github.com/owncloud/enterprise/issues/6338

## Motivation and Context
In rare cases, the id column in the `file_locks` table could hit its limit (currently defined as `int(10) unsigned`) as it is set as autoincrement.

## How Has This Been Tested?
- Manually, by running `occ upgrade` or `occ migrations:execute core 20240112140951` and be sure the id column is set to `bigint(20) unsigned`

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Database schema changes (next release will require increase of minor version instead of patch)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [X] Technical debt
- [ ] Tests only (no source changes)

## Checklist:
- [X] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised
- [x] Changelog item
