### PR TITLE
chore: remove Windows SMB server test pipeline

### DIFF
--- a/.drone.star
+++ b/.drone.star
@@ -130,41 +130,6 @@ config = {
                 "ls -l /var/cache/samba",
             ],
         },
-        "external-windows": {
-            "phpVersions": [
-                DEFAULT_PHP_VERSION,
-            ],
-            "databases": [
-                "sqlite",
-            ],
-            "externalTypes": [
-                "windows",
-            ],
-            "coverage": True,
-            "extraEnvironment": {
-                "SMB_WINDOWS_HOST": {
-                    "from_secret": "SMB_WINDOWS_HOST",
-                },
-                "SMB_WINDOWS_USERNAME": {
-                    "from_secret": "SMB_WINDOWS_USERNAME",
-                },
-                "SMB_WINDOWS_PWD": {
-                    "from_secret": "SMB_WINDOWS_PWD",
-                },
-                "SMB_WINDOWS_DOMAIN": {
-                    "from_secret": "SMB_WINDOWS_DOMAIN",
-                },
-                "SMB_WINDOWS_SHARE_NAME": {
-                    "from_secret": "SMB_WINDOWS_SHARE_NAME",
-                },
-            },
-            "extraCommandsBeforeTestRun": [
-                "ls -l /var/cache",
-                "mkdir /var/cache/samba",
-                "ls -l /var/cache",
-                "ls -l /var/cache/samba",
-            ],
-        },
         "external-other": {
             "phpVersions": [
                 DEFAULT_PHP_VERSION,


### PR DESCRIPTION
## Description
We are facing some issues within the test network - windows smb tests will be disabled for the time being to allow release of 10.16

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
- Fixes <issue_link>

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
- test environment:
- test case 1:
- test case 2:
- ...

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Database schema changes (next release will require increase of minor version instead of patch)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [ ] Tests only (no source changes)

## Checklist:
<!-- Tick the checkboxes when done. -->
<!-- Raise documentation ticket in https://github.com/owncloud/documentation -->
- [ ] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 
- [ ] Changelog item, see [TEMPLATE](https://github.com/owncloud/core/blob/master/changelog/TEMPLATE)
