### PR TITLE
fix(settings): pass target user ID to sendEmail in setMailAddress subadmin path

### DIFF
--- a/changelog/unreleased/41574
+++ b/changelog/unreleased/41574
@@ -1,0 +1,8 @@
+Bugfix: Fix subadmin email change updating caller's address instead of target's
+
+The verification token and confirmation link in the subadmin path of
+setMailAddress were associated with the caller's account instead of the
+target user's account. Clicking the confirmation link changed the
+subadmin's email rather than the intended target's email.
+
+https://github.com/owncloud/core/pull/41574

--- a/settings/Controller/UsersController.php
+++ b/settings/Controller/UsersController.php
@@ -985,7 +985,7 @@ class UsersController extends Controller {
 		}
 
 		try {
-			if ($this->sendEmail($userId, $mailAddress)) {
+			if ($this->sendEmail($id, $mailAddress)) {
 				return new DataResponse(
 					[
 						'status' => 'success',

--- a/tests/Settings/Controller/UsersControllerTest.php
+++ b/tests/Settings/Controller/UsersControllerTest.php
@@ -2276,6 +2276,80 @@ class UsersControllerTest extends TestCase {
 		$this->assertSame($responseCode, $response->getStatus());
 	}
 
+	/**
+	 * When a subadmin calls setMailAddress for a different user, the verification
+	 * email and token must be stored under the target user's ID, not the caller's.
+	 * Regression test for GHSA-5945-5fp8-4283 (subadmin path).
+	 */
+	public function testSetMailAddressSubadminSendsEmailToTargetNotCaller(): void {
+		$this->container['IsAdmin'] = false;
+
+		$callerUser = $this->createMock(User::class);
+		$callerUser->method('getUID')->willReturn('subadmin');
+
+		$targetUser = $this->createMock(User::class);
+		$targetUser->method('getUID')->willReturn('targetuser');
+		$targetUser->method('canChangeMailAddress')->willReturn(true);
+
+		$subAdmin = $this->createMock(SubAdmin::class);
+		$subAdmin->method('isUserAccessible')->willReturn(true);
+
+		$this->container['GroupManager']
+			->method('getSubAdmin')
+			->willReturn($subAdmin);
+
+		$this->container['UserSession']
+			->method('getUser')
+			->willReturn($callerUser);
+
+		$this->container['UserManager']
+			->method('get')
+			->willReturnCallback(function ($id) use ($callerUser, $targetUser) {
+				return $id === 'subadmin' ? $callerUser : ($id === 'targetuser' ? $targetUser : null);
+			});
+
+		$this->container['Mailer']
+			->method('validateMailAddress')
+			->willReturn(true);
+
+		// Token must be read from and stored under 'targetuser', not 'subadmin'
+		$this->container['Config']
+			->method('getUserValue')
+			->with('targetuser', 'owncloud', 'changeMail')
+			->willReturn('');
+
+		$this->container['Config']
+			->expects($this->once())
+			->method('setUserValue')
+			->with('targetuser', 'owncloud', 'changeMail', $this->anything());
+
+		$this->container['TimeFactory']
+			->method('getTime')
+			->willReturn(12345);
+
+		$this->container['SecureRandom']
+			->method('generate')
+			->willReturn('SomeToken');
+
+		// Confirmation link must carry 'targetuser', not 'subadmin'
+		$this->container['URLGenerator']
+			->expects($this->once())
+			->method('linkToRouteAbsolute')
+			->with('settings.Users.changeMail', $this->callback(function ($params) {
+				return isset($params['userId']) && $params['userId'] === 'targetuser';
+			}))
+			->willReturn('https://example.com/changeMail');
+
+		$message = $this->createMock(Message::class);
+		$this->container['Mailer']
+			->method('createMessage')
+			->willReturn($message);
+
+		$response = $this->container['UsersController']->setMailAddress('targetuser', 'new@example.com');
+		$this->assertSame(Http::STATUS_OK, $response->getStatus());
+		$this->assertSame('success', $response->getData()['status']);
+	}
+
 	public function testStatsAdmin(): void {
 		$this->container['IsAdmin'] = true;
 

--- a/tests/Settings/Controller/UsersControllerTest.php
+++ b/tests/Settings/Controller/UsersControllerTest.php
@@ -2305,7 +2305,8 @@ class UsersControllerTest extends TestCase {
 		$this->container['UserManager']
 			->method('get')
 			->willReturnCallback(function ($id) use ($callerUser, $targetUser) {
-				return $id === 'subadmin' ? $callerUser : ($id === 'targetuser' ? $targetUser : null);
+				$userMap = ['subadmin' => $callerUser, 'targetuser' => $targetUser];
+				return $userMap[$id] ?? null;
 			});
 
 		$this->container['Mailer']


### PR DESCRIPTION
## Summary

- Fixes the subadmin path of `UsersController::setMailAddress` which was passing `$userId` (the caller's session UID) to `sendEmail()` instead of `$id` (the target user's UID)
- The verification token and confirmation link were being stored/generated under the caller's account, causing the caller's email to be changed instead of the target's when the link was clicked
- The admin path was already corrected in commit 3ff2884; this fixes the remaining subadmin path
- Adds a regression test `testSetMailAddressSubadminSendsEmailToTargetNotCaller` that asserts the token is stored and the confirmation link is generated with the target user's ID

Fixes GHSA-5945-5fp8-4283 (subadmin path).

## Test plan

- [ ] Run `tests/Settings/Controller/UsersControllerTest.php::testSetMailAddressSubadminSendsEmailToTargetNotCaller` — verifies `setUserValue` and `linkToRouteAbsolute` are called with the target user's ID, not the caller's
- [ ] Run existing `testSetEmailAddress` suite to confirm no regression in admin path
- [ ] Manual: as a subadmin, change a group member's email address and confirm the verification email is sent to the new address with a link that changes the *member's* email, not the subadmin's

🤖 Generated with [Claude Code](https://claude.com/claude-code)