### PR TITLE
[tests-only] test: return the LDAP port number as a string

### DIFF
--- a/tests/acceptance/features/bootstrap/FeatureContext.php
+++ b/tests/acceptance/features/bootstrap/FeatureContext.php
@@ -448,10 +448,10 @@ class FeatureContext extends BehatVariablesContext {
 	}
 
 	/**
-	 * @return integer
+	 * @return string
 	 */
-	public function getLdapPort():int {
-		return $this->ldapPort;
+	public function getLdapPortAsString(): string {
+		return (string)$this->ldapPort;
 	}
 
 	/**

--- a/tests/acceptance/features/bootstrap/Provisioning.php
+++ b/tests/acceptance/features/bootstrap/Provisioning.php
@@ -821,7 +821,7 @@ trait Provisioning {
 				"code" => "%ldap_port%",
 				"function" => [
 					$this,
-					"getLdapPort"
+					"getLdapPortAsString"
 				],
 				"parameter" => []
 			]


### PR DESCRIPTION
The number is substituted into Behat Gherkin step text, as a textual number. We need to be able to use str_replace() with the LDAP port "number" as the replacement string.

In PHP8 the parameters passed to str_replace() must be strings.

In user_ldap acceptance tests we are getting:
  When the administrator sets the LDAP config "LDAPTestId" key "ldapPort" to "%ldap_port%" using the occ command # UserLdapGeneralContext::ldapConfigHasKeySetTo()
  Type error: str_replace(): Argument 2 ($replace) must be of type array|string, int given (Behat\Testwork\Call\Exception\FatalThrowableError)

This change should fix the problem.
