### PR TITLE
skip new preview test on old oC10 and bump version to 10.14.0

### DIFF
--- a/sonar-project.properties
+++ b/sonar-project.properties
@@ -1,7 +1,7 @@
 # Organization and project keys are displayed in the right sidebar of the project homepage
 sonar.organization=owncloud-1
 sonar.projectKey=owncloud_core
-sonar.projectVersion=10.13.5
+sonar.projectVersion=10.14.0
 sonar.host.url=https://sonarcloud.io
 
 # =====================================================

--- a/tests/acceptance/features/apiWebdavPreviews/previews.feature
+++ b/tests/acceptance/features/apiWebdavPreviews/previews.feature
@@ -277,7 +277,7 @@ Feature: previews of files downloaded through the webdav API
     Then the HTTP status code should be "200"
     And the requested JPEG image should have a quality value of "100"
 
-
+  @skipOnOcV10.12 @skipOnOcV10.13
   Scenario: the preview should be of content in the first page of a multi-page document
     Given the administrator has updated system config key "enabledPreviewProviders 0" with value "OC\Preview\PDF"
     And user "Alice" has uploaded file "fixtures/Preview-test.pdf" to "/Preview-test.pdf"

--- a/version.php
+++ b/version.php
@@ -25,10 +25,10 @@
 // We only can count up. The 4. digit is only for the internal patchlevel to trigger DB upgrades
 // between betas, final and RCs. This is _not_ the public version number. Reset minor/patchlevel
 // when updating major/minor version number.
-$OC_Version = [10, 13, 5, 0];
+$OC_Version = [10, 14, 0, 0];
 
 // The human-readable string
-$OC_VersionString = '10.13.5 prealpha';
+$OC_VersionString = '10.14.0 prealpha';
 
 $OC_VersionCanBeUpgradedFrom = [[8, 2, 11],[9, 0, 9],[9, 1]];
 


### PR DESCRIPTION
## Description
1) skip the new test for previews of multi-page documents on older oC10 versions (because we know that it will only pass on current master)
2) bump the version in master to 10.14.0 to recognise that master really does have code for 10.14 (if a 10.13.5 happens unexpectedly then it won't be the code currently in master)

Changelog not needed for this sort of thing.

## Related Issue
- Fixes #41179 

## How Has This Been Tested?
CI

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Database schema changes (next release will require increase of minor version instead of patch)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [x] Tests only (no source changes)

## Checklist:
- [ ] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 
- [ ] Changelog item, see [TEMPLATE](https://github.com/owncloud/core/blob/master/changelog/TEMPLATE)
