### PR TITLE
fix: federation token exchange

### DIFF
--- a/apps/federation/lib/Controller/OCSAuthAPIController.php
+++ b/apps/federation/lib/Controller/OCSAuthAPIController.php
@@ -26,6 +26,7 @@
 
 namespace OCA\Federation\Controller;
 
+use Exception;
 use OCA\Federation\DbHandler;
 use OCA\Federation\TrustedServers;
 use OCP\AppFramework\Http;
@@ -170,8 +171,21 @@ class OCSAuthAPIController extends OCSController {
 			'data' => ['sharedSecret' => $sharedSecret]];
 	}
 
-	protected function isValidToken($url, $token) {
+	/**
+	 * @note method is public for testing purposes
+	 * @param string|null $url
+	 * @param string|null $token
+	 * @return bool
+	 * @throws Exception
+	 */
+	public function isValidToken(?string $url, ?string $token): bool {
+		if ($token === '' || $token === null) {
+			return false;
+		}
 		$storedToken = $this->dbHandler->getToken($url);
+		if ($storedToken === '' || $storedToken === null) {
+			return false;
+		}
 		return \hash_equals($storedToken, $token);
 	}
 }

--- a/apps/federation/tests/API/OCSAuthAPITest.php
+++ b/apps/federation/tests/API/OCSAuthAPITest.php
@@ -182,4 +182,40 @@ class OCSAuthAPITest extends TestCase {
 			[false, false, Http::STATUS_FORBIDDEN],
 		];
 	}
+
+	/**
+	 * @dataProvider dataTestIsTokenValid
+	 */
+	public function testIsTokenValid($storedToken, $requestToken): void {
+		$url = 'url';
+
+		/** @var OCSAuthAPIController | \PHPUnit\Framework\MockObject\MockObject $ocsAuthApi */
+		$ocsAuthApi = $this->getMockBuilder(OCSAuthAPIController::class)
+			->setConstructorArgs(
+				[
+					'federation',
+					$this->request,
+					$this->secureRandom,
+					$this->jobList,
+					$this->trustedServers,
+					$this->dbHandler,
+					$this->logger
+				]
+			)->getMock();
+
+		$this->dbHandler
+			->method('getToken')->willReturn($storedToken);
+
+		$result = $ocsAuthApi->isValidToken($url, $requestToken);
+		$this->assertFalse($result);
+	}
+
+	public function dataTestIsTokenValid(): \Generator {
+		yield 'no match' => ['xxx', 'yyy'];
+		yield 'empty token stored' => ['', 'yyy'];
+		yield 'null token stored' => [null, 'yyy'];
+		yield 'empty token requested' => ['xxx', ''];
+		yield 'null token requested' => ['xxx', null];
+	}
+
 }

--- a/changelog/unreleased/41434
+++ b/changelog/unreleased/41434
@@ -1,0 +1,5 @@
+Bugfix: Disallow empty tokens when pairing trusted servers
+
+An empty token could be used to pair trusted servers, which is not secure.
+
+https://github.com/owncloud/core/pull/41434


### PR DESCRIPTION
## Description
Bugfix: Disallow empty tokens when pairing trusted servers

An empty token could be used to pair trusted servers, which is not secure.

## How Has This Been Tested?
- :robot: 

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Database schema changes (next release will require increase of minor version instead of patch)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [ ] Tests only (no source changes)

## Checklist:
<!-- Tick the checkboxes when done. -->
<!-- Raise documentation ticket in https://github.com/owncloud/documentation -->
- [x] Code changes
- [x] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 
- [ ] Changelog item, see [TEMPLATE](https://github.com/owncloud/core/blob/master/changelog/TEMPLATE)
