### PR TITLE
fix(security): OC10-75 - restrict AppConfigController read methods to full admins only

### DIFF
--- a/changelog/unreleased/41550
+++ b/changelog/unreleased/41550
@@ -1,0 +1,9 @@
+Security: Restrict AppConfigController read methods to full admins only
+
+Subadmin users could read all oc_appconfig values including SMTP passwords,
+LDAP bind credentials, and encryption master keys via the Settings API.
+Removed @NoAdminRequired from getApps, getKeys, and getValue so that the
+AdminMiddleware enforces full-admin-only access, consistent with the write
+methods.
+
+https://github.com/owncloud/core/pull/41550

--- a/settings/Controller/AppConfigController.php
+++ b/settings/Controller/AppConfigController.php
@@ -27,9 +27,7 @@ use OCP\AppFramework\Http\JSONResponse;
 
 /**
  * The code is mostly copied from core/ajax/appconfig.php
- * Read methods (getApps, getKeys and getValue) are available to subadmins,
- * which wasn't possible with the core/ajax/appconfig.php file. The rest of
- * the methods require admin privileges.
+ * All methods require full admin privileges.
  * Note that the "hasKey" method is missing. You can do the same in a lot of
  * cases by trying to get the value of the key.
  *
@@ -54,8 +52,6 @@ class AppConfigController extends Controller {
 	}
 
 	/**
-	 * @NoAdminRequired
-	 *
 	 * Get the list of apps
 	 */
 	public function getApps() {
@@ -63,8 +59,6 @@ class AppConfigController extends Controller {
 	}
 
 	/**
-	 * @NoAdminRequired
-	 *
 	 * Get the list of keys for that particular app
 	 * @param string $app
 	 */
@@ -73,8 +67,6 @@ class AppConfigController extends Controller {
 	}
 
 	/**
-	 * @NoAdminRequired
-	 *
 	 * Get the value of the key for that app, or the default value provided
 	 * if it's missing.
 	 * @param string $app

--- a/settings/js/users/users.js
+++ b/settings/js/users/users.js
@@ -751,18 +751,16 @@ $(document).ready(function () {
 	// TODO: move other init calls inside of initialize
 	UserList.initialize($('#userlist'));
 
-	OC.AppConfig.getValue('core', 'umgmt_set_password', 'false', function (data) {
-		var showPassword = $.parseJSON(data);
-		if (showPassword === true) {
+	(function () {
+		var showPassword = $('#CheckBoxPasswordOnUserCreate').prop('checked');
+		if (showPassword) {
 			$("#newuserpassword").show();
 			$("#newemail").hide();
-			$('#CheckBoxPasswordOnUserCreate').attr('checked', true);
 		} else {
 			$("#newemail").show();
 			$("#newuserpassword").hide();
-			$('#CheckBoxPasswordOnUserCreate').attr('checked', false);
 		}
-	});
+	}());
 
 	$userListBody.on('click', '.password', function (event) {
 		event.stopPropagation();

--- a/tests/Settings/Controller/AppConfigControllerTest.php
+++ b/tests/Settings/Controller/AppConfigControllerTest.php
@@ -156,4 +156,22 @@ class AppConfigControllerTest extends TestCase {
 		$this->assertEquals([], $response->getData());
 		$this->assertSame(Http::STATUS_BAD_REQUEST, $response->getStatus());
 	}
+
+	public function testGetAppsRequiresAdmin(): void {
+		$reflection = new \ReflectionMethod(AppConfigController::class, 'getApps');
+		$docComment = (string)$reflection->getDocComment();
+		$this->assertStringNotContainsString('@NoAdminRequired', $docComment);
+	}
+
+	public function testGetKeysRequiresAdmin(): void {
+		$reflection = new \ReflectionMethod(AppConfigController::class, 'getKeys');
+		$docComment = (string)$reflection->getDocComment();
+		$this->assertStringNotContainsString('@NoAdminRequired', $docComment);
+	}
+
+	public function testGetValueRequiresAdmin(): void {
+		$reflection = new \ReflectionMethod(AppConfigController::class, 'getValue');
+		$docComment = (string)$reflection->getDocComment();
+		$this->assertStringNotContainsString('@NoAdminRequired', $docComment);
+	}
 }


### PR DESCRIPTION
## Summary

- **Security fix (CVSS 7.7):** Removes `@NoAdminRequired` from `getApps()`, `getKeys()`, and `getValue()` in `AppConfigController` so the AppFramework's `AdminMiddleware` blocks Subadmin users from reading all `oc_appconfig` values (SMTP passwords, LDAP bind credentials, encryption master keys, etc.)
- **Collateral fix:** Replaces a now-blocked `OC.AppConfig.getValue` AJAX call in `settings/js/users/users.js` with a synchronous DOM read of the server-rendered checkbox state — preserving correct UI behavior on the Subadmin-accessible `/settings/users` page
- Updated the `AppConfigController` class docblock to accurately reflect that all methods now require full admin privileges

## Details

The three read endpoints were annotated with `@NoAdminRequired`, which caused `SecurityMiddleware` to skip the admin check. Subadmins could exploit this to enumerate all app config keys and read any value — including credentials stored by SMTP, LDAP, OAuth, and encryption apps.

Write methods (`setValue`, `deleteKey`, `deleteApp`) were already admin-only. This PR makes the read methods consistent with them.

A cross-repo search of the entire ownCloud GitHub org found no other apps using the affected endpoints from Subadmin accessible UI, with one exception fixed here.

Reported by Pablo Giovanni. Confirmed on ownCloud 10.14.0 and 10.16.1.

Fixes: OC10-75

## Test Plan
- [ ] Log in as Subadmin → `GET /index.php/settings/appconfig` → HTTP 403
- [ ] Log in as full admin → `GET /index.php/settings/appconfig` → HTTP 200
- [ ] Log in as Subadmin → `/settings/users` → password/email field toggles correctly on page load
- [ ] Log in as full admin → `/settings/users` → same behavior