### PR TITLE
fix: handle no longer existing user in preview cleanup

### DIFF
--- a/changelog/unreleased/41246
+++ b/changelog/unreleased/41246
@@ -1,0 +1,5 @@
+Bugfix: handle no longer existing user in preview cleanup
+
+A no longer existing user no longer causes an exception in the preview cleanup job.
+
+https://github.com/owncloud/core/pull/41247

--- a/lib/public/Files/IRootFolder.php
+++ b/lib/public/Files/IRootFolder.php
@@ -23,6 +23,7 @@
 namespace OCP\Files;
 
 use OC\Hooks\Emitter;
+use OC\User\NoUserException;
 
 /**
  * Interface IRootFolder
@@ -36,6 +37,7 @@ interface IRootFolder extends Folder, Emitter {
 	 *
 	 * @param String $userId user ID
 	 * @return \OCP\Files\Folder
+	 * @throws  NoUserException
 	 * @since 8.2.0
 	 */
 	public function getUserFolder($userId);


### PR DESCRIPTION
## Description
A deleted user can still have previews in database (mainly because the final delete job did not finish).
To prevent any issues in preview cleanup these users will no be processed,

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Database schema changes (next release will require increase of minor version instead of patch)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [ ] Tests only (no source changes)

## Checklist:
<!-- Tick the checkboxes when done. -->
<!-- Raise documentation ticket in https://github.com/owncloud/documentation -->
- [x] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 
- [ ] Changelog item, see [TEMPLATE](https://github.com/owncloud/core/blob/master/changelog/TEMPLATE)
