### PR TITLE
fix: Gradients in SVG prevented thumbnail generation

### DIFF
--- a/lib/private/Preview/SVG.php
+++ b/lib/private/Preview/SVG.php
@@ -51,7 +51,10 @@ class SVG implements IProvider2 {
 			\fclose($stream);
 
 			// Do not parse SVG files with references
-			if (\stripos($content, 'xlink:href') !== false) {
+			// accepted:   xlink:href=#...     xlink:href= '#...'   xlink:href = " #..."
+			// rejected:   xlink:href=../secr  xlink:href= "https://..."
+			if (\preg_match('/xlink:href\s*=[\s"\']*[^#"\']/', $content, $matches)) {
+				\OCP\Util::writeLog('core', "getThumbnail {$file->getName()}: rejected $matches[0]", \OCP\Util::ERROR);
 				return false;
 			}
 


### PR DESCRIPTION
Fixes: #41218 

harmless internal xlink:href="#linearGradient4069" attributes prevented thumbnail generation for SVG files.
fine tuning to only reject external references.

----

This file was rejected due to internal hrefs, it is now accepted:
https://dev.w3.org/SVG/tools/svgweb/samples/svg-files/car.svg
![car](https://dev.w3.org/SVG/tools/svgweb/samples/svg-files/car.svg)

----

This file must be rejected, it attempts to read /etc/passed:
![car_e](https://github.com/owncloud/core/assets/1108546/fc0432bb-c0a9-47b3-8ef1-0a16216716cb)

----