### PR TITLE
feat: add translation sync workflow

### DIFF
--- a/.github/workflows/translation-sync.yml
+++ b/.github/workflows/translation-sync.yml
@@ -5,6 +5,8 @@ on:
     - cron: '0 2 * * 1'
   workflow_dispatch:
 
+permissions: {}
+
 jobs:
   sync:
     uses: owncloud/reusable-workflows/.github/workflows/translation-sync.yml@main

--- a/.github/workflows/translation-sync.yml
+++ b/.github/workflows/translation-sync.yml
@@ -1,0 +1,17 @@
+name: Translation Sync
+
+on:
+  schedule:
+    - cron: '0 2 * * 1'
+  workflow_dispatch:
+
+jobs:
+  sync:
+    uses: owncloud/reusable-workflows/.github/workflows/translation-sync.yml@main
+    with:
+      mode: make
+      sub_path: l10n
+    secrets:
+      TX_TOKEN: ${{ secrets.TX_TOKEN }}
+      TRANSLATION_APP_ID: ${{ secrets.TRANSLATION_APP_ID }}
+      TRANSLATION_APP_PRIVATE_KEY: ${{ secrets.TRANSLATION_APP_PRIVATE_KEY }}

--- a/.github/workflows/translation-sync.yml
+++ b/.github/workflows/translation-sync.yml
@@ -2,7 +2,7 @@ name: Translation Sync
 
 on:
   schedule:
-    - cron: '0 2 * * 1'
+    - cron: '0 2 * * *'
   workflow_dispatch:
 
 permissions: {}


### PR DESCRIPTION
Adds the reusable translation sync workflow from [owncloud/reusable-workflows](https://github.com/owncloud/reusable-workflows/pull/24).

Translations are synced weekly via Transifex and proposed as a pull request using a GitHub App token. See [owncloud/reusable-workflows#24](https://github.com/owncloud/reusable-workflows/pull/24) for details.

**Required org secrets:** `TX_TOKEN`, `TRANSLATION_APP_ID`, `TRANSLATION_APP_PRIVATE_KEY`

🤖 Generated with [Claude Code](https://claude.com/claude-code)