### PR TITLE
chore: bump version to 10.14.1

### DIFF
--- a/sonar-project.properties
+++ b/sonar-project.properties
@@ -1,7 +1,7 @@
 # Organization and project keys are displayed in the right sidebar of the project homepage
 sonar.organization=owncloud-1
 sonar.projectKey=owncloud_core
-sonar.projectVersion=10.14.0
+sonar.projectVersion=10.14.1
 sonar.host.url=https://sonarcloud.io
 
 # =====================================================

--- a/version.php
+++ b/version.php
@@ -25,10 +25,10 @@
 // We only can count up. The 4. digit is only for the internal patchlevel to trigger DB upgrades
 // between betas, final and RCs. This is _not_ the public version number. Reset minor/patchlevel
 // when updating major/minor version number.
-$OC_Version = [10, 14, 0, 3];
+$OC_Version = [10, 14, 1, 0];
 
 // The human-readable string
-$OC_VersionString = '10.14.0';
+$OC_VersionString = '10.14.1 prealpha';
 
 $OC_VersionCanBeUpgradedFrom = [[8, 2, 11],[9, 0, 9],[9, 1]];
 


### PR DESCRIPTION
## Description
The code in master is for the next release, which will be at least 10.14.1

Bump the version to 10.14.1 so that CI and tests can be aware that the code is no longer 10.14.0


## How Has This Been Tested?
CI

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Database schema changes (next release will require increase of minor version instead of patch)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [ ] Tests only (no source changes)

## Checklist:
- [ ] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 
- [ ] Changelog item, see [TEMPLATE](https://github.com/owncloud/core/blob/master/changelog/TEMPLATE)
