### PR TITLE
fix: bring back tipsy fallback implementation

### DIFF
--- a/core/js/js.js
+++ b/core/js/js.js
@@ -2477,6 +2477,66 @@ function getScrollBarWidth() {
 	return OC.Util.getScrollBarWidth();
 }
 
+/**
+* jQuery tipsy shim for the bootstrap tooltip
+*/
+jQuery.fn.tipsy = function (argument) {
+	console.warn('Deprecation warning: tipsy is deprecated. Use tooltip instead.');
+	if (typeof argument === 'object' && argument !== null) {
+
+		// tipsy defaults
+		var options = {
+			placement: 'bottom',
+			delay: {'show': 0, 'hide': 0},
+			trigger: 'hover',
+			html: false,
+			container: 'body'
+		};
+		if (argument.gravity) {
+			switch (argument.gravity) {
+				case 'n':
+				case 'nw':
+				case 'ne':
+					options.placement = 'bottom';
+					break;
+				case 's':
+				case 'sw':
+				case 'se':
+					options.placement = 'top';
+					break;
+				case 'w':
+					options.placement = 'right';
+					break;
+				case 'e':
+					options.placement = 'left';
+					break;
+			}
+		}
+		if (argument.trigger) {
+			options.trigger = argument.trigger;
+		}
+		if (argument.delayIn) {
+			options.delay["show"] = argument.delayIn;
+		}
+		if (argument.delayOut) {
+			options.delay["hide"] = argument.delayOut;
+		}
+		if (argument.html) {
+			options.html = true;
+		}
+		if (argument.fallback) {
+			options.title = argument.fallback;
+		}
+		// destroy old tooltip in case the title has changed
+		jQuery.fn.tooltip.call(this, 'destroy');
+		jQuery.fn.tooltip.call(this, options);
+	} else {
+		this.tooltip(argument);
+		jQuery.fn.tooltip.call(this, argument);
+	}
+	return this;
+}
+
 jQuery.extend = jQuery.fn.extend = function() {
 	var options, name, src, copy, copyIsArray, clone,
 		target = arguments[0] || {},


### PR DESCRIPTION
## Description
Some apps are still using tipsy() :see_no_evil: 

Let's bring back the function for the time being .... :shrug: 

## Related Issue
- Fixes #41186 

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Database schema changes (next release will require increase of minor version instead of patch)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [ ] Tests only (no source changes)

## Checklist:
<!-- Tick the checkboxes when done. -->
<!-- Raise documentation ticket in https://github.com/owncloud/documentation -->
- [ ] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 
- [ ] Changelog item, see [TEMPLATE](https://github.com/owncloud/core/blob/master/changelog/TEMPLATE)
