### PR TITLE
fix(comments): prevent IDOR in WebDAV comments API

### DIFF
--- a/apps/comments/lib/Dav/EntityCollection.php
+++ b/apps/comments/lib/Dav/EntityCollection.php
@@ -98,6 +98,10 @@ class EntityCollection extends RootCollection implements IProperties {
 	public function getChild($name) {
 		try {
 			$comment = $this->commentsManager->get($name);
+			// objectType/objectId identify the entity (e.g. file) the comment is attached to
+			if ($comment->getObjectType() !== $this->name || $comment->getObjectId() !== $this->id) {
+				throw new NotFound();
+			}
 			return new CommentNode(
 				$this->commentsManager,
 				$comment,
@@ -151,8 +155,10 @@ class EntityCollection extends RootCollection implements IProperties {
 	 */
 	public function childExists($name) {
 		try {
-			$this->commentsManager->get($name);
-			return true;
+			$comment = $this->commentsManager->get($name);
+			// objectType/objectId identify the entity (e.g. file) the comment is attached to
+			return $comment->getObjectType() === $this->name
+				&& $comment->getObjectId() === $this->id;
 		} catch (NotFoundException $e) {
 			return false;
 		}

--- a/apps/comments/tests/unit/Dav/EntityCollectionTest.php
+++ b/apps/comments/tests/unit/Dav/EntityCollectionTest.php
@@ -142,4 +142,60 @@ class EntityCollectionTest extends \Test\TestCase {
 
 		$this->assertFalse($this->collection->childExists('44'));
 	}
+
+	public function testGetChildWrongFile(): void {
+		$this->expectException(\Sabre\DAV\Exception\NotFound::class);
+
+		$comment = $this->createMock(IComment::class);
+		$comment->method('getObjectType')->willReturn('files');
+		$comment->method('getObjectId')->willReturn('999'); // different file
+
+		$this->commentsManager->expects($this->once())
+			->method('get')
+			->with('55')
+			->willReturn($comment);
+
+		$this->collection->getChild('55');
+	}
+
+	public function testGetChildWrongObjectType(): void {
+		$this->expectException(\Sabre\DAV\Exception\NotFound::class);
+
+		$comment = $this->createMock(IComment::class);
+		$comment->method('getObjectType')->willReturn('albums'); // wrong type
+		$comment->method('getObjectId')->willReturn('19');
+
+		$this->commentsManager->expects($this->once())
+			->method('get')
+			->with('55')
+			->willReturn($comment);
+
+		$this->collection->getChild('55');
+	}
+
+	public function testChildExistsWrongFile(): void {
+		$comment = $this->createMock(IComment::class);
+		$comment->method('getObjectType')->willReturn('files');
+		$comment->method('getObjectId')->willReturn('999'); // different file
+
+		$this->commentsManager->expects($this->once())
+			->method('get')
+			->with('44')
+			->willReturn($comment);
+
+		$this->assertFalse($this->collection->childExists('44'));
+	}
+
+	public function testChildExistsWrongObjectType(): void {
+		$comment = $this->createMock(IComment::class);
+		$comment->method('getObjectType')->willReturn('albums'); // wrong type
+		$comment->method('getObjectId')->willReturn('19');
+
+		$this->commentsManager->expects($this->once())
+			->method('get')
+			->with('44')
+			->willReturn($comment);
+
+		$this->assertFalse($this->collection->childExists('44'));
+	}
 }

--- a/apps/comments/tests/unit/Dav/EntityCollectionTest.php
+++ b/apps/comments/tests/unit/Dav/EntityCollectionTest.php
@@ -70,10 +70,14 @@ class EntityCollectionTest extends \Test\TestCase {
 	}
 
 	public function testGetChild(): void {
+		$comment = $this->createMock(IComment::class);
+		$comment->method('getObjectType')->willReturn('files');
+		$comment->method('getObjectId')->willReturn('19');
+
 		$this->commentsManager->expects($this->once())
 			->method('get')
 			->with('55')
-			->will($this->returnValue($this->createMock(IComment::class)));
+			->willReturn($comment);
 
 		$node = $this->collection->getChild('55');
 		$this->assertInstanceOf(\OCA\Comments\Dav\CommentNode::class, $node);
@@ -118,6 +122,15 @@ class EntityCollectionTest extends \Test\TestCase {
 	}
 
 	public function testChildExistsTrue(): void {
+		$comment = $this->createMock(IComment::class);
+		$comment->method('getObjectType')->willReturn('files');
+		$comment->method('getObjectId')->willReturn('19');
+
+		$this->commentsManager->expects($this->once())
+			->method('get')
+			->with('44')
+			->willReturn($comment);
+
 		$this->assertTrue($this->collection->childExists('44'));
 	}
 

--- a/changelog/unreleased/41558
+++ b/changelog/unreleased/41558
@@ -1,0 +1,5 @@
+Fix: Prevent IDOR in WebDAV comments API
+
+Authenticated users could read, edit, or delete comments on files they have no access to by supplying an arbitrary comment ID in the WebDAV comments endpoint. The fix verifies that a requested comment belongs to the file in the URL before returning it.
+
+https://github.com/owncloud/core/pull/41558


### PR DESCRIPTION
## Summary

- Fixes OC10-53: authenticated users could read, edit, or delete comments on files they have no access to by supplying an arbitrary `comment_id` paired with any `file_id` they own
- `EntityCollection::getChild()` and `childExists()` now verify the fetched comment's `objectType`/`objectId` match the collection's own entity type and file ID before returning
- Because Sabre DAV resolves tree paths before dispatching any verb, this single boundary fix covers PROPFIND (read), DELETE, and PROPPATCH (edit) uniformly

## Test Plan

- [x] Run `./lib/composer/phpunit/phpunit/phpunit apps/comments/tests/unit/Dav/EntityCollectionTest.php` — all 12 tests pass
- [x] Manually reproduce POC from OC10-53: user B's `PROPFIND /remote.php/dav/comments/files/{userB_file_id}/{userA_comment_id}` returns 404

🤖 Generated with [Claude Code](https://claude.com/claude-code)