### PR TITLE
chore: adjust composer license to be current

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -1,7 +1,7 @@
 {
     "name": "owncloud/core",
     "description": "A safe home for all your data",
-    "license": "AGPL-1.0",
+    "license": "AGPL-3.0-or-later",
     "config" : {
         "vendor-dir": "lib/composer",
         "optimize-autoloader": true,


### PR DESCRIPTION
## Description
Adjust the value if "license" in `composer.json` so it has "AGPL-3.0-or-later"
This repo has an AGPL 3.0 license already in `COPYING`

This is only a software development/dependencies thing, so no changelog needed.

## Related Issue
- Fixes #41227 

## How Has This Been Tested?
```
composer diag
```
no longer reports the warning in the issue.

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Database schema changes (next release will require increase of minor version instead of patch)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [ ] Tests only (no source changes)

## Checklist:
- [ ] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 
- [ ] Changelog item, see [TEMPLATE](https://github.com/owncloud/core/blob/master/changelog/TEMPLATE)
