### PR TITLE
docs: add changelog item on dropped classes and methods

### DIFF
--- a/changelog/unreleased/PHPRemovedCodeOC11
+++ b/changelog/unreleased/PHPRemovedCodeOC11
@@ -1,0 +1,20 @@
+Change: Removed legacy and deprecated code from ownCloud 11
+
+The following have been removed:
+- class OC_DB
+- class OC_DB_StatementWrapper
+- class OC_Group_Backend
+- class OC_Group_Database
+- class OC_OCS_Result
+- class \OCP\DB
+- class MDBSchemaWriter
+- interface OC_Group_Interface
+- interface OC_User_Interface
+- method MDB2SchemaManager::getDbStructure()
+- method MDB2SchemaManager::generateChangeScript()
+
+https://github.com/owncloud/core/pull/41455
+https://github.com/owncloud/core/pull/41458
+https://github.com/owncloud/core/pull/41462
+https://github.com/owncloud/core/pull/41464
+https://github.com/owncloud/core/pull/41468


### PR DESCRIPTION
## Description
Change: Removed legacy and deprecated code from ownCloud 11.

The following have been removed:
- class OC_DB
- class OC_DB_StatementWrapper
- class OC_Group_Backend
- class OC_Group_Database
- class OC_OCS_Result
- class \OCP\DB
- class MDBSchemaWriter
- interface OC_Group_Interface
- interface OC_User_Interface
- method MDB2SchemaManager::getDbStructure()
- method MDB2SchemaManager::generateChangeScript()

https://github.com/owncloud/core/pull/41455
https://github.com/owncloud/core/pull/41458
https://github.com/owncloud/core/pull/41462
https://github.com/owncloud/core/pull/41464
https://github.com/owncloud/core/pull/41468

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Database schema changes (next release will require increase of minor version instead of patch)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [ ] Tests only (no source changes)

## Checklist:
<!-- Tick the checkboxes when done. -->
<!-- Raise documentation ticket in https://github.com/owncloud/documentation -->
- [ ] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 
- [x] Changelog item, see [TEMPLATE](https://github.com/owncloud/core/blob/master/changelog/TEMPLATE)
