### PR TITLE
fix: call fclose() only on resource

### DIFF
--- a/lib/private/Files/Storage/Wrapper/Encryption.php
+++ b/lib/private/Files/Storage/Wrapper/Encryption.php
@@ -855,8 +855,12 @@ class Encryption extends Wrapper {
 				\fclose($target);
 			} catch (\Exception $e) {
 				Encryption::setDisableWriteEncryption(false);
-				\fclose($source);
-				\fclose($target);
+				if (\is_resource($source)) {
+					\fclose($source);
+				}
+				if (\is_resource($target)) {
+					\fclose($target);
+				}
 				throw $e;
 			}
 			if ($result) {


### PR DESCRIPTION
## Description
seen in acceptance tests of encryption app:
```
The command was not successful, exit code was 1.
      stdOut was: 'Decryption started
      
      prepare encryption modules...
       done.
      
      
      An unhandled exception has been thrown:
      TypeError: fclose(): Argument #1 ($stream) must be of type resource, string given in /var/www/owncloud/server/lib/private/Files/Storage/Wrapper/Encryption.php:858
      Stack trace:
      #0 /var/www/owncloud/server/lib/private/Files/Storage/Wrapper/Encryption.php(858): fclose()
      #1 /var/www/owncloud/server/lib/private/Files/Storage/Wrapper/Encryption.php(727): OC\Files\Storage\Wrapper\Encryption->copyBetweenStorage()
      #2 /var/www/owncloud/server/lib/private/Files/Storage/Wrapper/Encryption.php(395): OC\Files\Storage\Wrapper\Encryption->copyFromStorage()
      #3 /var/www/owncloud/server/lib/private/Files/Storage/Wrapper/Wrapper.php(291): OC\Files\Storage\Wrapper\Encryption->copy()
      #4 /var/www/owncloud/server/lib/private/Files/Storage/Wrapper/Wrapper.php(291): OC\Files\Storage\Wrapper\Wrapper->copy()
      #5 /var/www/owncloud/server/lib/private/Files/View.php(986): OC\Files\Storage\Wrapper\Wrapper->copy()
      #6 /var/www/owncloud/server/lib/public/Events/EventEmitterTrait.php(50): OC\Files\View->OC\Files\{closure}()
      #7 /var/www/owncloud/server/lib/private/Files/View.php(939): OC\Files\View->emittingCall()
      #8 /var/www/owncloud/server/lib/private/Encryption/DecryptAll.php(271): OC\Files\View->copy()
      #9 /var/www/owncloud/server/lib/private/Encryption/DecryptAll.php(238): OC\Encryption\DecryptAll->decryptFile()
      #10 /var/www/owncloud/server/lib/private/Encryption/DecryptAll.php(179): OC\Encryption\DecryptAll->decryptUsersFiles()
      #11 /var/www/owncloud/server/lib/private/User/Manager.php(492): OC\Encryption\DecryptAll->OC\Encryption\{closure}()
      #12 /var/www/owncloud/server/lib/private/User/AccountMapper.php(249): OC\User\Manager->OC\User\{closure}()
      #13 /var/www/owncloud/server/lib/private/User/Manager.php(490): OC\User\AccountMapper->callForUsers()
      #14 /var/www/owncloud/server/lib/private/User/Manager.php(459): OC\User\Manager->callForUsers()
      #15 /var/www/owncloud/server/lib/private/User/Manager.php(477): OC\User\Manager->callForAllUsers()
      #16 /var/www/owncloud/server/lib/private/Encryption/DecryptAll.php(173): OC\User\Manager->callForSeenUsers()
      #17 /var/www/owncloud/server/lib/private/Encryption/DecryptAll.php(107): OC\Encryption\DecryptAll->decryptAllUsersFiles()
      #18 /var/www/owncloud/server/apps/encryption/lib/Command/RecreateMasterKey.php(125): OC\Encryption\DecryptAll->decryptAll()
      #19 /var/www/owncloud/server/lib/composer/symfony/console/Command/Command.php(341): OCA\Encryption\Command\RecreateMasterKey->execute()
      #20 /var/www/owncloud/server/lib/composer/symfony/console/Application.php(1094): Symfony\Component\Console\Command\Command->run()
      #21 /var/www/owncloud/server/lib/composer/symfony/console/Application.php(356): Symfony\Component\Console\Application->doRunCommand()
      #22 /var/www/owncloud/server/lib/composer/symfony/console/Application.php(195): Symfony\Component\Console\Application->doRun()
      #23 /var/www/owncloud/server/lib/private/Console/Application.php(165): Symfony\Component\Console\Application->run()
      #24 /var/www/owncloud/server/console.php(96): OC\Console\Application->run()
      #25 {main}'
```

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
- Fixes <issue_link>

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
- test environment:
- test case 1:
- test case 2:
- ...

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Database schema changes (next release will require increase of minor version instead of patch)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [ ] Tests only (no source changes)

## Checklist:
<!-- Tick the checkboxes when done. -->
<!-- Raise documentation ticket in https://github.com/owncloud/documentation -->
- [ ] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 
- [ ] Changelog item, see [TEMPLATE](https://github.com/owncloud/core/blob/master/changelog/TEMPLATE)
