### PR TITLE
feat: make restore abortable from within pre_restore

### DIFF
--- a/apps/files_trashbin/lib/Trashbin.php
+++ b/apps/files_trashbin/lib/Trashbin.php
@@ -549,6 +549,7 @@ class Trashbin {
 	public static function restore($file, $filename, $timestamp, $targetLocation = null) {
 		$user = User::getUser();
 		$view = new View('/' . $user);
+		$originalLocation = null;
 
 		if ($targetLocation === null) {
 			$location = '';
@@ -563,6 +564,7 @@ class Trashbin {
 						(!$view->is_dir('files/' . $location) ||
 							!$view->isCreatable('files/' . $location))
 					) {
+						$originalLocation = $location;
 						$location = '';
 					}
 				}
@@ -583,8 +585,14 @@ class Trashbin {
 		Util::emitHook('\OCA\Files_Trashbin\Trashbin', 'pre_restore', [
 			'user' => $user,
 			'source' => $source,
-			'target' => $target
+			'target' => $target,
+			'originalLocation' => $originalLocation,
+			'abortRestore' => &$abortRestore,
 		]);
+
+		if ($abortRestore) {
+			return false;
+		}
 
 		// restore file
 		$restoreResult = $view->rename($source, $target);


### PR DESCRIPTION
Adds a mechanism to make restores abortable from within a pre_restore hook. 

Additionally this also passes the original restore location of the inaccessible path before it is rewritten to the path in home.

