### PR TITLE
fix(federation): remove plaintext auth token from error log in getSharedSecret

### DIFF
--- a/apps/federation/lib/BackgroundJob/GetSharedSecret.php
+++ b/apps/federation/lib/BackgroundJob/GetSharedSecret.php
@@ -159,11 +159,21 @@ class GetSharedSecret extends Job {
 			if ($status === Http::STATUS_FORBIDDEN) {
 				$this->logger->info($target . ' refused to exchange a shared secret with you.', ['app' => 'federation']);
 			} else {
-				$this->logger->logException($e, ['app' => 'federation']);
+				// NB: do not log the exception verbatim - the token is sent as a
+				// GET query parameter, so the Guzzle message embeds the full
+				// request URI including "?token=...", leaking the plaintext token.
+				$this->logger->error(
+					'Could not exchange a shared secret with ' . $target . ' (HTTP ' . $status . ')',
+					['app' => 'federation']
+				);
 			}
 		} catch (\Exception $e) {
 			$status = Http::STATUS_INTERNAL_SERVER_ERROR;
-			$this->logger->logException($e, ['app' => 'federation']);
+			// NB: see above - the token must not reach the log via the request URI.
+			$this->logger->error(
+				'Could not exchange a shared secret with ' . $target,
+				['app' => 'federation']
+			);
 		}
 
 		// if we received a unexpected response we try again later

--- a/apps/federation/lib/Controller/OCSAuthAPIController.php
+++ b/apps/federation/lib/Controller/OCSAuthAPIController.php
@@ -159,9 +159,8 @@ class OCSAuthAPIController extends OCSController {
 		}
 
 		if ($this->isValidToken($url, $token) === false) {
-			$expectedToken = $this->dbHandler->getToken($url);
 			$this->logger->error(
-				'remote server (' . $url . ') didn\'t send a valid token (got "' . $token . '" but expected "'. $expectedToken . '") while getting shared secret',
+				'remote server (' . $url . ') didn\'t send a valid token while getting shared secret',
 				['app' => 'federation']
 			);
 			return ['statuscode' => Http::STATUS_FORBIDDEN];

--- a/apps/federation/tests/API/OCSAuthAPITest.php
+++ b/apps/federation/tests/API/OCSAuthAPITest.php
@@ -236,6 +236,40 @@ class OCSAuthAPITest extends TestCase {
 	}
 
 	/**
+	 * Verify that when an invalid token is supplied, the error log message does NOT
+	 * contain either the attacker-supplied token or the expected stored token.
+	 * Leaking either value allows an attacker with log-read access to replay the
+	 * valid token and obtain the shared secret (CVE-class: information disclosure).
+	 */
+	public function testGetSharedSecretDoesNotLogTokenValues() {
+		$url = 'https://trusted.example.com';
+		$attackerToken = 'attacker_supplied_token_XYZ';
+		$storedToken = 'super_secret_expected_token_ABC';
+
+		$this->trustedServers
+			->method('isTrustedServer')->with($url)->willReturn(true);
+
+		// dbHandler->getToken is used by isValidToken; return the stored token
+		$this->dbHandler
+			->method('getToken')->with($url)->willReturn($storedToken);
+
+		// Capture every call to logger->error and assert no token values appear
+		$this->logger
+			->expects($this->once())
+			->method('error')
+			->with(
+				$this->logicalAnd(
+					$this->logicalNot($this->stringContains($attackerToken)),
+					$this->logicalNot($this->stringContains($storedToken))
+				),
+				$this->anything()
+			);
+
+		$result = $this->ocsAuthApi->getSharedSecret($url, $attackerToken);
+		$this->assertSame(Http::STATUS_FORBIDDEN, $result['statuscode']);
+	}
+
+	/**
 	 * @dataProvider dataTestIsTokenValid
 	 */
 	public function testIsTokenValid($storedToken, $requestToken): void {

--- a/apps/federation/tests/BackgroundJob/GetSharedSecretTest.php
+++ b/apps/federation/tests/BackgroundJob/GetSharedSecretTest.php
@@ -23,6 +23,9 @@
 
 namespace OCA\Federation\Tests\BackgroundJob;
 
+use GuzzleHttp\Exception\ClientException;
+use GuzzleHttp\Psr7\Request;
+use GuzzleHttp\Psr7\Response;
 use OCA\Federation\BackgroundJob\GetSharedSecret;
 use OCA\Federation\DbHandler;
 use OCA\Federation\TrustedServers;
@@ -202,5 +205,52 @@ class GetSharedSecretTest extends TestCase {
 			[Http::STATUS_FORBIDDEN],
 			[Http::STATUS_CONFLICT],
 		];
+	}
+
+	/**
+	 * On a non-403 HTTP failure the shared secret is sent as a GET query
+	 * parameter, so the Guzzle exception message embeds the full request URI
+	 * including "?token=...". Logging that exception verbatim would leak the
+	 * plaintext token, so the token value must never reach the logger.
+	 */
+	public function testRunDoesNotLogTokenOnClientException() {
+		$target = 'https://remote.example.com';
+		$source = 'https://local.example.com';
+		$token = 'super-secret-federation-token';
+
+		$argument = ['url' => $target, 'token' => $token];
+
+		$this->urlGenerator->expects($this->once())->method('getAbsoluteURL')->with('/')
+			->willReturn($source);
+
+		// Build a real Guzzle ClientException whose request URI carries the
+		// token in the query string, exactly as the live client would produce.
+		$request = new Request(
+			'GET',
+			$target . '/ocs/v2.php/apps/federation/api/v1/shared-secret?url=' . $source . '&token=' . $token . '&format=json'
+		);
+		$exception = new ClientException(
+			'Client error: `' . $request->getUri() . '` resulted in a `409 Conflict` response',
+			$request,
+			new Response(Http::STATUS_CONFLICT)
+		);
+
+		$this->httpClient->expects($this->once())->method('get')
+			->willThrowException($exception);
+
+		// The token must not appear in any exception logged verbatim...
+		$this->logger->expects($this->never())->method('logException');
+		// ...nor in any error/info message string.
+		$assertNoToken = function ($message) use ($token) {
+			$this->assertStringNotContainsString($token, $message);
+			return true;
+		};
+		$this->logger->method('error')->with($this->callback($assertNoToken));
+		$this->logger->method('info')->with($this->callback($assertNoToken));
+
+		self::invokePrivate($this->getSharedSecret, 'run', [$argument]);
+
+		// A 409 is an unexpected response, so the job is retained for retry.
+		$this->assertTrue(self::invokePrivate($this->getSharedSecret, 'retainJob'));
 	}
 }

