### PR TITLE
chore: add namespaces for acceptance tests

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -20,7 +20,9 @@
             "OC\\": "lib/private",
             "OC\\Core\\": "core/",
             "OC\\Settings\\": "settings/",
-            "OCP\\": "lib/public"
+            "OCP\\": "lib/public",
+            "Tests\\Acceptance\\": "tests/acceptance/features/bootstrap",
+            "Tests\\Acceptance\\Page\\": "tests/acceptance/features/lib"
         },
         "classmap": ["lib/private/legacy"],
         "files": [

--- a/core/Migrations/Version20170101010100.php
+++ b/core/Migrations/Version20170101010100.php
@@ -18,7 +18,7 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>
  *
  */
-namespace OC\Migrations;
+namespace OC\Core\Migrations;
 
 use Doctrine\DBAL\Schema\Schema;
 use Doctrine\DBAL\Types\Types;

--- a/core/Migrations/Version20170101215145.php
+++ b/core/Migrations/Version20170101215145.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace OC\Migrations;
+namespace OC\Core\Migrations;
 
 use Doctrine\DBAL\Schema\Schema;
 use Doctrine\DBAL\Types\Type;

--- a/core/Migrations/Version20170111103310.php
+++ b/core/Migrations/Version20170111103310.php
@@ -19,7 +19,7 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>
  *
  */
-namespace OC\Migrations;
+namespace OC\Core\Migrations;
 
 use Doctrine\DBAL\Schema\Schema;
 use OCP\Migration\ISchemaMigration;

--- a/core/Migrations/Version20170213215145.php
+++ b/core/Migrations/Version20170213215145.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace OC\Migrations;
+namespace OC\Core\Migrations;
 
 use Doctrine\DBAL\Schema\Schema;
 use OCP\Migration\ISchemaMigration;

--- a/core/Migrations/Version20170214112458.php
+++ b/core/Migrations/Version20170214112458.php
@@ -1,5 +1,5 @@
 <?php
-namespace OC\Migrations;
+namespace OC\Core\Migrations;
 
 use Doctrine\DBAL\Schema\Schema;
 use Doctrine\DBAL\Types\Types;

--- a/core/Migrations/Version20170221114437.php
+++ b/core/Migrations/Version20170221114437.php
@@ -1,5 +1,5 @@
 <?php
-namespace OC\Migrations;
+namespace OC\Core\Migrations;
 
 use OC\User\AccountMapper;
 use OC\User\AccountTermMapper;

--- a/core/Migrations/Version20170221121536.php
+++ b/core/Migrations/Version20170221121536.php
@@ -18,7 +18,7 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>
  *
  */
-namespace OC\Migrations;
+namespace OC\Core\Migrations;
 
 use OCP\Migration\ISimpleMigration;
 use OCP\Migration\IOutput;

--- a/core/Migrations/Version20170315173825.php
+++ b/core/Migrations/Version20170315173825.php
@@ -18,7 +18,7 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>
  *
  */
-namespace OC\Migrations;
+namespace OC\Core\Migrations;
 
 use Doctrine\DBAL\Schema\Schema;
 use OCP\Migration\ISchemaMigration;

--- a/core/Migrations/Version20170320173955.php
+++ b/core/Migrations/Version20170320173955.php
@@ -18,7 +18,7 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>
  *
  */
-namespace OC\Migrations;
+namespace OC\Core\Migrations;
 
 use Doctrine\DBAL\Schema\Schema;
 use OCP\Migration\ISchemaMigration;

--- a/core/Migrations/Version20170418154659.php
+++ b/core/Migrations/Version20170418154659.php
@@ -18,7 +18,7 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>
  *
  */
-namespace OC\Migrations;
+namespace OC\Core\Migrations;
 
 use Doctrine\DBAL\Schema\Schema;
 use OCP\Migration\ISchemaMigration;

--- a/core/Migrations/Version20170516100103.php
+++ b/core/Migrations/Version20170516100103.php
@@ -20,7 +20,7 @@
  *
  */
 
-namespace OC\Migrations;
+namespace OC\Core\Migrations;
 
 use Doctrine\DBAL\Schema\Schema;
 use Doctrine\DBAL\Types\Types;

--- a/core/Migrations/Version20170526104128.php
+++ b/core/Migrations/Version20170526104128.php
@@ -1,5 +1,5 @@
 <?php
-namespace OC\Migrations;
+namespace OC\Core\Migrations;
 
 use Doctrine\DBAL\Schema\Schema;
 use OC\DB\QueryBuilder\Literal;

--- a/core/Migrations/Version20170605143658.php
+++ b/core/Migrations/Version20170605143658.php
@@ -1,5 +1,5 @@
 <?php
-namespace OC\Migrations;
+namespace OC\Core\Migrations;
 
 use Doctrine\DBAL\Schema\Schema;
 use OCP\Migration\ISchemaMigration;

--- a/core/Migrations/Version20170711191432.php
+++ b/core/Migrations/Version20170711191432.php
@@ -1,5 +1,5 @@
 <?php
-namespace OC\Migrations;
+namespace OC\Core\Migrations;
 
 use Doctrine\DBAL\Schema\Schema;
 use Doctrine\DBAL\Types\Type;

--- a/core/Migrations/Version20170804201253.php
+++ b/core/Migrations/Version20170804201253.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace OC\Migrations;
+namespace OC\Core\Migrations;
 
 use Doctrine\DBAL\Schema\Schema;
 use Doctrine\DBAL\Types\Type;

--- a/core/Migrations/Version20170928120000.php
+++ b/core/Migrations/Version20170928120000.php
@@ -1,5 +1,5 @@
 <?php
-namespace OC\Migrations;
+namespace OC\Core\Migrations;
 
 use Doctrine\DBAL\Schema\Schema;
 use Doctrine\DBAL\Types\Type;

--- a/core/Migrations/Version20171026130750.php
+++ b/core/Migrations/Version20171026130750.php
@@ -1,5 +1,5 @@
 <?php
-namespace OC\Migrations;
+namespace OC\Core\Migrations;
 
 use OCP\Migration\ISimpleMigration;
 use OCP\Migration\IOutput;

--- a/core/Migrations/Version20180123131835.php
+++ b/core/Migrations/Version20180123131835.php
@@ -1,5 +1,5 @@
 <?php
-namespace OC\Migrations;
+namespace OC\Core\Migrations;
 
 use OCP\Migration\ISimpleMigration;
 use OCP\Migration\IOutput;

--- a/core/Migrations/Version20180302155233.php
+++ b/core/Migrations/Version20180302155233.php
@@ -20,7 +20,7 @@
  *
  */
 
-namespace OC\Migrations;
+namespace OC\Core\Migrations;
 
 use OCP\IDBConnection;
 use OCP\Migration\ISqlMigration;

--- a/core/Migrations/Version20180319102121.php
+++ b/core/Migrations/Version20180319102121.php
@@ -1,5 +1,5 @@
 <?php
-namespace OC\Migrations;
+namespace OC\Core\Migrations;
 
 use OCP\IDBConnection;
 use OCP\Migration\ISqlMigration;

--- a/core/Migrations/Version20180607072706.php
+++ b/core/Migrations/Version20180607072706.php
@@ -1,5 +1,5 @@
 <?php
-namespace OC\Migrations;
+namespace OC\Core\Migrations;
 
 use Doctrine\DBAL\Schema\Schema;
 use Doctrine\DBAL\Types\Types;

--- a/core/Migrations/Version20181017105216.php
+++ b/core/Migrations/Version20181017105216.php
@@ -19,7 +19,7 @@
  *
  */
 
-namespace OC\Migrations;
+namespace OC\Core\Migrations;
 
 use Doctrine\DBAL\Schema\Schema;
 use OCP\Migration\ISchemaMigration;

--- a/core/Migrations/Version20181017120818.php
+++ b/core/Migrations/Version20181017120818.php
@@ -19,7 +19,7 @@
  *
  */
 
-namespace OC\Migrations;
+namespace OC\Core\Migrations;
 
 use OCP\IDBConnection;
 use OCP\Migration\ISqlMigration;

--- a/core/Migrations/Version20181113071753.php
+++ b/core/Migrations/Version20181113071753.php
@@ -19,7 +19,7 @@
  *
  */
 
-namespace OC\Migrations;
+namespace OC\Core\Migrations;
 
 use Doctrine\DBAL\Schema\Schema;
 use OCP\Migration\ISchemaMigration;

--- a/core/Migrations/Version20181220085457.php
+++ b/core/Migrations/Version20181220085457.php
@@ -19,7 +19,7 @@
  *
  */
 
-namespace OC\Migrations;
+namespace OC\Core\Migrations;
 
 use Doctrine\DBAL\Schema\Schema;
 use Doctrine\DBAL\Types\Types;

--- a/core/Migrations/Version20190125162909.php
+++ b/core/Migrations/Version20190125162909.php
@@ -19,7 +19,7 @@
  *
  */
 
-namespace OC\Migrations;
+namespace OC\Core\Migrations;
 
 use Doctrine\DBAL\Schema\Schema;
 use OCP\Migration\ISchemaMigration;

--- a/core/Migrations/Version20200610110817.php
+++ b/core/Migrations/Version20200610110817.php
@@ -1,5 +1,5 @@
 <?php
-namespace OC\Migrations;
+namespace OC\Core\Migrations;
 
 use OCP\Migration\ISimpleMigration;
 use OCP\Migration\IOutput;

--- a/core/Migrations/Version20210928123126.php
+++ b/core/Migrations/Version20210928123126.php
@@ -1,5 +1,5 @@
 <?php
-namespace OC\Migrations;
+namespace OC\Core\Migrations;
 
 use OCP\Migration\ISimpleMigration;
 use OCP\Migration\IOutput;

--- a/core/Migrations/Version20230105001100.php
+++ b/core/Migrations/Version20230105001100.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace OC\Migrations;
+namespace OC\Core\Migrations;
 
 use Doctrine\DBAL\Schema\Schema;
 use OCP\Migration\ISchemaMigration;

--- a/core/Migrations/Version20230120101715.php
+++ b/core/Migrations/Version20230120101715.php
@@ -19,7 +19,7 @@
  *
  */
 
-namespace OC\Migrations;
+namespace OC\Core\Migrations;
 
 use Doctrine\DBAL\Schema\Schema;
 use Doctrine\DBAL\Types\Types;

--- a/core/Migrations/Version20230210073645.php
+++ b/core/Migrations/Version20230210073645.php
@@ -1,5 +1,5 @@
 <?php
-namespace OC\Migrations;
+namespace OC\Core\Migrations;
 
 use Doctrine\DBAL\Schema\Schema;
 use Doctrine\DBAL\Schema\SchemaException;

--- a/core/Migrations/Version20230210103154.php
+++ b/core/Migrations/Version20230210103154.php
@@ -1,5 +1,5 @@
 <?php
-namespace OC\Migrations;
+namespace OC\Core\Migrations;
 
 use OCP\Migration\ISimpleMigration;
 use OCP\Migration\IOutput;

--- a/core/Migrations/Version20240112140951.php
+++ b/core/Migrations/Version20240112140951.php
@@ -1,5 +1,5 @@
 <?php
-namespace OC\Migrations;
+namespace OC\Core\Migrations;
 
 use Doctrine\DBAL\Schema\Schema;
 use Doctrine\DBAL\Types\Type;

--- a/core/Migrations/Version20240131080456.php
+++ b/core/Migrations/Version20240131080456.php
@@ -1,5 +1,5 @@
 <?php
-namespace OC\Migrations;
+namespace OC\Core\Migrations;
 
 use OCP\Migration\ISimpleMigration;
 use OCP\Migration\IOutput;

--- a/lib/private/DB/MigrationService.php
+++ b/lib/private/DB/MigrationService.php
@@ -83,7 +83,7 @@ class MigrationService {
 
 		if ($appName === 'core') {
 			$this->migrationsPath = \OC::$SERVERROOT . '/core/Migrations';
-			$this->migrationsNamespace = 'OC\\Migrations';
+			$this->migrationsNamespace = 'OC\\Core\\Migrations';
 		} else {
 			if ($appLocator === null) {
 				$appLocator = new AppLocator();

--- a/tests/Settings/Controller/SettingsPageControllerTest.php
+++ b/tests/Settings/Controller/SettingsPageControllerTest.php
@@ -19,7 +19,7 @@
  *
  */
 
-namespace Test;
+namespace Tests\Settings\Controller;
 
 use OC\Helper\LocaleHelper;
 use OC\Settings\Controller\SettingsPageController;
@@ -33,6 +33,7 @@ use OCP\IUser;
 use OCP\IUserSession;
 use OCP\L10N\IFactory;
 use OCP\Settings\ISettingsManager;
+use Test\TestCase;
 
 class SettingsPageControllerTest extends TestCase {
 	protected $settingsManager;

--- a/tests/Settings/Panels/Personal/CorsTest.php
+++ b/tests/Settings/Panels/Personal/CorsTest.php
@@ -18,7 +18,7 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>
  */
 
-namespace Settings\Panels\Personal;
+namespace Tests\Settings\Panels\Personal;
 
 use OC\Settings\Panels\Personal\Cors;
 use OCP\IConfig;

--- a/tests/TestHelpers/Unit/DeleteHelperTest.php
+++ b/tests/TestHelpers/Unit/DeleteHelperTest.php
@@ -20,6 +20,9 @@
  *
  */
 
+namespace TestHelpers\Unit;
+
+use PHPUnit;
 use TestHelpers\DeleteHelper;
 use GuzzleHttp\Client;
 use GuzzleHttp\Handler\MockHandler;
@@ -42,7 +45,7 @@ class DeleteHelperTest extends PHPUnit\Framework\TestCase {
 	 */
 	public function setUp(): void {
 		$mock = new MockHandler(
-			[ new Response(204, [])]
+			[new Response(204, [])]
 		);
 		$handler = HandlerStack::create($mock);
 		$history = Middleware::history($this->container);
@@ -56,7 +59,7 @@ class DeleteHelperTest extends PHPUnit\Framework\TestCase {
 	 *
 	 * @return void
 	 */
-	public function testDeleteHelperWithOlderDavVersion():void {
+	public function testDeleteHelperWithOlderDavVersion(): void {
 		DeleteHelper::delete(
 			'http://localhost',
 			'user',
@@ -86,7 +89,7 @@ class DeleteHelperTest extends PHPUnit\Framework\TestCase {
 	 *
 	 * @return void
 	 */
-	public function testDeleteHelperWithNewerDavVersion():void {
+	public function testDeleteHelperWithNewerDavVersion(): void {
 		DeleteHelper::delete(
 			'http://localhost',
 			'user',
@@ -116,7 +119,7 @@ class DeleteHelperTest extends PHPUnit\Framework\TestCase {
 	 *
 	 * @return void
 	 */
-	public function testDeleteHelperSendsWithGivenHeaders():void {
+	public function testDeleteHelperSendsWithGivenHeaders(): void {
 		$headers = ["Cache-Control" => "no-cache"];
 		DeleteHelper::delete(
 			'http://localhost',

--- a/tests/TestHelpers/Unit/WebDavHelperTest.php
+++ b/tests/TestHelpers/Unit/WebDavHelperTest.php
@@ -20,6 +20,9 @@
  *
  */
 
+namespace TestHelpers\Unit;
+
+use PHPUnit;
 use TestHelpers\WebDavHelper;
 use GuzzleHttp\Client;
 use GuzzleHttp\Handler\MockHandler;
@@ -61,7 +64,7 @@ class WebDavHelperTest extends PHPUnit\Framework\TestCase {
 	 * @return void
 	 * @throws \GuzzleHttp\Exception\GuzzleException
 	 */
-	public function testUrlIsSanitizedByMakeDavRequestForNewerDav():void {
+	public function testUrlIsSanitizedByMakeDavRequestForNewerDav(): void {
 		WebDavHelper::makeDavRequest(
 			'http://own.cloud///core',
 			'user1',
@@ -99,7 +102,7 @@ class WebDavHelperTest extends PHPUnit\Framework\TestCase {
 	 * @return void
 	 * @throws \GuzzleHttp\Exception\GuzzleException
 	 */
-	public function testUrlIsSanitizedByMakeDavRequestForOlderDavPath():void {
+	public function testUrlIsSanitizedByMakeDavRequestForOlderDavPath(): void {
 		WebDavHelper::makeDavRequest(
 			'http://own.cloud///core',
 			'user1',
@@ -137,7 +140,7 @@ class WebDavHelperTest extends PHPUnit\Framework\TestCase {
 	 * @return void
 	 * @throws \GuzzleHttp\Exception\GuzzleException
 	 */
-	public function testMakeDavRequestReplacesAsteriskAndHashesOnUrls():void {
+	public function testMakeDavRequestReplacesAsteriskAndHashesOnUrls(): void {
 		WebDavHelper::makeDavRequest(
 			'http://own.cloud///core',
 			'user1',
@@ -180,7 +183,7 @@ class WebDavHelperTest extends PHPUnit\Framework\TestCase {
 	 * @return void
 	 * @throws \GuzzleHttp\Exception\GuzzleException
 	 */
-	public function testMakeDavRequestOnBearerAuthorization():void {
+	public function testMakeDavRequestOnBearerAuthorization(): void {
 		WebDavHelper::makeDavRequest(
 			'http://own.cloud/core',
 			'user1',
@@ -221,7 +224,7 @@ class WebDavHelperTest extends PHPUnit\Framework\TestCase {
 	 *
 	 * @return void
 	 */
-	public function testSanitizationOnDefault(?string $unsanitizedUrl, ?string $expectedUrl):void {
+	public function testSanitizationOnDefault(?string $unsanitizedUrl, ?string $expectedUrl): void {
 		$sanitizedUrl = WebDavHelper::sanitizeUrl($unsanitizedUrl);
 		$this->assertEquals($expectedUrl, $sanitizedUrl);
 	}
@@ -236,7 +239,7 @@ class WebDavHelperTest extends PHPUnit\Framework\TestCase {
 	 *
 	 * @return void
 	 */
-	public function testSanitizationWhenTrailingSlashIsSetToFalse(?string $unsanitizedUrl, ?string $expectedUrl):void {
+	public function testSanitizationWhenTrailingSlashIsSetToFalse(?string $unsanitizedUrl, ?string $expectedUrl): void {
 		$sanitizedUrl = WebDavHelper::sanitizeUrl($unsanitizedUrl);
 		$this->assertEquals($expectedUrl, $sanitizedUrl);
 	}
@@ -251,7 +254,7 @@ class WebDavHelperTest extends PHPUnit\Framework\TestCase {
 	 *
 	 * @return void
 	 */
-	public function testSanitizationWhenTrailingSlashIsSetToTrue(?string $unsanitizedUrl, ?string $expectedUrl):void {
+	public function testSanitizationWhenTrailingSlashIsSetToTrue(?string $unsanitizedUrl, ?string $expectedUrl): void {
 		$sanitizedUrl = WebDavHelper::sanitizeUrl($unsanitizedUrl, true);
 		$this->assertEquals($expectedUrl, $sanitizedUrl);
 	}
@@ -261,7 +264,7 @@ class WebDavHelperTest extends PHPUnit\Framework\TestCase {
 	 *
 	 * @return void
 	 */
-	public function testGetDavPathForOlderDavVersion():void {
+	public function testGetDavPathForOlderDavVersion(): void {
 		$davPath = WebDavHelper::getDavPath('user1', 1);
 		$this->assertEquals('remote.php/webdav/', $davPath);
 
@@ -279,7 +282,7 @@ class WebDavHelperTest extends PHPUnit\Framework\TestCase {
 	 *
 	 * @return void
 	 */
-	public function testGetDavPathForNewerDavPath():void {
+	public function testGetDavPathForNewerDavPath(): void {
 		// `type` should be `files` by default.
 		// check that both returns same thing.
 		$davPath = WebDavHelper::getDavPath('user1', 2);
@@ -295,7 +298,7 @@ class WebDavHelperTest extends PHPUnit\Framework\TestCase {
 	 *
 	 * @return void
 	 */
-	public function testGetDavPathForNewerDavPathButNotForFiles():void {
+	public function testGetDavPathForNewerDavPathButNotForFiles(): void {
 		$davPath = WebDavHelper::getDavPath('user1', 2, null);
 		$this->assertEquals('remote.php/dav', $davPath);
 
@@ -309,7 +312,7 @@ class WebDavHelperTest extends PHPUnit\Framework\TestCase {
 	 *
 	 * @return void
 	 */
-	public function testGetDavPathForInvalidVersionsShouldThrowException():void {
+	public function testGetDavPathForInvalidVersionsShouldThrowException(): void {
 		$this->expectException(InvalidArgumentException::class);
 		$this->expectExceptionMessage("DAV path version 3 is unknown");
 
@@ -322,7 +325,7 @@ class WebDavHelperTest extends PHPUnit\Framework\TestCase {
 	 *
 	 * @return array
 	 */
-	public function withoutTrailingSlashUrlsProvider():array {
+	public function withoutTrailingSlashUrlsProvider(): array {
 		return [
 			['http://own.cloud/', 'http://own.cloud'],
 			['http://own.cloud//index.php', 'http://own.cloud/index.php'],
@@ -344,7 +347,7 @@ class WebDavHelperTest extends PHPUnit\Framework\TestCase {
 	 *
 	 * @return string[][]
 	 */
-	public function withTrailingSlashUrlsProvider():array {
+	public function withTrailingSlashUrlsProvider(): array {
 		return [
 			['http://own.cloud/', 'http://own.cloud/'],
 			['http://own.cloud', 'http://own.cloud/'],

--- a/tests/acceptance/features/bootstrap/AppConfigurationContext.php
+++ b/tests/acceptance/features/bootstrap/AppConfigurationContext.php
@@ -22,6 +22,8 @@
  *
  */
 
+namespace Tests\Acceptance;
+
 use Behat\Behat\Hook\Scope\BeforeScenarioScope;
 use GuzzleHttp\Exception\GuzzleException;
 use PHPUnit\Framework\Assert;

--- a/tests/acceptance/features/bootstrap/AppManagementContext.php
+++ b/tests/acceptance/features/bootstrap/AppManagementContext.php
@@ -19,6 +19,8 @@
  *
  */
 
+namespace Tests\Acceptance;
+
 use Behat\Behat\Context\Context;
 use Behat\Behat\Hook\Scope\BeforeScenarioScope;
 use Behat\Gherkin\Node\TableNode;

--- a/tests/acceptance/features/bootstrap/AuthContext.php
+++ b/tests/acceptance/features/bootstrap/AuthContext.php
@@ -19,6 +19,8 @@
  *
  */
 
+namespace Tests\Acceptance;
+
 use Behat\Behat\Hook\Scope\BeforeScenarioScope;
 use TestHelpers\HttpRequestHelper;
 use Behat\Gherkin\Node\TableNode;

--- a/tests/acceptance/features/bootstrap/CalDavContext.php
+++ b/tests/acceptance/features/bootstrap/CalDavContext.php
@@ -19,6 +19,8 @@
  *
  */
 
+namespace Tests\Acceptance;
+
 use Behat\Behat\Context\Context;
 use Behat\Behat\Hook\Scope\BeforeScenarioScope;
 use PHPUnit\Framework\Assert;

--- a/tests/acceptance/features/bootstrap/CapabilitiesContext.php
+++ b/tests/acceptance/features/bootstrap/CapabilitiesContext.php
@@ -22,6 +22,8 @@
  *
  */
 
+namespace Tests\Acceptance;
+
 use Behat\Behat\Context\Context;
 use Behat\Behat\Hook\Scope\BeforeScenarioScope;
 use PHPUnit\Framework\Assert;

--- a/tests/acceptance/features/bootstrap/CardDavContext.php
+++ b/tests/acceptance/features/bootstrap/CardDavContext.php
@@ -19,6 +19,8 @@
  *
  */
 
+namespace Tests\Acceptance;
+
 use Behat\Behat\Context\Context;
 use Behat\Behat\Hook\Scope\BeforeScenarioScope;
 use PHPUnit\Framework\Assert;

--- a/tests/acceptance/features/bootstrap/ChecksumContext.php
+++ b/tests/acceptance/features/bootstrap/ChecksumContext.php
@@ -19,6 +19,8 @@
  *
  */
 
+namespace Tests\Acceptance;
+
 use Behat\Behat\Context\Context;
 use Behat\Behat\Hook\Scope\BeforeScenarioScope;
 use PHPUnit\Framework\Assert;

--- a/tests/acceptance/features/bootstrap/CommentsContext.php
+++ b/tests/acceptance/features/bootstrap/CommentsContext.php
@@ -20,6 +20,8 @@
  *
  */
 
+namespace Tests\Acceptance;
+
 use Behat\Behat\Context\Context;
 use Behat\Behat\Hook\Scope\BeforeScenarioScope;
 use Behat\Gherkin\Node\TableNode;

--- a/tests/acceptance/features/bootstrap/CorsContext.php
+++ b/tests/acceptance/features/bootstrap/CorsContext.php
@@ -20,6 +20,8 @@
  *
  */
 
+namespace Tests\Acceptance;
+
 use Behat\Behat\Context\Context;
 use Behat\Behat\Hook\Scope\BeforeScenarioScope;
 use PHPUnit\Framework\Assert;

--- a/tests/acceptance/features/bootstrap/EmailContext.php
+++ b/tests/acceptance/features/bootstrap/EmailContext.php
@@ -20,6 +20,8 @@
  *
  */
 
+namespace Tests\Acceptance;
+
 use Behat\Behat\Context\Context;
 use Behat\Behat\Hook\Scope\BeforeScenarioScope;
 use Behat\Gherkin\Node\PyStringNode;

--- a/tests/acceptance/features/bootstrap/EncryptionContext.php
+++ b/tests/acceptance/features/bootstrap/EncryptionContext.php
@@ -20,6 +20,8 @@
  *
  */
 
+namespace Tests\Acceptance;
+
 use Behat\Behat\Context\Context;
 use Behat\Behat\Hook\Scope\BeforeScenarioScope;
 use PHPUnit\Framework\Assert;

--- a/tests/acceptance/features/bootstrap/FavoritesContext.php
+++ b/tests/acceptance/features/bootstrap/FavoritesContext.php
@@ -20,6 +20,8 @@
  *
  */
 
+namespace Tests\Acceptance;
+
 use Behat\Behat\Context\Context;
 use Behat\Behat\Hook\Scope\BeforeScenarioScope;
 use Behat\Gherkin\Node\TableNode;

--- a/tests/acceptance/features/bootstrap/FeatureContext.php
+++ b/tests/acceptance/features/bootstrap/FeatureContext.php
@@ -21,6 +21,8 @@
  *
  */
 
+namespace Tests\Acceptance;
+
 use Behat\Behat\Hook\Scope\BeforeStepScope;
 use GuzzleHttp\Exception\GuzzleException;
 use Helmich\JsonAssert\JsonAssertions;

--- a/tests/acceptance/features/bootstrap/FederationContext.php
+++ b/tests/acceptance/features/bootstrap/FederationContext.php
@@ -22,6 +22,8 @@
  *
  */
 
+namespace Tests\Acceptance;
+
 use Behat\Behat\Context\Context;
 use Behat\Behat\Hook\Scope\BeforeScenarioScope;
 use TestHelpers\SharingHelper;

--- a/tests/acceptance/features/bootstrap/FilesVersionsContext.php
+++ b/tests/acceptance/features/bootstrap/FilesVersionsContext.php
@@ -20,6 +20,8 @@
  *
  */
 
+namespace Tests\Acceptance;
+
 use Behat\Behat\Context\Context;
 use Behat\Behat\Hook\Scope\BeforeScenarioScope;
 use Behat\Gherkin\Node\TableNode;

--- a/tests/acceptance/features/bootstrap/IpContext.php
+++ b/tests/acceptance/features/bootstrap/IpContext.php
@@ -20,6 +20,8 @@
  *
  */
 
+namespace Tests\Acceptance;
+
 use Behat\Behat\Context\Context;
 use Behat\Behat\Hook\Scope\BeforeScenarioScope;
 use TestHelpers\IpHelper;

--- a/tests/acceptance/features/bootstrap/LoggingContext.php
+++ b/tests/acceptance/features/bootstrap/LoggingContext.php
@@ -20,6 +20,8 @@
  *
  */
 
+namespace Tests\Acceptance;
+
 use Behat\Behat\Context\Context;
 use Behat\Behat\Hook\Scope\BeforeScenarioScope;
 use Behat\Gherkin\Node\TableNode;

--- a/tests/acceptance/features/bootstrap/NotificationsCoreContext.php
+++ b/tests/acceptance/features/bootstrap/NotificationsCoreContext.php
@@ -20,6 +20,8 @@
  *
  */
 
+namespace Tests\Acceptance;
+
 use Behat\Behat\Context\Context;
 use Behat\Behat\Hook\Scope\BeforeScenarioScope;
 use Behat\Gherkin\Node\TableNode;

--- a/tests/acceptance/features/bootstrap/OCSContext.php
+++ b/tests/acceptance/features/bootstrap/OCSContext.php
@@ -20,6 +20,8 @@
  *
  */
 
+namespace Tests\Acceptance;
+
 use Behat\Behat\Context\Context;
 use Behat\Behat\Hook\Scope\BeforeScenarioScope;
 use Behat\Gherkin\Node\PyStringNode;

--- a/tests/acceptance/features/bootstrap/OccAppManagementContext.php
+++ b/tests/acceptance/features/bootstrap/OccAppManagementContext.php
@@ -20,6 +20,8 @@
  *
  */
 
+namespace Tests\Acceptance;
+
 use Behat\Behat\Context\Context;
 use Behat\Behat\Hook\Scope\BeforeScenarioScope;
 use Behat\Gherkin\Node\TableNode;

--- a/tests/acceptance/features/bootstrap/OccContext.php
+++ b/tests/acceptance/features/bootstrap/OccContext.php
@@ -20,6 +20,8 @@
  *
  */
 
+namespace Tests\Acceptance;
+
 use Behat\Behat\Context\Context;
 use Behat\Behat\Hook\Scope\BeforeScenarioScope;
 use Behat\Gherkin\Node\TableNode;

--- a/tests/acceptance/features/bootstrap/OccUsersGroupsContext.php
+++ b/tests/acceptance/features/bootstrap/OccUsersGroupsContext.php
@@ -20,6 +20,8 @@
  *
  */
 
+namespace Tests\Acceptance;
+
 use Behat\Behat\Context\Context;
 use Behat\Behat\Hook\Scope\BeforeScenarioScope;
 use Behat\Gherkin\Node\TableNode;

--- a/tests/acceptance/features/bootstrap/Provisioning.php
+++ b/tests/acceptance/features/bootstrap/Provisioning.php
@@ -19,6 +19,8 @@
  *
  */
 
+namespace Tests\Acceptance;
+
 use Behat\Gherkin\Node\TableNode;
 use GuzzleHttp\Exception\ClientException;
 use GuzzleHttp\Exception\GuzzleException;

--- a/tests/acceptance/features/bootstrap/PublicWebDavContext.php
+++ b/tests/acceptance/features/bootstrap/PublicWebDavContext.php
@@ -20,6 +20,8 @@
  *
  */
 
+namespace Tests\Acceptance;
+
 use Behat\Behat\Context\Context;
 use Behat\Behat\Hook\Scope\BeforeScenarioScope;
 use PHPUnit\Framework\Assert;

--- a/tests/acceptance/features/bootstrap/SearchContext.php
+++ b/tests/acceptance/features/bootstrap/SearchContext.php
@@ -20,6 +20,8 @@
  *
  */
 
+namespace Tests\Acceptance;
+
 use Behat\Behat\Context\Context;
 use Behat\Behat\Hook\Scope\BeforeScenarioScope;
 use Behat\Gherkin\Node\TableNode;

--- a/tests/acceptance/features/bootstrap/ShareesContext.php
+++ b/tests/acceptance/features/bootstrap/ShareesContext.php
@@ -22,6 +22,8 @@
  *
  */
 
+namespace Tests\Acceptance;
+
 use Behat\Behat\Context\Context;
 use Behat\Behat\Hook\Scope\BeforeScenarioScope;
 use Behat\Gherkin\Node\TableNode;

--- a/tests/acceptance/features/bootstrap/Sharing.php
+++ b/tests/acceptance/features/bootstrap/Sharing.php
@@ -22,6 +22,8 @@
  *
  */
 
+namespace Tests\Acceptance;
+
 use Behat\Gherkin\Node\PyStringNode;
 use Behat\Gherkin\Node\TableNode;
 use Psr\Http\Message\ResponseInterface;

--- a/tests/acceptance/features/bootstrap/TUSContext.php
+++ b/tests/acceptance/features/bootstrap/TUSContext.php
@@ -19,6 +19,8 @@
  *
  */
 
+namespace Tests\Acceptance;
+
 use Behat\Behat\Context\Context;
 use Behat\Behat\Hook\Scope\BeforeScenarioScope;
 use Behat\Gherkin\Node\TableNode;

--- a/tests/acceptance/features/bootstrap/TagsContext.php
+++ b/tests/acceptance/features/bootstrap/TagsContext.php
@@ -20,6 +20,8 @@
  *
  */
 
+namespace Tests\Acceptance;
+
 use Behat\Behat\Context\Context;
 use Behat\Behat\Hook\Scope\BeforeScenarioScope;
 use Behat\Gherkin\Node\TableNode;

--- a/tests/acceptance/features/bootstrap/TransferOwnershipContext.php
+++ b/tests/acceptance/features/bootstrap/TransferOwnershipContext.php
@@ -20,6 +20,8 @@
  *
  */
 
+namespace Tests\Acceptance;
+
 use Behat\Behat\Context\Context;
 use Behat\Behat\Hook\Scope\BeforeScenarioScope;
 

--- a/tests/acceptance/features/bootstrap/TrashbinContext.php
+++ b/tests/acceptance/features/bootstrap/TrashbinContext.php
@@ -19,6 +19,8 @@
  *
  */
 
+namespace Tests\Acceptance;
+
 use Behat\Behat\Context\Context;
 use Behat\Behat\Hook\Scope\BeforeScenarioScope;
 use Behat\Gherkin\Node\TableNode;

--- a/tests/acceptance/features/bootstrap/WebDav.php
+++ b/tests/acceptance/features/bootstrap/WebDav.php
@@ -19,6 +19,8 @@
  *
  */
 
+namespace Tests\Acceptance;
+
 use Behat\Gherkin\Node\PyStringNode;
 use Behat\Gherkin\Node\TableNode;
 use GuzzleHttp\Exception\BadResponseException;

--- a/tests/acceptance/features/bootstrap/WebDavLockingContext.php
+++ b/tests/acceptance/features/bootstrap/WebDavLockingContext.php
@@ -20,6 +20,8 @@
  *
  */
 
+namespace Tests\Acceptance;
+
 use Behat\Behat\Context\Context;
 use Behat\Behat\Hook\Scope\BeforeScenarioScope;
 use Behat\Gherkin\Node\TableNode;

--- a/tests/acceptance/features/bootstrap/WebDavPropertiesContext.php
+++ b/tests/acceptance/features/bootstrap/WebDavPropertiesContext.php
@@ -20,6 +20,8 @@
  *
  */
 
+namespace Tests\Acceptance;
+
 use Behat\Behat\Context\Context;
 use Behat\Behat\Hook\Scope\BeforeScenarioScope;
 use Behat\Gherkin\Node\TableNode;

--- a/tests/acceptance/features/bootstrap/WebUIAdminAppsSettingsContext.php
+++ b/tests/acceptance/features/bootstrap/WebUIAdminAppsSettingsContext.php
@@ -21,10 +21,12 @@
  *
  */
 
+namespace Tests\Acceptance;
+
 use Behat\Behat\Context\Context;
 use Behat\Behat\Hook\Scope\BeforeScenarioScope;
 use Behat\MinkExtension\Context\RawMinkContext;
-use Page\AdminAppsSettingsPage;
+use Tests\Acceptance\Page\AdminAppsSettingsPage;
 
 require_once 'bootstrap.php';
 

--- a/tests/acceptance/features/bootstrap/WebUIAdminEncryptionSettingsContext.php
+++ b/tests/acceptance/features/bootstrap/WebUIAdminEncryptionSettingsContext.php
@@ -20,6 +20,8 @@
  *
  */
 
+namespace Tests\Acceptance;
+
 use Behat\Behat\Context\Context;
 use Behat\Behat\Hook\Scope\BeforeScenarioScope;
 use Behat\MinkExtension\Context\RawMinkContext;

--- a/tests/acceptance/features/bootstrap/WebUIAdminGeneralSettingsContext.php
+++ b/tests/acceptance/features/bootstrap/WebUIAdminGeneralSettingsContext.php
@@ -21,14 +21,16 @@
  *
  */
 
+namespace Tests\Acceptance;
+
 use Behat\Behat\Context\Context;
 use Behat\Behat\Hook\Scope\BeforeScenarioScope;
 use Behat\Gherkin\Node\TableNode;
 use Behat\MinkExtension\Context\RawMinkContext;
-use Page\AdminGeneralSettingsPage;
 use PHPUnit\Framework\Assert;
 use TestHelpers\AppConfigHelper;
 use TestHelpers\SetupHelper;
+use Tests\Acceptance\Page\AdminGeneralSettingsPage;
 
 require_once 'bootstrap.php';
 

--- a/tests/acceptance/features/bootstrap/WebUIAdminSharingSettingsContext.php
+++ b/tests/acceptance/features/bootstrap/WebUIAdminSharingSettingsContext.php
@@ -21,13 +21,15 @@
  *
  */
 
+namespace Tests\Acceptance;
+
 use Behat\Behat\Context\Context;
 use Behat\Behat\Hook\Scope\BeforeScenarioScope;
 use Behat\Mink\Element\NodeElement;
 use Behat\MinkExtension\Context\RawMinkContext;
-use Page\AdminSharingSettingsPage;
 use PHPUnit\Framework\Assert;
 use TestHelpers\SetupHelper;
+use Tests\Acceptance\Page\AdminSharingSettingsPage;
 
 require_once 'bootstrap.php';
 

--- a/tests/acceptance/features/bootstrap/WebUIAdminStorageSettingsContext.php
+++ b/tests/acceptance/features/bootstrap/WebUIAdminStorageSettingsContext.php
@@ -21,12 +21,14 @@
  *
  */
 
+namespace Tests\Acceptance;
+
 use Behat\Behat\Context\Context;
 use Behat\Behat\Hook\Scope\BeforeScenarioScope;
 use Behat\MinkExtension\Context\RawMinkContext;
-use Page\AdminStorageSettingsPage;
 use PHPUnit\Framework\Assert;
 use TestHelpers\SetupHelper;
+use Tests\Acceptance\Page\AdminStorageSettingsPage;
 
 require_once 'bootstrap.php';
 

--- a/tests/acceptance/features/bootstrap/WebUIFileActionsMenuContext.php
+++ b/tests/acceptance/features/bootstrap/WebUIFileActionsMenuContext.php
@@ -20,12 +20,14 @@
  *
  */
 
-require_once 'bootstrap.php';
+namespace Tests\Acceptance;
 
 use Behat\Behat\Context\Context;
 use Behat\Gherkin\Node\TableNode;
 use Behat\MinkExtension\Context\RawMinkContext;
-use Page\FilesPage;
+use Tests\Acceptance\Page\FilesPage;
+
+require_once 'bootstrap.php';
 
 /**
  * Context for file actions menu

--- a/tests/acceptance/features/bootstrap/WebUIFilesContext.php
+++ b/tests/acceptance/features/bootstrap/WebUIFilesContext.php
@@ -20,25 +20,27 @@
  *
  */
 
+namespace Tests\Acceptance;
+
 use Behat\Behat\Context\Context;
 use Behat\Behat\Hook\Scope\BeforeScenarioScope;
 use Behat\Gherkin\Node\TableNode;
 use Behat\MinkExtension\Context\RawMinkContext;
 use GuzzleHttp\Exception\GuzzleException;
-use Page\ExternalStoragePage;
-use Page\FavoritesPage;
-use Page\FilesPage;
-use Page\FilesPageBasic;
-use Page\FilesPageElement\DetailsDialog;
-use Page\FilesPageElement\FileRow;
-use Page\OwncloudPage;
-use Page\SharedByLinkPage;
-use Page\SharedWithOthersPage;
-use Page\SharedWithYouPage;
-use Page\TagsPage;
-use Page\TrashbinPage;
-use Page\FilesPageElement\ConflictDialog;
-use Page\FilesPageElement\FileActionsMenu;
+use Tests\Acceptance\Page\ExternalStoragePage;
+use Tests\Acceptance\Page\FavoritesPage;
+use Tests\Acceptance\Page\FilesPage;
+use Tests\Acceptance\Page\FilesPageBasic;
+use Tests\Acceptance\Page\FilesPageElement\DetailsDialog;
+use Tests\Acceptance\Page\FilesPageElement\FileRow;
+use Tests\Acceptance\Page\OwncloudPage;
+use Tests\Acceptance\Page\SharedByLinkPage;
+use Tests\Acceptance\Page\SharedWithOthersPage;
+use Tests\Acceptance\Page\SharedWithYouPage;
+use Tests\Acceptance\Page\TagsPage;
+use Tests\Acceptance\Page\TrashbinPage;
+use Tests\Acceptance\Page\FilesPageElement\ConflictDialog;
+use Tests\Acceptance\Page\FilesPageElement\FileActionsMenu;
 use PHPUnit\Framework\Assert;
 use SensioLabs\Behat\PageObjectExtension\PageObject\Exception\ElementNotFoundException;
 use TestHelpers\Asserts\WebDav as WebDavAssert;

--- a/tests/acceptance/features/bootstrap/WebUIGeneralContext.php
+++ b/tests/acceptance/features/bootstrap/WebUIGeneralContext.php
@@ -20,22 +20,24 @@
  *
  */
 
+namespace Tests\Acceptance;
+
 use Behat\Behat\Context\Context;
 use Behat\Behat\Hook\Scope\AfterScenarioScope;
 use Behat\Behat\Hook\Scope\BeforeScenarioScope;
 use Behat\Gherkin\Node\TableNode;
 use Behat\MinkExtension\Context\RawMinkContext;
 use GuzzleHttp\Exception\GuzzleException;
-use Page\LoginPage;
-use Page\OwncloudPage;
+use Tests\Acceptance\Page\LoginPage;
+use Tests\Acceptance\Page\OwncloudPage;
 use PHPUnit\Framework\Assert;
 use SensioLabs\Behat\PageObjectExtension\PageObject\Exception\ElementNotFoundException;
 use SensioLabs\Behat\PageObjectExtension\PageObject\Page;
 use TestHelpers\AppConfigHelper;
 use TestHelpers\EmailHelper;
 use TestHelpers\SetupHelper;
-use Page\GeneralErrorPage;
-use Page\GeneralExceptionPage;
+use Tests\Acceptance\Page\GeneralErrorPage;
+use Tests\Acceptance\Page\GeneralExceptionPage;
 
 require_once 'bootstrap.php';
 

--- a/tests/acceptance/features/bootstrap/WebUIHelpAndTipsContext.php
+++ b/tests/acceptance/features/bootstrap/WebUIHelpAndTipsContext.php
@@ -21,10 +21,12 @@
  *
  */
 
+namespace Tests\Acceptance;
+
 use Behat\Behat\Context\Context;
 use Behat\Behat\Hook\Scope\BeforeScenarioScope;
 use Behat\MinkExtension\Context\RawMinkContext;
-use Page\HelpAndTipsPage;
+use Tests\Acceptance\Page\HelpAndTipsPage;
 use PHPUnit\Framework\Assert;
 use TestHelpers\SetupHelper;
 

--- a/tests/acceptance/features/bootstrap/WebUILoginContext.php
+++ b/tests/acceptance/features/bootstrap/WebUILoginContext.php
@@ -20,15 +20,17 @@
  *
  */
 
+namespace Tests\Acceptance;
+
 use Behat\Behat\Context\Context;
 use Behat\Behat\Hook\Scope\BeforeScenarioScope;
 use Behat\Gherkin\Node\PyStringNode;
 use Behat\Mink\Exception\ElementNotFoundException;
 use Behat\MinkExtension\Context\RawMinkContext;
 use GuzzleHttp\Exception\GuzzleException;
-use Page\LoginPage;
 use PHPUnit\Framework\Assert;
 use SensioLabs\Behat\PageObjectExtension\PageObject\Page;
+use Tests\Acceptance\Page\LoginPage;
 
 require_once 'bootstrap.php';
 

--- a/tests/acceptance/features/bootstrap/WebUINewFileMenuContext.php
+++ b/tests/acceptance/features/bootstrap/WebUINewFileMenuContext.php
@@ -21,10 +21,12 @@
  *
  */
 
+namespace Tests\Acceptance;
+
 use Behat\Behat\Context\Context;
 use Behat\MinkExtension\Context\RawMinkContext;
-use Page\FilesPageElement\NewFileMenu;
 use PHPUnit\Framework\Assert;
+use Tests\Acceptance\Page\FilesPageElement\NewFileMenu;
 
 require_once 'bootstrap.php';
 

--- a/tests/acceptance/features/bootstrap/WebUINotificationsContext.php
+++ b/tests/acceptance/features/bootstrap/WebUINotificationsContext.php
@@ -19,6 +19,9 @@
  * License along with this library.  If not, see <http://www.gnu.org/licenses/>.
  *
  */
+
+namespace Tests\Acceptance;
+
 require_once 'bootstrap.php';
 
 use Behat\Behat\Context\Context;
@@ -26,9 +29,9 @@ use Behat\Behat\Hook\Scope\BeforeScenarioScope;
 use Behat\Gherkin\Node\TableNode;
 use Behat\Mink\Session;
 use Behat\MinkExtension\Context\RawMinkContext;
-use Page\Notification;
-use Page\NotificationsEnabledOwncloudPage;
 use PHPUnit\Framework\Assert;
+use Tests\Acceptance\Page\Notification;
+use Tests\Acceptance\Page\NotificationsEnabledOwncloudPage;
 
 /**
  * Context for Notifications App

--- a/tests/acceptance/features/bootstrap/WebUIPersonalEncryptionSettingsContext.php
+++ b/tests/acceptance/features/bootstrap/WebUIPersonalEncryptionSettingsContext.php
@@ -20,9 +20,11 @@
  *
  */
 
+namespace Tests\Acceptance;
+
 use Behat\Behat\Context\Context;
 use Behat\MinkExtension\Context\RawMinkContext;
-use Page\PersonalEncryptionSettingsPage;
+use Tests\Acceptance\Page\PersonalEncryptionSettingsPage;
 
 require_once 'bootstrap.php';
 

--- a/tests/acceptance/features/bootstrap/WebUIPersonalGeneralSettingsContext.php
+++ b/tests/acceptance/features/bootstrap/WebUIPersonalGeneralSettingsContext.php
@@ -20,12 +20,14 @@
  *
  */
 
+namespace Tests\Acceptance;
+
 use Behat\Behat\Context\Context;
 use Behat\Behat\Hook\Scope\BeforeScenarioScope;
 use Behat\MinkExtension\Context\RawMinkContext;
-use Page\PersonalGeneralSettingsPage;
 use PHPUnit\Framework\Assert;
 use TestHelpers\EmailHelper;
+use Tests\Acceptance\Page\PersonalGeneralSettingsPage;
 
 require_once 'bootstrap.php';
 

--- a/tests/acceptance/features/bootstrap/WebUIPersonalSecuritySettingsContext.php
+++ b/tests/acceptance/features/bootstrap/WebUIPersonalSecuritySettingsContext.php
@@ -20,12 +20,14 @@
  *
  */
 
+namespace Tests\Acceptance;
+
 use Behat\Behat\Context\Context;
 use Behat\Behat\Hook\Scope\BeforeScenarioScope;
 use Behat\MinkExtension\Context\RawMinkContext;
-use Page\LoginPage;
-use Page\PersonalSecuritySettingsPage;
 use PHPUnit\Framework\Assert;
+use Tests\Acceptance\Page\LoginPage;
+use Tests\Acceptance\Page\PersonalSecuritySettingsPage;
 
 require_once 'bootstrap.php';
 

--- a/tests/acceptance/features/bootstrap/WebUIPersonalSharingSettingsContext.php
+++ b/tests/acceptance/features/bootstrap/WebUIPersonalSharingSettingsContext.php
@@ -20,12 +20,14 @@
  *
  */
 
+namespace Tests\Acceptance;
+
 require_once 'bootstrap.php';
 
 use Behat\Behat\Context\Context;
 use Behat\MinkExtension\Context\RawMinkContext;
-use Page\PersonalSharingSettingsPage;
 use PHPUnit\Framework\Assert;
+use Tests\Acceptance\Page\PersonalSharingSettingsPage;
 
 /**
  * steps for personal sharing settings

--- a/tests/acceptance/features/bootstrap/WebUISearchContext.php
+++ b/tests/acceptance/features/bootstrap/WebUISearchContext.php
@@ -20,11 +20,13 @@
  *
  */
 
+namespace Tests\Acceptance;
+
 use Behat\Behat\Context\Context;
 use Behat\Behat\Hook\Scope\BeforeScenarioScope;
 use Behat\MinkExtension\Context\RawMinkContext;
-use Page\FilesPage;
-use Page\SearchResultInOtherFoldersPage;
+use Tests\Acceptance\Page\FilesPage;
+use Tests\Acceptance\Page\SearchResultInOtherFoldersPage;
 
 require_once 'bootstrap.php';
 

--- a/tests/acceptance/features/bootstrap/WebUISharingContext.php
+++ b/tests/acceptance/features/bootstrap/WebUISharingContext.php
@@ -20,17 +20,19 @@
  *
  */
 
+namespace Tests\Acceptance;
+
 use Behat\Behat\Context\Context;
 use Behat\Behat\Hook\Scope\BeforeScenarioScope;
 use Behat\Gherkin\Node\TableNode;
 use Behat\MinkExtension\Context\RawMinkContext;
 use Psr\Http\Message\ResponseInterface;
-use Page\FilesPage;
-use Page\FilesPageElement\SharingDialogElement\EditPublicLinkPopup;
-use Page\FilesPageElement\SharingDialogElement\PublicLinkTab;
-use Page\GeneralErrorPage;
-use Page\PublicLinkFilesPage;
-use Page\SharedWithYouPage;
+use Tests\Acceptance\Page\FilesPage;
+use Tests\Acceptance\Page\FilesPageElement\SharingDialogElement\EditPublicLinkPopup;
+use Tests\Acceptance\Page\FilesPageElement\SharingDialogElement\PublicLinkTab;
+use Tests\Acceptance\Page\GeneralErrorPage;
+use Tests\Acceptance\Page\PublicLinkFilesPage;
+use Tests\Acceptance\Page\SharedWithYouPage;
 use PHPUnit\Framework\Assert;
 use SensioLabs\Behat\PageObjectExtension\PageObject\Exception\ElementNotFoundException;
 use SensioLabs\Behat\PageObjectExtension\PageObject\Page;

--- a/tests/acceptance/features/bootstrap/WebUITagsContext.php
+++ b/tests/acceptance/features/bootstrap/WebUITagsContext.php
@@ -20,12 +20,14 @@
  *
  */
 
+namespace Tests\Acceptance;
+
 use Behat\Behat\Context\Context;
 use Behat\Behat\Hook\Scope\BeforeScenarioScope;
 use Behat\MinkExtension\Context\RawMinkContext;
 use Behat\Gherkin\Node\TableNode;
-use Page\FilesPage;
 use PHPUnit\Framework\Assert;
+use Tests\Acceptance\Page\FilesPage;
 
 require_once 'bootstrap.php';
 

--- a/tests/acceptance/features/bootstrap/WebUIUserContext.php
+++ b/tests/acceptance/features/bootstrap/WebUIUserContext.php
@@ -20,10 +20,12 @@
  *
  */
 
+namespace Tests\Acceptance;
+
 use Behat\Behat\Context\Context;
 use Behat\MinkExtension\Context\RawMinkContext;
-use Page\OwncloudPage;
 use PHPUnit\Framework\Assert;
+use Tests\Acceptance\Page\OwncloudPage;
 
 require_once 'bootstrap.php';
 

--- a/tests/acceptance/features/bootstrap/WebUIUsersContext.php
+++ b/tests/acceptance/features/bootstrap/WebUIUsersContext.php
@@ -20,17 +20,19 @@
  *
  */
 
+namespace Tests\Acceptance;
+
 use Behat\Behat\Context\Context;
 use Behat\Behat\Hook\Scope\AfterScenarioScope;
 use Behat\Behat\Hook\Scope\BeforeScenarioScope;
 use Behat\Gherkin\Node\TableNode;
 use Behat\Mink\Exception\ElementNotFoundException;
 use Behat\MinkExtension\Context\RawMinkContext;
-use Page\DisabledUserPage;
-use Page\GeneralErrorPage;
-use Page\LoginPage;
-use Page\UsersPage;
-use Page\OwncloudPage;
+use Tests\Acceptance\Page\DisabledUserPage;
+use Tests\Acceptance\Page\GeneralErrorPage;
+use Tests\Acceptance\Page\LoginPage;
+use Tests\Acceptance\Page\UsersPage;
+use Tests\Acceptance\Page\OwncloudPage;
 use PHPUnit\Framework\Assert;
 use TestHelpers\AppConfigHelper;
 use WebDriver\Exception\ElementNotVisible;

--- a/tests/acceptance/features/bootstrap/WebUIWebDavLockingContext.php
+++ b/tests/acceptance/features/bootstrap/WebUIWebDavLockingContext.php
@@ -20,6 +20,8 @@
  *
  */
 
+namespace Tests\Acceptance;
+
 use Behat\Behat\Context\Context;
 use Behat\Behat\Hook\Scope\BeforeScenarioScope;
 use Behat\MinkExtension\Context\RawMinkContext;

--- a/tests/acceptance/features/cliMain/occMigrationStatus.feature
+++ b/tests/acceptance/features/cliMain/occMigrationStatus.feature
@@ -8,16 +8,16 @@ Feature: Migration status of apps
     When the administrator lists migration status of app "core"
     Then the command should have been successful
     And the following migration status should have been listed
-      | App                             | core          |
-      | Version Table Name              | oc_migrations |
-      | Migrations Namespace            | OC\Migrations |
-      | Migrations Directory            | /\S/          |
-      | Previous Version                | /\d+/         |
-      | Current Version                 | /\d+/         |
-      | Next Version                    | /\S+/         |
-      | Latest Version                  | /\d+/         |
-      | Executed Migrations             | /\d+/         |
-      | Executed Unavailable Migrations | 0             |
-      | Available Migrations            | /\d+/         |
-      | New Migrations                  | 0             |
+      | App                             | core               |
+      | Version Table Name              | oc_migrations      |
+      | Migrations Namespace            | OC\Core\Migrations |
+      | Migrations Directory            | /\S/               |
+      | Previous Version                | /\d+/              |
+      | Current Version                 | /\d+/              |
+      | Next Version                    | /\S+/              |
+      | Latest Version                  | /\d+/              |
+      | Executed Migrations             | /\d+/              |
+      | Executed Unavailable Migrations | 0                  |
+      | Available Migrations            | /\d+/              |
+      | New Migrations                  | 0                  |
     And the Executed Migrations should equal the Available Migrations

--- a/tests/acceptance/features/lib/AdminAppsSettingsPage.php
+++ b/tests/acceptance/features/lib/AdminAppsSettingsPage.php
@@ -21,7 +21,7 @@
  *
  */
 
-namespace Page;
+namespace Tests\Acceptance\Page;
 
 use Behat\Mink\Session;
 use Exception;

--- a/tests/acceptance/features/lib/AdminEncryptionSettingsPage.php
+++ b/tests/acceptance/features/lib/AdminEncryptionSettingsPage.php
@@ -21,7 +21,7 @@
  *
  */
 
-namespace Page;
+namespace Tests\Acceptance\Page;
 
 use Behat\Mink\Session;
 

--- a/tests/acceptance/features/lib/AdminGeneralSettingsPage.php
+++ b/tests/acceptance/features/lib/AdminGeneralSettingsPage.php
@@ -6,7 +6,7 @@
  * @author Paurakh Sharma Humagain <paurakh@jankaritech.com>
  * @copyright Copyright (c) 2018 Paurakh Sharma Humagain paurakh@jankaritech.com
  *
- * This code is free software: you can redistribute it and/or modify
+ * This code is Tests\Acceptance\free software: you can redistribute it and/or modify
  * it under the terms of the GNU Affero General Public License,
  * as published by the Free Software Foundation;
  * either version 3 of the License, or any later version.
@@ -21,7 +21,7 @@
  *
  */
 
-namespace Page;
+namespace Tests\Acceptance\Page;
 
 use Behat\Gherkin\Node\TableNode;
 use Behat\Mink\Exception\ElementNotFoundException;

--- a/tests/acceptance/features/lib/AdminSharingSettingsPage.php
+++ b/tests/acceptance/features/lib/AdminSharingSettingsPage.php
@@ -21,7 +21,7 @@
  *
  */
 
-namespace Page;
+namespace Tests\Acceptance\Page;
 
 use Behat\Mink\Element\NodeElement;
 use Behat\Mink\Session;

--- a/tests/acceptance/features/lib/AdminStorageSettingsPage.php
+++ b/tests/acceptance/features/lib/AdminStorageSettingsPage.php
@@ -21,7 +21,7 @@
  *
  */
 
-namespace Page;
+namespace Tests\Acceptance\Page;
 
 use Behat\Mink\Exception\ElementNotFoundException;
 use Behat\Mink\Session;

--- a/tests/acceptance/features/lib/DisabledUserPage.php
+++ b/tests/acceptance/features/lib/DisabledUserPage.php
@@ -20,7 +20,7 @@
  *
  */
 
-namespace Page;
+namespace Tests\Acceptance\Page;
 
 /**
  * Disabled page.

--- a/tests/acceptance/features/lib/ExternalStoragePage.php
+++ b/tests/acceptance/features/lib/ExternalStoragePage.php
@@ -20,7 +20,7 @@
  *
  */
 
-namespace Page;
+namespace Tests\Acceptance\Page;
 
 use Exception;
 

--- a/tests/acceptance/features/lib/FavoritesPage.php
+++ b/tests/acceptance/features/lib/FavoritesPage.php
@@ -20,7 +20,7 @@
  *
  */
 
-namespace Page;
+namespace Tests\Acceptance\Page;
 
 use Behat\Mink\Session;
 use Page\FilesPageElement\FileRow;

--- a/tests/acceptance/features/lib/FilesPage.php
+++ b/tests/acceptance/features/lib/FilesPage.php
@@ -20,7 +20,7 @@
  *
  */
 
-namespace Page;
+namespace Tests\Acceptance\Page;
 
 use Behat\Mink\Exception\DriverException;
 use Behat\Mink\Exception\UnsupportedDriverActionException;

--- a/tests/acceptance/features/lib/FilesPageBasic.php
+++ b/tests/acceptance/features/lib/FilesPageBasic.php
@@ -20,7 +20,7 @@
  *
  */
 
-namespace Page;
+namespace Tests\Acceptance\Page;
 
 use Behat\Mink\Element\NodeElement;
 use Behat\Mink\Session;

--- a/tests/acceptance/features/lib/FilesPageCRUD.php
+++ b/tests/acceptance/features/lib/FilesPageCRUD.php
@@ -20,7 +20,7 @@
  *
  */
 
-namespace Page;
+namespace Tests\Acceptance\Page;
 
 use Behat\Mink\Session;
 use Behat\Mink\Element\NodeElement;

--- a/tests/acceptance/features/lib/FilesPageElement/ConflictDialog.php
+++ b/tests/acceptance/features/lib/FilesPageElement/ConflictDialog.php
@@ -21,9 +21,9 @@
  *
  */
 
-namespace Page\FilesPageElement;
+namespace Tests\Acceptance\Page\FilesPageElement;
 
-use Page\OwncloudPageElement\OCDialog;
+use Tests\Acceptance\Page\OwncloudPageElement\OCDialog;
 use SensioLabs\Behat\PageObjectExtension\PageObject\Exception\ElementNotFoundException;
 
 /**

--- a/tests/acceptance/features/lib/FilesPageElement/DetailsDialog.php
+++ b/tests/acceptance/features/lib/FilesPageElement/DetailsDialog.php
@@ -21,12 +21,12 @@
  *
  */
 
-namespace Page\FilesPageElement;
+namespace Tests\Acceptance\Page\FilesPageElement;
 
 use Behat\Mink\Element\NodeElement;
 use Behat\Mink\Session;
 use Exception;
-use Page\OwncloudPage;
+use Tests\Acceptance\Page\OwncloudPage;
 use SensioLabs\Behat\PageObjectExtension\PageObject\Exception\ElementNotFoundException;
 use WebDriver\Exception\NoSuchElement;
 use WebDriver\Exception\StaleElementReference;

--- a/tests/acceptance/features/lib/FilesPageElement/FavoritesFileRow.php
+++ b/tests/acceptance/features/lib/FilesPageElement/FavoritesFileRow.php
@@ -21,7 +21,7 @@
  *
  */
 
-namespace Page\FilesPageElement;
+namespace Tests\Acceptance\Page\FilesPageElement;
 
 /**
  * Object of a row on the FilesPage

--- a/tests/acceptance/features/lib/FilesPageElement/FileActionsMenu.php
+++ b/tests/acceptance/features/lib/FilesPageElement/FileActionsMenu.php
@@ -21,12 +21,12 @@
  *
  */
 
-namespace Page\FilesPageElement;
+namespace Tests\Acceptance\Page\FilesPageElement;
 
 use Behat\Mink\Session;
 use Behat\Mink\Element\NodeElement;
 use Exception;
-use Page\OwncloudPage;
+use Tests\Acceptance\Page\OwncloudPage;
 use SensioLabs\Behat\PageObjectExtension\PageObject\Exception\ElementNotFoundException;
 
 /**

--- a/tests/acceptance/features/lib/FilesPageElement/FileRow.php
+++ b/tests/acceptance/features/lib/FilesPageElement/FileRow.php
@@ -21,13 +21,13 @@
  *
  */
 
-namespace Page\FilesPageElement;
+namespace Tests\Acceptance\Page\FilesPageElement;
 
 use Behat\Mink\Element\NodeElement;
 use Behat\Mink\Session;
 use Exception;
-use Page\FilesPage;
-use Page\OwncloudPage;
+use Tests\Acceptance\Page\FilesPage;
+use Tests\Acceptance\Page\OwncloudPage;
 use SensioLabs\Behat\PageObjectExtension\PageObject\Exception\ElementNotFoundException;
 
 /**

--- a/tests/acceptance/features/lib/FilesPageElement/LockDialog.php
+++ b/tests/acceptance/features/lib/FilesPageElement/LockDialog.php
@@ -21,13 +21,13 @@
  *
  */
 
-namespace Page\FilesPageElement;
+namespace Tests\Acceptance\Page\FilesPageElement;
 
 use Behat\Mink\Session;
 use Behat\Mink\Element\NodeElement;
 use Exception;
-use Page\OwncloudPage;
-use Page\FilesPageElement\LockDialogElement\LockEntry;
+use Tests\Acceptance\Page\OwncloudPage;
+use Tests\Acceptance\Page\FilesPageElement\LockDialogElement\LockEntry;
 
 /**
  * The Lock Dialog, lists all the locks and gives a possibility to delete them

--- a/tests/acceptance/features/lib/FilesPageElement/LockDialogElement/LockEntry.php
+++ b/tests/acceptance/features/lib/FilesPageElement/LockDialogElement/LockEntry.php
@@ -21,12 +21,12 @@
  *
  */
 
-namespace Page\FilesPageElement\LockDialogElement;
+namespace Tests\Acceptance\Page\FilesPageElement\LockDialogElement;
 
 use Behat\Mink\Session;
 use Behat\Mink\Element\NodeElement;
 use Exception;
-use Page\OwncloudPage;
+use Tests\Acceptance\Page\OwncloudPage;
 
 /**
  * A single Lock Entry

--- a/tests/acceptance/features/lib/FilesPageElement/NewFileMenu.php
+++ b/tests/acceptance/features/lib/FilesPageElement/NewFileMenu.php
@@ -22,12 +22,12 @@
  *
  */
 
-namespace Page\FilesPageElement;
+namespace Tests\Acceptance\Page\FilesPageElement;
 
 use ast\Node;
 use Behat\Mink\Session;
 use Behat\Mink\Element\NodeElement;
-use Page\OwncloudPage;
+use Tests\Acceptance\Page\OwncloudPage;
 use SensioLabs\Behat\PageObjectExtension\PageObject\Exception\ElementNotFoundException;
 
 /**

--- a/tests/acceptance/features/lib/FilesPageElement/SharedByLinkFileRow.php
+++ b/tests/acceptance/features/lib/FilesPageElement/SharedByLinkFileRow.php
@@ -21,7 +21,7 @@
  *
  */
 
-namespace Page\FilesPageElement;
+namespace Tests\Acceptance\Page\FilesPageElement;
 
 /**
  * Object of a row on the SharedByLinkPage

--- a/tests/acceptance/features/lib/FilesPageElement/SharedWithOthersFileRow.php
+++ b/tests/acceptance/features/lib/FilesPageElement/SharedWithOthersFileRow.php
@@ -21,7 +21,7 @@
  *
  */
 
-namespace Page\FilesPageElement;
+namespace Tests\Acceptance\Page\FilesPageElement;
 
 /**
  * Object of a row on the Shared with others page

--- a/tests/acceptance/features/lib/FilesPageElement/SharingDialog.php
+++ b/tests/acceptance/features/lib/FilesPageElement/SharingDialog.php
@@ -21,15 +21,15 @@
  *
  */
 
-namespace Page\FilesPageElement;
+namespace Tests\Acceptance\Page\FilesPageElement;
 
 use Behat\Mink\Element\NodeElement;
 use Behat\Mink\Session;
 use Exception;
-use Page\FilesPageElement\SharingDialogElement\PublicLinkTab;
-use Page\OwncloudPage;
+use Tests\Acceptance\Page\FilesPageElement\SharingDialogElement\PublicLinkTab;
+use Tests\Acceptance\Page\OwncloudPage;
 use SensioLabs\Behat\PageObjectExtension\PageObject\Exception\ElementNotFoundException;
-use Page\OwncloudPageElement\OCDialog;
+use Tests\Acceptance\Page\OwncloudPageElement\OCDialog;
 use WebDriver\Exception\StaleElementReference;
 use PHPUnit\Framework\Assert;
 

--- a/tests/acceptance/features/lib/FilesPageElement/SharingDialogElement/EditPublicLinkPopup.php
+++ b/tests/acceptance/features/lib/FilesPageElement/SharingDialogElement/EditPublicLinkPopup.php
@@ -21,12 +21,12 @@
  *
  */
 
-namespace Page\FilesPageElement\SharingDialogElement;
+namespace Tests\Acceptance\Page\FilesPageElement\SharingDialogElement;
 
 use Behat\Mink\Session;
 use Behat\Mink\Element\NodeElement;
 use Exception;
-use Page\OwncloudPage;
+use Tests\Acceptance\Page\OwncloudPage;
 use SensioLabs\Behat\PageObjectExtension\PageObject\Exception\ElementNotFoundException;
 
 /**

--- a/tests/acceptance/features/lib/FilesPageElement/SharingDialogElement/PublicLinkTab.php
+++ b/tests/acceptance/features/lib/FilesPageElement/SharingDialogElement/PublicLinkTab.php
@@ -21,12 +21,12 @@
  *
  */
 
-namespace Page\FilesPageElement\SharingDialogElement;
+namespace Tests\Acceptance\Page\FilesPageElement\SharingDialogElement;
 
 use Behat\Mink\Element\NodeElement;
 use Behat\Mink\Session;
 use Exception;
-use Page\OwncloudPage;
+use Tests\Acceptance\Page\OwncloudPage;
 use SensioLabs\Behat\PageObjectExtension\PageObject\Exception\ElementNotFoundException;
 use SensioLabs\Behat\PageObjectExtension\PageObject\Page;
 

--- a/tests/acceptance/features/lib/FilesPageElement/TrashBinFileRow.php
+++ b/tests/acceptance/features/lib/FilesPageElement/TrashBinFileRow.php
@@ -21,7 +21,7 @@
  *
  */
 
-namespace Page\FilesPageElement;
+namespace Tests\Acceptance\Page\FilesPageElement;
 
 /**
  * Object of a row on the FilesPage

--- a/tests/acceptance/features/lib/GeneralErrorPage.php
+++ b/tests/acceptance/features/lib/GeneralErrorPage.php
@@ -20,7 +20,7 @@
  *
  */
 
-namespace Page;
+namespace Tests\Acceptance\Page;
 
 use Behat\Mink\Session;
 use Exception;

--- a/tests/acceptance/features/lib/GeneralExceptionPage.php
+++ b/tests/acceptance/features/lib/GeneralExceptionPage.php
@@ -20,7 +20,7 @@
  *
  */
 
-namespace Page;
+namespace Tests\Acceptance\Page;
 
 use Behat\Mink\Session;
 use Exception;

--- a/tests/acceptance/features/lib/HelpAndTipsPage.php
+++ b/tests/acceptance/features/lib/HelpAndTipsPage.php
@@ -21,7 +21,7 @@
  *
  */
 
-namespace Page;
+namespace Tests\Acceptance\Page;
 
 use Behat\Mink\Element\NodeElement;
 

--- a/tests/acceptance/features/lib/LoginPage.php
+++ b/tests/acceptance/features/lib/LoginPage.php
@@ -20,7 +20,7 @@
  *
  */
 
-namespace Page;
+namespace Tests\Acceptance\Page;
 
 use Behat\Mink\Element\NodeElement;
 use Behat\Mink\Session;

--- a/tests/acceptance/features/lib/Notification.php
+++ b/tests/acceptance/features/lib/Notification.php
@@ -20,7 +20,7 @@
  *
  */
 
-namespace Page;
+namespace Tests\Acceptance\Page;
 
 use Behat\Mink\Session;
 use Behat\Mink\Element\NodeElement;

--- a/tests/acceptance/features/lib/NotificationsAppDialog.php
+++ b/tests/acceptance/features/lib/NotificationsAppDialog.php
@@ -20,7 +20,7 @@
  *
  */
 
-namespace Page;
+namespace Tests\Acceptance\Page;
 
 use Behat\Mink\Session;
 use Exception;

--- a/tests/acceptance/features/lib/NotificationsEnabledOwncloudPage.php
+++ b/tests/acceptance/features/lib/NotificationsEnabledOwncloudPage.php
@@ -20,7 +20,7 @@
  *
  */
 
-namespace Page;
+namespace Tests\Acceptance\Page;
 
 use Behat\Mink\Session;
 use Behat\Mink\Element\NodeElement;

--- a/tests/acceptance/features/lib/OwncloudPage.php
+++ b/tests/acceptance/features/lib/OwncloudPage.php
@@ -21,7 +21,7 @@
  *
  */
 
-namespace Page;
+namespace Tests\Acceptance\Page;
 
 use Behat\Mink\Element\NodeElement;
 use Behat\Mink\Exception\DriverException;

--- a/tests/acceptance/features/lib/OwncloudPageElement/OCDialog.php
+++ b/tests/acceptance/features/lib/OwncloudPageElement/OCDialog.php
@@ -21,12 +21,12 @@
  *
  */
 
-namespace Page\OwncloudPageElement;
+namespace Tests\Acceptance\Page\OwncloudPageElement;
 
 use Behat\Mink\Element\NodeElement;
 use Behat\Mink\Session;
 use Exception;
-use Page\OwncloudPage;
+use Tests\Acceptance\Page\OwncloudPage;
 use SensioLabs\Behat\PageObjectExtension\PageObject\Exception\ElementNotFoundException;
 
 /**

--- a/tests/acceptance/features/lib/OwncloudPageElement/SettingsMenu.php
+++ b/tests/acceptance/features/lib/OwncloudPageElement/SettingsMenu.php
@@ -21,11 +21,11 @@
  *
  */
 
-namespace Page\OwncloudPageElement;
+namespace Tests\Acceptance\Page\OwncloudPageElement;
 
 use Behat\Mink\Session;
 use Exception;
-use Page\OwncloudPage;
+use Tests\Acceptance\Page\OwncloudPage;
 
 /**
  * The Settings Menu

--- a/tests/acceptance/features/lib/PersonalEncryptionSettingsPage.php
+++ b/tests/acceptance/features/lib/PersonalEncryptionSettingsPage.php
@@ -21,7 +21,7 @@
  *
  */
 
-namespace Page;
+namespace Tests\Acceptance\Page;
 
 use Behat\Mink\Session;
 use Exception;

--- a/tests/acceptance/features/lib/PersonalGeneralSettingsPage.php
+++ b/tests/acceptance/features/lib/PersonalGeneralSettingsPage.php
@@ -21,7 +21,7 @@
  *
  */
 
-namespace Page;
+namespace Tests\Acceptance\Page;
 
 use Behat\Mink\Session;
 use Exception;

--- a/tests/acceptance/features/lib/PersonalSecuritySettingsPage.php
+++ b/tests/acceptance/features/lib/PersonalSecuritySettingsPage.php
@@ -21,7 +21,7 @@
  *
  */
 
-namespace Page;
+namespace Tests\Acceptance\Page;
 
 use Behat\Mink\Session;
 use Behat\Mink\Element\NodeElement;

--- a/tests/acceptance/features/lib/PersonalSharingSettingsPage.php
+++ b/tests/acceptance/features/lib/PersonalSharingSettingsPage.php
@@ -21,7 +21,7 @@
  *
  */
 
-namespace Page;
+namespace Tests\Acceptance\Page;
 
 use Behat\Mink\Session;
 use Exception;

--- a/tests/acceptance/features/lib/PublicLinkFilesPage.php
+++ b/tests/acceptance/features/lib/PublicLinkFilesPage.php
@@ -20,7 +20,7 @@
  *
  */
 
-namespace Page;
+namespace Tests\Acceptance\Page;
 
 use Behat\Mink\Session;
 use Exception;

--- a/tests/acceptance/features/lib/SearchResultInOtherFoldersPage.php
+++ b/tests/acceptance/features/lib/SearchResultInOtherFoldersPage.php
@@ -20,7 +20,7 @@
  *
  */
 
-namespace Page;
+namespace Tests\Acceptance\Page;
 
 /**
  * Page that shows the search results.

--- a/tests/acceptance/features/lib/SharedByLinkPage.php
+++ b/tests/acceptance/features/lib/SharedByLinkPage.php
@@ -20,7 +20,7 @@
  *
  */
 
-namespace Page;
+namespace Tests\Acceptance\Page;
 
 use Behat\Mink\Session;
 use Exception;

--- a/tests/acceptance/features/lib/SharedWithOthersPage.php
+++ b/tests/acceptance/features/lib/SharedWithOthersPage.php
@@ -20,7 +20,7 @@
  *
  */
 
-namespace Page;
+namespace Tests\Acceptance\Page;
 
 use Behat\Mink\Session;
 use Exception;

--- a/tests/acceptance/features/lib/SharedWithYouPage.php
+++ b/tests/acceptance/features/lib/SharedWithYouPage.php
@@ -20,7 +20,7 @@
  *
  */
 
-namespace Page;
+namespace Tests\Acceptance\Page;
 
 use Behat\Mink\Session;
 use Exception;

--- a/tests/acceptance/features/lib/SharingSettingsPage.php
+++ b/tests/acceptance/features/lib/SharingSettingsPage.php
@@ -21,7 +21,7 @@
  *
  */
 
-namespace Page;
+namespace Tests\Acceptance\Page;
 
 use Behat\Mink\Session;
 use Exception;

--- a/tests/acceptance/features/lib/TagsPage.php
+++ b/tests/acceptance/features/lib/TagsPage.php
@@ -20,7 +20,7 @@
  *
  */
 
-namespace Page;
+namespace Tests\Acceptance\Page;
 
 use Behat\Mink\Session;
 use Exception;

--- a/tests/acceptance/features/lib/TrashbinPage.php
+++ b/tests/acceptance/features/lib/TrashbinPage.php
@@ -20,7 +20,7 @@
  *
  */
 
-namespace Page;
+namespace Tests\Acceptance\Page;
 
 use Behat\Mink\Element\NodeElement;
 use Behat\Mink\Session;

--- a/tests/acceptance/features/lib/UserPageElement/GroupList.php
+++ b/tests/acceptance/features/lib/UserPageElement/GroupList.php
@@ -21,12 +21,12 @@
  *
  */
 
-namespace Page\UserPageElement;
+namespace Tests\Acceptance\Page\UserPageElement;
 
 use Behat\Mink\Element\NodeElement;
 use Exception;
-use Page\OwncloudPage;
 use SensioLabs\Behat\PageObjectExtension\PageObject\Exception\ElementNotFoundException;
+use Tests\Acceptance\Page\OwncloudPage;
 
 /**
  * The list of groups

--- a/tests/acceptance/features/lib/UsersPage.php
+++ b/tests/acceptance/features/lib/UsersPage.php
@@ -20,7 +20,7 @@
  *
  */
 
-namespace Page;
+namespace Tests\Acceptance\Page;
 
 use Behat\Mink\Element\NodeElement;
 use Behat\Mink\Session;

--- a/tests/lib/DB/MigrationsTest.php
+++ b/tests/lib/DB/MigrationsTest.php
@@ -47,7 +47,7 @@ class MigrationsTest extends \Test\TestCase {
 
 		$this->assertEquals('core', $this->migrationService->getApp());
 		$this->assertEquals(\OC::$SERVERROOT . '/core/Migrations', $this->migrationService->getMigrationsDirectory());
-		$this->assertEquals('OC\Migrations', $this->migrationService->getMigrationsNamespace());
+		$this->assertEquals('OC\Core\Migrations', $this->migrationService->getMigrationsNamespace());
 		$this->assertEquals('test_oc_migrations', $this->migrationService->getMigrationsTableName());
 	}
 

--- a/tests/lib/Preview/PDFTest.php
+++ b/tests/lib/Preview/PDFTest.php
@@ -19,7 +19,7 @@
  *
  */
 
-namespace lib\Preview;
+namespace Test\Preview;
 
 use OC\Preview\PDF;
 use OCP\Files\NotFoundException;

--- a/tests/lib/Share/GetUsersSharingFileTest.php
+++ b/tests/lib/Share/GetUsersSharingFileTest.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace lib\Share;
+namespace Test\Share;
 
 use OC;
 use OC\Share\Constants;

--- a/tests/lib/User/Sync/BackendUsersIteratorTest.php
+++ b/tests/lib/User/Sync/BackendUsersIteratorTest.php
@@ -19,8 +19,10 @@
  *
  */
 
-namespace OC\User\Sync;
+namespace Test\User\Sync;
 
+use OC\User\Sync\BackendUsersIterator;
+use OC\User\Sync\UsersIterator;
 use OCP\UserInterface;
 use Test\TestCase;
 

--- a/tests/lib/User/Sync/SeenUsersIteratorTest.php
+++ b/tests/lib/User/Sync/SeenUsersIteratorTest.php
@@ -19,9 +19,11 @@
  *
  */
 
-namespace OC\User\Sync;
+namespace Test\User\Sync;
 
 use OC\User\AccountMapper;
+use OC\User\Sync\SeenUsersIterator;
+use OC\User\Sync\UsersIterator;
 use Test\TestCase;
 
 /**


### PR DESCRIPTION
## Description
When doing `composer update` 
`> Google\Task\Composer::cleanup`
is called.

That emits lots of messages about code that has a namespace declared that does not properly match the directory structure where the file is found. That is a lot of annoying "noise", and actually it would be nice to correct all the reported cases where it is easy to correct the problem.

This PR corrects all the places in tests where this occurs and it is clear/easy to fix.

Only test code is touched, so a changelog entry is not required.

## Related Issue
None

## How Has This Been Tested?
CI

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Database schema changes (next release will require increase of minor version instead of patch)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [x] Tests only (no source changes)

## Checklist:
- [ ] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 
- [ ] Changelog item, see [TEMPLATE](https://github.com/owncloud/core/blob/master/changelog/TEMPLATE)
