### PR TITLE
fix: hint user in share dialog about password policy

### DIFF
--- a/apps/files_sharing/css/sharetabview.css
+++ b/apps/files_sharing/css/sharetabview.css
@@ -349,7 +349,6 @@
 
 .public-link-modal--input[type="password"],
 .public-link-modal--input.datepicker {
-	max-width: 50%;
 	min-width: 175px;
 }
 

--- a/changelog/unreleased/41314
+++ b/changelog/unreleased/41314
@@ -1,0 +1,6 @@
+Change: Add user hint in share dialog that password policy can apply
+
+To avoid user confusion the share dialog informs the user that password policy
+can apply in case enabled.
+
+https://github.com/owncloud/core/pull/41314

--- a/core/js/sharedialoglinkshareview.js
+++ b/core/js/sharedialoglinkshareview.js
@@ -14,7 +14,7 @@
 	}
 
 	var PASSWORD_PLACEHOLDER_STARS = '**********';
-	var PASSWORD_PLACEHOLDER_MESSAGE = t('core', 'Choose a password');
+	var PASSWORD_PLACEHOLDER_MESSAGE = t('core', 'Choose a password - password policy may apply');
 	var TEMPLATE =
 		'<div class="error-message-global hidden"></div>' +
 		'<div class="public-link-modal">'+

--- a/core/js/tests/specs/sharedialoglinkshareviewSpec.js
+++ b/core/js/tests/specs/sharedialoglinkshareviewSpec.js
@@ -28,7 +28,7 @@ describe('OC.Share.ShareDialogLinkShareView', function() {
 	var view;
 
 	var PASSWORD_PLACEHOLDER_STARS = '**********';
-	var PASSWORD_PLACEHOLDER_MESSAGE = 'Choose a password';
+	var PASSWORD_PLACEHOLDER_MESSAGE = 'Choose a password - password policy may apply';
 
 	beforeEach(function() {
 		configModel = new OC.Share.ShareConfigModel();


### PR DESCRIPTION
## Description
Add hint about password policy

## Related Issue
- Fixes #41313 

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
- :hand: 

## Screenshots (if appropriate):
![image](https://github.com/user-attachments/assets/801b6beb-f8ca-4970-865d-87a346ebf556)

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Database schema changes (next release will require increase of minor version instead of patch)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [ ] Tests only (no source changes)

## Checklist:
<!-- Tick the checkboxes when done. -->
<!-- Raise documentation ticket in https://github.com/owncloud/documentation -->
- [x] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 
- [ ] Changelog item, see [TEMPLATE](https://github.com/owncloud/core/blob/master/changelog/TEMPLATE)
