### PR TITLE
fix: PHP Deprecated:  explode(): Passing null to parameter #2 ($strin…

### DIFF
--- a/lib/private/Files/External/StoragesBackendService.php
+++ b/lib/private/Files/External/StoragesBackendService.php
@@ -68,9 +68,10 @@ class StoragesBackendService implements IStoragesBackendService {
 		if ($this->config->getAppValue('files_external', 'allow_user_mounting', 'no') !== 'yes') {
 			$this->userMountingAllowed = false;
 		}
+		$user_mounting_backends = $this->config->getAppValue('files_external', 'user_mounting_backends', '');
 		$this->userMountingBackends = \explode(
 			',',
-			$this->config->getAppValue('files_external', 'user_mounting_backends', '')
+			$user_mounting_backends
 		);
 
 		// if no backend is in the list an empty string is in the array and user mounting is disabled

--- a/tests/lib/Files/External/StoragesBackendServiceTest.php
+++ b/tests/lib/Files/External/StoragesBackendServiceTest.php
@@ -22,6 +22,8 @@ namespace Test\Files\External;
 
 use OC\Files\External\StoragesBackendService;
 use OCP\Files\External\IStoragesBackendService;
+use OCP\IConfig;
+use PHPUnit\Framework\MockObject\MockObject;
 
 class StoragesBackendServiceTest extends \Test\TestCase {
 	/** @var \OCP\IConfig */
@@ -29,19 +31,24 @@ class StoragesBackendServiceTest extends \Test\TestCase {
 
 	protected function setUp(): void {
 		$this->config = $this->createMock('\OCP\IConfig');
+		$this->config
+			->method('getAppValue')
+			->willReturnMap([
+				['files_external', 'user_mounting_backends', '', '']
+			]);
 	}
 
 	/**
 	 * @param string $class
 	 *
-	 * @return \OCP\Files\External\Backend\Backend
+	 * @return \OCP\Files\External\Backend\Backend|MockObject
 	 */
 	protected function getBackendMock($class) {
 		$backend = $this->getMockBuilder('\OCP\Files\External\Backend\Backend')
 			->disableOriginalConstructor()
 			->getMock();
-		$backend->method('getIdentifier')->will($this->returnValue('identifier:'.$class));
-		$backend->method('getIdentifierAliases')->will($this->returnValue(['identifier:'.$class]));
+		$backend->method('getIdentifier')->willReturn('identifier:' . $class);
+		$backend->method('getIdentifierAliases')->willReturn(['identifier:' . $class]);
 		return $backend;
 	}
 
@@ -149,14 +156,15 @@ class StoragesBackendServiceTest extends \Test\TestCase {
 	}
 
 	public function testUserMountingBackends() {
-		$this->config->expects($this->exactly(2))
+		$config = $this->createMock(IConfig::class);
+		$config->expects($this->exactly(2))
 			->method('getAppValue')
-			->will($this->returnValueMap([
+			->willReturnMap([
 				['files_external', 'allow_user_mounting', 'no', 'yes'],
 				['files_external', 'user_mounting_backends', '', 'identifier:\User\Mount\Allowed,identifier_alias']
-			]));
+			]);
 
-		$service = new StoragesBackendService($this->config);
+		$service = new StoragesBackendService($config);
 
 		$backendAllowed = $this->getBackendMock('\User\Mount\Allowed');
 		$backendAllowed->expects($this->never())


### PR DESCRIPTION
…g) of type string is deprecated in /home/runner/work/core/core/lib/private/Files/External/StoragesBackendService.php on line 71

<!--
Thanks for submitting a change to ownCloud!

This is the bug tracker for the Server component. Find other components at https://github.com/owncloud/core/blob/master/.github/CONTRIBUTING.md#guidelines

For fixing potential security issues please see https://owncloud.com/security/

To make it possible for us to get your change reviewed and merged please carefully fill out the requested information below.

Please note that any kind of change needs first be submitted to the master branch which holds the next version of ownCloud.

Please set the following labels:

- Set label "3 - To review" for review or "2 - Development" if the PR still has open tasks
- Assignment: assign to self
- Milestone: set the same as the ticket this PR fixes, or "development" by default
- Reviewers: pick at least one
-->

## Description
<!--- Describe your changes in detail -->

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
- Fixes <issue_link>

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
- test environment:
- test case 1:
- test case 2:
- ...

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Database schema changes (next release will require increase of minor version instead of patch)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [ ] Tests only (no source changes)

## Checklist:
<!-- Tick the checkboxes when done. -->
<!-- Raise documentation ticket in https://github.com/owncloud/documentation -->
- [ ] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 
- [ ] Changelog item, see [TEMPLATE](https://github.com/owncloud/core/blob/master/changelog/TEMPLATE)
