### PR TITLE
[10.15.0] fix: Update StoragesBackendService.php to default handling (#41273)

### DIFF
--- a/lib/private/Files/External/StoragesBackendService.php
+++ b/lib/private/Files/External/StoragesBackendService.php
@@ -65,7 +65,7 @@ class StoragesBackendService implements IStoragesBackendService {
 		$this->config = $config;
 
 		// Load config values
-		if ($this->config->getAppValue('files_external', 'allow_user_mounting', 'yes') !== 'yes') {
+		if ($this->config->getAppValue('files_external', 'allow_user_mounting', 'no') !== 'yes') {
 			$this->userMountingAllowed = false;
 		}
 		$this->userMountingBackends = \explode(

--- a/tests/lib/Files/External/StoragesBackendServiceTest.php
+++ b/tests/lib/Files/External/StoragesBackendServiceTest.php
@@ -152,7 +152,7 @@ class StoragesBackendServiceTest extends \Test\TestCase {
 		$this->config->expects($this->exactly(2))
 			->method('getAppValue')
 			->will($this->returnValueMap([
-				['files_external', 'allow_user_mounting', 'yes', 'yes'],
+				['files_external', 'allow_user_mounting', 'no', 'yes'],
 				['files_external', 'user_mounting_backends', '', 'identifier:\User\Mount\Allowed,identifier_alias']
 			]));
 


### PR DESCRIPTION
## Description
Backport #41273 to 10.15.0 release branch.

* fix: Update StoragesBackendService.php to default handling

also needed for #41271

* fix: Update StoragesBackendServiceTest to pass

---------

## Related Issue

## How Has This Been Tested?
CI

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Database schema changes (next release will require increase of minor version instead of patch)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [ ] Tests only (no source changes)

## Checklist:
- [ ] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 
- [ ] Changelog item, see [TEMPLATE](https://github.com/owncloud/core/blob/master/changelog/TEMPLATE)
