### PR TITLE
fix: update route to richdocuments.document.index

### DIFF
--- a/changelog/unreleased/41161
+++ b/changelog/unreleased/41161
@@ -1,3 +1,3 @@
-Bugfix: update route to richdocuments.document.index
+Bugfix: add compatibility to richdocuments.document.index route
 
 https://github.com/owncloud/core/pull/41161

--- a/changelog/unreleased/41161
+++ b/changelog/unreleased/41161
@@ -1,5 +1,3 @@
 Bugfix: update route to richdocuments.document.index
 
 https://github.com/owncloud/core/pull/41161
-
-

--- a/changelog/unreleased/41161
+++ b/changelog/unreleased/41161
@@ -1,0 +1,5 @@
+Bugfix: update route to richdocuments.document.index
+
+https://github.com/owncloud/core/pull/41161
+
+

--- a/core/Controller/AppRegistryController.php
+++ b/core/Controller/AppRegistryController.php
@@ -285,7 +285,7 @@ class AppRegistryController extends Controller {
 		}
 		# https://github.com/owncloud/richdocuments/blob/5adc1dd3a0ab39918b2c3f7a3c62f3231f216cb6/appinfo/routes.php#L26
 		if ($app_name === 'richdocuments') {
-			$uri = $this->generator->linkToRouteAbsolute('richdocuments.document.index', [
+			$uri = $this->generator->linkToRouteAbsolute('richdocuments.Document.index', [
 				'fileId' => $fileId
 			]);
 		}

--- a/core/Controller/AppRegistryController.php
+++ b/core/Controller/AppRegistryController.php
@@ -285,9 +285,13 @@ class AppRegistryController extends Controller {
 		}
 		# https://github.com/owncloud/richdocuments/blob/5adc1dd3a0ab39918b2c3f7a3c62f3231f216cb6/appinfo/routes.php#L26
 		if ($app_name === 'richdocuments') {
-			$uri = $this->generator->linkToRouteAbsolute('richdocuments.Document.index', [
-				'fileId' => $fileId
-			]);
+			# this is required in order to keep compatibility with richdocuments < 4.1.0 where the old richdocuments.document.index route is present
+			$link = $this->generator->linkToRoute('richdocuments.Document.index', ['fileId' => $fileId]);
+			if ($link !== '') {
+				$uri = $this->generator->getAbsoluteUrl($link);
+			} else {
+				$uri = $this->generator->linkToRouteAbsolute('richdocuments.document.index', ['fileId' => $fileId]);
+			}
 		}
 		# https://github.com/owncloud/wopi/blob/f24b081d8bc1ac89b73ae211636cb4194d0cf0a8/appinfo/routes.php#LL22C15-L22C26
 		if ($app_name === 'wopi') {


### PR DESCRIPTION
## Description
Update route to richdocuments.document.index

## Related Issue
- https://github.com/owncloud/enterprise/issues/6349
- https://github.com/owncloud/richdocuments/pull/535

## Motivation and Context
https://github.com/owncloud/richdocuments/pull/522/files#diff-6301937af1cc1575e9e18ecd27c4a51f0d3cf9ce12e59a14709f626dfa3ef952R28 (first added in richdocuments 4.1.0) introduced a change to the documents.php/index route.

## How Has This Been Tested?
Manually: without this fix the `Files->Office` menu is not reachable on 10.13.4 + richdocuments 4.1.0. With the fix, menu can be again reached.

## Types of changes
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Database schema changes (next release will require increase of minor version instead of patch)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [ ] Tests only (no source changes)

## Checklist:
- [X] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised
- [ ] Changelog item
