### PR TITLE
Update sonar scanner cli 11

### DIFF
--- a/.drone.star
+++ b/.drone.star
@@ -130,41 +130,6 @@ config = {
                 "ls -l /var/cache/samba",
             ],
         },
-        "external-windows": {
-            "phpVersions": [
-                DEFAULT_PHP_VERSION,
-            ],
-            "databases": [
-                "sqlite",
-            ],
-            "externalTypes": [
-                "windows",
-            ],
-            "coverage": True,
-            "extraEnvironment": {
-                "SMB_WINDOWS_HOST": {
-                    "from_secret": "SMB_WINDOWS_HOST",
-                },
-                "SMB_WINDOWS_USERNAME": {
-                    "from_secret": "SMB_WINDOWS_USERNAME",
-                },
-                "SMB_WINDOWS_PWD": {
-                    "from_secret": "SMB_WINDOWS_PWD",
-                },
-                "SMB_WINDOWS_DOMAIN": {
-                    "from_secret": "SMB_WINDOWS_DOMAIN",
-                },
-                "SMB_WINDOWS_SHARE_NAME": {
-                    "from_secret": "SMB_WINDOWS_SHARE_NAME",
-                },
-            },
-            "extraCommandsBeforeTestRun": [
-                "ls -l /var/cache",
-                "mkdir /var/cache/samba",
-                "ls -l /var/cache",
-                "ls -l /var/cache/samba",
-            ],
-        },
         "external-other": {
             "phpVersions": [
                 DEFAULT_PHP_VERSION,

--- a/.drone.star
+++ b/.drone.star
@@ -22,7 +22,7 @@ PLUGINS_S3_CACHE = "plugins/s3-cache:1"
 POTTAVA_PROXY = "pottava/proxy"
 SELENIUM_STANDALONE_CHROME_DEBUG = "selenium/standalone-chrome-debug:3.141.59-oxygen"
 SELENIUM_STANDALONE_FIREFOX_DEBUG = "selenium/standalone-firefox-debug:3.8.1"
-SONARSOURCE_SONAR_SCANNER_CLI = "sonarsource/sonar-scanner-cli:5"
+SONARSOURCE_SONAR_SCANNER_CLI = "sonarsource/sonar-scanner-cli:11.0"
 TOOLHIPPIE_CALENS = "toolhippie/calens:latest"
 WEBHIPPIE_REDIS = "webhippie/redis:latest"
 

--- a/tests/lib/Files/ViewTest.php
+++ b/tests/lib/Files/ViewTest.php
@@ -2739,7 +2739,7 @@ class ViewTest extends TestCase {
 	public function testDeleteNonShareFolder($shareFolder, $deleteFolder) {
 		/**
 		 * Using overwriteService in this method instead of setUp, because there
-		 * are other methods in the test's which might get affected if we use it
+		 * are other methods in the tests which might get affected if we use it
 		 * in setUp.
 		 */
 		$this->overwriteService('AllConfig', $this->config);


### PR DESCRIPTION
## Description
Update the Sonar Scanner CLI version used in CI.

Temporary: remove the Windows SMB server test pipeline, because the SMB server is not currently responding properly.


## Related Issue
- Fixes <issue_link>

## Motivation and Context

## How Has This Been Tested?
- test environment:
- test case 1:
- test case 2:
- ...

## Screenshots (if appropriate):

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Database schema changes (next release will require increase of minor version instead of patch)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [ ] Tests only (no source changes)

## Checklist:
<!-- Tick the checkboxes when done. -->
<!-- Raise documentation ticket in https://github.com/owncloud/documentation -->
- [ ] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 
- [ ] Changelog item, see [TEMPLATE](https://github.com/owncloud/core/blob/master/changelog/TEMPLATE)
