### PR TITLE
fix: catch new type error being thrown

### DIFF
--- a/apps/files_trashbin/lib/Storage.php
+++ b/apps/files_trashbin/lib/Storage.php
@@ -230,7 +230,17 @@ class Storage extends Wrapper {
 			if ($sourceStorage !== null) {
 				$sourcePath = '/' . $owner . '/files_trashbin/files/'. $filename . '.d' . $timestamp;
 				$targetPath = '/' . $owner . '/files/' . $ownerPath;
-				return $sourceStorage->copyKeys($sourcePath, $targetPath);
+				try {
+					return $sourceStorage->copyKeys($sourcePath, $targetPath);
+				} catch (\TypeError $e) {
+					// FIXME: The copyKeys method isn't fully implemented in all the storages / wrappers.
+					// The call will likely trigger this error if the OC\Files\Storage\Wrapper\Encryption
+					// isn't part if the wrappers in the $sourceStorage.
+					// In PHP 7.4, this error was ignored and logged, but in PHP 8.3 it throws an
+					// exception that breaks the code execution.
+					// For the short term, we'll keep the previous behavior and catch the exception here.
+					return false;
+				}
 			}
 		}
 		return false;


### PR DESCRIPTION
This is a new error that is thrown due to the update to php 8.3

<!--
Thanks for submitting a change to ownCloud!

This is the bug tracker for the Server component. Find other components at https://github.com/owncloud/core/blob/master/.github/CONTRIBUTING.md#guidelines

For fixing potential security issues please see https://owncloud.com/security/

To make it possible for us to get your change reviewed and merged please carefully fill out the requested information below.

Please note that any kind of change needs first be submitted to the master branch which holds the next version of ownCloud.

Please set the following labels:

- Set label "3 - To review" for review or "2 - Development" if the PR still has open tasks
- Assignment: assign to self
- Milestone: set the same as the ticket this PR fixes, or "development" by default
- Reviewers: pick at least one
-->

## Description
The `copyKeys` method isn't part of the interface and isn't likely available in most of the storages. It relies on the encryption wrapper (https://github.com/owncloud/core/blob/04fbcb0829a33820466713efc715540736f274d5/lib/private/Files/Storage/Wrapper/Encryption.php#L1108) to stop the call from reaching the storage.

## Related Issue
Found in https://github.com/owncloud/encryption/pull/418 . Further details in that PR.

## Motivation and Context
This is a quick and dirty solution to restore the previous behavior (from php 7.4) to make the tests from https://github.com/owncloud/encryption/pull/418 pass

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
- test environment:
- test case 1:
- test case 2:
- ...

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Database schema changes (next release will require increase of minor version instead of patch)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [ ] Tests only (no source changes)

## Checklist:
<!-- Tick the checkboxes when done. -->
<!-- Raise documentation ticket in https://github.com/owncloud/documentation -->
- [ ] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 
- [ ] Changelog item, see [TEMPLATE](https://github.com/owncloud/core/blob/master/changelog/TEMPLATE)
