### PR TITLE
fix: run update check in updatenotification app only when internet co…

### DIFF
--- a/apps/updatenotification/appinfo/app.php
+++ b/apps/updatenotification/appinfo/app.php
@@ -21,6 +21,10 @@
  *
  */
 
+if (\OC::$server->getConfig()->getSystemValue('has_internet_connection', true) !== true) {
+	return;
+}
+
 if (\OC::$server->getConfig()->getSystemValue('updatechecker', true) === true) {
 	$updater = new \OC\Updater\VersionCheck(
 		\OC::$server->getHTTPClientService(),

--- a/changelog/unreleased/41262
+++ b/changelog/unreleased/41262
@@ -1,0 +1,6 @@
+Bugfix: No update check if not connected to the internet
+
+In case an owncloud instance is not connected to the internet there is no need
+in polling for updates in the update notification app.
+
+https://github.com/owncloud/core/pull/41262


### PR DESCRIPTION
…nnection is available

## Description
In case an owncloud instance is not connected to the internet there is no need in polling for updates in the update notification app.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Database schema changes (next release will require increase of minor version instead of patch)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [ ] Tests only (no source changes)

## Checklist:
<!-- Tick the checkboxes when done. -->
<!-- Raise documentation ticket in https://github.com/owncloud/documentation -->
- [ ] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 
- [ ] Changelog item, see [TEMPLATE](https://github.com/owncloud/core/blob/master/changelog/TEMPLATE)
