### PR TITLE
feat: log which fed-share is scanned

### DIFF
--- a/apps/files_sharing/lib/External/ScanExternalSharesJob.php
+++ b/apps/files_sharing/lib/External/ScanExternalSharesJob.php
@@ -130,6 +130,7 @@ class ScanExternalSharesJob extends TimedJob {
 					$this->updateLastScanned($share['id'], \time());
 
 					// do scan share
+					$this->logger->debug("Scanning fed share with id " . $share['id']);
 					$this->scan($share);
 					$scannedShares += 1;
 				}


### PR DESCRIPTION
ScanExternalShares Job should log which share it is attempting to scan so the admin can see in the logs which share is faulty and returns a 401.

