### PR TITLE
fix: the substr function will return an empty string instead of false

### DIFF
--- a/lib/private/Share/Share.php
+++ b/lib/private/Share/Share.php
@@ -179,6 +179,8 @@ class Share extends Constants {
 			$mountPath = $meta->getMountPoint()->getMountPoint();
 			if ($mountPath !== false) {
 				$mountPath = \substr($mountPath, \strlen('/' . $ownerUser . '/files'));
+				// Note: if the mountPath is shorter than the strlen, substr in php 7.4 returns false
+				// but in php 8+ returns an empty string
 			}
 		}
 
@@ -312,7 +314,7 @@ class Share extends Constants {
 				$result = $query->executeQuery();
 				while ($row = $result->fetchAssociative()) {
 					foreach ($fileTargets[$row['fileid']] as $uid => $shareData) {
-						if ($mountPath !== false) {
+						if ($mountPath !== false && $mountPath !== '') {
 							$sharedPath = $shareData['file_target'];
 							$sharedPath .= \substr($path, \strlen($mountPath) + \strlen($paths[$row['fileid']]));
 							$sharePaths[$uid] = $sharedPath;


### PR DESCRIPTION
<!--
Thanks for submitting a change to ownCloud!

This is the bug tracker for the Server component. Find other components at https://github.com/owncloud/core/blob/master/.github/CONTRIBUTING.md#guidelines

For fixing potential security issues please see https://owncloud.com/security/

To make it possible for us to get your change reviewed and merged please carefully fill out the requested information below.

Please note that any kind of change needs first be submitted to the master branch which holds the next version of ownCloud.

Please set the following labels:

- Set label "3 - To review" for review or "2 - Development" if the PR still has open tasks
- Assignment: assign to self
- Milestone: set the same as the ticket this PR fixes, or "development" by default
- Reviewers: pick at least one
-->

## Description
With the php8 update, the substr function returns an empty string instead of false.
In this particular cases, the `$mountPath` check for `false` fails, causing the code to go through an unintended path. Information returned by the affected function (`getUsersSharingFile`) is wrong, and it can affect to other apps, such as the activity app (see linked ticket)

## Related Issue
Related to https://github.com/owncloud/activity/pull/1230

## Motivation and Context
Wrong information is stored and shown to the user. This PR fixes it.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
- test environment:
- test case 1:
- test case 2:
- ...

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Database schema changes (next release will require increase of minor version instead of patch)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [ ] Tests only (no source changes)

## Checklist:
<!-- Tick the checkboxes when done. -->
<!-- Raise documentation ticket in https://github.com/owncloud/documentation -->
- [ ] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 
- [ ] Changelog item, see [TEMPLATE](https://github.com/owncloud/core/blob/master/changelog/TEMPLATE)
