### PR TITLE
fix: set return of getHeader to blank if null

### DIFF
--- a/apps/dav/lib/Connector/Sabre/Auth.php
+++ b/apps/dav/lib/Connector/Sabre/Auth.php
@@ -298,7 +298,8 @@ class Auth extends AbstractBasic {
 	public function challenge(RequestInterface $request, ResponseInterface $response): void {
 		$schema = 'Basic';
 		// do not re-authenticate over ajax, use dummy auth name to prevent browser popup
-		if (\in_array('XMLHttpRequest', \explode(',', $request->getHeader('X-Requested-With')), true)) {
+		$xRequestedWithHeader = $request->getHeader('X-Requested-With') ?? '';
+		if (\in_array('XMLHttpRequest', \explode(',', $xRequestedWithHeader), true)) {
 			$schema = 'DummyBasic';
 		}
 


### PR DESCRIPTION
RequestInterface getHeader can return null.
But various PHP functions in PHP8 expect a proper string to be passed in - for example explode() and str_replace()

We need to be careful to not pass null.

I noticed this in user_ldap CI https://drone.owncloud.com/owncloud/user_ldap/5469/28/13
The log has:
```
{"reqId":"YycJ16gQgNODfnKRnqSr","level":3,"time":"2026-03-16T01:48:41+00:00","remoteAddr":"172.25.2.6","user":"--",
"app":"PHP","method":"GET","url":"\/remote.php\/webdav\/textfile0.txt","message":
"explode(): Passing null to parameter #2 ($string) of type string is deprecated 
at \/var\/www\/owncloud\/server\/apps\/dav\/lib\/Connector\/Sabre\/Auth.php#301"}
```

I wonder how places like this might need to check for `null` and replace it with the empty string or...