### PR TITLE
fix: add support for port number

### DIFF
--- a/apps/files_sharing/lib/External/Manager.php
+++ b/apps/files_sharing/lib/External/Manager.php
@@ -570,13 +570,22 @@ class Manager {
 	}
 
 	public function testRemoteUrl(IClientService $clientService, string $remote) {
-		$parsed_url = parse_url($remote, PHP_URL_HOST);
-		if (\is_string($parsed_url)) {
-			$remote = $parsed_url;
+		$parsed_host = parse_url($remote, PHP_URL_HOST);
+		$parsed_port = parse_url($remote, PHP_URL_PORT);
+		if (\is_string($parsed_host)) {
+			$remote = $parsed_host;
+			if ($parsed_port !== null) {
+				$remote .= ':' . $parsed_port;
+			}
 		} else {
-			$parsed_url = parse_url('http://' . $remote, PHP_URL_HOST);
-			if (\is_string($parsed_url)) {
-				$remote = $parsed_url;
+			$string_to_parse = 'http://' . $remote;
+			$parsed_host = parse_url($string_to_parse, PHP_URL_HOST);
+			$parsed_port = parse_url($string_to_parse, PHP_URL_PORT);
+			if (\is_string($parsed_host)) {
+				$remote = $parsed_host;
+				if ($parsed_port !== null) {
+					$remote .= ':' . $parsed_port;
+				}
 			}
 		}
 		try {


### PR DESCRIPTION
## Description
This is on top of the linked PR.

If I am running the ownCloud federated server(s) on some other port (not on port 80), then the checks for reachability need to include the port number as well as the host. This happens in development, when starting 2 different servers on the same local system for testing, and it could happen in production installs, I suppose.

It is not a problem in CI, because the drone CI configuration starts the 2 test servers in docker containers that have their own host names, and both of them use port 80 at their respective hosts.

## Related Issue
PR #41210 

## How Has This Been Tested?

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Database schema changes (next release will require increase of minor version instead of patch)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [ ] Tests only (no source changes)

## Checklist:
- [ ] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 
- [ ] Changelog item, see [TEMPLATE](https://github.com/owncloud/core/blob/master/changelog/TEMPLATE)
