### PR TITLE
fix(ci): use correct CALENS_* secrets for changelog workflow

### DIFF
--- a/.github/workflows/changelog.yml
+++ b/.github/workflows/changelog.yml
@@ -12,5 +12,5 @@ jobs:
   changelog:
     uses: owncloud/reusable-workflows/.github/workflows/calens.yml@main
     secrets:
-      APP_ID: ${{ secrets.CHANGELOG_APP_ID }}
-      APP_PRIVATE_KEY: ${{ secrets.CHANGELOG_APP_PRIVATE_KEY }}
+      APP_ID: ${{ secrets.CALENS_APP_ID }}
+      APP_PRIVATE_KEY: ${{ secrets.CALENS_APP_PRIVATE_KEY }}


### PR DESCRIPTION
## Description

The changelog workflow (`.github/workflows/changelog.yml`) calls the reusable `owncloud/reusable-workflows/.github/workflows/calens.yml@main`, which requires the secrets `APP_ID` and `APP_PRIVATE_KEY`. This PR updates the **source** secrets mapped into those inputs:

- `CHANGELOG_APP_ID` → `CALENS_APP_ID`
- `CHANGELOG_APP_PRIVATE_KEY` → `CALENS_APP_PRIVATE_KEY`

## Motivation and Context

The org standardized the GitHub App secrets used by the changelog automation on the `CALENS_*` names. `owncloud/web` and `owncloud/client` already map `APP_ID: ${{ secrets.CALENS_APP_ID }}` / `APP_PRIVATE_KEY: ${{ secrets.CALENS_APP_PRIVATE_KEY }}`, and `owncloud/core` was the only repo still referencing the old `CHANGELOG_*` names — leaving its changelog automation unable to authenticate. This brings `core` in line with the rest of the org.

The reusable workflow's contract is unchanged: only the right-hand side (the source secret names) is updated; the required `APP_ID` / `APP_PRIVATE_KEY` keys remain intact.

## How Has This Been Tested?

The token-dependent steps in the reusable workflow are gated by `if: github.ref == format('refs/heads/{0}', inputs.branch)`, so they only run on `master`, not on this PR. To be verified via the first changelog run on `master` after merge.

Prerequisite: the `CALENS_APP_ID` / `CALENS_APP_PRIVATE_KEY` secrets must be provisioned for this repo (org-level secret with `owncloud/core` in its repository-access allowlist, or repo-level secrets). This is very likely already satisfied since web/client use the same names.

## Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Database schema changes (next release will require increase of minor version instead of patch)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [ ] Tests only (no source changes)

## Checklist:

- [x] Code changes
- [ ] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: n/a
- [ ] Changelog item — n/a (CI-only change)