### PR TITLE
docs(ospo): community health rollout v2 — README, agents.md, health files

### DIFF
--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -1,0 +1,8 @@
+# Code of Conduct
+
+This project follows the ownCloud Code of Conduct.
+
+Please read the full Code of Conduct at:
+**<https://owncloud.com/contribute/code-of-conduct/>**
+
+By participating in this project, you agree to abide by its terms.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,9 @@
+# Contributing
+
+Thank you for your interest in contributing to this project!
+
+Please read the full contributing guidelines at:
+**<https://owncloud.com/contribute/>**
+
+For development setup, coding standards, and pull request process,
+see the README in this repository.

--- a/README.md
+++ b/README.md
@@ -1,57 +1,111 @@
 # ownCloud Core
 
-[![Build Status](https://drone.owncloud.com/api/badges/owncloud/core/status.svg?branch=master)](https://drone.owncloud.com/owncloud/core)
-[![Quality Gate Status](https://sonarcloud.io/api/project_badges/measure?project=owncloud_core&metric=alert_status)](https://sonarcloud.io/dashboard?id=owncloud_core)
-[![Security Rating](https://sonarcloud.io/api/project_badges/measure?project=owncloud_core&metric=security_rating)](https://sonarcloud.io/dashboard?id=owncloud_core)
-[![Coverage](https://sonarcloud.io/api/project_badges/measure?project=owncloud_core&metric=coverage)](https://sonarcloud.io/dashboard?id=owncloud_core)
-[![Design](https://contribute.design/api/shield/owncloud/core)](https://contribute.design/owncloud/core)
+<!-- OSPO-managed README | Generated: 2026-04-16 | v2 -->
 
-**[ownCloud](http://ownCloud.com) offers file sharing and collaboration trusted by 200+ million users worldwide regardless of device or location.**
+[![License](https://img.shields.io/badge/License-AGPL--3.0-blue.svg)](COPYING) [![ownCloud OSPO](https://img.shields.io/badge/OSPO-ownCloud-blue)](https://kiteworks.com/opensource) [![Docker Hub](https://img.shields.io/docker/pulls/owncloud)](https://hub.docker.com/r/owncloud/server)
 
-![](https://github.com/owncloud/screenshots/blob/master/files/sidebar_1.png)
+ownCloud Core is the server-side component of ownCloud 10 (Classic), providing file storage, synchronization, and sharing trusted by over 200 million users worldwide. It includes WebDAV, CalDAV, and CardDAV servers, a plugin architecture for apps, user and group management, encryption support, external storage backends, and a comprehensive REST API. The server runs on PHP with support for MySQL, MariaDB, PostgreSQL, and SQLite databases.
 
-## Why Is This so Awesome?
-* :file_folder: **Access your Data** You can store your files, contacts, calendars and more on a server of your choosing.
-* :package: **Sync your Data** You keep your files, contacts, calendars and more synchronized amongst your devices.
-* :arrows_counterclockwise: **Share your Data** You share your data with others, and give them access to your latest photo galleries, your calendar or anything else you want them to see.
-* :rocket: **Expandable with dozens of Apps** ...like Calendar, Contacts, Mail or News.
-* :cloud: **All Benefits of the Cloud** ...on your own Server.
-* :lock: **Encryption** You can encrypt data in transit with secure https connections. You can enable the encryption app to encrypt data on storage for improved security and privacy.
-* ...
+## Part of Classic (OC10)
 
-## Installation Instructions
-For installing ownCloud, see the official
-[ownCloud 10](https://doc.owncloud.com/server/latest/admin_manual/installation/) installation manual.
+This is the main repository for [ownCloud Server (Classic)](https://github.com/owncloud/core), also known as ownCloud 10 or OC10. It is the foundation that apps like [Activity](https://github.com/owncloud/activity), [Calendar](https://github.com/owncloud/calendar), [Contacts](https://github.com/owncloud/contacts), and many others extend. The server is available as a Docker image on [Docker Hub](https://hub.docker.com/r/owncloud/server).
 
-## Development Build Prerequisites
-Note that when doing a local development build, you need to have **Composer v2** installed. If your OS provides a lower version than v2, you can install Composer v2 manually. As an example, which may be valid for other releases/distros too, see [How to install Composer on Ubuntu 22.04 | 20.04 LTS](https://www.how2shout.com/linux/how-to-install-composer-on-ubuntu-22-04-20-04-lts/).
+For the next-generation ownCloud platform, see [ownCloud Infinite Scale (oCIS)](https://github.com/owncloud/ocis).
 
-You also must have installed `yarn` and `node` (v14 or higher).
+## Getting Started
 
-## Contribution Guidelines
-https://owncloud.com/contribute/
+For installing ownCloud Server, see the official [ownCloud 10 installation manual](https://doc.owncloud.com/server/latest/admin_manual/installation/).
 
-## Commit Messages
-To ease bringing commits into context, a CI job check that the commit message satisfies a specification for adding human and machine readable meaning to commit messages. For details see: [Conventional Commits](www.conventionalcommits.org/). Note that if conventional commits are not satisfied, CI will not be green. In this case, you need to rewrite the git commit history to meet the requirement.
+### Development Build Prerequisites
 
-You must at least provide a `type` + `description` as described in the [Examples](https://www.conventionalcommits.org/en/v1.0.0/#examples) section.
+- **Composer v2**
+- **Yarn** and **Node.js** (v14 or higher)
 
-For a quickstart, the following types can be used:
+```bash
+make
+```
 
-`fix:`, `feat:`, `build:`, `chore:`, `ci:`, `docs:`, `style:`, `refactor:`, `perf:`, `test:`
+## Documentation
 
+- [ownCloud Server documentation](https://doc.owncloud.com)
+- [Developer documentation](https://doc.owncloud.com/server/latest/developer_manual/)
+- [CHANGELOG.md](https://github.com/owncloud/core/blob/master/CHANGELOG.md)
+- [Conventional Commits specification](https://www.conventionalcommits.org/)
 
-## Support
-Learn about the different ways you can get support for ownCloud: https://owncloud.com/support/
+## Community & Support
 
-## Get in Touch
-* :clipboard: [Forum](https://central.owncloud.org)
-* :hash: [IRC channel](https://web.libera.chat/?channels=#owncloud)
-* :busts_in_silhouette: [Facebook](https://facebook.com/ownclouders)
-* :hatching_chick: [Twitter](https://twitter.com/ownCloud)
+**[Star](https://github.com/owncloud/core)** this repo and **Watch** for release notifications!
 
-## Important Notice on Translations
-Please submit translations via Transifex:
-https://explore.transifex.com/owncloud-org/
+- [ownCloud Website](https://owncloud.com)
+- [Community Discussions](https://github.com/orgs/owncloud/discussions)
+- [Matrix Chat](https://app.element.io/#/room/#owncloud:matrix.org)
+- [Documentation](https://doc.owncloud.com)
+- [Enterprise Support](https://owncloud.com/contact-us/)
+- [OSPO Home](https://kiteworks.com/opensource)
 
-See the detailed information about [translations](https://doc.owncloud.com/server/latest/developer_manual/core/translation.html) here.
+## Contributing
+
+We welcome contributions! Please read the [Contributing Guidelines](CONTRIBUTING.md)
+and our [Code of Conduct](CODE_OF_CONDUCT.md) before getting started.
+
+### Workflow
+
+- **Rebase Early, Rebase Often!** We use a rebase workflow. Always rebase on the target branch before submitting a PR.
+- **Dependabot**: Automated dependency updates are managed via Dependabot. Review and merge dependency PRs promptly.
+- **Signed Commits**: All commits **must** be PGP/GPG signed. See [GitHub's signing guide](https://docs.github.com/en/authentication/managing-commit-signature-verification).
+- **DCO Sign-off**: Every commit must carry a `Signed-off-by` line:
+  ```
+  git commit -s -S -m "your commit message"
+  ```
+- **GitHub Actions Policy**: Workflows may only use actions that are (a) owned by `owncloud`, (b) created by GitHub (`actions/*`), or (c) verified in the GitHub Marketplace.
+
+## Translations
+
+Help translate this project on Transifex:
+**<https://explore.transifex.com/owncloud-org/owncloud/>**
+
+Please submit translations via Transifex -- do not open pull requests for translation changes.
+
+## Security
+
+**Do not open a public GitHub issue for security vulnerabilities.**
+
+Report vulnerabilities at **<https://security.owncloud.com>** -- see [SECURITY.md](SECURITY.md).
+
+Bug bounty: [YesWeHack ownCloud Program](https://yeswehack.com/programs/owncloud-bug-bounty-program)
+
+## License
+
+This project is licensed under the [AGPL-3.0](COPYING).
+
+## About the ownCloud OSPO
+
+The [Kiteworks Open Source Program Office](https://kiteworks.com/opensource), operating under
+the [ownCloud](https://owncloud.com) brand, launched on May 5, 2026, to steward the open source
+ecosystem around ownCloud's products. The OSPO ensures transparent governance, license compliance,
+community health, and sustainable collaboration between the open source community and
+[Kiteworks](https://www.kiteworks.com), which acquired ownCloud in 2023.
+
+- **OSPO Home**: <https://kiteworks.com/opensource>
+- **GitHub**: <https://github.com/owncloud>
+- **ownCloud**: <https://owncloud.com>
+
+For questions about the OSPO or licensing, contact ospo@kiteworks.com.
+
+### License Migration to Apache 2.0
+
+The OSPO is driving a strategic relicensing of ownCloud repositories toward the
+[Apache License 2.0](https://www.apache.org/licenses/LICENSE-2.0), following
+the [Apache Software Foundation's third-party license policy](https://www.apache.org/legal/resolved.html).
+
+Individual repositories will migrate as their audit is completed. The LICENSE file
+in each repo reflects its **current** license status (not the target).
+
+**Current license: AGPL-3.0** (Category X per Apache policy -- cannot be included in Apache-2.0 works).
+
+Migration prerequisites for this repository:
+
+- **CLA/DCO coverage**: All past contributors must have signed agreements permitting relicensing
+- **Copyleft dependency audit**: All AGPL/GPL dependencies must be replaced or isolated
+- **KDE heritage review**: Any code with KDE-era copyrights requires legal analysis
+- **Complete relicensing**: AGPL-3.0 is a strong copyleft license; migration requires full relicensing of all files, not just a header change

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,11 @@
+# Security Policy
+
+## Reporting a Vulnerability
+
+**Do NOT open a public GitHub issue for security vulnerabilities.**
+
+Please report security issues responsibly via:
+**<https://security.owncloud.com>**
+
+You can also report vulnerabilities through our YesWeHack bug bounty program:
+**<https://yeswehack.com/programs/owncloud-bug-bounty-program>**

--- a/SUPPORT.md
+++ b/SUPPORT.md
@@ -1,0 +1,10 @@
+# Support
+
+For support with this project, please use the following channels:
+
+- **Enterprise Support**: <https://owncloud.com/contact-us/>
+- **Community discussions**: https://github.com/orgs/owncloud/discussions
+- **Matrix Chat**: <https://app.element.io/#/room/#owncloud:matrix.org>
+- **Documentation**: <https://doc.owncloud.com>
+
+Please do not use GitHub issues for general support questions.

--- a/agents.md
+++ b/agents.md
@@ -53,6 +53,9 @@ make test-acceptance-api
 # Test (acceptance - CLI)
 make test-acceptance-cli
 
+# Test (acceptance - Web User Interface)
+make test-acceptance-webui
+
 # Lint (PHP)
 make test-php-style
 

--- a/agents.md
+++ b/agents.md
@@ -1,0 +1,97 @@
+# AI Agent Guidelines for ownCloud Core
+
+This file provides context for AI coding agents (Claude Code, GitHub Copilot, Cursor, etc.) working in this repository.
+
+## Repository Overview
+- **Product family:** Classic (OC10)
+- **Primary language(s):** PHP, JavaScript
+- **Build system:** Composer, Make, npm/Yarn
+- **Test framework:** PHPUnit, JavaScript tests (Node), Acceptance tests (Behat)
+- **CI system:** GitHub Actions
+
+## Architecture & Key Paths
+- `lib/` - Core PHP library (private and public APIs)
+- `core/` - Core app (login, file list, etc.)
+- `apps/` - Bundled apps
+- `config/` - Configuration samples and defaults
+- `ocs/` - OCS API endpoints
+- `ocs-provider/` - OCS provider discovery
+- `ocm-provider/` - Open Cloud Mesh provider
+- `build/` - Build scripts and tools
+- `l10n/` - Translations
+- `tests/` - Test suites (unit, integration, acceptance)
+- `Makefile` - Build and test automation
+- `composer.json` - PHP dependencies
+- `phpcs.xml` - PHP_CodeSniffer configuration
+- `phpstan.neon` - PHPStan configuration
+- `CHANGELOG.md` - Release history
+- `console.php` - CLI entry point
+- `occ` - ownCloud console CLI tool
+- `cron.php` - Background job runner
+- `index.php` - Web entry point
+
+## Development Conventions
+- **Branching:** master
+- **Commit messages:** DCO sign-off required (`git commit -s`). Must follow [Conventional Commits](https://www.conventionalcommits.org/) format.
+- **Code style:** PHP_CodeSniffer (phpcs.xml), ownCloud coding standard
+- **PR process:** Open a PR against master. All CI checks must pass.
+
+## Build & Test Commands
+```bash
+# Build (install all dependencies)
+make
+
+# Test (PHP unit)
+make test-php-unit
+
+# Test (JavaScript)
+make test-js
+
+# Test (acceptance - API)
+make test-acceptance-api
+
+# Test (acceptance - CLI)
+make test-acceptance-cli
+
+# Lint (PHP)
+make test-php-style
+
+# Fix code style
+make test-php-style-fix
+```
+
+## Important Constraints
+- All code contributions must be compatible with the **AGPL-3.0** license
+- Do not introduce new **copyleft-licensed dependencies** (GPL, AGPL, LGPL, MPL) without explicit discussion in an issue first. This is especially important for repos migrating to Apache 2.0.
+- Do not introduce new dependencies without discussion in an issue first
+- Conventional Commits are enforced by CI
+- Translations must be submitted via Transifex, not as PRs
+- This is a large, complex codebase with many interdependencies
+
+
+## OSPO Policy Constraints
+
+### GitHub Actions
+- **Only** use actions owned by `owncloud`, created by GitHub (`actions/*`), verified on the GitHub Marketplace, or verified by the ownCloud Maintainers.
+- Pin all actions to their full commit SHA (not tags): `uses: actions/checkout@<SHA> # vX.Y.Z`
+- Never introduce actions from unverified third parties.
+
+### Dependency Management
+- Dependabot is configured for automated dependency updates.
+- Review and merge Dependabot PRs as part of regular maintenance.
+- Do not introduce new dependencies without discussion in an issue first.
+
+### Git Workflow
+- **Rebase policy**: Always rebase; never create merge commits. Use `git pull --rebase` and `git rebase` before pushing.
+- **Signed commits**: All commits **must** be PGP/GPG signed (`git commit -S -s`).
+- **DCO sign-off**: Every commit needs a `Signed-off-by` line (`git commit -s`).
+- **Conventional Commits & Squash Merge**: Use the [Conventional Commits](https://www.conventionalcommits.org/) format where the repository enforces it. Many repos use squash merge, where the PR title becomes the commit message on the default branch — apply Conventional Commits format to PR titles as well. A reusable GitHub Actions workflow enforces this.
+
+## Context for AI Agents
+- Match existing code style
+- Do not refactor unrelated code in the same PR
+- Write tests for new functionality
+- Keep PRs focused and atomic
+- Use Conventional Commits format for all commit messages
+- Be aware of the public API surface (OCP namespace) - breaking changes require careful consideration
+- The `lib/private/` directory contains internal APIs; `lib/public/` contains the stable public API


### PR DESCRIPTION
## Summary

This PR is part of the **Kiteworks OSPO community health rollout** ([kiteworks.com/opensource](https://kiteworks.com/opensource)), applied to all ~110 public ownCloud repositories starting May 5, 2026.

- **README.md**: Rewritten with v2 OSPO template
  * License-specific OSPO section with Apache 2.0 migration guidance
  * Mandatory Community & Support section: GitHub Discussions, Matrix, docs, enterprise support, OSPO home
  * Contributing workflow: Rebase Early/Often, Dependabot, PGP/GPG-signed commits, DCO sign-off, GitHub Actions policy
  * Security section pointing to security.owncloud.com + YesWeHack bug bounty
  * Translations link to Transifex ([owncloud project](https://explore.transifex.com/owncloud-org/owncloud/))
- **agents.md** *(new)*: AI agent context file with architecture, build commands, OSPO policy constraints
- **CODE_OF_CONDUCT.md** *(new)*: Redirect to <https://owncloud.com/contribute/code-of-conduct/>
- **CONTRIBUTING.md** *(new)*: Redirect to <https://owncloud.com/contribute/>
- **SECURITY.md** *(new)*: Redirect to <https://security.owncloud.com> + YesWeHack
- **SUPPORT.md** *(new)*: Redirect to <https://owncloud.com/contact-us/> and support channels

## Test plan

- [ ] README renders correctly on GitHub (badges, sections, links)
- [ ] All health file links resolve (CODE_OF_CONDUCT, CONTRIBUTING, SECURITY, SUPPORT)
- [ ] agents.md loads correctly in Claude Code and GitHub Copilot
- [ ] License referenced in README matches actual LICENSE file in repo

---

🤖 Generated with [Claude Code](https://claude.com/claude-code) as part of the ownCloud OSPO rollout.
Kiteworks OSPO: <https://kiteworks.com/opensource>