### PR TITLE
chore: safely eliminate future 8.4 deprecation warning

### DIFF
--- a/apps/comments/lib/Dav/EntityCollection.php
+++ b/apps/comments/lib/Dav/EntityCollection.php
@@ -128,7 +128,7 @@ class EntityCollection extends RootCollection implements IProperties {
 	 * @param \DateTime|null $datetime
 	 * @return CommentNode[]
 	 */
-	public function findChildren($limit = 0, $offset = 0, \DateTime $datetime = null) {
+	public function findChildren($limit = 0, $offset = 0, ?\DateTime $datetime = null) {
 		$comments = $this->commentsManager->getForObject($this->name, $this->id, $limit, $offset, $datetime);
 		$result = [];
 		foreach ($comments as $comment) {

--- a/apps/dav/lib/CardDAV/CardDavBackend.php
+++ b/apps/dav/lib/CardDAV/CardDavBackend.php
@@ -85,7 +85,7 @@ class CardDavBackend implements BackendInterface, SyncSupport {
 		IDBConnection $db,
 		Principal $principalBackend,
 		GroupPrincipalBackend $groupPrincipalBackend,
-		EventDispatcherInterface $dispatcher = null,
+		?EventDispatcherInterface $dispatcher = null,
 		$legacyMode = false
 	) {
 		$this->db = $db;

--- a/apps/dav/lib/CardDAV/SyncService.php
+++ b/apps/dav/lib/CardDAV/SyncService.php
@@ -290,7 +290,7 @@ class SyncService {
 		return $this->localSystemAddressBook;
 	}
 
-	public function syncInstance(\Closure $progressCallback = null) {
+	public function syncInstance(?\Closure $progressCallback = null) {
 		$systemAddressBook = $this->getLocalSystemAddressBook();
 		$this->userManager->callForAllUsers(function ($user) use ($progressCallback) {
 			$this->updateUser($user);

--- a/apps/dav/lib/Connector/Sabre/Directory.php
+++ b/apps/dav/lib/Connector/Sabre/Directory.php
@@ -84,7 +84,7 @@ class Directory extends Node implements ICollection, IQuota, IMoveTarget {
 	 * @param ObjectTree|null $tree
 	 * @param \OCP\Share\IManager $shareManager
 	 */
-	public function __construct($view, $info, ObjectTree $tree = null, $shareManager = null) {
+	public function __construct($view, $info, ?ObjectTree $tree = null, $shareManager = null) {
 		parent::__construct($view, $info, $shareManager);
 		$this->tree = $tree;
 	}

--- a/apps/dav/lib/Connector/Sabre/Exception/FileLocked.php
+++ b/apps/dav/lib/Connector/Sabre/Exception/FileLocked.php
@@ -28,7 +28,7 @@ namespace OCA\DAV\Connector\Sabre\Exception;
 use Exception;
 
 class FileLocked extends \Sabre\DAV\Exception {
-	public function __construct($message = '', $code = 0, Exception $previous = null) {
+	public function __construct($message = '', $code = 0, ?Exception $previous = null) {
 		if ($previous instanceof \OCP\Files\LockNotAcquiredException) {
 			$message = \sprintf('Target file %s is locked by another process.', $previous->path);
 		}

--- a/apps/dav/lib/Connector/Sabre/Exception/FileNameTooLong.php
+++ b/apps/dav/lib/Connector/Sabre/Exception/FileNameTooLong.php
@@ -25,7 +25,7 @@ namespace OCA\DAV\Connector\Sabre\Exception;
 use Exception;
 
 class FileNameTooLong extends \Sabre\DAV\Exception {
-	public function __construct($message = '', $code = 0, Exception $previous = null) {
+	public function __construct($message = '', $code = 0, ?Exception $previous = null) {
 		if ($message === '') {
 			$message = 'File name is too long.';
 		}

--- a/apps/dav/lib/Connector/Sabre/Exception/Forbidden.php
+++ b/apps/dav/lib/Connector/Sabre/Exception/Forbidden.php
@@ -34,7 +34,7 @@ class Forbidden extends \Sabre\DAV\Exception\Forbidden {
 	 * @param bool $retry
 	 * @param \Exception $previous
 	 */
-	public function __construct($message, $retry = false, \Exception $previous = null) {
+	public function __construct($message, $retry = false, ?\Exception $previous = null) {
 		parent::__construct($message, 0, $previous);
 		$this->retry = $retry;
 	}

--- a/apps/dav/lib/Connector/Sabre/File.php
+++ b/apps/dav/lib/Connector/Sabre/File.php
@@ -75,7 +75,7 @@ class File extends Node implements IFile, IFileNode {
 	 * @param \OCP\Files\FileInfo $info
 	 * @param \OCP\Share\IManager $shareManager
 	 */
-	public function __construct($view, $info, $shareManager = null, Request $request = null) {
+	public function __construct($view, $info, $shareManager = null, ?Request $request = null) {
 		if (isset($request)) {
 			$this->request = $request;
 		} else {

--- a/apps/dav/lib/Connector/Sabre/FilesPlugin.php
+++ b/apps/dav/lib/Connector/Sabre/FilesPlugin.php
@@ -466,7 +466,7 @@ class FilesPlugin extends ServerPlugin {
 	 * @param \Sabre\DAV\INode $node
 	 * @throws \Sabre\DAV\Exception\BadRequest
 	 */
-	public function sendFileIdHeader($filePath, \Sabre\DAV\INode $node = null) {
+	public function sendFileIdHeader($filePath, ?\Sabre\DAV\INode $node = null) {
 		// chunked upload handling
 		if (\OC_FileChunking::isWebdavChunk()) {
 			list($path, $name) = \Sabre\Uri\split($filePath);

--- a/apps/dav/lib/Connector/Sabre/MaintenancePlugin.php
+++ b/apps/dav/lib/Connector/Sabre/MaintenancePlugin.php
@@ -43,7 +43,7 @@ class MaintenancePlugin extends ServerPlugin {
 	/**
 	 * @param IConfig $config
 	 */
-	public function __construct(IConfig $config = null) {
+	public function __construct(?IConfig $config = null) {
 		$this->config = $config;
 		if ($config === null) {
 			$this->config = \OC::$server->getConfig();

--- a/apps/dav/lib/Connector/Sabre/Node.php
+++ b/apps/dav/lib/Connector/Sabre/Node.php
@@ -79,7 +79,7 @@ abstract class Node implements \Sabre\DAV\INode {
 	 * @param \OCP\Files\FileInfo $info
 	 * @param IManager $shareManager
 	 */
-	public function __construct($view, $info, IManager $shareManager = null) {
+	public function __construct($view, $info, ?IManager $shareManager = null) {
 		$this->fileView = $view;
 		$this->path = $this->fileView->getRelativePath($info->getPath());
 		$this->info = $info;

--- a/apps/dav/lib/DAV/Sharing/Xml/Invite.php
+++ b/apps/dav/lib/DAV/Sharing/Xml/Invite.php
@@ -79,7 +79,7 @@ class Invite implements XmlSerializable {
 	 *
 	 * @param array $users
 	 */
-	public function __construct(array $users, array $organizer = null) {
+	public function __construct(array $users, ?array $organizer = null) {
 		$this->users = $users;
 		$this->organizer = $organizer;
 	}

--- a/apps/dav/lib/HookManager.php
+++ b/apps/dav/lib/HookManager.php
@@ -133,7 +133,7 @@ class HookManager {
 		$this->syncService->updateUser($user);
 	}
 
-	public function firstLogin(IUser $user = null) {
+	public function firstLogin(?IUser $user = null) {
 		if ($user !== null) {
 			$principal = 'principals/users/' . $user->getUID();
 			$calendars = $this->calDav->getCalendarsForUser($principal);

--- a/apps/dav/lib/TrashBin/TrashBinManager.php
+++ b/apps/dav/lib/TrashBin/TrashBinManager.php
@@ -49,7 +49,7 @@ class TrashBinManager {
 		}
 	}
 
-	public function getChildren(string $user, string $fileId = null) {
+	public function getChildren(string $user, ?string $fileId = null) {
 		try {
 			$view = new View('/' . $user . '/files_trashbin/files');
 			$path = '/';

--- a/apps/dav/tests/unit/Connector/Sabre/FileTest.php
+++ b/apps/dav/tests/unit/Connector/Sabre/FileTest.php
@@ -429,7 +429,7 @@ class FileTest extends TestCase {
 	 *
 	 * @return null|string of the PUT operation which is usually the etag
 	 */
-	private function doPut($path, $viewRoot = null, \OC\AppFramework\Http\Request $request = null) {
+	private function doPut($path, $viewRoot = null, ?\OC\AppFramework\Http\Request $request = null) {
 		$view = Filesystem::getView();
 		if ($viewRoot !== null) {
 			$view = new View($viewRoot);
@@ -1400,7 +1400,7 @@ class FileTest extends TestCase {
 	 *
 	 * @return array list of part files
 	 */
-	private function listPartFiles(View $userView = null, $path = '') {
+	private function listPartFiles(?View $userView = null, $path = '') {
 		if ($userView === null) {
 			$userView = Filesystem::getView();
 		}
@@ -1426,7 +1426,7 @@ class FileTest extends TestCase {
 	 * @param View $userView
 	 * @return array
 	 */
-	private function getFileInfos($path = '', View $userView = null) {
+	private function getFileInfos($path = '', ?View $userView = null) {
 		if ($userView === null) {
 			$userView = Filesystem::getView();
 		}

--- a/apps/federatedfilesharing/lib/BackgroundJob/RetryJob.php
+++ b/apps/federatedfilesharing/lib/BackgroundJob/RetryJob.php
@@ -54,7 +54,7 @@ class RetryJob extends Job {
 	 *
 	 * @param Notifications $notifications
 	 */
-	public function __construct(Notifications $notifications = null) {
+	public function __construct(?Notifications $notifications = null) {
 		if ($notifications) {
 			$this->notifications = $notifications;
 		} else {
@@ -69,7 +69,7 @@ class RetryJob extends Job {
 	 * @param JobList $jobList
 	 * @param ILogger $logger
 	 */
-	public function execute($jobList, ILogger $logger = null) {
+	public function execute($jobList, ?ILogger $logger = null) {
 		if ($this->shouldRun($this->argument)) {
 			parent::execute($jobList, $logger);
 			$jobList->remove($this, $this->argument);

--- a/apps/federatedfilesharing/lib/Command/PollIncomingShares.php
+++ b/apps/federatedfilesharing/lib/Command/PollIncomingShares.php
@@ -61,7 +61,7 @@ class PollIncomingShares extends Command {
 	 * @param MountProvider $externalMountProvider
 	 * @param IStorageFactory $loader
 	 */
-	public function __construct(IDBConnection $dbConnection, IUserManager $userManager, IStorageFactory $loader, Manager $externalManager = null, MountProvider $externalMountProvider = null) {
+	public function __construct(IDBConnection $dbConnection, IUserManager $userManager, IStorageFactory $loader, ?Manager $externalManager = null, ?MountProvider $externalMountProvider = null) {
 		parent::__construct();
 		$this->dbConnection = $dbConnection;
 		$this->userManager = $userManager;

--- a/apps/federation/lib/BackgroundJob/GetSharedSecret.php
+++ b/apps/federation/lib/BackgroundJob/GetSharedSecret.php
@@ -77,12 +77,12 @@ class GetSharedSecret extends Job {
 	 * @param DbHandler $dbHandler
 	 */
 	public function __construct(
-		IClient $httpClient = null,
-		IURLGenerator $urlGenerator = null,
-		IJobList $jobList = null,
-		TrustedServers $trustedServers = null,
-		ILogger $logger = null,
-		DbHandler $dbHandler = null
+		?IClient $httpClient = null,
+		?IURLGenerator $urlGenerator = null,
+		?IJobList $jobList = null,
+		?TrustedServers $trustedServers = null,
+		?ILogger $logger = null,
+		?DbHandler $dbHandler = null
 	) {
 		$this->logger = $logger ? $logger : \OC::$server->getLogger();
 		$this->httpClient = $httpClient ? $httpClient : \OC::$server->getHTTPClientService()->newClient();
@@ -110,7 +110,7 @@ class GetSharedSecret extends Job {
 	 * @param JobList $jobList
 	 * @param ILogger $logger
 	 */
-	public function execute($jobList, ILogger $logger = null) {
+	public function execute($jobList, ?ILogger $logger = null) {
 		$target = $this->argument['url'];
 		// only execute if target is still in the list of trusted domains
 		if ($this->trustedServers->isTrustedServer($target)) {

--- a/apps/federation/lib/BackgroundJob/RequestSharedSecret.php
+++ b/apps/federation/lib/BackgroundJob/RequestSharedSecret.php
@@ -76,11 +76,11 @@ class RequestSharedSecret extends Job {
 	 * @param DbHandler $dbHandler
 	 */
 	public function __construct(
-		IClient $httpClient = null,
-		IURLGenerator $urlGenerator = null,
-		IJobList $jobList = null,
-		TrustedServers $trustedServers = null,
-		DbHandler $dbHandler = null
+		?IClient $httpClient = null,
+		?IURLGenerator $urlGenerator = null,
+		?IJobList $jobList = null,
+		?TrustedServers $trustedServers = null,
+		?DbHandler $dbHandler = null
 	) {
 		$this->httpClient = $httpClient ? $httpClient : \OC::$server->getHTTPClientService()->newClient();
 		$this->jobList = $jobList ? $jobList : \OC::$server->getJobList();
@@ -108,7 +108,7 @@ class RequestSharedSecret extends Job {
 	 * @param JobList $jobList
 	 * @param ILogger $logger
 	 */
-	public function execute($jobList, ILogger $logger = null) {
+	public function execute($jobList, ?ILogger $logger = null) {
 		$target = $this->argument['url'];
 		// only execute if target is still in the list of trusted domains
 		if ($this->trustedServers->isTrustedServer($target)) {

--- a/apps/files/lib/BackgroundJob/ScanFiles.php
+++ b/apps/files/lib/BackgroundJob/ScanFiles.php
@@ -52,9 +52,9 @@ class ScanFiles extends \OC\BackgroundJob\TimedJob {
 	 * @param ILogger|null $logger
 	 */
 	public function __construct(
-		IConfig $config = null,
-		IUserManager $userManager = null,
-		ILogger $logger = null
+		?IConfig $config = null,
+		?IUserManager $userManager = null,
+		?ILogger $logger = null
 	) {
 		// Run once per 10 minutes
 		$this->setInterval(60 * 10);

--- a/apps/files_external/lib/Lib/Backend/SMB.php
+++ b/apps/files_external/lib/Lib/Backend/SMB.php
@@ -55,7 +55,7 @@ class SMB extends ExternalBackend {
 	 * @param StorageConfig $storage
 	 * @param IUser $user
 	 */
-	public function manipulateStorageConfig(IStorageConfig &$storage, IUser $user = null) {
+	public function manipulateStorageConfig(IStorageConfig &$storage, ?IUser $user = null) {
 		$userFromBackendOption = $storage->getBackendOption('user');
 		if ($domain = $storage->getBackendOption('domain')) {
 			$storage->setBackendOption('user', $domain.'\\'.$userFromBackendOption);

--- a/apps/files_external/lib/Lib/Backend/SMB2.php
+++ b/apps/files_external/lib/Lib/Backend/SMB2.php
@@ -55,7 +55,7 @@ class SMB2 extends ExternalBackend {
 		;
 	}
 
-	public function manipulateStorageConfig(IStorageConfig &$storage, IUser $user = null) {
+	public function manipulateStorageConfig(IStorageConfig &$storage, ?IUser $user = null) {
 		$userFromBackendOption = $storage->getBackendOption('user');
 		if ($domain = $storage->getBackendOption('domain')) {
 			$storage->setBackendOption('user', $domain.'\\'.$userFromBackendOption);

--- a/apps/files_external/lib/Lib/Backend/SMB_OC.php
+++ b/apps/files_external/lib/Lib/Backend/SMB_OC.php
@@ -57,7 +57,7 @@ class SMB_OC extends ExternalBackend {
 		;
 	}
 
-	public function manipulateStorageConfig(IStorageConfig &$storage, IUser $user = null) {
+	public function manipulateStorageConfig(IStorageConfig &$storage, ?IUser $user = null) {
 		$username_as_share = ($storage->getBackendOption('username_as_share') === true);
 
 		if ($username_as_share) {

--- a/apps/files_sharing/lib/External/ScanExternalSharesJob.php
+++ b/apps/files_sharing/lib/External/ScanExternalSharesJob.php
@@ -64,11 +64,11 @@ class ScanExternalSharesJob extends TimedJob {
 	public const BATCH_SIZE = 10;
 
 	public function __construct(
-		IDBConnection $connection = null,
-		IConfig $config = null,
-		IUserManager $userManager = null,
-		ILogger $logger = null,
-		Manager $externalManager = null
+		?IDBConnection $connection = null,
+		?IConfig $config = null,
+		?IUserManager $userManager = null,
+		?ILogger $logger = null,
+		?Manager $externalManager = null
 	) {
 		// Run once per 10 minutes
 		$this->setInterval(60 * 10);

--- a/apps/files_sharing/lib/ShareBackend/File.php
+++ b/apps/files_sharing/lib/ShareBackend/File.php
@@ -47,7 +47,7 @@ class File implements \OCP\Share_Backend_File_Dependent {
 	/** @var FederatedShareProvider */
 	private $federatedShareProvider;
 
-	public function __construct(FederatedShareProvider $federatedShareProvider = null) {
+	public function __construct(?FederatedShareProvider $federatedShareProvider = null) {
 		if ($federatedShareProvider) {
 			$this->federatedShareProvider = $federatedShareProvider;
 		} else {

--- a/apps/files_trashbin/lib/BackgroundJob/ExpireTrash.php
+++ b/apps/files_trashbin/lib/BackgroundJob/ExpireTrash.php
@@ -57,9 +57,9 @@ class ExpireTrash extends TimedJob {
 	 * @param TrashExpiryManager|null $trashExpiryManager
 	 */
 	public function __construct(
-		IConfig $config = null,
-		IUserManager $userManager = null,
-		TrashExpiryManager $trashExpiryManager = null
+		?IConfig $config = null,
+		?IUserManager $userManager = null,
+		?TrashExpiryManager $trashExpiryManager = null
 	) {
 		// Run once per 10 minutes
 		$this->setInterval(60 * 10);

--- a/apps/files_trashbin/lib/Command/ExpireTrash.php
+++ b/apps/files_trashbin/lib/Command/ExpireTrash.php
@@ -47,8 +47,8 @@ class ExpireTrash extends Command {
 	 * @param TrashExpiryManager|null $trashExpiryManager
 	 */
 	public function __construct(
-		IUserManager $userManager = null,
-		TrashExpiryManager $trashExpiryManager = null
+		?IUserManager $userManager = null,
+		?TrashExpiryManager $trashExpiryManager = null
 	) {
 		parent::__construct();
 

--- a/apps/files_trashbin/lib/Storage.php
+++ b/apps/files_trashbin/lib/Storage.php
@@ -52,7 +52,7 @@ class Storage extends Wrapper {
 	/** @var  TrashbinSkipChecker */
 	private $trashbinSkipChecker;
 
-	public function __construct($parameters, IUserManager $userManager = null, TrashbinSkipChecker $trashbinSkipChecker = null) {
+	public function __construct($parameters, ?IUserManager $userManager = null, ?TrashbinSkipChecker $trashbinSkipChecker = null) {
 		$this->mountPoint = $parameters['mountPoint'];
 		$this->userManager = $userManager;
 		$this->trashbinSkipChecker = $trashbinSkipChecker;

--- a/apps/files_versions/lib/BackgroundJob/ExpireVersions.php
+++ b/apps/files_versions/lib/BackgroundJob/ExpireVersions.php
@@ -42,7 +42,7 @@ class ExpireVersions extends \OC\BackgroundJob\TimedJob {
 	 */
 	private $userManager;
 
-	public function __construct(IUserManager $userManager = null, Expiration $expiration = null) {
+	public function __construct(?IUserManager $userManager = null, ?Expiration $expiration = null) {
 		// Run once per 30 minutes
 		$this->setInterval(60 * 30);
 

--- a/apps/files_versions/lib/Command/ExpireVersions.php
+++ b/apps/files_versions/lib/Command/ExpireVersions.php
@@ -48,8 +48,8 @@ class ExpireVersions extends Command {
 	 * @param Expiration|null $expiration
 	 */
 	public function __construct(
-		IUserManager $userManager = null,
-		Expiration $expiration = null
+		?IUserManager $userManager = null,
+		?Expiration $expiration = null
 	) {
 		parent::__construct();
 

--- a/apps/updatenotification/lib/ResetTokenBackgroundJob.php
+++ b/apps/updatenotification/lib/ResetTokenBackgroundJob.php
@@ -43,8 +43,8 @@ class ResetTokenBackgroundJob extends TimedJob {
 	 * @param ITimeFactory|null $timeFactory
 	 */
 	public function __construct(
-		IConfig $config = null,
-		ITimeFactory $timeFactory = null
+		?IConfig $config = null,
+		?ITimeFactory $timeFactory = null
 	) {
 		// Run all 10 minutes
 		$this->setInterval(60 * 10);

--- a/core/Command/User/SyncBackend.php
+++ b/core/Command/User/SyncBackend.php
@@ -360,7 +360,7 @@ class SyncBackend extends Command {
 	 * @param callable|null $callbackMissing the callback used if the account doesn't exist.
 	 * The uid and account are passed as parameters to the callback
 	 */
-	private function doActionForAccountUids(array $uidToAccountMap, callable $callbackExists, callable $callbackMissing = null): void {
+	private function doActionForAccountUids(array $uidToAccountMap, callable $callbackExists, ?callable $callbackMissing = null): void {
 		foreach ($uidToAccountMap as $uid => $account) {
 			$user = $this->userManager->get($uid);
 			if ($user === null) {

--- a/lib/private/Activity/Manager.php
+++ b/lib/private/Activity/Manager.php
@@ -62,7 +62,7 @@ class Manager implements IManager {
 	 */
 	public function __construct(
 		IRequest $request,
-		IUserSession $session = null,
+		?IUserSession $session = null,
 		IConfig $config
 	) {
 		$this->request = $request;

--- a/lib/private/App/AppManager.php
+++ b/lib/private/App/AppManager.php
@@ -106,9 +106,9 @@ class AppManager implements IAppManager {
 	 * @param IConfig $config
 	 */
 	public function __construct(
-		IUserSession $userSession = null,
-		IAppConfig $appConfig = null,
-		IGroupManager $groupManager = null,
+		?IUserSession $userSession = null,
+		?IAppConfig $appConfig = null,
+		?IGroupManager $groupManager = null,
 		ICacheFactory $memCacheFactory,
 		EventDispatcherInterface $dispatcher,
 		IConfig $config
@@ -165,7 +165,7 @@ class AppManager implements IAppManager {
 	 * @param \OCP\IUser|null $user
 	 * @return string[]
 	 */
-	public function getEnabledAppsForUser(IUser $user = null) {
+	public function getEnabledAppsForUser(?IUser $user = null) {
 		$apps = $this->getInstalledAppsValues();
 		$appsForUser = \array_filter($apps, function ($enabled, $appName) use ($user) {
 			return $this->checkAppForUser($enabled, $appName, $user);

--- a/lib/private/AppFramework/App.php
+++ b/lib/private/AppFramework/App.php
@@ -63,7 +63,7 @@ class App {
 	 * @param DIContainer $container an instance of a pimple container.
 	 * @param array $urlParams list of URL parameters (optional)
 	 */
-	public static function main($controllerName, $methodName, DIContainer $container, array $urlParams = null) {
+	public static function main($controllerName, $methodName, DIContainer $container, ?array $urlParams = null) {
 		if ($urlParams !== null) {
 			$container['OCP\\IRequest']->setUrlParameters($urlParams);
 		} elseif (isset($container['urlParams']) && $container['urlParams'] !== null) {

--- a/lib/private/AppFramework/Db/Db.php
+++ b/lib/private/AppFramework/Db/Db.php
@@ -110,7 +110,7 @@ class Db implements IDb {
 	/**
 	 * @inheritdoc
 	 */
-	public function insertIfNotExist($table, $input, array $compare = null) {
+	public function insertIfNotExist($table, $input, ?array $compare = null) {
 		return $this->connection->insertIfNotExist($table, $input, $compare);
 	}
 
@@ -271,7 +271,7 @@ class Db implements IDb {
 	/**
 	 * @inheritdoc
 	 */
-	public function upsert($table, $input, array $compare = null) {
+	public function upsert($table, $input, ?array $compare = null) {
 		return $this->connection->upsert($table, $input, $compare);
 	}
 }

--- a/lib/private/AppFramework/Http.php
+++ b/lib/private/AppFramework/Http.php
@@ -114,7 +114,7 @@ class Http extends BaseHttp {
 	 */
 	public function getStatusHeader(
 		$status,
-		\DateTime $lastModified=null,
+		?\DateTime $lastModified=null,
 		$ETag=null
 	) {
 		if ($lastModified !== null) {

--- a/lib/private/AppFramework/Http/Request.php
+++ b/lib/private/AppFramework/Http/Request.php
@@ -119,9 +119,9 @@ class Request implements ArrayAccess, Countable, IRequest {
 	 */
 	public function __construct(
 		array $vars= [],
-		ISecureRandom $secureRandom = null,
-		IConfig $config = null,
-		CsrfTokenManager $csrfTokenManager = null,
+		?ISecureRandom $secureRandom = null,
+		?IConfig $config = null,
+		?CsrfTokenManager $csrfTokenManager = null,
 		$stream = 'php://input'
 	) {
 		$this->inputStream = $stream;

--- a/lib/private/Autoloader.php
+++ b/lib/private/Autoloader.php
@@ -155,7 +155,7 @@ class Autoloader {
 	 *
 	 * @param \OC\Memcache\Cache $memoryCache Instance of memory cache.
 	 */
-	public function setMemoryCache(\OC\Memcache\Cache $memoryCache = null) {
+	public function setMemoryCache(?\OC\Memcache\Cache $memoryCache = null) {
 		$this->memoryCache = $memoryCache;
 	}
 }

--- a/lib/private/BackgroundJob/Job.php
+++ b/lib/private/BackgroundJob/Job.php
@@ -61,7 +61,7 @@ abstract class Job implements IJob {
 	 * @param JobList $jobList
 	 * @param ILogger $logger
 	 */
-	public function execute($jobList, ILogger $logger = null) {
+	public function execute($jobList, ?ILogger $logger = null) {
 		$jobList->setLastRun($this);
 		try {
 			//storing job start time

--- a/lib/private/BackgroundJob/QueuedJob.php
+++ b/lib/private/BackgroundJob/QueuedJob.php
@@ -37,7 +37,7 @@ abstract class QueuedJob extends Job {
 	 * @param JobList $jobList
 	 * @param ILogger $logger
 	 */
-	public function execute($jobList, ILogger $logger = null) {
+	public function execute($jobList, ?ILogger $logger = null) {
 		$jobList->remove($this, $this->argument);
 		parent::execute($jobList, $logger);
 	}

--- a/lib/private/BackgroundJob/TimedJob.php
+++ b/lib/private/BackgroundJob/TimedJob.php
@@ -48,7 +48,7 @@ abstract class TimedJob extends Job {
 	 * @param JobList $jobList
 	 * @param ILogger $logger
 	 */
-	public function execute($jobList, ILogger $logger = null) {
+	public function execute($jobList, ?ILogger $logger = null) {
 		if ((\time() - $this->lastRun) > $this->interval) {
 			if ($logger !== null) {
 				$id = $this->getId();

--- a/lib/private/Comments/Comment.php
+++ b/lib/private/Comments/Comment.php
@@ -48,7 +48,7 @@ class Comment implements IComment {
 	 * @param array|null $data	optional, array with keys according to column names from
 	 * 					the comments database scheme
 	 */
-	public function __construct(array $data = null) {
+	public function __construct(?array $data = null) {
 		if (\is_array($data)) {
 			$this->fromArray($data);
 		}
@@ -311,7 +311,7 @@ class Comment implements IComment {
 	 * @return IComment
 	 * @since 9.0.0
 	 */
-	public function setLatestChildDateTime(\DateTime $dateTime = null) {
+	public function setLatestChildDateTime(?\DateTime $dateTime = null) {
 		$this->data['latestChildDT'] = $dateTime;
 		return $this;
 	}

--- a/lib/private/Comments/Manager.php
+++ b/lib/private/Comments/Manager.php
@@ -332,7 +332,7 @@ class Manager implements ICommentsManager {
 		$objectId,
 		$limit = 0,
 		$offset = 0,
-		\DateTime $notOlderThan = null
+		?\DateTime $notOlderThan = null
 	) {
 		$comments = [];
 
@@ -427,7 +427,7 @@ class Manager implements ICommentsManager {
 	 * @return Int
 	 * @since 9.0.0
 	 */
-	public function getNumberOfCommentsForObject($objectType, $objectId, \DateTime $notOlderThan = null) {
+	public function getNumberOfCommentsForObject($objectType, $objectId, ?\DateTime $notOlderThan = null) {
 		$qb = $this->dbConn->getQueryBuilder();
 		$query = $qb->select($qb->createFunction('COUNT(`id`)'))
 				->from('comments')

--- a/lib/private/Console/Application.php
+++ b/lib/private/Console/Application.php
@@ -156,7 +156,7 @@ class Application {
 	 * @return int
 	 * @throws \Exception
 	 */
-	public function run(InputInterface $input = null, OutputInterface $output = null) {
+	public function run(?InputInterface $input = null, ?OutputInterface $output = null) {
 		$args = isset($this->request->server['argv']) ? $this->request->server['argv'] : [];
 		$this->dispatcher->dispatch(
 			new ConsoleEvent(ConsoleEvent::EVENT_RUN, $args),

--- a/lib/private/DB/Adapter.php
+++ b/lib/private/DB/Adapter.php
@@ -91,7 +91,7 @@ class Adapter {
 	 * @return int number of inserted rows
 	 * @throws \Doctrine\DBAL\DBALException
 	 */
-	public function insertIfNotExist($table, $input, array $compare = null) {
+	public function insertIfNotExist($table, $input, ?array $compare = null) {
 		if (empty($compare)) {
 			$compare = \array_keys($input);
 		}

--- a/lib/private/DB/AdapterSqlite.php
+++ b/lib/private/DB/AdapterSqlite.php
@@ -58,7 +58,7 @@ class AdapterSqlite extends Adapter {
 	 * @return int number of inserted rows
 	 * @throws \Doctrine\DBAL\DBALException
 	 */
-	public function insertIfNotExist($table, $input, array $compare = null) {
+	public function insertIfNotExist($table, $input, ?array $compare = null) {
 		if (empty($compare)) {
 			$compare = \array_keys($input);
 		}

--- a/lib/private/DB/Connection.php
+++ b/lib/private/DB/Connection.php
@@ -132,8 +132,8 @@ class Connection extends \Doctrine\DBAL\Connection implements IDBConnection {
 	public function __construct(
 		array $params,
 		Driver $driver,
-		Configuration $config = null,
-		EventManager $eventManager = null
+		?Configuration $config = null,
+		?EventManager $eventManager = null
 	) {
 		if (!isset($params['adapter'])) {
 			throw new \Exception('adapter not set');
@@ -185,7 +185,7 @@ class Connection extends \Doctrine\DBAL\Connection implements IDBConnection {
 	 *
 	 * @throws \Doctrine\DBAL\DBALException
 	 */
-	public function executeQuery($query, array $params = [], $types = [], QueryCacheProfile $qcp = null) {
+	public function executeQuery($query, array $params = [], $types = [], ?QueryCacheProfile $qcp = null) {
 		$query = $this->replaceTablePrefix($query);
 		$query = $this->adapter->fixupStatement($query);
 		return parent::executeQuery($query, $params, $types, $qcp);
@@ -272,7 +272,7 @@ class Connection extends \Doctrine\DBAL\Connection implements IDBConnection {
 	 * @return int number of inserted rows
 	 * @throws \Doctrine\DBAL\DBALException
 	 */
-	public function insertIfNotExist($table, $input, array $compare = null) {
+	public function insertIfNotExist($table, $input, ?array $compare = null) {
 		return $this->adapter->insertIfNotExist($table, $input, $compare);
 	}
 
@@ -287,7 +287,7 @@ class Connection extends \Doctrine\DBAL\Connection implements IDBConnection {
 	 * @return int number of affected rows
 	 * @throws \Doctrine\DBAL\DBALException
 	 */
-	public function upsert($table, $input, array $compare = null) {
+	public function upsert($table, $input, ?array $compare = null) {
 		return $this->adapter->upsert($table, $input, $compare);
 	}
 

--- a/lib/private/DB/MigrationService.php
+++ b/lib/private/DB/MigrationService.php
@@ -66,9 +66,9 @@ class MigrationService {
 	public function __construct(
 		$appName,
 		IDBConnection $connection,
-		IOutput $output = null,
-		AppLocator $appLocator = null,
-		ILogger $logger = null
+		?IOutput $output = null,
+		?AppLocator $appLocator = null,
+		?ILogger $logger = null
 	) {
 		$this->appName = $appName;
 		$this->connection = $connection;

--- a/lib/private/DB/Migrator.php
+++ b/lib/private/DB/Migrator.php
@@ -65,7 +65,7 @@ class Migrator {
 		\Doctrine\DBAL\Connection $connection,
 		ISecureRandom $random,
 		IConfig $config,
-		EventDispatcher $dispatcher = null
+		?EventDispatcher $dispatcher = null
 	) {
 		$this->connection = $connection;
 		$this->random = $random;
@@ -184,7 +184,7 @@ class Migrator {
 	 * @param \Doctrine\DBAL\Schema\Schema $targetSchema
 	 * @param \Doctrine\DBAL\Connection $connection
 	 */
-	protected function applySchema(Schema $targetSchema, \Doctrine\DBAL\Connection $connection = null) {
+	protected function applySchema(Schema $targetSchema, ?\Doctrine\DBAL\Connection $connection = null) {
 		if ($connection === null) {
 			$connection = $this->connection;
 		}

--- a/lib/private/DateTimeFormatter.php
+++ b/lib/private/DateTimeFormatter.php
@@ -76,7 +76,7 @@ class DateTimeFormatter implements \OCP\IDateTimeFormatter {
 	 * @param \DateTimeZone $timeZone	The timezone to use
 	 * @return \DateTime
 	 */
-	protected function getDateTime($timestamp, \DateTimeZone $timeZone = null) {
+	protected function getDateTime($timestamp, ?\DateTimeZone $timeZone = null) {
 		if ($timestamp === null) {
 			return new \DateTime('now', $timeZone);
 		} elseif (!$timestamp instanceof \DateTime) {
@@ -104,7 +104,7 @@ class DateTimeFormatter implements \OCP\IDateTimeFormatter {
 	 * @param \OCP\IL10N	$l			The locale to use
 	 * @return string Formatted date string
 	 */
-	public function formatDate($timestamp, $format = 'long', \DateTimeZone $timeZone = null, \OCP\IL10N $l = null) {
+	public function formatDate($timestamp, $format = 'long', ?\DateTimeZone $timeZone = null, ?\OCP\IL10N $l = null) {
 		return $this->format($timestamp, 'date', $format, $timeZone, $l);
 	}
 
@@ -123,7 +123,7 @@ class DateTimeFormatter implements \OCP\IDateTimeFormatter {
 	 * @param \OCP\IL10N	$l			The locale to use
 	 * @return string Formatted relative date string
 	 */
-	public function formatDateRelativeDay($timestamp, $format = 'long', \DateTimeZone $timeZone = null, \OCP\IL10N $l = null) {
+	public function formatDateRelativeDay($timestamp, $format = 'long', ?\DateTimeZone $timeZone = null, ?\OCP\IL10N $l = null) {
 		if (\substr($format, -1) !== '*') {
 			$format .= '^';
 		}
@@ -144,7 +144,7 @@ class DateTimeFormatter implements \OCP\IDateTimeFormatter {
 	 * @param \OCP\IL10N	$l			The locale to use
 	 * @return string Formatted date span
 	 */
-	public function formatDateSpan($timestamp, $baseTimestamp = null, \OCP\IL10N $l = null) {
+	public function formatDateSpan($timestamp, $baseTimestamp = null, ?\OCP\IL10N $l = null) {
 		$l = $this->getLocale($l);
 		$timestamp = $this->getDateTime($timestamp);
 		$timestamp->setTime(0, 0, 0);
@@ -185,7 +185,7 @@ class DateTimeFormatter implements \OCP\IDateTimeFormatter {
 	 * @param \OCP\IL10N	$l			The locale to use
 	 * @return string Formatted time string
 	 */
-	public function formatTime($timestamp, $format = 'medium', \DateTimeZone $timeZone = null, \OCP\IL10N $l = null) {
+	public function formatTime($timestamp, $format = 'medium', ?\DateTimeZone $timeZone = null, ?\OCP\IL10N $l = null) {
 		return $this->format($timestamp, 'time', $format, $timeZone, $l);
 	}
 
@@ -204,7 +204,7 @@ class DateTimeFormatter implements \OCP\IDateTimeFormatter {
 	 * @param \OCP\IL10N	$l			The locale to use
 	 * @return string Formatted time span
 	 */
-	public function formatTimeSpan($timestamp, $baseTimestamp = null, \OCP\IL10N $l = null) {
+	public function formatTimeSpan($timestamp, $baseTimestamp = null, ?\OCP\IL10N $l = null) {
 		$l = $this->getLocale($l);
 		$timestamp = $this->getDateTime($timestamp);
 		if ($baseTimestamp === null) {
@@ -235,7 +235,7 @@ class DateTimeFormatter implements \OCP\IDateTimeFormatter {
 	 * @param \OCP\IL10N	$l			The locale to use
 	 * @return string Formatted date and time string
 	 */
-	public function formatDateTime($timestamp, $formatDate = 'long', $formatTime = 'medium', \DateTimeZone $timeZone = null, \OCP\IL10N $l = null) {
+	public function formatDateTime($timestamp, $formatDate = 'long', $formatTime = 'medium', ?\DateTimeZone $timeZone = null, ?\OCP\IL10N $l = null) {
 		return $this->format($timestamp, 'datetime', $formatDate . '|' . $formatTime, $timeZone, $l);
 	}
 
@@ -250,7 +250,7 @@ class DateTimeFormatter implements \OCP\IDateTimeFormatter {
 	 * @param \OCP\IL10N	$l			The locale to use
 	 * @return string Formatted relative date and time string
 	 */
-	public function formatDateTimeRelativeDay($timestamp, $formatDate = 'long', $formatTime = 'medium', \DateTimeZone $timeZone = null, \OCP\IL10N $l = null) {
+	public function formatDateTimeRelativeDay($timestamp, $formatDate = 'long', $formatTime = 'medium', ?\DateTimeZone $timeZone = null, ?\OCP\IL10N $l = null) {
 		if (\substr($formatDate, -1) !== '^' && \substr($formatDate, -1) !== '*') {
 			$formatDate .= '^';
 		}
@@ -268,7 +268,7 @@ class DateTimeFormatter implements \OCP\IDateTimeFormatter {
 	 * @param \OCP\IL10N	$l			The locale to use
 	 * @return string Formatted date and time string
 	 */
-	protected function format($timestamp, $type, $format, \DateTimeZone $timeZone = null, \OCP\IL10N $l = null) {
+	protected function format($timestamp, $type, $format, ?\DateTimeZone $timeZone = null, ?\OCP\IL10N $l = null) {
 		$l = $this->getLocale($l);
 		$timeZone = $this->getTimeZone($timeZone);
 		$timestamp = $this->getDateTime($timestamp, $timeZone);

--- a/lib/private/Diagnostics/QueryLogger.php
+++ b/lib/private/Diagnostics/QueryLogger.php
@@ -47,7 +47,7 @@ class QueryLogger implements IQueryLogger {
 	/**
 	 * @inheritdoc
 	 */
-	public function startQuery($sql, array $params = null, array $types = null) {
+	public function startQuery($sql, ?array $params = null, ?array $types = null) {
 		if ($this->activated) {
 			$this->activeQuery = new Query($sql, $params ?? [], $this->getMicrotime());
 		}

--- a/lib/private/Encryption/Util.php
+++ b/lib/private/Encryption/Util.php
@@ -113,7 +113,7 @@ class Util {
 	 * @return string
 	 * @throws ModuleDoesNotExistsException
 	 */
-	public function getEncryptionModuleId(array $header = null) {
+	public function getEncryptionModuleId(?array $header = null) {
 		$id = '';
 		$encryptionModuleKey = self::HEADER_ENCRYPTION_MODULE_KEY;
 

--- a/lib/private/Files/External/Auth/Password/SessionCredentials.php
+++ b/lib/private/Files/External/Auth/Password/SessionCredentials.php
@@ -67,7 +67,7 @@ class SessionCredentials extends AuthMechanism {
 		$this->session->set('password::sessioncredentials/credentials', $this->crypto->encrypt(\json_encode($params)));
 	}
 
-	public function manipulateStorageConfig(IStorageConfig &$storage, IUser $user = null) {
+	public function manipulateStorageConfig(IStorageConfig &$storage, ?IUser $user = null) {
 		$encrypted = $this->session->get('password::sessioncredentials/credentials');
 		if (!isset($encrypted)) {
 			throw new InsufficientDataForMeaningfulAnswerException('No session credentials saved');

--- a/lib/private/Files/External/StorageModifierTrait.php
+++ b/lib/private/Files/External/StorageModifierTrait.php
@@ -50,7 +50,7 @@ trait StorageModifierTrait {
 	 * @throws InsufficientDataForMeaningfulAnswerException
 	 * @throws StorageNotAvailableException
 	 */
-	public function manipulateStorageConfig(IStorageConfig &$storage, IUser $user = null) {
+	public function manipulateStorageConfig(IStorageConfig &$storage, ?IUser $user = null) {
 	}
 
 	/**

--- a/lib/private/Files/Node/Folder.php
+++ b/lib/private/Files/Node/Folder.php
@@ -106,7 +106,7 @@ class Folder extends Node implements \OCP\Files\Folder {
 	 * @param FileInfo $info
 	 * @return File|Folder
 	 */
-	protected function createNode($path, FileInfo $info = null) {
+	protected function createNode($path, ?FileInfo $info = null) {
 		if ($info === null) {
 			$isDir = $this->view->is_dir($path);
 		} else {

--- a/lib/private/Files/Node/LazyRoot.php
+++ b/lib/private/Files/Node/LazyRoot.php
@@ -81,7 +81,7 @@ class LazyRoot implements IRootFolder {
 	/**
 	 * @inheritDoc
 	 */
-	public function removeListener($scope = null, $method = null, callable $callback = null) {
+	public function removeListener($scope = null, $method = null, ?callable $callback = null) {
 		$this->__call(__FUNCTION__, \func_get_args());
 	}
 

--- a/lib/private/Files/Node/Root.php
+++ b/lib/private/Files/Node/Root.php
@@ -108,7 +108,7 @@ class Root extends Folder implements IRootFolder {
 	 * @param string $method optional
 	 * @param callable $callback optional
 	 */
-	public function removeListener($scope = null, $method = null, callable $callback = null) {
+	public function removeListener($scope = null, $method = null, ?callable $callback = null) {
 		$this->emitter->removeListener($scope, $method, $callback);
 	}
 

--- a/lib/private/Files/Storage/Wrapper/Encryption.php
+++ b/lib/private/Files/Storage/Wrapper/Encryption.php
@@ -105,15 +105,15 @@ class Encryption extends Wrapper {
 	 */
 	public function __construct(
 		$parameters,
-		IManager $encryptionManager = null,
-		Util $util = null,
-		ILogger $logger = null,
-		IFile $fileHelper = null,
+		?IManager $encryptionManager = null,
+		?Util $util = null,
+		?ILogger $logger = null,
+		?IFile $fileHelper = null,
 		$uid = null,
-		IStorage $keyStorage = null,
-		Update $update = null,
-		Manager $mountManager = null,
-		ArrayCache $arrayCache = null
+		?IStorage $keyStorage = null,
+		?Update $update = null,
+		?Manager $mountManager = null,
+		?ArrayCache $arrayCache = null
 	) {
 		$this->mountPoint = $parameters['mountPoint'];
 		$this->mount = $parameters['mount'];

--- a/lib/private/Group/Database.php
+++ b/lib/private/Group/Database.php
@@ -59,8 +59,8 @@ class Database extends \OC\Group\Backend {
 	 * @param \OCP\IConfig|null $config
 	 */
 	public function __construct(
-		\OCP\IDBConnection $dbConn = null,
-		\OCP\IConfig $config = null
+		?\OCP\IDBConnection $dbConn = null,
+		?\OCP\IConfig $config = null
 	) {
 		$this->dbConn = $dbConn;
 		$this->config = $config;

--- a/lib/private/Helper/UserTypeHelper.php
+++ b/lib/private/Helper/UserTypeHelper.php
@@ -28,7 +28,7 @@ class UserTypeHelper {
 	/** @var IConfig */
 	private $config;
 
-	public function __construct(IConfig $config = null) {
+	public function __construct(?IConfig $config = null) {
 		$this->config = $config;
 		if ($config === null) {
 			$this->config = \OC::$server->getConfig();

--- a/lib/private/HintException.php
+++ b/lib/private/HintException.php
@@ -28,7 +28,7 @@ namespace OC;
 class HintException extends \Exception {
 	private $hint;
 
-	public function __construct($message, $hint = '', $code = 0, \Exception $previous = null) {
+	public function __construct($message, $hint = '', $code = 0, ?\Exception $previous = null) {
 		$this->hint = $hint;
 		parent::__construct($message, $code, $previous);
 	}

--- a/lib/private/Hooks/Emitter.php
+++ b/lib/private/Hooks/Emitter.php
@@ -45,5 +45,5 @@ interface Emitter {
 	 * @param callable $callback optional
 	 * @return void
 	 */
-	public function removeListener($scope = null, $method = null, callable $callback = null);
+	public function removeListener($scope = null, $method = null, ?callable $callback = null);
 }

--- a/lib/private/Hooks/EmitterTrait.php
+++ b/lib/private/Hooks/EmitterTrait.php
@@ -48,7 +48,7 @@ trait EmitterTrait {
 	 * @param string $method optional
 	 * @param callable $callback optional
 	 */
-	public function removeListener($scope = null, $method = null, callable $callback = null) {
+	public function removeListener($scope = null, $method = null, ?callable $callback = null) {
 		$names = [];
 		$allNames = \array_keys($this->listeners);
 		if ($scope and $method) {

--- a/lib/private/IntegrityCheck/Checker.php
+++ b/lib/private/IntegrityCheck/Checker.php
@@ -80,9 +80,9 @@ class Checker {
 		EnvironmentHelper $environmentHelper,
 		FileAccessHelper $fileAccessHelper,
 		AppLocator $appLocator,
-		IConfig $config = null,
+		?IConfig $config = null,
 		ICacheFactory $cacheFactory,
-		IAppManager $appManager = null,
+		?IAppManager $appManager = null,
 		ITempManager $tempManager
 	) {
 		$this->environmentHelper = $environmentHelper;

--- a/lib/private/L10N/Factory.php
+++ b/lib/private/L10N/Factory.php
@@ -78,7 +78,7 @@ class Factory implements IFactory {
 		IConfig $config,
 		IRequest $request,
 		IThemeService $themeService,
-		IUserSession $userSession = null,
+		?IUserSession $userSession = null,
 		$serverRoot
 	) {
 		$this->config = $config;

--- a/lib/private/License/LicenseManager.php
+++ b/lib/private/License/LicenseManager.php
@@ -207,7 +207,7 @@ class LicenseManager implements ILicenseManager {
 		return $info[1];  // license state is the second item.
 	}
 
-	public function getLicenseMessageFor(string $appid, string $language = null): array {
+	public function getLicenseMessageFor(string $appid, ?string $language = null): array {
 		$info = $this->getLicenseWithState($appid);
 		if ($info[0] === null) {
 			// no license

--- a/lib/private/License/MessageService.php
+++ b/lib/private/License/MessageService.php
@@ -63,7 +63,7 @@ class MessageService {
 	 * "contains_html. Both "raw_message" and "translated_message" will contain an array with the texts that
 	 * should be displayed one text per line
 	 */
-	public function getMessageForLicense(array $info, string $language = null): array {
+	public function getMessageForLicense(array $info, ?string $language = null): array {
 		$l = $this->l10nFactory->get('core', $language);
 
 		// check if present

--- a/lib/private/Log.php
+++ b/lib/private/Log.php
@@ -129,9 +129,9 @@ class Log implements ILogger {
 	 */
 	public function __construct(
 		$logger = null,
-		SystemConfig $config = null,
+		?SystemConfig $config = null,
 		$normalizer = null,
-		EventDispatcherInterface $eventDispatcher = null
+		?EventDispatcherInterface $eventDispatcher = null
 	) {
 		// FIXME: Add this for backwards compatibility, should be fixed at some point probably
 		if ($config === null) {

--- a/lib/private/Migration/BackgroundRepair.php
+++ b/lib/private/Migration/BackgroundRepair.php
@@ -53,7 +53,7 @@ class BackgroundRepair extends TimedJob {
 	 * @param JobList $jobList
 	 * @param ILogger $logger
 	 */
-	public function execute($jobList, ILogger $logger = null) {
+	public function execute($jobList, ?ILogger $logger = null) {
 		// add an interval of 15 mins
 		$this->setInterval(15*60);
 

--- a/lib/private/NavigationManager.php
+++ b/lib/private/NavigationManager.php
@@ -56,12 +56,12 @@ class NavigationManager implements INavigationManager {
 	private $config;
 
 	public function __construct(
-		IAppManager $appManager = null,
-		IURLGenerator $urlGenerator = null,
-		IFactory $l10nFac = null,
-		IUserSession $userSession = null,
-		IGroupManager $groupManager = null,
-		IConfig $config = null
+		?IAppManager $appManager = null,
+		?IURLGenerator $urlGenerator = null,
+		?IFactory $l10nFac = null,
+		?IUserSession $userSession = null,
+		?IGroupManager $groupManager = null,
+		?IConfig $config = null
 	) {
 		$this->appManager = $appManager;
 		$this->urlGenerator = $urlGenerator;

--- a/lib/private/Preview.php
+++ b/lib/private/Preview.php
@@ -105,7 +105,7 @@ class Preview {
 	public function __construct(
 		$user = '',
 		$root = '/',
-		Node $file = null,
+		?Node $file = null,
 		$maxX = 1,
 		$maxY = 1,
 		$scalingUp = true,

--- a/lib/private/PreviewCleanup.php
+++ b/lib/private/PreviewCleanup.php
@@ -41,7 +41,7 @@ class PreviewCleanup {
 		$this->connection = $connection;
 	}
 
-	public function process(bool $all = false, int $chunkSize = 1000, \Closure $progress = null): int {
+	public function process(bool $all = false, int $chunkSize = 1000, ?\Closure $progress = null): int {
 		$root = \OC::$server->getLazyRootFolder();
 		$count = 0;
 

--- a/lib/private/Repair.php
+++ b/lib/private/Repair.php
@@ -69,7 +69,7 @@ class Repair implements IOutput {
 	 * @param IRepairStep[] $repairSteps array of RepairStep instances
 	 * @param EventDispatcherInterface $dispatcher
 	 */
-	public function __construct($repairSteps = [], EventDispatcherInterface $dispatcher = null) {
+	public function __construct($repairSteps = [], ?EventDispatcherInterface $dispatcher = null) {
 		$this->repairSteps = $repairSteps;
 		$this->dispatcher = $dispatcher;
 	}

--- a/lib/private/Security/CSRF/TokenStorage/SessionStorage.php
+++ b/lib/private/Security/CSRF/TokenStorage/SessionStorage.php
@@ -35,7 +35,7 @@ class SessionStorage {
 	/**
 	 * @param ISession $session
 	 */
-	public function __construct(ISession $session = null) {
+	public function __construct(?ISession $session = null) {
 		$this->session = $session;
 	}
 

--- a/lib/private/Security/SignedUrl/Verifier.php
+++ b/lib/private/Security/SignedUrl/Verifier.php
@@ -38,7 +38,7 @@ class Verifier {
 	 */
 	private $now;
 
-	public function __construct(RequestInterface $request, IConfig $config, \DateTime $now = null) {
+	public function __construct(RequestInterface $request, IConfig $config, ?\DateTime $now = null) {
 		$this->request = $request;
 		$this->config = $config;
 		$this->now = $now ?? new \DateTime();

--- a/lib/private/Server.php
+++ b/lib/private/Server.php
@@ -1709,7 +1709,7 @@ class Server extends ServerContainer implements IServerContainer, IServiceLoader
 	/**
 	 * @inheritdoc
 	 */
-	public function load(array $xmlPath, IUser $user = null) {
+	public function load(array $xmlPath, ?IUser $user = null) {
 		$appManager = $this->getAppManager();
 		$allApps = $appManager->getEnabledAppsForUser($user);
 

--- a/lib/private/Share/SearchResultSorter.php
+++ b/lib/private/Share/SearchResultSorter.php
@@ -38,7 +38,7 @@ class SearchResultSorter {
 	 * @param string $encoding optional, encoding to use, defaults to UTF-8
 	 * @param ILogger $log optional
 	 */
-	public function __construct($search, $key, ILogger $log = null, $encoding = 'UTF-8') {
+	public function __construct($search, $key, ?ILogger $log = null, $encoding = 'UTF-8') {
 		$this->encoding = $encoding;
 		$this->key = $key;
 		$this->log = $log;

--- a/lib/private/Share/Share.php
+++ b/lib/private/Share/Share.php
@@ -743,7 +743,7 @@ class Share extends Constants {
 	 * @throws \OC\HintException when the share type is remote and the shareWith is invalid
 	 * @throws \Exception
 	 */
-	public static function shareItem($itemType, $itemSource, $shareType, $shareWith, $permissions, $itemSourceName = null, \DateTime $expirationDate = null, $passwordChanged = null) {
+	public static function shareItem($itemType, $itemSource, $shareType, $shareWith, $permissions, $itemSourceName = null, ?\DateTime $expirationDate = null, $passwordChanged = null) {
 		$backend = self::getBackend($itemType);
 		$l = \OC::$server->getL10N('lib');
 
@@ -2333,7 +2333,7 @@ class Share extends Constants {
 		$parentFolder = null,
 		$token = null,
 		$itemSourceName = null,
-		\DateTime $expirationDate = null
+		?\DateTime $expirationDate = null
 	) {
 		$queriesToExecute = [];
 		$suggestedItemTarget = null;

--- a/lib/private/Share20/Manager.php
+++ b/lib/private/Share20/Manager.php
@@ -129,7 +129,7 @@ class Manager implements IManager {
 		View $view,
 		IDBConnection $connection,
 		ActivityIManager $activityManager,
-		IUserSession $userSession = null
+		?IUserSession $userSession = null
 	) {
 		$this->logger = $logger;
 		$this->config = $config;

--- a/lib/private/Updater.php
+++ b/lib/private/Updater.php
@@ -76,7 +76,7 @@ class Updater extends BasicEmitter {
 	public function __construct(
 		IConfig $config,
 		Checker $checker,
-		ILogger $log = null
+		?ILogger $log = null
 	) {
 		$this->log = $log;
 		$this->config = $config;

--- a/lib/private/User/Session.php
+++ b/lib/private/User/Session.php
@@ -172,7 +172,7 @@ class Session implements IUserSession, Emitter {
 	 * @param string $method optional
 	 * @param callable $callback optional
 	 */
-	public function removeListener($scope = null, $method = null, callable $callback = null) {
+	public function removeListener($scope = null, $method = null, ?callable $callback = null) {
 		$this->manager->removeListener($scope, $method, $callback);
 	}
 
@@ -937,7 +937,7 @@ class Session implements IUserSession, Emitter {
 	 * @return boolean True if the user can be authenticated, false otherwise
 	 * @throws LoginException if an app canceled the login process or the user is not enabled
 	 */
-	public function loginUser(IUser $user = null, $password = null, $authModuleClass = '') {
+	public function loginUser(?IUser $user = null, $password = null, $authModuleClass = '') {
 		if ($user === null) {
 			$this->emitFailedLogin(null);
 			return false;

--- a/lib/private/User/SyncService.php
+++ b/lib/private/User/SyncService.php
@@ -123,7 +123,7 @@ class SyncService {
 	 * @param \Traversable $userIds of users
 	 * @param \Closure $callback is called for every user to progress display
 	 */
-	public function run(UserInterface $backend, \Traversable $userIds, \Closure $callback = null) {
+	public function run(UserInterface $backend, \Traversable $userIds, ?\Closure $callback = null) {
 		// update existing and insert new users
 		foreach ($userIds as $uid) {
 			try {

--- a/lib/private/User/User.php
+++ b/lib/private/User/User.php
@@ -111,11 +111,11 @@ class User implements IUser {
 		Account $account,
 		AccountMapper $mapper,
 		$emitter = null,
-		IConfig $config = null,
+		?IConfig $config = null,
 		$urlGenerator = null,
-		EventDispatcher $eventDispatcher = null,
-		\OC\Group\Manager $groupManager = null,
-		Session $userSession = null
+		?EventDispatcher $eventDispatcher = null,
+		?\OC\Group\Manager $groupManager = null,
+		?Session $userSession = null
 	) {
 		$this->account = $account;
 		$this->mapper = $mapper;

--- a/lib/private/legacy/db.php
+++ b/lib/private/legacy/db.php
@@ -106,7 +106,7 @@ class OC_DB {
 	 * @return OC_DB_StatementWrapper
 	 * @throws \OC\DatabaseException
 	 */
-	public static function executeAudited($stmt, array $parameters = null) {
+	public static function executeAudited($stmt, ?array $parameters = null) {
 		if (\is_string($stmt)) {
 			// convert to an array with 'sql'
 			if (\stripos($stmt, 'LIMIT') !== false) { //OFFSET requires LIMIT, so we only need to check for LIMIT

--- a/lib/private/legacy/response.php
+++ b/lib/private/legacy/response.php
@@ -285,7 +285,7 @@ class OC_Response {
 	 *
 	 * @return array
 	 */
-	public static function setCorsHeaders($userId, $domain, \OCP\IConfig $config = null, array $headers = []) {
+	public static function setCorsHeaders($userId, $domain, ?\OCP\IConfig $config = null, array $headers = []) {
 		if ($config === null) {
 			$config = \OC::$server->getConfig();
 		}
@@ -331,7 +331,7 @@ class OC_Response {
 	 * @param \OCP\IConfig|null $config
 	 * @return Sabre\HTTP\ResponseInterface $response
 	 */
-	public static function setOptionsRequestHeaders($response, $headers = [], \OCP\IConfig $config = null) {
+	public static function setOptionsRequestHeaders($response, $headers = [], ?\OCP\IConfig $config = null) {
 		// TODO: infer allowed verbs from existing known routes
 		$allHeaders['Access-Control-Allow-Headers'] = self::getAllowedCorsHeaders($config);
 		$allHeaders['Access-Control-Allow-Origin'] = ['*'];
@@ -382,7 +382,7 @@ class OC_Response {
 	 * @param \OCP\IConfig $config
 	 * @return array|mixed
 	 */
-	private static function getAllowedCorsHeaders(\OCP\IConfig $config = null) {
+	private static function getAllowedCorsHeaders(?\OCP\IConfig $config = null) {
 		if ($config === null) {
 			$config = \OC::$server->getConfig();
 		}

--- a/lib/public/App/IAppManager.php
+++ b/lib/public/App/IAppManager.php
@@ -85,7 +85,7 @@ interface IAppManager {
 	 * @return string[]
 	 * @since 8.1.0
 	 */
-	public function getEnabledAppsForUser(IUser $user = null);
+	public function getEnabledAppsForUser(?IUser $user = null);
 
 	/**
 	 * List all installed apps

--- a/lib/public/App/IServiceLoader.php
+++ b/lib/public/App/IServiceLoader.php
@@ -46,5 +46,5 @@ interface IServiceLoader {
 	 * @return \Generator
 	 * @since 10.0.4
 	 */
-	public function load(array $xmlPath, IUser $user = null);
+	public function load(array $xmlPath, ?IUser $user = null);
 }

--- a/lib/public/App/ManagerEvent.php
+++ b/lib/public/App/ManagerEvent.php
@@ -49,7 +49,7 @@ class ManagerEvent extends Event {
 	 * @param \OCP\IGroup[] $groups
 	 * @since 9.0.0
 	 */
-	public function __construct($event, $appID, array $groups = null) {
+	public function __construct($event, $appID, ?array $groups = null) {
 		$this->event = $event;
 		$this->appID = $appID;
 		$this->groups = $groups;

--- a/lib/public/AppFramework/Http/Response.php
+++ b/lib/public/AppFramework/Http/Response.php
@@ -103,7 +103,7 @@ class Response {
 	 * @return $this
 	 * @since 8.0.0
 	 */
-	public function addCookie($name, $value, \DateTime $expireDate = null) {
+	public function addCookie($name, $value, ?\DateTime $expireDate = null) {
 		$this->cookies[$name] = ['value' => $value, 'expireDate' => $expireDate];
 		return $this;
 	}

--- a/lib/public/Authentication/Exceptions/AccountCheckException.php
+++ b/lib/public/Authentication/Exceptions/AccountCheckException.php
@@ -49,7 +49,7 @@ class AccountCheckException extends Exception {
 		RedirectResponse $redirectResponse,
 		$message = '',
 		$code = 0,
-		\Throwable $previous = null
+		?\Throwable $previous = null
 	) {
 		parent::__construct($message, $code, $previous);
 		$this->redirectResponse = $redirectResponse;

--- a/lib/public/BackgroundJob/IJob.php
+++ b/lib/public/BackgroundJob/IJob.php
@@ -38,7 +38,7 @@ interface IJob {
 	 * @param ILogger $logger
 	 * @since 7.0.0
 	 */
-	public function execute($jobList, ILogger $logger = null);
+	public function execute($jobList, ?ILogger $logger = null);
 
 	/**
 	 * @param int $id

--- a/lib/public/Comments/IComment.php
+++ b/lib/public/Comments/IComment.php
@@ -208,7 +208,7 @@ interface IComment {
 	 * @return IComment
 	 * @since 9.0.0
 	 */
-	public function setLatestChildDateTime(\DateTime $dateTime = null);
+	public function setLatestChildDateTime(?\DateTime $dateTime = null);
 
 	/**
 	 * returns the object type the comment is attached to

--- a/lib/public/Comments/ICommentsManager.php
+++ b/lib/public/Comments/ICommentsManager.php
@@ -111,7 +111,7 @@ interface ICommentsManager {
 		$objectId,
 		$limit = 0,
 		$offset = 0,
-		\DateTime $notOlderThan = null
+		?\DateTime $notOlderThan = null
 	);
 
 	/**
@@ -143,7 +143,7 @@ interface ICommentsManager {
 	 * @return Int
 	 * @since 9.0.0
 	 */
-	public function getNumberOfCommentsForObject($objectType, $objectId, \DateTime $notOlderThan = null);
+	public function getNumberOfCommentsForObject($objectType, $objectId, ?\DateTime $notOlderThan = null);
 
 	/**
 	 * creates a new comment and returns it. At this point of time, it is not

--- a/lib/public/DB.php
+++ b/lib/public/DB.php
@@ -72,7 +72,7 @@ class DB {
 	 * @since 5.0.0 - parameter $compare was added in 8.1.0
 	 *
 	 */
-	public static function insertIfNotExist($table, $input, array $compare = null) {
+	public static function insertIfNotExist($table, $input, ?array $compare = null) {
 		return \OC::$server->getDatabaseConnection()->insertIfNotExist($table, $input, $compare);
 	}
 

--- a/lib/public/Diagnostics/IQueryLogger.php
+++ b/lib/public/Diagnostics/IQueryLogger.php
@@ -42,7 +42,7 @@ interface IQueryLogger extends SQLLogger {
 	 * @param array $types
 	 * @since 8.0.0
 	 */
-	public function startQuery($sql, array $params = null, array $types = null);
+	public function startQuery($sql, ?array $params = null, ?array $types = null);
 
 	/**
 	 * Mark the end of the current active query. Ending query should store \OCP\Diagnostics\IQuery to

--- a/lib/public/Encryption/Exceptions/GenericEncryptionException.php
+++ b/lib/public/Encryption/Exceptions/GenericEncryptionException.php
@@ -40,7 +40,7 @@ class GenericEncryptionException extends HintException {
 	 * @param \Exception $previous
 	 * @since 8.1.0
 	 */
-	public function __construct($message = '', $hint = '', $code = 0, \Exception $previous = null) {
+	public function __construct($message = '', $hint = '', $code = 0, ?\Exception $previous = null) {
 		if (empty($message)) {
 			$message = 'Unspecified encryption exception';
 		}

--- a/lib/public/Files/External/InsufficientDataForMeaningfulAnswerException.php
+++ b/lib/public/Files/External/InsufficientDataForMeaningfulAnswerException.php
@@ -39,7 +39,7 @@ class InsufficientDataForMeaningfulAnswerException extends StorageNotAvailableEx
 	 * @param \Exception $previous
 	 * @since 6.0.0
 	 */
-	public function __construct($message = '', $code = self::STATUS_INDETERMINATE, \Exception $previous = null) {
+	public function __construct($message = '', $code = self::STATUS_INDETERMINATE, ?\Exception $previous = null) {
 		parent::__construct($message, $code, $previous);
 	}
 }

--- a/lib/public/Files/ForbiddenException.php
+++ b/lib/public/Files/ForbiddenException.php
@@ -39,7 +39,7 @@ class ForbiddenException extends \Exception {
 	 * @param \Exception $previous previous exception for cascading
 	 * @since 9.0.0
 	 */
-	public function __construct($message, $retry, \Exception $previous = null) {
+	public function __construct($message, $retry, ?\Exception $previous = null) {
 		parent::__construct($message, 0, $previous);
 		$this->retry = $retry;
 	}

--- a/lib/public/Files/LockNotAcquiredException.php
+++ b/lib/public/Files/LockNotAcquiredException.php
@@ -45,7 +45,7 @@ class LockNotAcquiredException extends \Exception {
 	/**
 	 * @since 7.0.0
 	 */
-	public function __construct($path, $lockType, $code = 0, \Exception $previous = null) {
+	public function __construct($path, $lockType, $code = 0, ?\Exception $previous = null) {
 		$message = \OC::$server->getL10N('lib')->t('Could not obtain lock type %d on "%s".', [$lockType, $path]);
 		parent::__construct($message, $code, $previous);
 		$this->path = $path;

--- a/lib/public/Files/StorageAuthException.php
+++ b/lib/public/Files/StorageAuthException.php
@@ -32,7 +32,7 @@ class StorageAuthException extends StorageNotAvailableException {
 	 * @param \Exception $previous
 	 * @since 9.0.0
 	 */
-	public function __construct($message = '', \Exception $previous = null) {
+	public function __construct($message = '', ?\Exception $previous = null) {
 		$l = \OC::$server->getL10N('lib');
 		parent::__construct($l->t('Storage unauthorized. %s', $message), self::STATUS_UNAUTHORIZED, $previous);
 	}

--- a/lib/public/Files/StorageBadConfigException.php
+++ b/lib/public/Files/StorageBadConfigException.php
@@ -32,7 +32,7 @@ class StorageBadConfigException extends StorageNotAvailableException {
 	 * @param \Exception $previous
 	 * @since 9.0.0
 	 */
-	public function __construct($message = '', \Exception $previous = null) {
+	public function __construct($message = '', ?\Exception $previous = null) {
 		$l = \OC::$server->getL10N('lib');
 		parent::__construct($l->t('Storage incomplete configuration. %s', $message), self::STATUS_INCOMPLETE_CONF, $previous);
 	}

--- a/lib/public/Files/StorageConnectionException.php
+++ b/lib/public/Files/StorageConnectionException.php
@@ -32,7 +32,7 @@ class StorageConnectionException extends StorageNotAvailableException {
 	 * @param \Exception $previous
 	 * @since 9.0.0
 	 */
-	public function __construct($message = '', \Exception $previous = null) {
+	public function __construct($message = '', ?\Exception $previous = null) {
 		$l = \OC::$server->getL10N('lib');
 		parent::__construct($l->t('Storage connection error. %s', $message), self::STATUS_NETWORK_ERROR, $previous);
 	}

--- a/lib/public/Files/StorageNotAvailableException.php
+++ b/lib/public/Files/StorageNotAvailableException.php
@@ -55,7 +55,7 @@ class StorageNotAvailableException extends HintException {
 	 * @param \Exception $previous
 	 * @since 6.0.0
 	 */
-	public function __construct($message = '', $code = self::STATUS_ERROR, \Exception $previous = null) {
+	public function __construct($message = '', $code = self::STATUS_ERROR, ?\Exception $previous = null) {
 		$l = \OC::$server->getL10N('lib');
 		parent::__construct($message, $l->t('Storage is temporarily not available'), $code, $previous);
 	}

--- a/lib/public/Files/StorageTimeoutException.php
+++ b/lib/public/Files/StorageTimeoutException.php
@@ -32,7 +32,7 @@ class StorageTimeoutException extends StorageNotAvailableException {
 	 * @param \Exception $previous
 	 * @since 9.0.0
 	 */
-	public function __construct($message = '', \Exception $previous = null) {
+	public function __construct($message = '', ?\Exception $previous = null) {
 		$l = \OC::$server->getL10N('lib');
 		parent::__construct($l->t('Storage connection timeout. %s', $message), self::STATUS_TIMEOUT, $previous);
 	}

--- a/lib/public/IDBConnection.php
+++ b/lib/public/IDBConnection.php
@@ -131,7 +131,7 @@ interface IDBConnection {
 	 * @throws \Doctrine\DBAL\DBALException
 	 * @since 6.0.0 - parameter $compare was added in 8.1.0, return type changed from boolean in 8.1.0
 	 */
-	public function insertIfNotExist($table, $input, array $compare = null);
+	public function insertIfNotExist($table, $input, ?array $compare = null);
 
 	/**
 	 * Attempt to update a row, else insert a new one
@@ -145,7 +145,7 @@ interface IDBConnection {
 	 * @throws \Doctrine\DBAL\DBALException
 	 * @since 10.0.3
 	 */
-	public function upsert($table, $input, array $compare = null);
+	public function upsert($table, $input, ?array $compare = null);
 
 	/**
 	 * Insert or update a row value

--- a/lib/public/IDateTimeFormatter.php
+++ b/lib/public/IDateTimeFormatter.php
@@ -44,7 +44,7 @@ interface IDateTimeFormatter {
 	 * @return string Formatted date string
 	 * @since 8.0.0
 	 */
-	public function formatDate($timestamp, $format = 'long', \DateTimeZone $timeZone = null, \OCP\IL10N $l = null);
+	public function formatDate($timestamp, $format = 'long', ?\DateTimeZone $timeZone = null, ?\OCP\IL10N $l = null);
 
 	/**
 	 * Formats the date of the given timestamp
@@ -62,7 +62,7 @@ interface IDateTimeFormatter {
 	 * @return string Formatted relative date string
 	 * @since 8.0.0
 	 */
-	public function formatDateRelativeDay($timestamp, $format = 'long', \DateTimeZone $timeZone = null, \OCP\IL10N $l = null);
+	public function formatDateRelativeDay($timestamp, $format = 'long', ?\DateTimeZone $timeZone = null, ?\OCP\IL10N $l = null);
 
 	/**
 	 * Gives the relative date of the timestamp
@@ -78,7 +78,7 @@ interface IDateTimeFormatter {
 	 * @return string Formatted date span
 	 * @since 8.0.0
 	 */
-	public function formatDateSpan($timestamp, $baseTimestamp = null, \OCP\IL10N $l = null);
+	public function formatDateSpan($timestamp, $baseTimestamp = null, ?\OCP\IL10N $l = null);
 
 	/**
 	 * Formats the time of the given timestamp
@@ -95,7 +95,7 @@ interface IDateTimeFormatter {
 	 * @return string Formatted time string
 	 * @since 8.0.0
 	 */
-	public function formatTime($timestamp, $format = 'medium', \DateTimeZone $timeZone = null, \OCP\IL10N $l = null);
+	public function formatTime($timestamp, $format = 'medium', ?\DateTimeZone $timeZone = null, ?\OCP\IL10N $l = null);
 
 	/**
 	 * Gives the relative past time of the timestamp
@@ -113,7 +113,7 @@ interface IDateTimeFormatter {
 	 * @return string Formatted time span
 	 * @since 8.0.0
 	 */
-	public function formatTimeSpan($timestamp, $baseTimestamp = null, \OCP\IL10N $l = null);
+	public function formatTimeSpan($timestamp, $baseTimestamp = null, ?\OCP\IL10N $l = null);
 
 	/**
 	 * Formats the date and time of the given timestamp
@@ -126,7 +126,7 @@ interface IDateTimeFormatter {
 	 * @return string Formatted date and time string
 	 * @since 8.0.0
 	 */
-	public function formatDateTime($timestamp, $formatDate = 'long', $formatTime = 'medium', \DateTimeZone $timeZone = null, \OCP\IL10N $l = null);
+	public function formatDateTime($timestamp, $formatDate = 'long', $formatTime = 'medium', ?\DateTimeZone $timeZone = null, ?\OCP\IL10N $l = null);
 
 	/**
 	 * Formats the date and time of the given timestamp
@@ -140,5 +140,5 @@ interface IDateTimeFormatter {
 	 * @return string Formatted relative date and time string
 	 * @since 8.0.0
 	 */
-	public function formatDateTimeRelativeDay($timestamp, $formatDate = 'long', $formatTime = 'medium', \DateTimeZone $timeZone = null, \OCP\IL10N $l = null);
+	public function formatDateTimeRelativeDay($timestamp, $formatDate = 'long', $formatTime = 'medium', ?\DateTimeZone $timeZone = null, ?\OCP\IL10N $l = null);
 }

--- a/lib/public/InvalidUserTokenException.php
+++ b/lib/public/InvalidUserTokenException.php
@@ -35,7 +35,7 @@ class InvalidUserTokenException extends UserTokenException {
 	 * @param int $code
 	 * @since 10.0.10
 	 */
-	public function __construct($message = "", $code = 0, \Exception $previous = null) {
+	public function __construct($message = "", $code = 0, ?\Exception $previous = null) {
 		parent::__construct($message, $code, $previous);
 	}
 }

--- a/lib/public/License/ILicenseManager.php
+++ b/lib/public/License/ILicenseManager.php
@@ -114,7 +114,7 @@ interface ILicenseManager {
 	 *   The lines start counting at 0
 	 *
 	 */
-	public function getLicenseMessageFor(string $appid, string $language = null): array;
+	public function getLicenseMessageFor(string $appid, ?string $language = null): array;
 
 	/**
 	 * @since 10.8.0

--- a/lib/public/Lock/LockedException.php
+++ b/lib/public/Lock/LockedException.php
@@ -45,7 +45,7 @@ class LockedException extends \Exception {
 	 *
 	 * @since 8.1.0
 	 */
-	public function __construct($path, \Exception $previous = null) {
+	public function __construct($path, ?\Exception $previous = null) {
 		$message = \OC::$server->getL10N('lib')->t('"%s" is locked', $path);
 		parent::__construct($message, 0, $previous);
 		$this->path = $path;

--- a/lib/public/Share.php
+++ b/lib/public/Share.php
@@ -288,7 +288,7 @@ class Share extends \OC\Share\Constants {
 	 * @throws \Exception
 	 * @since 5.0.0 - parameter $itemSourceName was added in 6.0.0, parameter $expirationDate was added in 7.0.0, parameter $passwordChanged added in 9.0.0
 	 */
-	public static function shareItem($itemType, $itemSource, $shareType, $shareWith, $permissions, $itemSourceName = null, \DateTime $expirationDate = null, $passwordChanged = null) {
+	public static function shareItem($itemType, $itemSource, $shareType, $shareWith, $permissions, $itemSourceName = null, ?\DateTime $expirationDate = null, $passwordChanged = null) {
 		return \OC\Share\Share::shareItem($itemType, $itemSource, $shareType, $shareWith, $permissions, $itemSourceName, $expirationDate, $passwordChanged);
 	}
 

--- a/lib/public/Share/Exceptions/GenericShareException.php
+++ b/lib/public/Share/Exceptions/GenericShareException.php
@@ -36,7 +36,7 @@ class GenericShareException extends HintException {
 	 * @param \Exception $previous
 	 * @since 9.0.0
 	 */
-	public function __construct($message = '', $hint = '', $code = 0, \Exception $previous = null) {
+	public function __construct($message = '', $hint = '', $code = 0, ?\Exception $previous = null) {
 		if (empty($message)) {
 			$message = 'Unspecified share exception';
 		}

--- a/lib/public/Share/Exceptions/TransferSharesException.php
+++ b/lib/public/Share/Exceptions/TransferSharesException.php
@@ -36,7 +36,7 @@ class TransferSharesException extends GenericShareException {
 	 * @param \Exception|null $previous
 	 * @since 10.0.9
 	 */
-	public function __construct($message = '', $hint = '', $code = 0, \Exception $previous = null) {
+	public function __construct($message = '', $hint = '', $code = 0, ?\Exception $previous = null) {
 		parent::__construct($message, $hint, $code, $previous);
 	}
 }

--- a/lib/public/SystemTag/ManagerEvent.php
+++ b/lib/public/SystemTag/ManagerEvent.php
@@ -49,7 +49,7 @@ class ManagerEvent extends Event {
 	 * @param ISystemTag $beforeTag
 	 * @since 9.0.0
 	 */
-	public function __construct($event, ISystemTag $tag, ISystemTag $beforeTag = null) {
+	public function __construct($event, ISystemTag $tag, ?ISystemTag $beforeTag = null) {
 		$this->event = $event;
 		$this->tag = $tag;
 		$this->beforeTag = $beforeTag;

--- a/lib/public/SystemTag/TagNotFoundException.php
+++ b/lib/public/SystemTag/TagNotFoundException.php
@@ -40,7 +40,7 @@ class TagNotFoundException extends \RuntimeException {
 	 * @param string[] $tags
 	 * @since 9.0.0
 	 */
-	public function __construct($message = '', $code = 0, \Exception $previous = null, array $tags = []) {
+	public function __construct($message = '', $code = 0, ?\Exception $previous = null, array $tags = []) {
 		parent::__construct($message, $code, $previous);
 		$this->tags = $tags;
 	}

--- a/lib/public/User/NotPermittedActionException.php
+++ b/lib/public/User/NotPermittedActionException.php
@@ -36,7 +36,7 @@ class NotPermittedActionException extends \Exception {
 	 * @param \Exception|null $previous
 	 * @since 10.11.0
 	 */
-	public function __construct($message = "", $code = 0, \Exception $previous = null) {
+	public function __construct($message = "", $code = 0, ?\Exception $previous = null) {
 		parent::__construct($message, $code, $previous);
 	}
 }

--- a/lib/public/UserTokenException.php
+++ b/lib/public/UserTokenException.php
@@ -36,7 +36,7 @@ class UserTokenException extends \Exception {
 	 * @param \Exception|null $previous
 	 * @since 10.0.10
 	 */
-	public function __construct($message = "", $code = 0, \Exception $previous = null) {
+	public function __construct($message = "", $code = 0, ?\Exception $previous = null) {
 		parent::__construct($message, $code, $previous);
 	}
 }

--- a/lib/public/UserTokenExpiredException.php
+++ b/lib/public/UserTokenExpiredException.php
@@ -38,7 +38,7 @@ class UserTokenExpiredException extends UserTokenException {
 	 * @param int $code
 	 * @since 10.0.10
 	 */
-	public function __construct($message = "", $code = 0, \Exception $previous = null) {
+	public function __construct($message = "", $code = 0, ?\Exception $previous = null) {
 		parent::__construct($message, $code, $previous);
 	}
 }

--- a/lib/public/UserTokenMismatchException.php
+++ b/lib/public/UserTokenMismatchException.php
@@ -35,7 +35,7 @@ class UserTokenMismatchException extends UserTokenException {
 	 * @param int $code
 	 * @since 10.0.10
 	 */
-	public function __construct($message = "", $code = 0, \Exception $previous = null) {
+	public function __construct($message = "", $code = 0, ?\Exception $previous = null) {
 		parent::__construct($message, $code, $previous);
 	}
 }

--- a/settings/Controller/UsersController.php
+++ b/settings/Controller/UsersController.php
@@ -170,7 +170,7 @@ class UsersController extends Controller {
 	 * @param IGroup[]|null $userGroups
 	 * @return array
 	 */
-	private function formatUserForIndex(IUser $user, array $userGroups = null) {
+	private function formatUserForIndex(IUser $user, ?array $userGroups = null) {
 		// TODO: eliminate this encryption specific code below and somehow
 		// hook in additional user info from other apps
 

--- a/settings/Panels/Admin/Certificates.php
+++ b/settings/Panels/Admin/Certificates.php
@@ -38,7 +38,7 @@ class Certificates implements ISettings {
 	public function __construct(
 		IConfig $config,
 		IURLGenerator $urlGenerator,
-		ICertificateManager $certificateManager = null
+		?ICertificateManager $certificateManager = null
 	) {
 		$this->config = $config;
 		$this->urlGenerator = $urlGenerator;

--- a/tests/TestHelpers/SharingHelper.php
+++ b/tests/TestHelpers/SharingHelper.php
@@ -100,7 +100,7 @@ class SharingHelper {
 		string $xRequestId = '',
 		?string $shareWith = null,
 		?bool	$publicUpload = false,
-		string $sharePassword = null,
+		?string $sharePassword = null,
 		$permissions = null,
 		?string  $linkName = null,
 		?string $expireDate = null,

--- a/tests/acceptance/features/bootstrap/CommentsContext.php
+++ b/tests/acceptance/features/bootstrap/CommentsContext.php
@@ -270,7 +270,7 @@ class CommentsContext implements Context {
 	 * @return void
 	 * @throws Exception
 	 */
-	public function userHasDeletedLastComment(string $user = null):void {
+	public function userHasDeletedLastComment(?string $user = null):void {
 		$this->userDeletesLastComment($user);
 		$this->featureContext->theHTTPStatusCodeShouldBe("204");
 	}

--- a/tests/acceptance/features/bootstrap/FeatureContext.php
+++ b/tests/acceptance/features/bootstrap/FeatureContext.php
@@ -1498,7 +1498,7 @@ class FeatureContext extends BehatVariablesContext {
 	 *
 	 * @return object
 	 */
-	public function getJsonDecodedResponseBodyContent(ResponseInterface $response = null):?object {
+	public function getJsonDecodedResponseBodyContent(?ResponseInterface $response = null):?object {
 		$response = $response ?? $this->response;
 		if ($response !== null) {
 			$response->getBody()->rewind();

--- a/tests/acceptance/features/bootstrap/PublicWebDavContext.php
+++ b/tests/acceptance/features/bootstrap/PublicWebDavContext.php
@@ -1135,7 +1135,7 @@ class PublicWebDavContext implements Context {
 	 */
 	public function publiclyUploadingShouldNotWork(
 		string $publicWebDAVAPIVersion,
-		string $expectedHttpCode = null
+		?string $expectedHttpCode = null
 	):void {
 		if ($publicWebDAVAPIVersion === "new") {
 			$techPreviewHadToBeEnabled = $this->occContext->enableDAVTechPreview();

--- a/tests/acceptance/features/bootstrap/SearchContext.php
+++ b/tests/acceptance/features/bootstrap/SearchContext.php
@@ -51,7 +51,7 @@ class SearchContext implements Context {
 		string    $user,
 		string  $pattern,
 		?string	  $limit = null,
-		TableNode $properties = null
+		?TableNode $properties = null
 	):void {
 		$user = $this->featureContext->getActualUsername($user);
 		$baseUrl = $this->featureContext->getBaseUrl();

--- a/tests/acceptance/features/bootstrap/Sharing.php
+++ b/tests/acceptance/features/bootstrap/Sharing.php
@@ -457,7 +457,7 @@ trait Sharing {
 		string $user,
 		string $path,
 		bool $publicUpload = false,
-		string $sharePassword = null,
+		?string $sharePassword = null,
 		$permissions = null,
 		?string $linkName = null,
 		?string $expireDate = null
@@ -1885,7 +1885,7 @@ trait Sharing {
 	 *
 	 * @return void
 	 */
-	public function deleteLastShareUsingSharingApi(string $user, string $sharer = null, bool $deleteLastPublicLink = false):void {
+	public function deleteLastShareUsingSharingApi(string $user, ?string $sharer = null, bool $deleteLastPublicLink = false):void {
 		$user = $this->getActualUsername($user);
 		if ($deleteLastPublicLink) {
 			$shareId = (string) $this->getLastCreatedPublicShare()->id;
@@ -3703,7 +3703,7 @@ trait Sharing {
 	 * @return void
 	 * @throws GuzzleException
 	 */
-	public function expireShare(string $shareId = null):void {
+	public function expireShare(?string $shareId = null):void {
 		$adminUser = $this->getAdminUsername();
 		if ($shareId === null) {
 			$shareId = $this->getLastCreatedUserGroupShareId();

--- a/tests/acceptance/features/bootstrap/TUSContext.php
+++ b/tests/acceptance/features/bootstrap/TUSContext.php
@@ -155,7 +155,7 @@ class TUSContext implements Context {
 		string $destination,
 		array $uploadMetadata = [],
 		int $noOfChunks = 1,
-		int $bytes = null,
+		?int $bytes = null,
 		string $checksum = ''
 	):void {
 		$user = $this->featureContext->getActualUsername($user);

--- a/tests/acceptance/features/bootstrap/WebUIFilesContext.php
+++ b/tests/acceptance/features/bootstrap/WebUIFilesContext.php
@@ -1482,7 +1482,7 @@ class WebUIFilesContext extends RawMinkContext implements Context {
 		string $typeOfFilesPage = "",
 		string $folder = "",
 		string $path = "",
-		FilesPageBasic $pageObject = null
+		?FilesPageBasic $pageObject = null
 	) {
 		$should = ($shouldOrNot !== "not");
 		switch ($typeOfFilesPage) {
@@ -1676,7 +1676,7 @@ class WebUIFilesContext extends RawMinkContext implements Context {
 		string $shouldOrNot,
 		string $typeOfFilesPage,
 		string $folder = "",
-		TableNode $namePartsTable = null
+		?TableNode $namePartsTable = null
 	):void {
 		$fileNameParts = [];
 

--- a/tests/acceptance/features/bootstrap/WebUIGeneralContext.php
+++ b/tests/acceptance/features/bootstrap/WebUIGeneralContext.php
@@ -363,7 +363,7 @@ class WebUIGeneralContext extends RawMinkContext implements Context {
 	 */
 	public function dialogsShouldBeDisplayedOnTheWebUI(
 		$count = null,
-		TableNode $table = null
+		?TableNode $table = null
 	):void {
 		$dialogs = $this->owncloudPage->getOcDialogs();
 		//check if the correct number of dialogs are open

--- a/tests/acceptance/features/bootstrap/WebUIUsersContext.php
+++ b/tests/acceptance/features/bootstrap/WebUIUsersContext.php
@@ -211,7 +211,7 @@ class WebUIUsersContext extends RawMinkContext implements Context {
 		string $attemptTo,
 		string $username,
 		?string $email,
-		TableNode $groupsTable = null
+		?TableNode $groupsTable = null
 	):void {
 		$this->theAdminCreatesAUserUsingTheWebUI(
 			$attemptTo,

--- a/tests/acceptance/features/lib/FilesPage.php
+++ b/tests/acceptance/features/lib/FilesPage.php
@@ -149,7 +149,7 @@ class FilesPage extends FilesPageBasic {
 	 */
 	public function createFolder(
 		Session $session,
-		string  $name = null,
+		?string  $name = null,
 		int $timeoutMsec = STANDARD_UI_WAIT_TIMEOUT_MILLISEC,
 		bool $useCreateButton = false
 	): string {

--- a/tests/lib/Comments/FakeManager.php
+++ b/tests/lib/Comments/FakeManager.php
@@ -17,11 +17,11 @@ class FakeManager implements \OCP\Comments\ICommentsManager {
 		$objectId,
 		$limit = 0,
 		$offset = 0,
-		\DateTime $notOlderThan = null
+		?\DateTime $notOlderThan = null
 	) {
 	}
 
-	public function getNumberOfCommentsForObject($objectType, $objectId, \DateTime $notOlderThan = null) {
+	public function getNumberOfCommentsForObject($objectType, $objectId, ?\DateTime $notOlderThan = null) {
 	}
 
 	public function create($actorType, $actorId, $objectType, $objectId) {

--- a/tests/lib/Files/Storage/FileTest.php
+++ b/tests/lib/Files/Storage/FileTest.php
@@ -34,7 +34,7 @@ class FileTest extends NodeTest {
 	 * @param IStorage|\PHPUnit\Framework\MockObject\MockObject|null $storage
 	 * @return File
 	 */
-	protected function createTestNode($path, IStorage $storage = null) {
+	protected function createTestNode($path, ?IStorage $storage = null) {
 		if ($storage === null) {
 			$storage = $this->storage;
 		}

--- a/tests/lib/Files/Storage/FolderTest.php
+++ b/tests/lib/Files/Storage/FolderTest.php
@@ -36,7 +36,7 @@ class FolderTest extends NodeTest {
 	 * @param IStorage|\PHPUnit\Framework\MockObject\MockObject|null $storage
 	 * @return Folder
 	 */
-	protected function createTestNode($path, IStorage $storage = null) {
+	protected function createTestNode($path, ?IStorage $storage = null) {
 		if ($storage === null) {
 			$storage = $this->storage;
 		}

--- a/tests/lib/Files/Storage/NodeTest.php
+++ b/tests/lib/Files/Storage/NodeTest.php
@@ -52,7 +52,7 @@ abstract class NodeTest extends TestCase {
 	 * @param IStorage $storage
 	 * @return Node
 	 */
-	abstract protected function createTestNode($path, IStorage $storage = null);
+	abstract protected function createTestNode($path, ?IStorage $storage = null);
 
 	public function testGetMimetype() {
 		$this->storage->expects($this->once())

--- a/tests/lib/TempManagerTest.php
+++ b/tests/lib/TempManagerTest.php
@@ -40,7 +40,7 @@ class TempManagerTest extends TestCase {
 		parent::tearDown();
 	}
 
-	protected function getManager(\OCP\ILogger $logger = null, IConfig $config = null): \OC\TempManager {
+	protected function getManager(?\OCP\ILogger $logger = null, ?IConfig $config = null): \OC\TempManager {
 		if (!$logger) {
 			$logger = new NullLogger();
 		}

--- a/tests/lib/Traits/AssertQueryCountTrait.php
+++ b/tests/lib/Traits/AssertQueryCountTrait.php
@@ -10,7 +10,7 @@ use function PHPUnit\Framework\assertTrue;
 
 trait AssertQueryCountTrait {
 	private static bool $trackingStarted = false;
-	public function assertNoQueriesExecuted(Closure $closure = null): void {
+	public function assertNoQueriesExecuted(?Closure $closure = null): void {
 		if ($closure) {
 			self::trackQueries();
 
@@ -25,7 +25,7 @@ trait AssertQueryCountTrait {
 		}
 	}
 
-	public function assertQueryCountMatches(int $count, Closure $closure = null): void {
+	public function assertQueryCountMatches(int $count, ?Closure $closure = null): void {
 		if ($closure) {
 			self::trackQueries();
 
@@ -40,7 +40,7 @@ trait AssertQueryCountTrait {
 		}
 	}
 
-	public function assertQueryCountLessThan(int $count, Closure $closure = null): void {
+	public function assertQueryCountLessThan(int $count, ?Closure $closure = null): void {
 		if ($closure) {
 			self::trackQueries();
 
@@ -55,7 +55,7 @@ trait AssertQueryCountTrait {
 		}
 	}
 
-	public function assertQueryCountGreaterThan(int $count, Closure $closure = null): void {
+	public function assertQueryCountGreaterThan(int $count, ?Closure $closure = null): void {
 		if ($closure) {
 			self::trackQueries();
 


### PR DESCRIPTION
## Description

It fixes an incompatibility with PHP 8.4. The code still can't run on 8.x out of the box, but that that change is cross-version compatible and you won't see that deprecation when you eventually upgrade.

RFC: https://wiki.php.net/rfc/deprecate-implicitly-nullable-types
Proposed fix: `?T`
Can be auto-fixed with `PHP_CodeSniffer` using the sniff `SlevomatCodingStandard.TypeHints.NullableTypeForNullDefaultValue`
Result: `A TOTAL OF 281 ERRORS WERE FIXED IN 172 FILES`.
I manually reviewed each change, especially where FQN is involved (`?\DateTime`).

## Motivation and Context

I stumbled upon this issue as part of my work on PHPCompatibility. Since I already did the work and reviewed the fix, it made sense to open a PR and not waste the effort.

## How Has This Been Tested?

- Ran `phpcbf` with the `SlevomatCodingStandard.TypeHints.NullableTypeForNullDefaultValue`
- Running `phpcs` again no longer flags this issue.
- I will rely on the remote CI to confirm this doesn't negatively interact with other static analysis tools, and that tests still pass (sniff auto-fixers are designed to make safe changes).

## Checklist:

- [x] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 
- [ ] Changelog item, see [TEMPLATE](https://github.com/owncloud/core/blob/master/changelog/TEMPLATE)

Notes about the checklist:
- No new tests are required. This simply makes code future-proof.
- No documentation or changelog is required, since there's no impact on existing behavior and no new feature was added. Dependency bumps also do not ship with any of these.
