### PR TITLE
chore: update dependabot to weekly Sunday schedule

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,69 +1,29 @@
 version: 2
 updates:
-- package-ecosystem: composer
-  directory: "/"
-  schedule:
-    interval: weekly
-    time: "22:00"
-  open-pull-requests-limit: 10
-  reviewers:
-  - phil-davis
-  assignees:
-  - phil-davis
-  groups:
-    symfony:
-      patterns:
-        - "symfony/*"
-  ignore:
-  - dependency-name: guzzlehttp/guzzle
-    versions:
-    - "< 7, >= 6.a"
-  - dependency-name: league/flysystem
-    versions:
-    - ">= 2.a, < 3"
-  - dependency-name: doctrine/dbal
-    versions:
-    - 2.13.0
-  - dependency-name: symfony/translation
-    versions:
-    - 4.4.21
-  - dependency-name: swiftmailer/swiftmailer
-    versions:
-    - 6.2.6
-  - dependency-name: phpseclib/phpseclib
-    versions:
-    - 3.0.2
-    - 3.0.5
-- package-ecosystem: npm
-  directory: "/build"
-  schedule:
-    interval: weekly
-    time: "22:00"
-  open-pull-requests-limit: 10
-  ignore:
-  - dependency-name: jasmine-core
-    versions:
-    - ">= 3.a, < 4"
-  - dependency-name: karma-jasmine
-    versions:
-    - ">= 2.a, < 3"
-  - dependency-name: karma
-    versions:
-    - 6.0.2
-    - 6.0.4
-    - 6.1.0
-    - 6.1.1
-    - 6.2.0
-    - 6.3.1
-  - dependency-name: y18n
-    versions:
-    - 4.0.1
-  - dependency-name: sinon
-    versions:
-    - 9.2.4
+  - package-ecosystem: composer
+    directory: "/"
+    schedule:
+      interval: weekly
+      day: sunday
+      time: '22:00'
+      timezone: Etc/UTC
+    open-pull-requests-limit: 5
+    groups:
+      minor-and-patch:
+        update-types:
+          - minor
+          - patch
 
-- package-ecosystem: "github-actions"
-  directory: "/" # Location of package manifests
-  schedule:
-    interval: "weekly"
-
+  - package-ecosystem: github-actions
+    directory: "/"
+    schedule:
+      interval: weekly
+      day: sunday
+      time: '22:00'
+      timezone: Etc/UTC
+    open-pull-requests-limit: 5
+    groups:
+      minor-and-patch:
+        update-types:
+          - minor
+          - patch

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -14,6 +14,20 @@ updates:
           - minor
           - patch
 
+  - package-ecosystem: npm
+    directory: "/build"
+    schedule:
+      interval: weekly
+      day: sunday
+      time: '22:00'
+      timezone: Etc/UTC
+    open-pull-requests-limit: 5
+    groups:
+      minor-and-patch:
+        update-types:
+          - minor
+          - patch
+
   - package-ecosystem: github-actions
     directory: "/"
     schedule:


### PR DESCRIPTION
This PR adds/updates the Dependabot configuration for this repository.

Dependabot is configured to run weekly (Sunday at 22:00 UTC) with a limit of 5 open pull requests per ecosystem. Minor and patch updates are grouped into a single PR per ecosystem to reduce the number of concurrent update PRs, lowering maintainer overhead and CI load. Major version updates remain as individual PRs so they receive deliberate review.
