### PR TITLE
test(acceptance): add setupApache configs to 10.16

### DIFF
--- a/tests/acceptance/setupApache/dual-server.conf
+++ b/tests/acceptance/setupApache/dual-server.conf
@@ -1,0 +1,17 @@
+<VirtualHost *:80>
+	ServerAdmin webmaster@localhost
+	DocumentRoot /var/www/html
+	ErrorLog ${APACHE_LOG_DIR}/error.log
+	CustomLog ${APACHE_LOG_DIR}/access.log combined
+
+	<Directory /var/www/html${SERVER_SUBDIR}>
+		Options Indexes FollowSymLinks MultiViews
+		AllowOverride All
+		Require all granted
+	</Directory>
+	<Directory /var/www/html${FEDERATED_SUBDIR}>
+		Options Indexes FollowSymLinks MultiViews
+		AllowOverride All
+		Require all granted
+	</Directory>
+</VirtualHost>

--- a/tests/acceptance/setupApache/single-server.conf
+++ b/tests/acceptance/setupApache/single-server.conf
@@ -1,0 +1,12 @@
+<VirtualHost *:80>
+	ServerAdmin webmaster@localhost
+	DocumentRoot /var/www/html
+	ErrorLog ${APACHE_LOG_DIR}/error.log
+	CustomLog ${APACHE_LOG_DIR}/access.log combined
+
+	<Directory /var/www/html${SERVER_SUBDIR}>
+		Options Indexes FollowSymLinks MultiViews
+		AllowOverride All
+		Require all granted
+	</Directory>
+</VirtualHost>


### PR DESCRIPTION
## Summary

- Backports `tests/acceptance/setupApache/single-server.conf` and `dual-server.conf` verbatim from `master`
- No existing files modified

## Why

`owncloud/reusable-workflows` `acceptance.yml` hardcodes a `cp` from `tests/acceptance/setupApache/` relative to the checked-out core directory. When an
OC10-targeted app sets `core-branch-for-test-code: '10.16'`, this step fails with exit code 1 because the directory does not exist on the `10.16` branch. The
configs were introduced on `master` after `10.16` was cut.

## Test plan

- [ ] Verify the two files are present and identical to their master counterparts
- [ ] Confirm an app using `core-branch-for-test-code: '10.16'` can reach and pass the "Configure Apache" step in acceptance tests

🤖 Generated with [Claude Code](https://claude.ai/claude-code)