### PR TITLE
test: remove unused array_reverse code

### DIFF
--- a/tests/acceptance/features/bootstrap/WebDav.php
+++ b/tests/acceptance/features/bootstrap/WebDav.php
@@ -5444,8 +5444,6 @@ trait WebDav {
 				$authors[] = $author->__toString();
 			}
 		}
-		// reverse the array to get the latest version first
-		\array_reverse($authors);
 		if (!isset($authors[$index - 1])) {
 			Assert::fail(
 				'could not find version with index "' . $index . '" for oc:meta-version-edited-by property in response to user "' . $this->responseUser . '"'
@@ -5468,8 +5466,6 @@ trait WebDav {
 				$displaynames[] = $displayname->__toString();
 			}
 		}
-		// reverse the array to get the latest version first
-		\array_reverse($displaynames);
 		if (!isset($displaynames[$index - 1])) {
 			Assert::fail(
 				'could not find version with index "' . $index . '" for oc:meta-version-edited-by-name property in response to user "' . $this->responseUser . '"'


### PR DESCRIPTION
## Description
https://www.php.net/manual/en/function.array-reverse.php returns the reversed array, but the calls here do not use the returned array. So the code is actually useless - delete it.

The array of version authors is already in order from latest to oldest. The first element (0) is for the current actual file, element (1) is the latest of the saved versions, element (2) is the next older saved version etc. There is actually no need to reverse the array (the comment was wrong)

## Related Issue
Part of https://github.com/owncloud/ocis/issues/9347

## How Has This Been Tested?

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Database schema changes (next release will require increase of minor version instead of patch)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [x] Tests only (no source changes)

## Checklist:
- [ ] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 
- [ ] Changelog item, see [TEMPLATE](https://github.com/owncloud/core/blob/master/changelog/TEMPLATE)
