### PR TITLE
chore: apply php-cs-fixer 3.62 changes

### DIFF
--- a/apps/dav/lib/Command/CleanupChunks.php
+++ b/apps/dav/lib/Command/CleanupChunks.php
@@ -98,7 +98,7 @@ class CleanupChunks extends Command {
 				return;
 			}
 
-			$output->writeln(sprintf("Cleaning %d chunks for %s", \count($filteredUploads), $user->getUID()));
+			$output->writeln(\sprintf("Cleaning %d chunks for %s", \count($filteredUploads), $user->getUID()));
 
 			$p = new ProgressBar($output);
 			$p->start(\count($filteredUploads));

--- a/apps/dav/templates/exception.php
+++ b/apps/dav/templates/exception.php
@@ -1,9 +1,9 @@
 <?php
-	/** @var array $_ */
-	/** @var \OCP\IL10N $l */
+/** @var array $_ */
+/** @var \OCP\IL10N $l */
 
-	style('core', ['styles', 'header']);
-	?>
+style('core', ['styles', 'header']);
+?>
 <span class="error error-wide">
 	<h2><strong><?php p($_['title']) ?></strong></h2>
 	<?php if (isset($_['hint']) && $_['hint']): ?>

--- a/apps/updatenotification/templates/admin.php
+++ b/apps/updatenotification/templates/admin.php
@@ -1,21 +1,21 @@
 <?php
-	script('updatenotification', 'admin');
+script('updatenotification', 'admin');
 
-	/** @var array $_ */
-	/** @var bool $isNewVersionAvailable */
-	$isNewVersionAvailable = $_['isNewVersionAvailable'];
-	/** @var string $newVersionString */
-	$newVersionString = $_['newVersionString'];
-	/** @var string $lastCheckedDate */
-	$lastCheckedDate = $_['lastChecked'];
-	/** @var array $channels */
-	$channels = $_['channels'];
-	/** @var string $currentChannel */
-	$currentChannel = $_['currentChannel'];
-	/** @var string $changeLogUrl */
-	$changeLogUrl = $_['changeLogUrl'];
-	
-	?>
+/** @var array $_ */
+/** @var bool $isNewVersionAvailable */
+$isNewVersionAvailable = $_['isNewVersionAvailable'];
+/** @var string $newVersionString */
+$newVersionString = $_['newVersionString'];
+/** @var string $lastCheckedDate */
+$lastCheckedDate = $_['lastChecked'];
+/** @var array $channels */
+$channels = $_['channels'];
+/** @var string $currentChannel */
+$currentChannel = $_['currentChannel'];
+/** @var string $changeLogUrl */
+$changeLogUrl = $_['changeLogUrl'];
+
+?>
 <form id="oca_updatenotification_section" class="section">
 	<h2 id="updater" class="app-name"><?php p($l->t('Updater')); ?></h2>
 

--- a/core/Command/App/ListApps.php
+++ b/core/Command/App/ListApps.php
@@ -121,7 +121,7 @@ class ListApps extends Base {
 				$appDetailRecord = [];
 
 				if ($minimalView) {
-					$apps['enabled'][$app] = sprintf('%s%s', $app, isset($versions[$app]) ? ' '.$versions[$app] : '');
+					$apps['enabled'][$app] = \sprintf('%s%s', $app, isset($versions[$app]) ? ' '.$versions[$app] : '');
 					continue;
 				}
 
@@ -140,7 +140,7 @@ class ListApps extends Base {
 				$appDetailRecord = [];
 
 				if ($minimalView) {
-					$apps['disabled'][$app] = sprintf('%s%s', $app, isset($versions[$app]) ? ' '.$versions[$app] : '');
+					$apps['disabled'][$app] = \sprintf('%s%s', $app, isset($versions[$app]) ? ' '.$versions[$app] : '');
 					continue;
 				}
 

--- a/core/templates/exception.php
+++ b/core/templates/exception.php
@@ -1,9 +1,9 @@
 <?php
-	/** @var array $_ */
-	/** @var \OCP\IL10N $l */
+/** @var array $_ */
+/** @var \OCP\IL10N $l */
 
-	style('core', ['styles', 'header']);
-	?>
+style('core', ['styles', 'header']);
+?>
 <span class="error error-wide">
 	<h2><strong><?php p($l->t('Internal Server Error')) ?></strong></h2>
 		<p><?php p($l->t('The server encountered an internal error and was unable to complete your request.')) ?></p>

--- a/core/templates/layout.noscript.warning.php
+++ b/core/templates/layout.noscript.warning.php
@@ -2,10 +2,10 @@
 	<div id="nojavascript">
 		<div>
 			<?php print_unescaped(\str_replace(
-	['{linkstart}', '{linkend}'],
-	['<a href="http://enable-javascript.com/" target="_blank" rel="noreferrer">', '</a>'],
-	$l->t('This application requires JavaScript for correct operation. Please {linkstart}enable JavaScript{linkend} and reload the page.')
-)); ?>
+				['{linkstart}', '{linkend}'],
+				['<a href="http://enable-javascript.com/" target="_blank" rel="noreferrer">', '</a>'],
+				$l->t('This application requires JavaScript for correct operation. Please {linkstart}enable JavaScript{linkend} and reload the page.')
+			)); ?>
 		</div>
 	</div>
 </noscript>

