### PR TITLE
fix: PHP Deprecations

### DIFF
--- a/apps/federatedfilesharing/lib/Notifications.php
+++ b/apps/federatedfilesharing/lib/Notifications.php
@@ -465,7 +465,8 @@ class Notifications {
 	 *
 	 * @return bool
 	 */
-	private function isOcsStatusOk($status) {
-		return \in_array($status['ocs']['meta']['statuscode'], [100, 200]);
+	private function isOcsStatusOk($status): bool {
+		$statusCode = $status['ocs']['meta']['statuscode'] ?? 500;
+		return \in_array($statusCode, [100, 200], true);
 	}
 }

--- a/lib/private/Share/Share.php
+++ b/lib/private/Share/Share.php
@@ -1772,7 +1772,7 @@ class Share extends Constants {
 		if (\count($collectionTypes) > 0) {
 			return $collectionTypes;
 		}
-		return false;
+		return [];
 	}
 
 	/**

--- a/lib/private/Share20/Manager.php
+++ b/lib/private/Share20/Manager.php
@@ -932,7 +932,8 @@ class Manager implements IManager {
 		} else {
 			$sharedWith = $share->getSharedWith();
 
-			$targetFile = '/' . \rtrim(\basename($finalTarget), '/') . '/' . \ltrim(\basename($share->getTarget()), '/');
+			$shareTarget = $share->getTarget() ?? '';
+			$targetFile = '/' . \rtrim(\basename($finalTarget), '/') . '/' . \ltrim(\basename($shareTarget), '/');
 			/**
 			 * Scenario where share is made by old owner to a user different
 			 * from new owner

--- a/tests/Core/Controller/AvatarControllerTest.php
+++ b/tests/Core/Controller/AvatarControllerTest.php
@@ -295,7 +295,7 @@ class AvatarControllerTest extends TestCase {
 
 	public function testPostAvatarFilePixelFlood(): void {
 		//Create temp file
-		$fileName = \tempnam(null, "avatarTest");
+		$fileName = \tempnam(\sys_get_temp_dir(), "avatarTest");
 		$copyRes = \copy(\OC::$SERVERROOT.'/tests/data/pixel.jpg', $fileName);
 		$this->assertTrue($copyRes);
 


### PR DESCRIPTION
## Description
```
PHP Deprecated:  ZipArchive::open(): Using empty file as ZipArchive is deprecated in /home/runner/work/core/core/lib/private/Archive/ZIP.php on line 48
```

```
PHP Deprecated:  explode(): Passing null to parameter #2 ($string) of type string is deprecated in /home/runner/work/core/core/lib/private/Files/External/StoragesBackendService.php on line 71
```

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
- Fixes <issue_link>

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
- test environment:
- test case 1:
- test case 2:
- ...

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Database schema changes (next release will require increase of minor version instead of patch)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Technical debt
- [ ] Tests only (no source changes)

## Checklist:
<!-- Tick the checkboxes when done. -->
<!-- Raise documentation ticket in https://github.com/owncloud/documentation -->
- [ ] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 
- [ ] Changelog item, see [TEMPLATE](https://github.com/owncloud/core/blob/master/changelog/TEMPLATE)
