### PR TITLE
[10.15.0] chore(deps): bump phpseclib/phpseclib from 3.0.38 to 3.0.39

### DIFF
--- a/changelog/10.15.0_2024-06-18/PHPdependencies20240228onward
+++ b/changelog/10.15.0_2024-06-18/PHPdependencies20240228onward
@@ -9,7 +9,7 @@ The following have been updated:
 - paragonie/constant_time_encoding (v2.6.3 to v2.7.0)
 - pear/archive_tar (1.4.14 to 1.15.0)
 - pear/pear-core-minimal (v1.10.14 to v1.10.15)
-- phpseclib/phpseclib (3.0.35 to 3.0.38)
+- phpseclib/phpseclib (3.0.35 to 3.0.39)
 - psr/http-factory (1.0.2 to 1.1.0)
 - sabre/xml (2.2.6 to 2.2.7)
 - symfony/event-dispatcher-contracts (v2.5.2 to v2.5.3)
@@ -32,3 +32,4 @@ https://github.com/owncloud/core/pull/41242
 https://github.com/owncloud/core/pull/41255
 https://github.com/owncloud/core/pull/41259
 https://github.com/owncloud/core/pull/41267
+https://github.com/owncloud/core/pull/41276

--- a/composer.lock
+++ b/composer.lock
@@ -2650,16 +2650,16 @@
         },
         {
             "name": "phpseclib/phpseclib",
-            "version": "3.0.38",
+            "version": "3.0.39",
             "source": {
                 "type": "git",
                 "url": "https://github.com/phpseclib/phpseclib.git",
-                "reference": "b18b8788e51156c4dd97b7f220a31149a0052067"
+                "reference": "211ebc399c6e73c225a018435fe5ae209d1d1485"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/phpseclib/phpseclib/zipball/b18b8788e51156c4dd97b7f220a31149a0052067",
-                "reference": "b18b8788e51156c4dd97b7f220a31149a0052067",
+                "url": "https://api.github.com/repos/phpseclib/phpseclib/zipball/211ebc399c6e73c225a018435fe5ae209d1d1485",
+                "reference": "211ebc399c6e73c225a018435fe5ae209d1d1485",
                 "shasum": ""
             },
             "require": {
@@ -2740,7 +2740,7 @@
             ],
             "support": {
                 "issues": "https://github.com/phpseclib/phpseclib/issues",
-                "source": "https://github.com/phpseclib/phpseclib/tree/3.0.38"
+                "source": "https://github.com/phpseclib/phpseclib/tree/3.0.39"
             },
             "funding": [
                 {
@@ -2756,7 +2756,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2024-06-17T10:11:32+00:00"
+            "time": "2024-06-24T06:27:33+00:00"
         },
         {
             "name": "pimple/pimple",


### PR DESCRIPTION
## Description
Apply dependabot PR #41274 to release-10.15.0

https://github.com/phpseclib/phpseclib/issues/2009 has a fix for an issue introduced in 3.0.38 and 3.0.38 is already in release-10.15.0

IMO we should not release with 3.0.38 - we should move forward to 3.0.39

## How Has This Been Tested?
CI

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Database schema changes (next release will require increase of minor version instead of patch)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [ ] Tests only (no source changes)

## Checklist:
- [ ] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 
- [ ] Changelog item, see [TEMPLATE](https://github.com/owncloud/core/blob/master/changelog/TEMPLATE)