--- a/core/templates/update.admin.php
+++ b/core/templates/update.admin.php
@@ -7,9 +7,9 @@
 		} else {
 			?>
 		<h2 class="title"><?php p($l->t(
-				'%s will be updated to version %s',
-				[$_['productName'], $_['version']]
-			)); ?></h2>
+			'%s will be updated to version %s',
+			[$_['productName'], $_['version']]
+		)); ?></h2>
 		<?php
 		} ?>
 		<?php if (!empty($_['appsToUpgrade'])) {

--- a/settings/templates/panels/personal/quota.php
+++ b/settings/templates/panels/personal/quota.php
@@ -5,9 +5,9 @@
 			<p id="quotatext">
 				<?php if ($_['quota'] === \OCP\Files\FileInfo::SPACE_UNLIMITED): ?>
 					<?php p($l->t(
-	'You are using %s',
-	[$_['usage']]
-));?>
+						'You are using %s',
+						[$_['usage']]
+					));?>
 				<?php else: ?>
 					<?php p($l->t(
 						'You are using %s of %s (%s %%)',

--- a/tests/lib/Encryption/ManagerTest.php
+++ b/tests/lib/Encryption/ManagerTest.php
@@ -187,63 +187,63 @@ class ManagerTest extends TestCase {
 		$this->assertEquals('ID1', $this->manager->getDefaultEncryptionModuleId());
 	}
 
-//	/**
-//	 * @expectedException \OC\Encryption\Exceptions\ModuleAlreadyExistsException
-//	 * @expectedExceptionMessage Id "0" already used by encryption module "TestDummyModule0"
-//	 */
-//	public function testModuleRegistration() {
-//		$config = $this->createMock('\OCP\IConfig');
-//		$config->expects($this->any())->method('getSystemValue')->willReturn(true);
-//		$em = $this->createMock('\OCP\Encryption\IEncryptionModule');
-//		$em->expects($this->any())->method('getId')->willReturn(0);
-//		$em->expects($this->any())->method('getDisplayName')->willReturn('TestDummyModule0');
-//		$m = new Manager($config);
-//		$m->registerEncryptionModule($em);
-//		$this->assertTrue($m->isEnabled());
-//		$m->registerEncryptionModule($em);
-//	}
-//
-//	public function testModuleUnRegistration() {
-//		$config = $this->createMock('\OCP\IConfig');
-//		$config->expects($this->any())->method('getSystemValue')->willReturn(true);
-//		$em = $this->createMock('\OCP\Encryption\IEncryptionModule');
-//		$em->expects($this->any())->method('getId')->willReturn(0);
-//		$em->expects($this->any())->method('getDisplayName')->willReturn('TestDummyModule0');
-//		$m = new Manager($config);
-//		$m->registerEncryptionModule($em);
-//		$this->assertTrue($m->isEnabled());
-//		$m->unregisterEncryptionModule($em);
-//		$this->assertFalse($m->isEnabled());
-//	}
-//
-//	/**
-//	 * @expectedException \OC\Encryption\Exceptions\ModuleDoesNotExistsException
-//	 * @expectedExceptionMessage Module with id: unknown does not exist.
-//	 */
-//	public function testGetEncryptionModuleUnknown() {
-//		$config = $this->createMock('\OCP\IConfig');
-//		$config->expects($this->any())->method('getSystemValue')->willReturn(true);
-//		$em = $this->createMock('\OCP\Encryption\IEncryptionModule');
-//		$em->expects($this->any())->method('getId')->willReturn(0);
-//		$em->expects($this->any())->method('getDisplayName')->willReturn('TestDummyModule0');
-//		$m = new Manager($config);
-//		$m->registerEncryptionModule($em);
-//		$this->assertTrue($m->isEnabled());
-//		$m->getEncryptionModule('unknown');
-//	}
-//
-//	public function testGetEncryptionModule() {
-//		$config = $this->createMock('\OCP\IConfig');
-//		$config->expects($this->any())->method('getSystemValue')->willReturn(true);
-//		$em = $this->createMock('\OCP\Encryption\IEncryptionModule');
-//		$em->expects($this->any())->method('getId')->willReturn(0);
-//		$em->expects($this->any())->method('getDisplayName')->willReturn('TestDummyModule0');
-//		$m = new Manager($config);
-//		$m->registerEncryptionModule($em);
-//		$this->assertTrue($m->isEnabled());
-//		$en0 = $m->getEncryptionModule(0);
-//		$this->assertEquals(0, $en0->getId());
-//	}
+	//	/**
+	//	 * @expectedException \OC\Encryption\Exceptions\ModuleAlreadyExistsException
+	//	 * @expectedExceptionMessage Id "0" already used by encryption module "TestDummyModule0"
+	//	 */
+	//	public function testModuleRegistration() {
+	//		$config = $this->createMock('\OCP\IConfig');
+	//		$config->expects($this->any())->method('getSystemValue')->willReturn(true);
+	//		$em = $this->createMock('\OCP\Encryption\IEncryptionModule');
+	//		$em->expects($this->any())->method('getId')->willReturn(0);
+	//		$em->expects($this->any())->method('getDisplayName')->willReturn('TestDummyModule0');
+	//		$m = new Manager($config);
+	//		$m->registerEncryptionModule($em);
+	//		$this->assertTrue($m->isEnabled());
+	//		$m->registerEncryptionModule($em);
+	//	}
+	//
+	//	public function testModuleUnRegistration() {
+	//		$config = $this->createMock('\OCP\IConfig');
+	//		$config->expects($this->any())->method('getSystemValue')->willReturn(true);
+	//		$em = $this->createMock('\OCP\Encryption\IEncryptionModule');
+	//		$em->expects($this->any())->method('getId')->willReturn(0);
+	//		$em->expects($this->any())->method('getDisplayName')->willReturn('TestDummyModule0');
+	//		$m = new Manager($config);
+	//		$m->registerEncryptionModule($em);
+	//		$this->assertTrue($m->isEnabled());
+	//		$m->unregisterEncryptionModule($em);
+	//		$this->assertFalse($m->isEnabled());
+	//	}
+	//
+	//	/**
+	//	 * @expectedException \OC\Encryption\Exceptions\ModuleDoesNotExistsException
+	//	 * @expectedExceptionMessage Module with id: unknown does not exist.
+	//	 */
+	//	public function testGetEncryptionModuleUnknown() {
+	//		$config = $this->createMock('\OCP\IConfig');
+	//		$config->expects($this->any())->method('getSystemValue')->willReturn(true);
+	//		$em = $this->createMock('\OCP\Encryption\IEncryptionModule');
+	//		$em->expects($this->any())->method('getId')->willReturn(0);
+	//		$em->expects($this->any())->method('getDisplayName')->willReturn('TestDummyModule0');
+	//		$m = new Manager($config);
+	//		$m->registerEncryptionModule($em);
+	//		$this->assertTrue($m->isEnabled());
+	//		$m->getEncryptionModule('unknown');
+	//	}
+	//
+	//	public function testGetEncryptionModule() {
+	//		$config = $this->createMock('\OCP\IConfig');
+	//		$config->expects($this->any())->method('getSystemValue')->willReturn(true);
+	//		$em = $this->createMock('\OCP\Encryption\IEncryptionModule');
+	//		$em->expects($this->any())->method('getId')->willReturn(0);
+	//		$em->expects($this->any())->method('getDisplayName')->willReturn('TestDummyModule0');
+	//		$m = new Manager($config);
+	//		$m->registerEncryptionModule($em);
+	//		$this->assertTrue($m->isEnabled());
+	//		$en0 = $m->getEncryptionModule(0);
+	//		$this->assertEquals(0, $en0->getId());
+	//	}
 
 	protected function addNewEncryptionModule(Manager $manager, $id) {
 		$encryptionModule = $this->createMock('\OCP\Encryption\IEncryptionModule');

--- a/tests/lib/Files/Cache/UpdaterLegacyTest.php
+++ b/tests/lib/Files/Cache/UpdaterLegacyTest.php
@@ -263,14 +263,14 @@ class UpdaterLegacyTest extends \Test\TestCase {
 		$this->assertIsString($cachedData['etag']);
 		$this->assertNotSame($substorageCachedData['etag'], $cachedData['etag']);
 		// rename can cause mtime change - invalid assert
-//		$this->assertEquals($mtime, $cachedData['mtime']);
+		//		$this->assertEquals($mtime, $cachedData['mtime']);
 
 		$cachedData = $view->getFileInfo('folder');
 		$this->assertIsString($folderCachedData['etag']);
 		$this->assertIsString($cachedData['etag']);
 		$this->assertNotSame($folderCachedData['etag'], $cachedData['etag']);
 		// rename can cause mtime change - invalid assert
-//		$this->assertEquals($mtime, $cachedData['mtime']);
+		//		$this->assertEquals($mtime, $cachedData['mtime']);
 	}
 
 	public function testTouch() {

--- a/tests/lib/Files/FilesystemTest.php
+++ b/tests/lib/Files/FilesystemTest.php
@@ -371,14 +371,14 @@ class FilesystemTest extends TestCase {
 		$rootView->mkdir('/' . $user);
 		$rootView->mkdir('/' . $user . '/files');
 
-//		\OC\Files\Filesystem::file_put_contents('/foo', 'foo');
+		//		\OC\Files\Filesystem::file_put_contents('/foo', 'foo');
 		Filesystem::mkdir('/bar');
-//		\OC\Files\Filesystem::file_put_contents('/bar//foo', 'foo');
+		//		\OC\Files\Filesystem::file_put_contents('/bar//foo', 'foo');
 
 		$tmpFile = \OC::$server->getTempManager()->getTemporaryFile();
 		\file_put_contents($tmpFile, 'foo');
 		$fh = \fopen($tmpFile, 'r');
-//		\OC\Files\Filesystem::file_put_contents('/bar//foo', $fh);
+		//		\OC\Files\Filesystem::file_put_contents('/bar//foo', $fh);
 	}
 
 	/**

--- a/tests/lib/Files/Storage/Wrapper/EncryptionTest.php
+++ b/tests/lib/Files/Storage/Wrapper/EncryptionTest.php
@@ -920,10 +920,10 @@ class EncryptionTest extends Storage {
 			->method('isEnabled')
 			->willReturn($encryptionEnabled);
 		// FIXME can not overwrite the return after definition
-//		$this->mount
-//			->method('getOption')
-//			->withConsecutive('encrypt', true)
-//			->willReturn($mountPointEncryptionEnabled);
+		//		$this->mount
+		//			->method('getOption')
+		//			->withConsecutive('encrypt', true)
+		//			->willReturn($mountPointEncryptionEnabled);
 		global $mockedMountPointEncryptionEnabled;
 		$mockedMountPointEncryptionEnabled = $mountPointEncryptionEnabled;
 

--- a/tests/lib/User/SessionTest.php
+++ b/tests/lib/User/SessionTest.php
@@ -260,9 +260,9 @@ class SessionTest extends TestCase {
 				unset($managerMethods[$i]);
 			}
 		}
-//		$manager = $this->getMockBuilder(Manager::class)
-//			->setMethods($managerMethods)
-//			->getMock();
+		//		$manager = $this->getMockBuilder(Manager::class)
+		//			->setMethods($managerMethods)
+		//			->getMock();
 
 		$manager = $this->createMock(Manager::class);
 		$user = $this->createMock(IUser::class);

--- a/vendor-bin/owncloud-codestyle/composer.json
+++ b/vendor-bin/owncloud-codestyle/composer.json
@@ -1,5 +1,5 @@
 {
     "require": {
-      "owncloud/coding-standard": "^5.1"
+      "owncloud/coding-standard": "^5.3"
     }
   }


### PR DESCRIPTION
## Description
https://github.com/owncloud/coding-standard/releases/tag/5.3.0 uses
https://github.com/PHP-CS-Fixer/PHP-CS-Fixer/releases/tag/v3.62.0

That suggests some changes to indentation etc. that are minor. Apply these changes so that the code-style checks in CI will pass.

## How Has This Been Tested?
CI

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Database schema changes (next release will require increase of minor version instead of patch)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [ ] Tests only (no source changes)

## Checklist:
- [ ] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 
- [ ] Changelog item, see [TEMPLATE](https://github.com/owncloud/core/blob/master/changelog/TEMPLATE)