--- a/changelog/unreleased/41578
+++ b/changelog/unreleased/41578
@@ -4,7 +4,12 @@ When getSharedSecret received an invalid token it logged both the
 submitted value and the expected valid token in plaintext. Since the
 endpoint is public, any unauthenticated caller could trigger this log
 entry at will for any trusted server URL, exposing the valid token to
-anyone with log-read access. The token values have been removed from
-the log message.
+anyone with log-read access.
+
+A second leak in the same code path has also been closed: the
+GetSharedSecret background job sends the token as a GET query
+parameter, so on an unexpected HTTP response the Guzzle exception -
+whose message embeds the full request URI including "?token=..." -
+was logged verbatim. Both log sites no longer emit the token value.
 
 https://github.com/owncloud/core/pull/41578

--- a/changelog/unreleased/41578
+++ b/changelog/unreleased/41578
@@ -1,0 +1,10 @@
+Security: Remove plaintext federation auth token from error log
+
+When getSharedSecret received an invalid token it logged both the
+submitted value and the expected valid token in plaintext. Since the
+endpoint is public, any unauthenticated caller could trigger this log
+entry at will for any trusted server URL, exposing the valid token to
+anyone with log-read access. The token values have been removed from
+the log message.
+
+https://github.com/owncloud/core/pull/41578


### PR DESCRIPTION
## Summary
- `getSharedSecret` (@PublicPage) logged both the submitted and expected tokens in plaintext on failure: `got "X" but expected "Y"`
- Any unauthenticated attacker who knows a trusted server URL could trigger this log entry at will, harvesting the valid token from logs
- Fix removes the `getToken()` DB call that existed only to populate the log, replacing the message with a generic non-disclosing string

## Security Impact
**Medium** — requires secondary log-read access to exploit; unauthenticated trigger

## Note
This PR touches the same file as `security/fix-federation-token-oracle` — merge that one first to avoid conflicts.

## Test plan
- [ ] `testGetSharedSecretDoesNotLogTokenValues` asserts neither attacker nor stored token appears in the logged string; fails without fix
- [ ] Run `make test TEST_PHP_SUITE=apps/federation`

🤖 Generated with [Claude Code](https://claude.com/claude-code)