### PR TITLE
fix: handle short classes in Autoloader

### DIFF
--- a/changelog/unreleased/41252
+++ b/changelog/unreleased/41252
@@ -1,0 +1,8 @@
+Bugfix: handle short classes in Autoloader
+
+The Autoloader findClass method was emitting a PHP notice "undefined offset"
+for class strings at the top OCA level. The code has been corrected so that
+the PHP notice is not emitted.
+
+https://github.com/owncloud/core/pull/41252
+https://github.com/owncloud/core/pull/41253

--- a/lib/private/Autoloader.php
+++ b/lib/private/Autoloader.php
@@ -76,7 +76,18 @@ class Autoloader {
 
 		$paths = [];
 		if (\strpos($class, 'OCA\\') === 0) {
-			list(, $app, $rest) = \explode('\\', $class, 3);
+			list(, $app, $rest) = \array_pad(\explode('\\', $class, 3), 3, '');
+			// findClass might be called with a string like 'OCA\Files'
+			// because there is code that has an event listener with a name like
+			// OCA\Files::loadAdditionalScripts
+			// That looks like there could be a class 'OCA\Files` with a method
+			// 'loadAdditionalScripts'. But that is just an event name.
+			// phpstan seems to do this when trying to find all "classes" that
+			// it might need to use and analyze.
+			// In this case, return early.
+			if ($rest === '') {
+				return $paths;
+			}
 			$app = \strtolower($app);
 			$appPath = \OC_App::getAppPath($app);
 			if ($appPath && \stream_resolve_include_path($appPath)) {

--- a/vendor-bin/phpstan/composer.json
+++ b/vendor-bin/phpstan/composer.json
@@ -1,5 +1,5 @@
 {
     "require": {
-        "phpstan/phpstan": "^1.10"
+        "phpstan/phpstan": "^1.11"
     }
 }


### PR DESCRIPTION
## Description
See the issue for details of the problem.

If `explode` does not return enough parts, pad the returned array with empty strings so that the `list()` will have a big enough array to fill the variables in `list()`.

## Related Issue
- Fixes #41252 

## How Has This Been Tested?
CI

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Database schema changes (next release will require increase of minor version instead of patch)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [ ] Tests only (no source changes)

## Checklist:
- [x] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 
- [x] Changelog item, see [TEMPLATE](https://github.com/owncloud/core/blob/master/changelog/TEMPLATE)
