### PR TITLE
fix: AllConfig::getUserKeys to return string[] only

### DIFF
--- a/lib/private/AllConfig.php
+++ b/lib/private/AllConfig.php
@@ -290,7 +290,7 @@ class AllConfig implements IConfig {
 	public function getUserKeys($userId, $appName) {
 		$data = $this->getUserValues($userId);
 		if (isset($data[$appName])) {
-			return \array_keys($data[$appName]);
+			return array_map('strval', array_keys($data[$appName]));
 		}
 		return [];
 	}


### PR DESCRIPTION
## Description
Side port of https://github.com/nextcloud/server/pull/44276

## How Has This Been Tested?
- :robot: 

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Database schema changes (next release will require increase of minor version instead of patch)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [ ] Tests only (no source changes)

## Checklist:
<!-- Tick the checkboxes when done. -->
<!-- Raise documentation ticket in https://github.com/owncloud/documentation -->
- [x] Code changes
- [x] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 
- [ ] Changelog item, see [TEMPLATE](https://github.com/owncloud/core/blob/master/changelog/TEMPLATE)
