### PR TITLE
fix: sanitize SVG

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -86,6 +86,7 @@
         "phpseclib/phpseclib": "^3.0",
         "pimple/pimple": "^3.5",
         "punic/punic": "^3.8",
+        "rhukster/dom-sanitizer": "dev-main",
         "sabre/dav": "^4.4",
         "sabre/http": "^5.1",
         "sabre/vobject": "^4.5",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "a21c5d2887359a7354108b26e04c8267",
+    "content-hash": "b8a857c8aa3885944380ae6742fe8c50",
     "packages": [
         {
             "name": "bantu/ini-get-wrapper",
@@ -3289,6 +3289,52 @@
                 "source": "https://github.com/ralouphie/getallheaders/tree/develop"
             },
             "time": "2019-03-08T08:55:37+00:00"
+        },
+        {
+            "name": "rhukster/dom-sanitizer",
+            "version": "dev-main",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/rhukster/dom-sanitizer.git",
+                "reference": "757e4d6ac03afe9afa4f97cbef453fc5c25f0729"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/rhukster/dom-sanitizer/zipball/757e4d6ac03afe9afa4f97cbef453fc5c25f0729",
+                "reference": "757e4d6ac03afe9afa4f97cbef453fc5c25f0729",
+                "shasum": ""
+            },
+            "require": {
+                "ext-dom": "*",
+                "ext-libxml": "*",
+                "php": ">=7.3"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "^9"
+            },
+            "default-branch": true,
+            "type": "library",
+            "autoload": {
+                "psr-4": {
+                    "Rhukster\\DomSanitizer\\": "src"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Andy Miller",
+                    "email": "rhuk@rhuk.net"
+                }
+            ],
+            "description": "A simple but effective DOM/SVG/MathML Sanitizer for PHP 7.4+",
+            "support": {
+                "issues": "https://github.com/rhukster/dom-sanitizer/issues",
+                "source": "https://github.com/rhukster/dom-sanitizer/tree/main"
+            },
+            "time": "2024-04-15T08:48:55+00:00"
         },
         {
             "name": "sabre/dav",
@@ -7259,6 +7305,7 @@
     "aliases": [],
     "minimum-stability": "stable",
     "stability-flags": {
+        "rhukster/dom-sanitizer": 20,
         "roave/security-advisories": 20
     },
     "prefer-stable": false,

--- a/tests/lib/Preview/SVGSanitizeTest.php
+++ b/tests/lib/Preview/SVGSanitizeTest.php
@@ -1,0 +1,63 @@
+<?php
+/**
+ * @author Thomas Müller <thomas.mueller@tmit.eu>
+ *
+ * @copyright Copyright (c) 2024, ownCloud GmbH
+ * @license AGPL-3.0
+ *
+ * This code is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License, version 3,
+ * as published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License, version 3,
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>
+ *
+ */
+
+namespace Test\Preview;
+
+use OC\Preview\SVG;
+use Test\TestCase;
+
+class SVGSanitizeTest extends TestCase {
+	/**
+	 * @dataProvider providesSVG
+	 */
+	public function test(string $test, string $svgContent): void {
+		$output = SVG::sanitizeSVGContent($svgContent);
+		self::assertStringNotContainsString($test, $output);
+	}
+
+	public function providesSVG(): \Generator {
+		$svgContent0 = <<<'SVG'
+<svg xmlns="http://www.w3.org/2000/svg" width="800" height="800">
+	<image href="/var/www/owncloud/stable10/tests/data/testimage.jpg" width="400" height="400"></image>
+</svg>
+SVG;
+		$svgContent1 = <<<'SVG'
+<svg xmlns="http://www.w3.org/2000/svg" 
+   xmlns:xlink="http://www.w3.org/1999/xlink"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+width="800" height="800">
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="/etc/passwd#linearGradient4061"
+       id="linearGradient4067"
+       x1="708.0863"
+       y1="416.54196"
+       x2="710.52051"
+       y2="423.02032"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="translate(-74.8682,-105.3782)" />
+</svg>
+SVG;
+
+		yield 'image href' => ['testimage', $svgContent0];
+		yield 'passwd href' => ['passwd', $svgContent1];
+	}
+}


### PR DESCRIPTION
## Description
SVG `xlink:href` will now completely be blocked as well as other `image` tag to harden SVG support.

## Motivation and Context
Harden SVG support

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Database schema changes (next release will require increase of minor version instead of patch)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [ ] Tests only (no source changes)

## Checklist:
<!-- Tick the checkboxes when done. -->
<!-- Raise documentation ticket in https://github.com/owncloud/documentation -->
- [ ] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 
- [ ] Changelog item, see [TEMPLATE](https://github.com/owncloud/core/blob/master/changelog/TEMPLATE)
