### PR TITLE
[tests-only] test: fix Then steps in test scenarios

### DIFF
--- a/tests/acceptance/features/webUIManageUsersGroups/addGroup.feature
+++ b/tests/acceptance/features/webUIManageUsersGroups/addGroup.feature
@@ -41,7 +41,7 @@ Feature: Add group
     And group "<group_id3>" has been created
     And the administrator reloads the users page
     When the administrator adds user "Alice" to group "<group_id1>" using the webUI
-    And user "Alice" should belong to group "<group_id1>"
+    Then user "Alice" should belong to group "<group_id1>"
     But user "Alice" should not belong to group "<group_id2>"
     And user "Alice" should not belong to group "<group_id3>"
     Examples:

--- a/tests/acceptance/features/webUIManageUsersGroups/editUsers.feature
+++ b/tests/acceptance/features/webUIManageUsersGroups/editUsers.feature
@@ -111,7 +111,7 @@ Feature: edit users
     And user "Alice" has been added to group "<group_id3>"
     And the administrator has browsed to the users page
     When the administrator removes user "Alice" from group "<group_id1>" using the webUI
-    And user "Alice" should not belong to group "<group_id1>"
+    Then user "Alice" should not belong to group "<group_id1>"
     But user "Alice" should belong to group "<group_id2>"
     And user "Alice" should belong to group "<group_id3>"
     Examples:


### PR DESCRIPTION
## Description
A couple of acceptance test scenarios were missing the `Then` keyword. Fix them.
There was/is no impact on the actual test execution - it is purely cosmetic.
Found while trying the Gherkin linter https://github.com/gherlint/gherlint/releases/tag/v1.1.0

## How Has This Been Tested?
CI

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Database schema changes (next release will require increase of minor version instead of patch)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [x] Tests only (no source changes)

## Checklist:
- [ ] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 
- [ ] Changelog item, see [TEMPLATE](https://github.com/owncloud/core/blob/master/changelog/TEMPLATE)
