### PR TITLE
fix: FS might have been wrongly initialized during authentication

### DIFF
--- a/apps/dav/appinfo/v1/publicwebdav.php
+++ b/apps/dav/appinfo/v1/publicwebdav.php
@@ -39,9 +39,9 @@ use OCP\Files\NotFoundException;
 use Sabre\DAV\Exception\NotAuthenticated;
 use Sabre\DAV\Exception\NotFound;
 
-$RUNTIME_APPTYPES = ['filesystem', 'authentication', 'logging'];
-
-OC_App::loadApps($RUNTIME_APPTYPES);
+OC_App::loadApps(['authentication']);
+OC_Util::tearDownFS();  // FS might have been prematurely initialized
+OC_App::loadApps(['filesystem', 'logging']);
 
 OC_Util::obEnd();
 \OC::$server->getSession()->close();

--- a/lib/kernel.php
+++ b/lib/kernel.php
@@ -886,6 +886,7 @@ class OC {
 		if (!self::checkUpgrade(false)
 			&& !$systemConfig->getValue('maintenance', false)) {
 			// For logged-in users: Load everything
+			OC_Util::tearDownFS();  // FS might have been prematurely initialized
 			$userSession = \OC::$server->getUserSession();
 			if ($userSession->isLoggedIn() && $userSession->verifyAuthHeaders($request)) {
 				OC_App::loadApps();

--- a/ocs/v1.php
+++ b/ocs/v1.php
@@ -54,6 +54,7 @@ if (\OCP\Util::needUpgrade()
 try {
 	OC_App::loadApps(['session']);
 	OC_App::loadApps(['authentication']);
+	OC_Util::tearDownFS();  // FS might have been prematurely initialized
 	// load all apps to get all api routes properly setup
 	OC_App::loadApps();
 

--- a/public.php
+++ b/public.php
@@ -63,6 +63,7 @@ try {
 	// Load all required applications
 	\OC::$REQUESTEDAPP = $app;
 	OC_App::loadApps(['authentication']);
+	OC_Util::tearDownFS();  // FS might have been prematurely initialized
 	OC_App::loadApps(['filesystem', 'logging']);
 
 	if (!\OC::$server->getAppManager()->isInstalled($app)) {

--- a/remote.php
+++ b/remote.php
@@ -159,6 +159,7 @@ try {
 	// Load all required applications
 	\OC::$REQUESTEDAPP = $app;
 	OC_App::loadApps(['authentication']);
+	OC_Util::tearDownFS();  // FS might have been prematurely initialized
 	OC_App::loadApps(['filesystem', 'logging']);
 
 	switch ($app) {


### PR DESCRIPTION
<!--
Thanks for submitting a change to ownCloud!

This is the bug tracker for the Server component. Find other components at https://github.com/owncloud/core/blob/master/.github/CONTRIBUTING.md#guidelines

For fixing potential security issues please see https://owncloud.com/security/

To make it possible for us to get your change reviewed and merged please carefully fill out the requested information below.

Please note that any kind of change needs first be submitted to the master branch which holds the next version of ownCloud.

Please set the following labels:

- Set label "3 - To review" for review or "2 - Development" if the PR still has open tasks
- Assignment: assign to self
- Milestone: set the same as the ticket this PR fixes, or "development" by default
- Reviewers: pick at least one
-->

## Description
Some authentication apps such as openidconnect might initialize the FS for the user too soon, before apps such as user_ldap have been loaded. This might lead to situations where the FS is wrongly initialized because ownCloud can't verify that the user belongs to certain LDAP groups; groups shares might be missing because ownCloud can't verify the user is member of those groups.

This PR tears down the FS preemptively before loading the FS apps, so the FS can be loaded correctly.

## Related Issue
https://github.com/owncloud/enterprise/issues/7432

## Motivation and Context
LDAP groups shares might not be available to the user.

## How Has This Been Tested?
Manually tested based on the related issue. It needs the openidconnect app without autoprovision, and the user_ldap app connected to the same LDAP server as the openidconnect app.

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Database schema changes (next release will require increase of minor version instead of patch)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [ ] Tests only (no source changes)

## Checklist:
<!-- Tick the checkboxes when done. -->
<!-- Raise documentation ticket in https://github.com/owncloud/documentation -->
- [x] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 
- [ ] Changelog item, see [TEMPLATE](https://github.com/owncloud/core/blob/master/changelog/TEMPLATE)
