### PR TITLE
fix: web updater is now disabled by default + discourage users to use the web updater

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -14,6 +14,7 @@
 /build/phan.phar
 /build/phpstan.phar*
 /core/vendor
+/updater/
 
 # ignore all apps except core ones
 /apps*/*

--- a/apps/updatenotification/appinfo/routes.php
+++ b/apps/updatenotification/appinfo/routes.php
@@ -24,6 +24,5 @@ use OCA\UpdateNotification\AppInfo\Application;
 
 $application = new Application();
 $application->registerRoutes($this, ['routes' => [
-	['name' => 'Admin#createCredentials', 'url' => '/credentials', 'verb' => 'GET'],
 	['name' => 'Admin#setChannel', 'url' => '/channel', 'verb' => 'POST'],
 ]]);

--- a/apps/updatenotification/js/admin.js
+++ b/apps/updatenotification/js/admin.js
@@ -10,36 +10,7 @@
  *
  */
 
-/**
- * Creates a new authentication token and loads the updater URL
- */
-var loginToken = '';
 $(document).ready(function(){
-	$('#oca_updatenotification_button').click(function() {
-		// Load the new token
-		$.ajax({
-			url: OC.generateUrl('/apps/updatenotification/credentials')
-		}).success(function(data) {
-			loginToken = data;
-			$.ajax({
-				url: OC.webroot+'/updater/',
-				headers: {
-					'X-Updater-Auth': loginToken
-				},
-				method: 'POST',
-				success: function(data){
-					if(data !== 'false') {
-						var body = $('body');
-						$('head').remove();
-						body.html(data);
-						body.removeAttr('id');
-						body.attr('id', 'body-settings');
-					}
-				}
-			});
-		});
-	});
-
 	$('#release-channel').change(function() {
 		var newChannel = $('#release-channel').find(":selected").val();
 

--- a/apps/updatenotification/templates/admin.php
+++ b/apps/updatenotification/templates/admin.php
@@ -12,8 +12,6 @@ $lastCheckedDate = $_['lastChecked'];
 $channels = $_['channels'];
 /** @var string $currentChannel */
 $currentChannel = $_['currentChannel'];
-/** @var string $changeLogUrl */
-$changeLogUrl = $_['changeLogUrl'];
 
 ?>
 <form id="oca_updatenotification_section" class="section">
@@ -21,10 +19,6 @@ $changeLogUrl = $_['changeLogUrl'];
 
 	<?php if ($isNewVersionAvailable === true): ?>
 		<strong><?php p($l->t('A new version is available: %s', [$newVersionString])); ?></strong>
-		<input type="button" id="oca_updatenotification_button" value="<?php p($l->t('Open updater')) ?>">
-		<?php if ($changeLogUrl): ?>
-			<a target="_blank" rel="noreferrer" class="icon-info svg" title="<?php p($l->t('Show changelog')); ?>" href="<?php print_unescaped($changeLogUrl) ?>"></a>
-		<?php endif; ?>
 	<?php else: ?>
 		<strong><?php print_unescaped($l->t('Your version is up to date.')); ?></strong>
 		<span class="icon-info svg" title="<?php p($l->t('Checked on %s', [$lastCheckedDate])) ?>"></span>

--- a/apps/updatenotification/tests/Controller/AdminControllerTest.php
+++ b/apps/updatenotification/tests/Controller/AdminControllerTest.php
@@ -27,7 +27,6 @@ namespace OCA\UpdateNotification\Tests\Controller;
 
 use OCA\UpdateNotification\Controller\AdminController;
 use OCA\UpdateNotification\UpdateChecker;
-use OCP\AppFramework\Http\DataResponse;
 use OCP\AppFramework\Http\TemplateResponse;
 use OCP\AppFramework\Utility\ITimeFactory;
 use OCP\BackgroundJob\IJobList;
@@ -121,7 +120,6 @@ class AdminControllerTest extends TestCase {
 			'currentChannel' => \OCP\Util::getChannel(),
 			'channels' => $channels,
 			'newVersionString' => 'ownCloud 10.7.0',
-			'changeLogUrl' => 'https://owncloud.com/changelog/server/#10.7.0',
 			'notify_groups' => 'admin'
 		];
 
@@ -166,39 +164,11 @@ class AdminControllerTest extends TestCase {
 			'currentChannel' => \OCP\Util::getChannel(),
 			'channels' => $channels,
 			'newVersionString' => '',
-			'changeLogUrl' => null,
 			'notify_groups' => 'admin',
 		];
 
 		$expected = new TemplateResponse('updatenotification', 'admin', $params, '');
 		$this->assertEquals($expected, $this->adminController->displayPanel());
-	}
-
-	public function testCreateCredentials() {
-		$this->jobList
-			->expects($this->once())
-			->method('add')
-			->with('OCA\UpdateNotification\ResetTokenBackgroundJob');
-		$this->secureRandom
-			->expects($this->once())
-			->method('generate')
-			->with(64)
-			->willReturn('MyGeneratedToken');
-		$this->config
-			->expects($this->once())
-			->method('setSystemValue')
-			->with('updater.secret');
-		$this->timeFactory
-			->expects($this->once())
-			->method('getTime')
-			->willReturn(12345);
-		$this->config
-			->expects($this->once())
-			->method('setAppValue')
-			->with('core', 'updater.secret.created', 12345);
-
-		$expected = new DataResponse('MyGeneratedToken');
-		$this->assertEquals($expected, $this->adminController->createCredentials());
 	}
 
 	public function testGetPriority() {

--- a/changelog/unreleased/41385
+++ b/changelog/unreleased/41385
@@ -1,0 +1,10 @@
+Bugfix: Disable web updater
+
+The web updater is a relic of the past and not recommended for a long time.
+At the end it can cause more pain than help.
+
+In addition the use of the web updater is discouraged by removing the
+integration in the admin ui.
+
+https://github.com/owncloud/core/issues/41149
+https://github.com/owncloud/core/pull/41385

--- a/config/config.sample.php
+++ b/config/config.sample.php
@@ -1711,6 +1711,12 @@ $CONFIG = [
 'upgrade.disable-web' => false,
 
 /**
+ * Explicitly enable the web updater - used by /updater/
+ * By default, it is disabled.
+ */
+'web-updater.enabled' => false,
+
+/**
  * Define whether to enable automatic update of market apps
  * Set to `false` to disable.
  */


### PR DESCRIPTION
## Description
The web updater is a relic of old times and can cause more trouble than help.
More details on #41149 

## Related Issue
- Fixes #41149 

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
- test environment:
- test case 1:
- test case 2:
- ...

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Database schema changes (next release will require increase of minor version instead of patch)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [ ] Tests only (no source changes)

## Checklist:
<!-- Tick the checkboxes when done. -->
<!-- Raise documentation ticket in https://github.com/owncloud/documentation -->
- [ ] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 
- [ ] Changelog item, see [TEMPLATE](https://github.com/owncloud/core/blob/master/changelog/TEMPLATE)
