### PR TITLE
fix(occ): prevent params command key from overriding validated allowlist command

### DIFF
--- a/changelog/unreleased/41577
+++ b/changelog/unreleased/41577
@@ -1,0 +1,10 @@
+Security: Prevent params body from overriding validated occ command
+
+OccController validated the URL-path command against an allowlist but
+then merged it with user-supplied params via array_merge, allowing a
+command key in the request body to overwrite the validated value. An
+authenticated caller with the updater secret could use this to execute
+any occ command regardless of the allowlist. The params array is now
+stripped of any command key before the merge.
+
+https://github.com/owncloud/core/pull/41577

--- a/core/Controller/OccController.php
+++ b/core/Controller/OccController.php
@@ -106,6 +106,8 @@ class OccController extends Controller {
 			$this->console->setAutoExit(false);
 			$this->console->loadCommands(new ArrayInput([]), $output);
 
+			// Prevent user-supplied params from overriding the validated command
+			unset($params['command']);
 			$inputArray = \array_merge(['command' => $command], $params);
 			$input = new ArrayInput($inputArray);
 

--- a/tests/Core/Controller/OccControllerTest.php
+++ b/tests/Core/Controller/OccControllerTest.php
@@ -84,6 +84,42 @@ class OccControllerTest extends TestCase {
 		$this->assertEquals('updater.secret does not match the provided token', $responseData['details']);
 	}
 
+	/**
+	 * Ensure that a 'command' key inside params cannot override the validated
+	 * command (CVE allowlist-bypass via array_merge key collision).
+	 */
+	public function testParamsCommandKeyCannotOverrideValidatedCommand() {
+		$this->getControllerMock('localhost');
+
+		// Track which command the console is actually asked to run
+		$capturedInput = null;
+		$this->console->expects($this->once())->method('run')
+			->willReturnCallback(
+				function ($input, $output) use (&$capturedInput) {
+					$capturedInput = $input;
+					return 0;
+				}
+			);
+
+		// 'status' is an allowed command; 'user:resetpassword' is not.
+		// The attacker embeds 'command' => 'user:resetpassword' inside params.
+		$response = $this->controller->execute(
+			'status',
+			self::TEMP_SECRET,
+			['command' => 'user:resetpassword', '--output' => 'json']
+		);
+		$responseData = $response->getData();
+
+		// Request must succeed (the validated command ran)
+		$this->assertArrayHasKey('exitCode', $responseData);
+		$this->assertEquals(0, $responseData['exitCode']);
+
+		// The ArrayInput actually passed to the console must carry 'status',
+		// not the attacker-supplied 'user:resetpassword'.
+		$this->assertNotNull($capturedInput);
+		$this->assertEquals('status', $capturedInput->getFirstArgument());
+	}
+
 	public function testSuccess() {
 		$this->getControllerMock('localhost');
 		$this->console->expects($this->once())->method('run')


### PR DESCRIPTION
## Summary
- `OccController::execute()` validated the URL-path `$command` against the allowlist, then merged it with user-supplied `$params` via `array_merge(['command' => $command], $params)`
- PHP's `array_merge` with string keys causes later duplicates to overwrite earlier ones — a `command` key in the POST body bypassed the allowlist entirely
- Fix: `unset($params['command'])` before the merge; one-line change, complete protection

## Security Impact
**Critical** — authenticated updater callers with `updater.secret` + localhost access can execute any `occ` command (user:resetpassword, config:system:set, encryption:decrypt-all, etc.) regardless of the allowlist

## Test plan
- [ ] `testParamsCommandKeyCannotOverrideValidatedCommand` sends `user:resetpassword` in params while URL says `status`; asserts console receives `status` — fails without fix
- [ ] Run `make test TEST_PHP_SUITE=core/Controller`

🤖 Generated with [Claude Code](https://claude.com/claude-code)