### PR TITLE
fix: use the right user id when changing the email

### DIFF
--- a/changelog/unreleased/41539
+++ b/changelog/unreleased/41539
@@ -1,0 +1,5 @@
+Fix: Use the correct user ID when changing email via admin API
+
+The admin API endpoint for changing a user's email address was incorrectly using the requesting admin's user ID instead of the target user's ID, causing the admin's email to be updated rather than the intended user's.
+
+https://github.com/owncloud/core/pull/41539

--- a/settings/Controller/UsersController.php
+++ b/settings/Controller/UsersController.php
@@ -972,7 +972,7 @@ class UsersController extends Controller {
 
 		// admins can set email without verification
 		if ($mailAddress === '' || $this->isAdmin) {
-			$this->setEmailAddress($userId, $mailAddress);
+			$this->setEmailAddress($id, $mailAddress);
 			return new DataResponse(
 				[
 					'status' => 'success',

--- a/tests/Settings/Controller/UsersControllerTest.php
+++ b/tests/Settings/Controller/UsersControllerTest.php
@@ -2183,10 +2183,10 @@ class UsersControllerTest extends TestCase {
 	 * @param string $mailAddress
 	 * @param bool $isValid
 	 * @param bool $expectsUpdate
-	 * @param bool $chanChangeMailAddress
+	 * @param bool $canChangeMailAddress
 	 * @param bool $responseCode
 	 */
-	public function testSetEmailAddress($mailAddress, $isValid, $expectsUpdate, $chanChangeMailAddress, $responseCode): void {
+	public function testSetEmailAddress($mailAddress, $isValid, $expectsUpdate, $canChangeMailAddress, $responseCode): void {
 		$this->container['IsAdmin'] = true;
 
 		$user = $this->getMockBuilder(User::class)
@@ -2199,12 +2199,21 @@ class UsersControllerTest extends TestCase {
 			->willReturn('foo@local');
 		$user
 			->method('canChangeMailAddress')
-			->willReturn($chanChangeMailAddress);
-		$user
-			->method('setEMailAddress')
-			->with(
-				$this->equalTo($mailAddress)
-			);
+			->willReturn($canChangeMailAddress);
+
+		$user2 = $this->createMock(User::class);
+		$user2->method('getUID')->willReturn('anotherUserId');
+		$user2->method('getEMailAddress')->willReturn('another@local');
+		$user2->method('canChangeMailAddress')->willReturn($canChangeMailAddress);
+
+		if ($isValid && $canChangeMailAddress) {
+			$user2
+				->expects($this->once())
+				->method('setEMailAddress')
+				->with(
+					$this->equalTo($mailAddress)
+				);
+		}
 
 		$this->container['UserSession']
 			->expects($this->atLeastOnce())
@@ -2215,24 +2224,26 @@ class UsersControllerTest extends TestCase {
 			->with($mailAddress)
 			->willReturn($isValid);
 
-		if ($isValid) {
-			$user->expects($this->atLeastOnce())
-				->method('canChangeMailAddress')
-				->willReturn(true);
-		}
-
 		$this->container['Config']
 			->method('getUserValue')
-			->with('foo', 'owncloud', 'changeMail')
-			->willReturn('12000:AVerySecretToken');
+			->willReturnMap([
+				['foo', 'owncloud', 'changeMail', '12000:AVerySecretToken'],
+				['anotherUserId', 'owncloud', 'changeMail', '120:ASecretToken'],
+			]);
 		$this->container['TimeFactory']
 			->method('getTime')
 			->willReturnOnConsecutiveCalls(12301, 12348);
 		$this->container['UserManager']
 			->expects($this->atLeastOnce())
 			->method('get')
-			->with('foo')
-			->willReturn($user);
+			->willReturnCallback(function ($id) use ($user, $user2) {
+				switch($id) {
+					case "foo":
+						return $user;
+					case "anotherUserId":
+						return $user2;
+				}
+			});
 		$this->container['SecureRandom']
 			->method('generate')
 			->with('21')
@@ -2265,7 +2276,7 @@ class UsersControllerTest extends TestCase {
 			->method('send')
 			->with($message);
 
-		$response = $this->container['UsersController']->setMailAddress($user->getUID(), $mailAddress);
+		$response = $this->container['UsersController']->setMailAddress("anotherUserId", $mailAddress);
 		$this->assertSame($responseCode, $response->getStatus());
 	}
 

--- a/tests/Settings/Controller/UsersControllerTest.php
+++ b/tests/Settings/Controller/UsersControllerTest.php
@@ -2189,17 +2189,11 @@ class UsersControllerTest extends TestCase {
 	public function testSetEmailAddress($mailAddress, $isValid, $expectsUpdate, $canChangeMailAddress, $responseCode): void {
 		$this->container['IsAdmin'] = true;
 
-		$user = $this->getMockBuilder(User::class)
-			->disableOriginalConstructor()->getMock();
-		$user
-			->method('getUID')
-			->willReturn('foo');
-		$user
-			->method('getEMailAddress')
-			->willReturn('foo@local');
-		$user
-			->method('canChangeMailAddress')
-			->willReturn($canChangeMailAddress);
+		$user = $this->createMock(User::class);
+		$user->method('getUID')->willReturn('foo');
+		$user->method('getEMailAddress')->willReturn('foo@local');
+		$user->method('canChangeMailAddress')->willReturn($canChangeMailAddress);
+		$user->expects($this->never())->method('setEmailAddress');
 
 		$user2 = $this->createMock(User::class);
 		$user2->method('getUID')->willReturn('anotherUserId');
@@ -2242,6 +2236,8 @@ class UsersControllerTest extends TestCase {
 						return $user;
 					case "anotherUserId":
 						return $user2;
+					default:
+						return null;
 				}
 			});
 		$this->container['SecureRandom']


### PR DESCRIPTION
<!--
Thanks for submitting a change to ownCloud!

This is the bug tracker for the Server component. Find other components at https://github.com/owncloud/core/blob/master/.github/CONTRIBUTING.md#guidelines

For fixing potential security issues please see https://owncloud.com/security/

To make it possible for us to get your change reviewed and merged please carefully fill out the requested information below.

Please note that any kind of change needs first be submitted to the master branch which holds the next version of ownCloud.

Please set the following labels:

- Set label "3 - To review" for review or "2 - Development" if the PR still has open tasks
- Assignment: assign to self
- Milestone: set the same as the ticket this PR fixes, or "development" by default
- Reviewers: pick at least one
-->

## Description
Change the email of the right user. Note that the code path isn't reachable from the web UI.
Note that there are checks some lines above for the existence of the user, so if we reach this particular line we know that there is an existing user with that id, no need to check it again.


## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
- Fixes <issue_link>

## Motivation and Context


## How Has This Been Tested?
Manually tested using curl. It now changes the target user's email instead of the admin's (requester) email.

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Database schema changes (next release will require increase of minor version instead of patch)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [ ] Tests only (no source changes)

## Checklist:
<!-- Tick the checkboxes when done. -->
<!-- Raise documentation ticket in https://github.com/owncloud/documentation -->
- [ ] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: <link> 
- [ ] Changelog item, see [TEMPLATE](https://github.com/owncloud/core/blob/master/changelog/TEMPLATE)
