### PR TITLE
fix: verify link in public link notification ocs api

### DIFF
--- a/changelog/unreleased/41214
+++ b/changelog/unreleased/41214
@@ -1,0 +1,3 @@
+Bugfix: Link in public link notification has to be from a trusted domain
+
+https://github.com/owncloud/core/pull/41214

--- a/lib/private/Security/TrustedDomainHelper.php
+++ b/lib/private/Security/TrustedDomainHelper.php
@@ -56,16 +56,29 @@ class TrustedDomainHelper {
 		return $host;
 	}
 
+	public function isUrlTrusted(string $url): bool {
+		$host = parse_url($url, PHP_URL_HOST);
+		$port = parse_url($url, PHP_URL_PORT);
+		if (!$host) {
+			return false;
+		}
+		if ($port) {
+			return $this->isTrustedDomain("$host:$port");
+		}
+		return $this->isTrustedDomain((string)$host);
+	}
+
 	/**
 	 * Checks whether a domain is considered as trusted from the list
 	 * of trusted domains. If no trusted domains have been configured, returns
 	 * true.
 	 * This is used to prevent Host Header Poisoning.
+	 *
 	 * @param string $domainWithPort
 	 * @return bool true if the given domain is trusted or if no trusted domains
 	 * have been configured
 	 */
-	public function isTrustedDomain($domainWithPort) {
+	public function isTrustedDomain(string $domainWithPort): bool {
 		$domain = $this->getDomainWithoutPort($domainWithPort);
 
 		// Read trusted domains from config


### PR DESCRIPTION
## Description
The frontend is generating the url to the public link share and submitting it to the server via the ocs share api.

Via the pure usage of this api any url can be sent out to any email address - as long as being logged in (aka have creds at hand)

This change validates that the url is pointing to one of the configured trusted domains to add some hardening.

## How Has This Been Tested?
- :hand: 
- :robot: 

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Database schema changes (next release will require increase of minor version instead of patch)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [ ] Tests only (no source changes)

## Checklist:
<!-- Tick the checkboxes when done. -->
<!-- Raise documentation ticket in https://github.com/owncloud/documentation -->
- [x] Code changes
- [x] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 
- [ ] Changelog item, see [TEMPLATE](https://github.com/owncloud/core/blob/master/changelog/TEMPLATE)
