### PR TITLE
chore: add GitHub Actions workflow to auto-update CHANGELOG.md via calens

### DIFF
--- a/.github/workflows/changelog.yml
+++ b/.github/workflows/changelog.yml
@@ -1,0 +1,16 @@
+name: Changelog
+
+on:
+  push:
+    branches:
+      - master
+
+permissions:
+  contents: read
+
+jobs:
+  changelog:
+    uses: owncloud/reusable-workflows/.github/workflows/calens.yml@main
+    secrets:
+      APP_ID: ${{ secrets.CHANGELOG_APP_ID }}
+      APP_PRIVATE_KEY: ${{ secrets.CHANGELOG_APP_PRIVATE_KEY }}


### PR DESCRIPTION
## Summary

- Adds `.github/workflows/changelog.yml` that calls the `owncloud/reusable-workflows` calens reusable workflow
- Triggers on every push to `master`, generating an updated `CHANGELOG.md` from entries in `changelog/unreleased/`
- The reusable workflow opens (or updates) a PR on branch `chore/changelog-update` automatically

## Notes

The following GitHub Actions secrets must be configured in the repo settings:
- `CHANGELOG_APP_ID` — GitHub App client ID
- `CHANGELOG_APP_PRIVATE_KEY` — GitHub App private key

(Adjust names if the repo already has a shared App under different secret names.)

## Test plan

- [ ] Merge to `master` and confirm the "Changelog" workflow runs successfully
- [ ] Verify a `chore: update changelog` PR is opened on branch `chore/changelog-update`
- [ ] Confirm the generated `CHANGELOG.md` matches a local `make changelog` run

🤖 Generated with [Claude Code](https://claude.com/claude-code)