### PR TITLE
fix(files_sharing): enforce minimum search length in getUsers() and getGroups()

### DIFF
--- a/apps/files_sharing/lib/Controller/ShareesController.php
+++ b/apps/files_sharing/lib/Controller/ShareesController.php
@@ -170,6 +170,10 @@ class ShareesController extends OCSController {
 			$this->result['users'] = [];
 			return;
 		}
+		if (!$this->userSearch->isSearchable($search)) {
+			$this->result['users'] = [];
+			return;
+		}
 
 		$userGroups = [];
 		if ($this->shareWithGroupOnly || $this->shareeEnumerationGroupMembers) {
@@ -307,6 +311,10 @@ class ShareesController extends OCSController {
 		$this->result['groups'] = $this->result['exact']['groups'] = [];
 
 		if (\strlen(\trim($search)) === 0 && $this->userSearch->getSearchMinLength() > 0) {
+			$this->result['groups'] = [];
+			return;
+		}
+		if (!$this->userSearch->isSearchable($search)) {
 			$this->result['groups'] = [];
 			return;
 		}

--- a/apps/files_sharing/tests/API/ShareesTest.php
+++ b/apps/files_sharing/tests/API/ShareesTest.php
@@ -2084,6 +2084,71 @@ class ShareesTest extends TestCase {
 		];
 	}
 
+	/**
+	 * Verify that a short but non-empty search term is blocked when
+	 * user.search_min_length is configured — the previous code only blocked
+	 * empty strings and allowed single-character enumeration attacks.
+	 */
+	public function testGetUsersBlocksShortSearchTerm() {
+		self::invokePrivate($this->sharees, 'limit', [2]);
+		self::invokePrivate($this->sharees, 'offset', [0]);
+		self::invokePrivate($this->sharees, 'shareWithGroupOnly', [false]);
+		self::invokePrivate($this->sharees, 'shareeEnumeration', [true]);
+		self::invokePrivate($this->sharees, 'shareeEnumerationGroupMembers', [false]);
+
+		// Simulate admin setting user.search_min_length = 2
+		$this->userSearch->expects($this->any())
+			->method('getSearchMinLength')
+			->willReturn(2);
+		$this->userSearch->expects($this->once())
+			->method('isSearchable')
+			->with('a')
+			->willReturn(false);
+
+		// userManager->find() must NOT be called for a too-short search term
+		$this->userManager->expects($this->never())
+			->method('find');
+		$this->userManager->expects($this->never())
+			->method('get');
+
+		self::invokePrivate($this->sharees, 'getUsers', ['a']);
+		$result = self::invokePrivate($this->sharees, 'result');
+
+		$this->assertEmpty($result['exact']['users'], 'Exact users must be empty for short search');
+		$this->assertEmpty($result['users'], 'Users must be empty for short search');
+	}
+
+	/**
+	 * Verify that a short but non-empty group search term is blocked when
+	 * user.search_min_length is configured.
+	 */
+	public function testGetGroupsBlocksShortSearchTerm() {
+		self::invokePrivate($this->sharees, 'limit', [2]);
+		self::invokePrivate($this->sharees, 'offset', [0]);
+		self::invokePrivate($this->sharees, 'shareWithMembershipGroupOnly', [false]);
+		self::invokePrivate($this->sharees, 'shareeEnumeration', [true]);
+		self::invokePrivate($this->sharees, 'shareeEnumerationGroupMembers', [false]);
+
+		// Simulate admin setting user.search_min_length = 2
+		$this->userSearch->expects($this->any())
+			->method('getSearchMinLength')
+			->willReturn(2);
+		$this->userSearch->expects($this->once())
+			->method('isSearchable')
+			->with('a')
+			->willReturn(false);
+
+		// groupManager->search() must NOT be called for a too-short search term
+		$this->groupManager->expects($this->never())
+			->method('search');
+
+		self::invokePrivate($this->sharees, 'getGroups', ['a']);
+		$result = self::invokePrivate($this->sharees, 'result');
+
+		$this->assertEmpty($result['exact']['groups'], 'Exact groups must be empty for short search');
+		$this->assertEmpty($result['groups'], 'Groups must be empty for short search');
+	}
+
 	public function testGetUserWithSearchAttributes() {
 		self::invokePrivate($this->sharees, 'limit', [2]);
 		self::invokePrivate($this->sharees, 'offset', [0]);

--- a/apps/files_sharing/tests/API/ShareesTest.php
+++ b/apps/files_sharing/tests/API/ShareesTest.php
@@ -124,6 +124,8 @@ class ShareesTest extends TestCase {
 		$this->userSearch = $this->getMockBuilder(UserSearch::class)
 			->disableOriginalConstructor()
 			->getMock();
+		// Default: all search terms are acceptable unless a specific test overrides this.
+		$this->userSearch->method('isSearchable')->willReturn(true);
 
 		$this->customRemoteSearchMock = $this->createMock(IRemoteShareesSearch::class);
 

--- a/changelog/unreleased/41580
+++ b/changelog/unreleased/41580
@@ -1,0 +1,9 @@
+Security: Enforce minimum search length server-side in sharees endpoint
+
+The admin-configured minimum search length was only enforced client-side
+and in the remote search path. The user and group search paths only
+blocked empty strings, allowing a single-character query to bypass the
+configured limit and enumerate users. The missing server-side guard has
+been added to both paths.
+
+https://github.com/owncloud/core/pull/41580


### PR DESCRIPTION
## Summary
- `getUsers()` and `getGroups()` in `ShareesController` only blocked empty strings, not strings shorter than the admin-configured `user.search_min_length`
- `isSearchable()` was already enforced in `getRemote()` but not in the other two search methods
- Fix adds the missing `isSearchable()` guard, closing the bypass

## Security Impact
Low — authenticated-only endpoint; bypass only relevant when admin raises min length above default

## Test plan
- [ ] New tests `testGetUsersBlocksShortSearchTerm()` and `testGetGroupsBlocksShortSearchTerm()` assert that backends are never queried when search term is below configured minimum
- [ ] Run `make test TEST_PHP_SUITE=apps/files_sharing`

🤖 Generated with [Claude Code](https://claude.com/claude-code)