### PR TITLE
feat: accept 2 characters Chinese/Japanese input to perform search action

### DIFF
--- a/core/search/js/search.js
+++ b/core/search/js/search.js
@@ -329,7 +329,9 @@
 						var query = $searchBox.val();
 						if (lastQuery !== query) {
 							currentResult = -1;
-							if (query.length > 2) {
+							var hasChineseOrJapaneseCharactor = query.match(/[\u3400-\u9FBF]/)
+							var minimumInputCount = hasChineseOrJapaneseCharactor ? 2 : 3
+							if (query.length >= minimumInputCount) {
 								self.search(query);
 							} else {
 								self.hideResults();


### PR DESCRIPTION
<!--
Thanks for submitting a change to ownCloud!

This is the bug tracker for the Server component. Find other components at https://github.com/owncloud/core/blob/master/.github/CONTRIBUTING.md#guidelines

For fixing potential security issues please see https://owncloud.com/security/

To make it possible for us to get your change reviewed and merged please carefully fill out the requested information below.

Please note that any kind of change needs first be submitted to the master branch which holds the next version of ownCloud.

Please set the following labels:

- Set label "3 - To review" for review or "2 - Development" if the PR still has open tasks
- Assignment: assign to self
- Milestone: set the same as the ticket this PR fixes, or "development" by default
- Reviewers: pick at least one
-->

## Description
As some user mentioned years ago  #25021,  #9916  about not able to perform search with Chineses/Japanese characters with less than 3 characters query input, it turns out that there is the hard limit in the front end code that requires minimum 3 characters input to perform the query on the server side, otherwise it only query in the front-end within the current folder displayed.

Since the Chinese/Japanese words are more "condense" with their meanings, it is so common for their users to search with 2 words so with the word splitting mechanism used by search engines such as elastic search. So if we decrease  the characters limit only for the Chinese/Japanese characters, it would not impact the server performance as some 2 characters English words would cause like "to", "go", "am" ext. And it is pretty easy to distinguish the Chinese/Japanese words only using the string match function on their encoding sequence which are adjacent.

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
- Fixes #25021,  #9916

## Motivation and Context
make the search experience a lot better for Chinese/Japanese users

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
- test environment:
- test case 1:
- test case 2:
- ...

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Database schema changes (next release will require increase of minor version instead of patch)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [ ] Tests only (no source changes)

## Checklist:
<!-- Tick the checkboxes when done. -->
<!-- Raise documentation ticket in https://github.com/owncloud/documentation -->
- [x] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 
- [ ] Changelog item, see [TEMPLATE](https://github.com/owncloud/core/blob/master/changelog/TEMPLATE)
