### PR TITLE
chore: add changelog folder for 10.16.3 release

### DIFF
--- a/changelog/10.16.3_2026-05-22/41538
+++ b/changelog/10.16.3_2026-05-22/41538
@@ -1,0 +1,8 @@
+Bugfix: Prevent mounting local storage if not allowed
+
+Mounting a local storage was possible if the internal class name was used as
+backend, despite local storage not allowed to be mounted. This problem is
+fixed and the local storage can't be mounted if it was explicitly disallowed in
+the configuration.
+
+https://github.com/owncloud/core/pull/41538

--- a/changelog/10.16.3_2026-05-22/41539
+++ b/changelog/10.16.3_2026-05-22/41539
@@ -1,0 +1,5 @@
+Bugfix: Use the correct user ID when changing email via admin API
+
+The admin API endpoint for changing a user's email address was incorrectly using the requesting admin's user ID instead of the target user's ID, causing the admin's email to be updated rather than the intended user's.
+
+https://github.com/owncloud/core/pull/41539

--- a/changelog/10.16.3_2026-05-22/41550
+++ b/changelog/10.16.3_2026-05-22/41550
@@ -1,0 +1,9 @@
+Security: Restrict AppConfigController read methods to full admins only
+
+Subadmin users could read all oc_appconfig values including SMTP passwords,
+LDAP bind credentials, and encryption master keys via the Settings API.
+Removed @NoAdminRequired from getApps, getKeys, and getValue so that the
+AdminMiddleware enforces full-admin-only access, consistent with the write
+methods.
+
+https://github.com/owncloud/core/pull/41550

--- a/changelog/10.16.3_2026-05-22/41558
+++ b/changelog/10.16.3_2026-05-22/41558
@@ -1,0 +1,5 @@
+Bugfix: Prevent IDOR in WebDAV comments API
+
+Authenticated users could read, edit, or delete comments on files they have no access to by supplying an arbitrary comment ID in the WebDAV comments endpoint. The fix verifies that a requested comment belongs to the file in the URL before returning it.
+
+https://github.com/owncloud/core/pull/41558

--- a/changelog/10.16.3_2026-05-22/phpseclib-security-2026-05
+++ b/changelog/10.16.3_2026-05-22/phpseclib-security-2026-05
@@ -1,0 +1,8 @@
+Security: Update phpseclib to 3.0.52 for CVE-2026-40194
+
+CVE-2026-40194: Timing attack vulnerability in SSH binary packet processing.
+Upgraded phpseclib/phpseclib from 3.0.50 to 3.0.52.
+
+https://github.com/owncloud/core/pull/41529
+https://github.com/owncloud/core/pull/41541
+https://github.com/phpseclib/phpseclib/releases/tag/3.0.51

--- a/changelog/10.16.3_2026-05-22/symfony-security-2026-05
+++ b/changelog/10.16.3_2026-05-22/symfony-security-2026-05
@@ -1,0 +1,8 @@
+Security: Update symfony/routing to 5.4.52 for CVE-2026-45065
+
+CVE-2026-45065: UrlGenerator route-requirement bypass via unanchored regex
+alternation allowing off-site URL injection. Upgraded symfony/routing from
+5.4.48 to 5.4.52.
+
+https://github.com/owncloud/core/pull/41559
+https://symfony.com/cve-2026-45065


### PR DESCRIPTION
## Summary

Backports `changelog/10.16.3_2026-05-22/` from the `v10.16.3` tag to `master`.

The folder was created on the `release/10.16.3` branch during the release process but was never merged back to `master`. This brings the versioned release notes in line with previous releases.

### Files added

| File | Description |
|------|-------------|
| `41538` | Bugfix: prevent mounting local storage if not allowed |
| `41539` | Bugfix: use correct user ID when changing email via admin API |
| `41550` | Security: restrict AppConfigController to full admins |
| `41558` | Bugfix: prevent IDOR in WebDAV comments API |
| `phpseclib-security-2026-05` | Security: phpseclib update for CVE-2026-40194 |
| `symfony-security-2026-05` | Security: symfony/routing update for CVE-2026-45065 |

## Test plan

- [x] Verify `changelog/10.16.3_2026-05-22/` contains exactly the 6 expected files
- [x] Confirm no other files were modified (pure addition)
- [x] Confirm commit carries `Signed-off-by` trailer (DCO)