### PR TITLE
docs: Update or correct default enabledPreviewProviders lists

### DIFF
--- a/config/config.sample.php
+++ b/config/config.sample.php
@@ -1056,7 +1056,9 @@ $CONFIG = [
  *  - OC\Preview\WEBP
  *  - OC\Preview\GIF
  *  - OC\Preview\BMP
+ *  - OC\Preview\Heic
  *  - OC\Preview\XBitmap
+ *  - OC\Preview\SGI
  *  - OC\Preview\MarkDown
  *  - OC\Preview\MP3
  *  - OC\Preview\TXT
@@ -1064,18 +1066,17 @@ $CONFIG = [
  * See the Previews Configuration documentation for more details.
  */
 'enabledPreviewProviders' => [
-	'OC\Preview\PDF',
-	'OC\Preview\SGI',
-	'OC\Preview\Heic',
 	'OC\Preview\PNG',
 	'OC\Preview\JPEG',
 	'OC\Preview\WEBP',
 	'OC\Preview\GIF',
 	'OC\Preview\BMP',
+	'OC\Preview\Heic',
 	'OC\Preview\XBitmap',
+	'OC\Preview\SGI',
+	'OC\Preview\MarkDown',
 	'OC\Preview\MP3',
-	'OC\Preview\TXT',
-	'OC\Preview\MarkDown'
+	'OC\Preview\TXT'
   ],
 
 /**

--- a/lib/private/PreviewManager.php
+++ b/lib/private/PreviewManager.php
@@ -236,7 +236,9 @@ class PreviewManager implements IPreview {
 	 *  - OC\Preview\WEBP
 	 *  - OC\Preview\GIF
 	 *  - OC\Preview\BMP
+	 *  - OC\Preview\Heic
 	 *  - OC\Preview\XBitmap
+   	 *  - OC\Preview\SGI
 	 *  - OC\Preview\MarkDown
 	 *  - OC\Preview\MP3
 	 *  - OC\Preview\TXT

--- a/lib/private/PreviewManager.php
+++ b/lib/private/PreviewManager.php
@@ -238,7 +238,7 @@ class PreviewManager implements IPreview {
 	 *  - OC\Preview\BMP
 	 *  - OC\Preview\Heic
 	 *  - OC\Preview\XBitmap
-   	 *  - OC\Preview\SGI
+	 *  - OC\Preview\SGI
 	 *  - OC\Preview\MarkDown
 	 *  - OC\Preview\MP3
 	 *  - OC\Preview\TXT


### PR DESCRIPTION
## Description
See this for the current default list:

https://github.com/owncloud/core/blob/v10.15.0/lib/private/PreviewManager.php#L266-L281

and the relevant comments / examples have been ordered the same way. `OC\Preview\PDF` was dropped from the config.sample.php because it is not in the default enabled list.

Question:

What about these in https://doc.owncloud.com/server/10.14/admin_manual/configuration/files/previews_configuration.html#preview-format-requirements not mentioned anywhere in the updated files:

```
OC\Preview\AI
OC\Preview\EPS
OC\Preview\PSD
OC\Preview\TTF
```

Are the docs even correct. few lines in the code we can see this:

https://github.com/owncloud/core/blob/v10.15.0/lib/private/PreviewManager.php#L334-L337

## Related Issue
N/A

## Motivation and Context
Better documentation

## How Has This Been Tested?
No testing, only documentation changes

## Screenshots (if appropriate):
N/A

## Types of changes
Not sure what to tick here

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Database schema changes (next release will require increase of minor version instead of patch)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [ ] Tests only (no source changes)

## Checklist:
Not sure what to tick here

- [ ] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 
- [ ] Changelog item, see [TEMPLATE](https://github.com/owncloud/core/blob/master/changelog/TEMPLATE)
