### PR TITLE
fix: update config.sample.php - remove oracle

### DIFF
--- a/config/config.sample.php
+++ b/config/config.sample.php
@@ -128,7 +128,6 @@ $CONFIG = [
  * 	- sqlite (SQLite3 - Not in Enterprise Edition)
  * 	- mysql (MySQL/MariaDB)
  * 	- pgsql (PostgreSQL)
- * 	- oci (Oracle - Enterprise Edition Only)
  */
 'dbtype' => 'mysql',
 
@@ -1421,13 +1420,11 @@ $CONFIG = [
  * 	- sqlite (SQLite3 - Not in Enterprise Edition)
  * 	- mysql (MySQL)
  * 	- pgsql (PostgreSQL)
- * 	- oci (Oracle - Enterprise Edition Only)
  */
 'supportedDatabases' => [
 	'sqlite',
 	'mysql',
 	'pgsql',
-	'oci',
   ],
 
 /**


### PR DESCRIPTION
This PR removes Oracle from the config sample file - Oracle is no longer a supported database.

Note that this PR must go into the final oc11 release. 