### PR TITLE
Docu: telemetry.enabled in config.sample.php 

### DIFF
--- a/config/config.sample.php
+++ b/config/config.sample.php
@@ -1884,11 +1884,12 @@ $CONFIG = [
 'loginPolicy.groupLoginPolicy.forbidMap' => [],
 
 /**
- * Enable Sending of Telemetry Reports
- * Telemetry data is a subset of the config report as produced by e.g. the command `occ configreport:generate`.
+ * Enable Sending Telemetry Reports
+ * Telemetry data is a subset of the config report as produced by the command `occ configreport:generate`.
  *
- * If set to true, a daily telemetry report is sent to https://telemetry.owncloud.com/oc10-telemetry
- * If set to false, no telemetry reports are sent.
+ * * If set to true, a daily telemetry report is sent to https://telemetry.owncloud.com/oc10-telemetry
+ * * If set to false, no telemetry reports are sent.
+ * 
  * Default: true
  */
 'telemetry.enabled' => true,

--- a/config/config.sample.php
+++ b/config/config.sample.php
@@ -1882,4 +1882,14 @@ $CONFIG = [
  * This could happen in earlier versions of the openidconnect app when using the web UI.
  */
 'loginPolicy.groupLoginPolicy.forbidMap' => [],
+
+/**
+ * Enable Sending of Telemetry Reports
+ * Telemetry data is a subset of the config report as produced by e.g. the command `occ configreport:generate`.
+ *
+ * If set to true, a daily telemetry report is sent to https://telemetry.owncloud.com/oc10-telemetry
+ * If set to false, no telemetry reports are sent.
+ * Default: true
+ */
+'telemetry.enabled' => true,
 ];

--- a/config/config.sample.php
+++ b/config/config.sample.php
@@ -1889,7 +1889,7 @@ $CONFIG = [
  *
  * * If set to true, a daily telemetry report is sent to https://telemetry.owncloud.com/oc10-telemetry
  * * If set to false, no telemetry reports are sent.
- * 
+ *
  * Default: true
  */
 'telemetry.enabled' => true,


### PR DESCRIPTION
Document the system config variable telemetry.enabled in config.sample.php
Needed for a clean config to docs run.