### PR TITLE
test: adjust acceptance tests for running GitHub workflows

### DIFF
--- a/tests/acceptance/features/bootstrap/TrashbinContext.php
+++ b/tests/acceptance/features/bootstrap/TrashbinContext.php
@@ -236,16 +236,24 @@ class TrashbinContext implements Context {
 			__METHOD__ . " $collectionPath"
 		);
 
+		$subfolder = parse_url($this->featureContext->getBaseUrl(), PHP_URL_PATH);
+		if ($subfolder === null) {
+			$subfolder = "";
+			$subfolderWithSlashAtEnd = "";
+		} else {
+			$subfolderWithSlashAtEnd = \trim($subfolder, "/") . "/";
+		}
+
 		$files = $this->getTrashbinContentFromResponseXml($responseXml);
 		// filter out the collection itself, we only want to return the members
 		$files = \array_filter(
 			$files,
-			static function ($element) use ($user, $collectionPath) {
+			static function ($element) use ($user, $collectionPath, $subfolder) {
 				$path = $collectionPath;
 				if ($path !== "") {
 					$path = $path . "/";
 				}
-				return ($element['href'] !== "/remote.php/dav/trash-bin/$user/$path");
+				return ($element['href'] !== "$subfolder/remote.php/dav/trash-bin/$user/$path");
 			}
 		);
 
@@ -254,7 +262,7 @@ class TrashbinContext implements Context {
 			// avoid "common" situations that could cause infinite recursion.
 			$trashbinRef = $file["href"];
 			$trimmedTrashbinRef = \trim($trashbinRef, "/");
-			$expectedStart = "remote.php/dav/trash-bin/$user";
+			$expectedStart = "{$subfolderWithSlashAtEnd}remote.php/dav/trash-bin/$user";
 			$expectedStartLength = \strlen($expectedStart);
 			if ((\substr($trimmedTrashbinRef, 0, $expectedStartLength) !== $expectedStart)
 				|| (\strlen($trimmedTrashbinRef) === $expectedStartLength)

--- a/tests/acceptance/run.sh
+++ b/tests/acceptance/run.sh
@@ -298,6 +298,7 @@ function assert_server_up() {
 	curl -k -sSf -L $1/status.php -o /dev/null
 	if [[ $? -eq 0 ]]
 	then
+		echo "Server on $1 is responding to status request"
 		return
 	else
 		echo >&2 "Server on $1 is down or not working correctly."
@@ -319,6 +320,7 @@ function assert_testing_app_enabled() {
 		echo >&2 "Please install and enable it to run the tests."
 		exit 98
 	else
+		echo "Testing app is enabled on the server on $1."
 		return
 	fi
 }

--- a/tests/acceptance/run.sh
+++ b/tests/acceptance/run.sh
@@ -790,7 +790,7 @@ then
 		OCC_FED_URL="${TESTING_APP_FED_URL}occ"
 		# test that fed server is up and running, and testing app is enabled.
 		assert_server_up ${TEST_SERVER_FED_URL}
-		assert_testing_app_enabled ${TEST_SERVER_URL}
+		assert_testing_app_enabled ${TEST_SERVER_FED_URL}
 	fi
 
 	echo "Not using php inbuilt server for running scenario ..."

--- a/tests/acceptance/setupApache/dual-server.conf
+++ b/tests/acceptance/setupApache/dual-server.conf
@@ -1,0 +1,17 @@
+<VirtualHost *:80>
+	ServerAdmin webmaster@localhost
+	DocumentRoot /var/www/html
+	ErrorLog ${APACHE_LOG_DIR}/error.log
+	CustomLog ${APACHE_LOG_DIR}/access.log combined
+
+	<Directory /var/www/html${SERVER_SUBDIR}>
+		Options Indexes FollowSymLinks MultiViews
+		AllowOverride All
+		Require all granted
+	</Directory>
+	<Directory /var/www/html${FEDERATED_SUBDIR}>
+		Options Indexes FollowSymLinks MultiViews
+		AllowOverride All
+		Require all granted
+	</Directory>
+</VirtualHost>

--- a/tests/acceptance/setupApache/single-server.conf
+++ b/tests/acceptance/setupApache/single-server.conf
@@ -1,0 +1,12 @@
+<VirtualHost *:80>
+	ServerAdmin webmaster@localhost
+	DocumentRoot /var/www/html
+	ErrorLog ${APACHE_LOG_DIR}/error.log
+	CustomLog ${APACHE_LOG_DIR}/access.log combined
+
+	<Directory /var/www/html${SERVER_SUBDIR}>
+		Options Indexes FollowSymLinks MultiViews
+		AllowOverride All
+		Require all granted
+	</Directory>
+</VirtualHost>


### PR DESCRIPTION
1) fix the trashbin restore test code so that it works when the owncloud server-under-test is in a sub-directory of the Apache root (e.g. at http://localhost/server) The "href" returned by API calls includes that folder - "/server/remote.php/...", so the test code needs to expect that.

2) the existing acceptance test run.sh script first checks that the servers (first server, and "federated" server if in use) are responding a basic endpoint like `status.php`. Add "echo" output that confirms success when the server(s) are up. This has proven helpful when trying to debug while getting GitHub workflows working - it is nice to be really sure that the server is up.

3) the env var TEST_SERVER_FED_URL was wrong in one place, fix it.

4) add Apache site conf files to support a single-server and dual-server configuration of Apache. These are being stored in core, so that all app acceptance test CI can find and copy them into place when setting up Apache in a GitHub workflow. They will also be used by the core acceptance test workflows (when I do them).

This code has all been used and works from demonstration PRs in activity, admin_audit and impersonate app repos:
https://github.com/owncloud/activity/pull/1237
https://github.com/owncloud/admin_audit/pull/451
https://github.com/owncloud/impersonate/pull/260