### PR TITLE
fix: a shared storage with no root info about the source storage will…

### DIFF
--- a/apps/files_sharing/lib/SharedStorage.php
+++ b/apps/files_sharing/lib/SharedStorage.php
@@ -323,7 +323,7 @@ class SharedStorage extends \OC\Files\Storage\Wrapper\Jail implements ISharedSto
 
 	public function getCache($path = '', $storage = null) {
 		$this->init();
-		if ($this->sourceStorage === null || $this->sourceStorage instanceof FailedStorage) {
+		if ($this->sourceStorage === null || $this->sourceStorage instanceof FailedStorage || $this->sourceRootInfo === false) {
 			return new FailedCache(false);
 		}
 		if (!$storage) {

--- a/changelog/unreleased/41338
+++ b/changelog/unreleased/41338
@@ -1,0 +1,6 @@
+Bugfix: Unavailable shares storage will not block folder listing
+
+In case a shared storage is not available in certain situations no folder
+listing would be shown to the user.
+
+https://github.com/owncloud/core/pull/41338


### PR DESCRIPTION
… behave as any other failed storage/cache

## Description
\OCA\Files_Sharing\Cache cannot be initialized with a bool as 3rd argument which would result in not listing any files.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
- test environment:
- test case 1:
- test case 2:
- ...

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Database schema changes (next release will require increase of minor version instead of patch)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [ ] Tests only (no source changes)

## Checklist:
<!-- Tick the checkboxes when done. -->
<!-- Raise documentation ticket in https://github.com/owncloud/documentation -->
- [ ] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 
- [ ] Changelog item, see [TEMPLATE](https://github.com/owncloud/core/blob/master/changelog/TEMPLATE)
