### PR TITLE
Fix Useless regular-expression character escape

### DIFF
--- a/apps/files/tests/js/filesSpec.js
+++ b/apps/files/tests/js/filesSpec.js
@@ -31,6 +31,9 @@ describe('OCA.Files.Files tests', function() {
 				'.a',
 				'..a',
 				'.dotfile',
+				'.apart',
+				'apart',
+				'party',
 				'single\'quote',
 				'  spaces before',
 				'spaces after   ',
@@ -64,7 +67,9 @@ describe('OCA.Files.Files tests', function() {
 				'/file',
 				'folder/file',
 				'foo.part',
-				'bar.filepart'
+				'bar.filepart',
+				'.part',
+				'.filepart'
 			];
 			for ( var i = 0; i < fileNames.length; i++ ) {
 				var threwException = false;

--- a/core/js/tests/specHelper.js
+++ b/core/js/tests/specHelper.js
@@ -94,7 +94,7 @@ window.oc_appswebroots = {
 window.oc_config = {
 	session_lifetime: 600 * 1000,
 	session_keepalive: false,
-	blacklist_files_regex: '\.(part|filepart)$'
+	blacklist_files_regex: '\\.(part|filepart)$'
 };
 window.oc_appconfig = {
 	core: {}


### PR DESCRIPTION

The problem is that the string literal `'\.(part|filepart)$'` does not correctly escape the `\.` for use in a regular expression pattern passed as a string. In JavaScript, a single backslash in a string is consumed as an escape character, so to get a literal backslash to the regex engine (so that `\.` is interpreted as "match a literal dot"), you need to write `'\\.'` in the string literal. Therefore, the correct value should be `'\\.(part|filepart)$'`. The only required change is to replace `'\.(part|filepart)$'` with `'\\.(part|filepart)$'` in core/js/tests/specHelper.js at line 97. No imports, method or variable definitions are needed. No other changes are required.


#### References
MDN: [Regular expression escape notation](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Guide/Regular_Expressions#Escaping)
MDN: [String escape notation](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String#Escape_notation)

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Database schema changes (next release will require increase of minor version instead of patch)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [ ] Tests only (no source changes)

## Checklist:
<!-- Tick the checkboxes when done. -->
<!-- Raise documentation ticket in https://github.com/owncloud/documentation -->
- [ ] Code changes
- [x] Unit tests added
- [x] Acceptance tests added
- [x] Documentation ticket raised: <link> 
- [x] Changelog item, see [TEMPLATE](https://github.com/owncloud/core/blob/master/changelog/TEMPLATE)
