### PR TITLE
Fix exception on external storages public links when encryption enabled

### DIFF
--- a/changelog/unreleased/41246
+++ b/changelog/unreleased/41246
@@ -1,0 +1,5 @@
+Bugfix: fix exception on external storages public links when encryption enabled
+
+Having masterkey encryption enabled, when trying to upload into a public link created on an external storage being assigned to at least one user/group, an exception was thrown and the upload operation was not possible. This is now fixed.
+
+https://github.com/owncloud/core/pull/41246  

--- a/lib/private/Encryption/Util.php
+++ b/lib/private/Encryption/Util.php
@@ -305,6 +305,9 @@ class Util {
 			$mounts = \OC\Files\External\LegacyUtil::getSystemMountPoints();
 			foreach ($mounts as $mount) {
 				if (\strpos($path, '/files/' . $mount['mountpoint']) === 0) {
+					if ($uid === false) {
+						return true;
+					}
 					if ($this->isMountPointApplicableToUser($mount, $uid)) {
 						return true;
 					}


### PR DESCRIPTION
## Description
Having masterkey encryption enabled, when trying to upload into a public link created on an external storage (i.e. of type "Local" or "WND") being assigned to at least one user/group, an exception `Attempted to initialize mount points for null user and no user in session` is being thrown and no upload is possible.

## Related Issue
- Fixes https://github.com/owncloud/enterprise/issues/6626

## Motivation and Context
There was a problem around https://github.com/owncloud/core/blob/master/lib/private/Encryption/Util.php#L303 as the `uid` provided to the method is `false` in this case. This happens because the external storage doesn't really have an owner and there is no user in the session. Therefore, when checking for `isMountPointApplicableToUser`, the provided user is `false` which will never find a match, so the mount point isn't considered system wide.

## How Has This Been Tested?
1. enable masterkey encryption
2. create an external storage through the "local" option (also reproducible with WND) and mount it for user `admin`
3. as user `admin` creates a public link on the external storage root 
4. try to upload into the created public link: an exception `Attempted to initialize mount points for null user and no user in session` is shown and file cannot be uploaded
5. try to download an existing file works. Try to download any other file added by user `admin` after the storage has been mounted into oC fails with `File cannot be downloaded` and same exception in logs
6. With this change in place both exceptions at 4. and 5. are solved.

## Types of changes
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Database schema changes (next release will require increase of minor version instead of patch)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [ ] Tests only (no source changes)

## Checklist:
- [X] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised
- [x] Changelog item