### PR TITLE
fix: validate length of displayname when setting it

### DIFF
--- a/changelog/unreleased/41172
+++ b/changelog/unreleased/41172
@@ -1,0 +1,3 @@
+Bugfix: input validation when setting the displayname of a user or self
+
+https://github.com/owncloud/core/pull/41172

--- a/settings/Controller/UsersController.php
+++ b/settings/Controller/UsersController.php
@@ -1071,6 +1071,11 @@ class UsersController extends Controller {
 	 * @return DataResponse
 	 */
 	public function setDisplayName($username, $displayName) {
+		$resp = $this->validateString($displayName, 64);
+		if ($resp) {
+			return $resp;
+		}
+
 		$currentUser = $this->userSession->getUser();
 
 		if ($username === null) {
@@ -1166,7 +1171,7 @@ class UsersController extends Controller {
 	 *
 	 * @param string $id
 	 * @param string $mailAddress
-	 * @return JSONResponse
+	 * @return JSONResponse|DataResponse
 	 */
 	public function setEmailAddress($id, $mailAddress) {
 		$resp = $this->validateEMail($mailAddress);


### PR DESCRIPTION
## Description
Simple input validation when setting the display name

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
- Fixes <issue_link>

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
- test environment:
- test case 1:
- test case 2:
- ...

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Database schema changes (next release will require increase of minor version instead of patch)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [ ] Tests only (no source changes)

## Checklist:
<!-- Tick the checkboxes when done. -->
<!-- Raise documentation ticket in https://github.com/owncloud/documentation -->
- [ ] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 
- [ ] Changelog item, see [TEMPLATE](https://github.com/owncloud/core/blob/master/changelog/TEMPLATE)
