### PR TITLE
test: process APP_NAME when deciding what apps to disable

### DIFF
--- a/tests/acceptance/run.sh
+++ b/tests/acceptance/run.sh
@@ -1063,10 +1063,21 @@ then
 	done
 fi
 
+if [ -z "${APP_NAME}" ]
+then
+	APP_NAME=""
+fi
+
 #Enable and disable apps as required for default
 if [ -z "${APPS_TO_DISABLE}" ]
 then
-	APPS_TO_DISABLE="firstrunwizard notifications"
+  if [[ "${APP_NAME}" == "notifications" ]]; then
+    APPS_TO_DISABLE="firstrunwizard"
+  elif [[ "${APP_NAME}" == "firstrunwizard" ]]; then
+    APPS_TO_DISABLE="notifications"
+  else
+    APPS_TO_DISABLE="firstrunwizard notifications"
+  fi
 fi
 
 if [ -z "${APPS_TO_ENABLE}" ]


### PR DESCRIPTION
When running acceptance tests, we disable the firstrunwizard and notifications app by default. These apps are often provided in a bundled ownCloud core tarball. But they can get in the way of webUI tests, because:

- the firstrunwizard might display itself at the very start of testing
- notifications can appear at the top of the webUI, and might obscure things that are being tested.

But if we are actually testing one of these apps, then we don't want to disable the app.

The logic in acceptance test run.sh is enhanced to avoid disabling the app when it is the app-under-test.
