### PR TITLE
refactor: replace `isAdmin` implementation

### DIFF
--- a/changelog/unreleased/41171
+++ b/changelog/unreleased/41171
@@ -1,0 +1,5 @@
+Enhancement: Replace the isAdmin implementation
+
+Instead of asking the backends for the groups an user belongs to, we now get the admin group and list the members to detect if user is admin or not
+
+https://github.com/owncloud/core/pull/41171

--- a/lib/private/Group/Manager.php
+++ b/lib/private/Group/Manager.php
@@ -346,7 +346,8 @@ class Manager extends PublicEmitter implements IGroupManager {
 	 * @return bool if admin
 	 */
 	public function isAdmin($userId) {
-		return $this->isInGroup($userId, 'admin');
+		$adminGroup = $this->get('admin');
+		return $adminGroup->inGroup($userId);
 	}
 
 	/**

--- a/lib/private/Group/Manager.php
+++ b/lib/private/Group/Manager.php
@@ -35,6 +35,7 @@
 
 namespace OC\Group;
 
+use OC\User\NoUserException;
 use OC\Hooks\PublicEmitter;
 use OC\User\Manager as UserManager;
 use OCP\GroupInterface;
@@ -347,7 +348,11 @@ class Manager extends PublicEmitter implements IGroupManager {
 	 */
 	public function isAdmin($userId) {
 		$adminGroup = $this->get('admin');
-		return $adminGroup->inGroup($this->userManager->get($userId));
+		$user = $this->userManager->get($userId);
+		if ($user === null) {
+			throw new NoUserException("user $userId not found");
+		}
+		return $adminGroup->inGroup($user);
 	}
 
 	/**

--- a/lib/private/Group/Manager.php
+++ b/lib/private/Group/Manager.php
@@ -347,7 +347,7 @@ class Manager extends PublicEmitter implements IGroupManager {
 	 */
 	public function isAdmin($userId) {
 		$adminGroup = $this->get('admin');
-		return $adminGroup->inGroup($userId);
+		return $adminGroup->inGroup($this->userManager->get($userId));
 	}
 
 	/**

--- a/lib/private/Group/Manager.php
+++ b/lib/private/Group/Manager.php
@@ -35,7 +35,6 @@
 
 namespace OC\Group;
 
-use OC\User\NoUserException;
 use OC\Hooks\PublicEmitter;
 use OC\User\Manager as UserManager;
 use OCP\GroupInterface;
@@ -350,7 +349,7 @@ class Manager extends PublicEmitter implements IGroupManager {
 		$adminGroup = $this->get('admin');
 		$user = $this->userManager->get($userId);
 		if ($user === null) {
-			throw new NoUserException("user $userId not found");
+			return false;
 		}
 		return $adminGroup->inGroup($user);
 	}

--- a/lib/private/Group/Manager.php
+++ b/lib/private/Group/Manager.php
@@ -346,11 +346,11 @@ class Manager extends PublicEmitter implements IGroupManager {
 	 * @return bool if admin
 	 */
 	public function isAdmin($userId) {
-		$adminGroup = $this->get('admin');
 		$user = $this->userManager->get($userId);
 		if ($user === null) {
 			return false;
 		}
+		$adminGroup = $this->get('admin');
 		return $adminGroup->inGroup($user);
 	}
 

--- a/tests/lib/Group/ManagerTest.php
+++ b/tests/lib/Group/ManagerTest.php
@@ -690,15 +690,19 @@ class ManagerTest extends \Test\TestCase {
 		 * @var \PHPUnit\Framework\MockObject\MockObject | \OC\Group\Backend $backend
 		 */
 		$backend = $this->getTestBackend();
-		$backend->expects($this->once())
-			->method('getUserGroups')
-			->with('user1')
-			->will($this->returnValue(['group1', 'admin', 'group2']));
 		$backend->expects($this->any())
 			->method('groupExists')
 			->will($this->returnValue(true));
+		$backend->expects($this->once())
+			->method('inGroup')
+			->with('user1')
+			->will($this->returnValue(true));
 
 		$this->manager->addBackend($backend);
+
+		$this->userManager->expects($this->once())
+			->method('get')
+			->will($this->returnValue($this->getTestUser('user1')));
 
 		$this->assertTrue($this->manager->isAdmin('user1'));
 	}
@@ -708,15 +712,19 @@ class ManagerTest extends \Test\TestCase {
 		 * @var \PHPUnit\Framework\MockObject\MockObject | \OC\Group\Backend $backend
 		 */
 		$backend = $this->getTestBackend();
-		$backend->expects($this->once())
-			->method('getUserGroups')
-			->with('user1')
-			->will($this->returnValue(['group1', 'group2']));
 		$backend->expects($this->any())
 			->method('groupExists')
 			->will($this->returnValue(true));
+		$backend->expects($this->once())
+			->method('inGroup')
+			->with('user1')
+			->will($this->returnValue(false));
 
 		$this->manager->addBackend($backend);
+
+		$this->userManager->expects($this->once())
+			->method('get')
+			->will($this->returnValue($this->getTestUser('user1')));
 
 		$this->assertFalse($this->manager->isAdmin('user1'));
 	}


### PR DESCRIPTION
## Description
Replace the `isAdmin` implementation

## Related Issue
- https://github.com/owncloud/enterprise/issues/6364
- https://github.com/owncloud/metrics/pull/182

## Motivation and Context
Currently, the `isAdmin` method is indirectly calling the `getUserIdGroups` which - in case an LDAP connection is configured - would require to hit the LDAP server. For this particular check, getting the admin group and listing the members should be preferable and would not have the disadvantages related to an unstable LDAP connection (it was i.e. observed that under certain circumstances the metrics app got disabled in case the LDAP server could not be reached)

## How Has This Been Tested?
Issue with the metrics app was not reproducible when intentionally causing an LDAP `BindFailedException`

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Database schema changes (next release will require increase of minor version instead of patch)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [X] Technical debt
- [ ] Tests only (no source changes)

## Checklist:
- [X] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised
- [X] Changelog item
