### PR TITLE
chore(ci): add missing workflow files for 10.16 branch

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,30 @@
+name: CI
+
+on:
+  push:
+    branches:
+      - "10.16"
+      - "release/*"
+  pull_request:
+    types:
+      - opened
+      - synchronize
+      - reopened
+
+permissions:
+  contents: read
+
+concurrency:
+  group: ci-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  semantic-git-messages:
+    name: Commits
+    uses: owncloud/reusable-workflows/.github/workflows/semantic-git-message.yml@main
+
+  php-unit:
+    name: PHP Unit
+    uses: ./.github/workflows/php-unit.yml
+    with:
+      php-versions: '["7.4"]'

--- a/.github/workflows/lint-and-codestyle.yml
+++ b/.github/workflows/lint-and-codestyle.yml
@@ -4,6 +4,8 @@ on:
   push:
     branches:
       - master
+      - "10.16"
+      - "release/*"
   pull_request:
     types:
       - opened

--- a/.github/workflows/lint-pr-title.yml
+++ b/.github/workflows/lint-pr-title.yml
@@ -1,0 +1,18 @@
+name: Lint PR title
+
+on:
+  pull_request:
+    types:
+      - opened
+      - edited
+      - synchronize
+
+permissions: {}
+
+jobs:
+  lint:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: amannn/action-semantic-pull-request@48f256284bd46cdaab1048c3721360e808335d50 # v6.1.1
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/php-unit.yml
+++ b/.github/workflows/php-unit.yml
@@ -19,13 +19,13 @@ jobs:
         php: ${{ fromJSON(inputs.php-versions) }}
         database: [sqlite]
         include:
-          - php: "8.3"
+          - php: "7.4"
             database: "mysql:8.0"
-          - php: "8.3"
+          - php: "7.4"
             database: "mariadb:10.6"
-          - php: "8.3"
+          - php: "7.4"
             database: "mariadb:10.11"
-          - php: "8.3"
+          - php: "7.4"
             database: "postgres:10.21"
 
     services:

--- a/.github/workflows/translation-sync.yml
+++ b/.github/workflows/translation-sync.yml
@@ -1,0 +1,20 @@
+name: Translation Sync
+
+on:
+  schedule:
+    - cron: '0 2 * * *'
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  sync:
+    uses: owncloud/reusable-workflows/.github/workflows/translation-sync.yml@main
+    with:
+      mode: make
+      sub_path: l10n
+    secrets:
+      TX_TOKEN: ${{ secrets.TX_TOKEN }}
+      TRANSLATION_APP_ID: ${{ secrets.TRANSLATION_APP_ID }}
+      TRANSLATION_APP_PRIVATE_KEY: ${{ secrets.TRANSLATION_APP_PRIVATE_KEY }}


### PR DESCRIPTION
## Summary

- Add `ci.yml` (the key missing piece — orchestrates PHP Unit tests via `workflow_call`, targets PHP 7.4 for 10.16)
- Add `lint-pr-title.yml` (PR title linting)
- Add `translation-sync.yml` (nightly translation sync)
- Extend `lint-and-codestyle.yml` push trigger to cover `10.16` and `release/*` branches

These files exist on `master` but were never backported to `10.16`, causing CI to not run on PRs targeting this branch.

## Test plan

- [ ] CI workflow triggers on this PR
- [ ] PHP Unit job runs with PHP 7.4
- [ ] Lint and code style job runs
- [ ] PR title lint job runs

🤖 Generated with [Claude Code](https://claude.com/claude-code)