### PR TITLE
fix(login): add per-IP brute-force throttling to tryLogin()

### DIFF
--- a/changelog/unreleased/41584
+++ b/changelog/unreleased/41584
@@ -1,0 +1,10 @@
+Security: Add per-IP brute-force throttling to the login endpoint
+
+The login endpoint had no rate limiting, account lockout, or progressive
+delay. A CSRF token obtained with a single GET request could be reused
+for unlimited password attempts. Per-IP exponential backoff has been
+added: after 10 failures within a 600-second window each subsequent
+attempt incurs an increasing delay capped at 25 seconds. The feature
+can be disabled via the login_brute_force_protection config key.
+
+https://github.com/owncloud/core/pull/41584

--- a/core/Application.php
+++ b/core/Application.php
@@ -124,7 +124,8 @@ class Application extends App {
 				$c->query('UserSession'),
 				$c->query('URLGenerator'),
 				$c->query('TwoFactorAuthManager'),
-				$c->query('ServerContainer')->getLicenseManager()
+				$c->query('ServerContainer')->getLicenseManager(),
+				$c->query('TimeFactory')
 			);
 		});
 		$container->registerService('TwoFactorChallengeController', static function (SimpleContainer $c) {

--- a/core/Controller/LoginController.php
+++ b/core/Controller/LoginController.php
@@ -67,24 +67,11 @@ class LoginController extends Controller {
 	/** @var ITimeFactory */
 	private $timeFactory;
 
-	/**
-	 * Number of failed attempts from one IP before throttling starts.
-	 * Configurable via system value 'login_brute_force_max_attempts'.
-	 */
-	const BRUTE_FORCE_MAX_ATTEMPTS = 10;
+	public const BRUTE_FORCE_MAX_ATTEMPTS = 10;
 
-	/**
-	 * Rolling window in seconds: the attempt counter resets after this period
-	 * of inactivity. Configurable via system value 'login_brute_force_time_window'.
-	 */
-	const BRUTE_FORCE_TIME_WINDOW = 600;
+	public const BRUTE_FORCE_TIME_WINDOW = 600;
 
-	/**
-	 * Maximum sleep penalty (in microseconds) applied after exceeding the
-	 * threshold. Caps the exponential back-off so legitimate users can still
-	 * recover via a valid password.  Default: 25 seconds.
-	 */
-	const BRUTE_FORCE_MAX_DELAY_US = 25000000;
+	public const BRUTE_FORCE_MAX_DELAY_US = 25000000;
 
 	/**
 	 * @param string $appName
@@ -136,7 +123,7 @@ class LoginController extends Controller {
 	 * Read the current throttle record for an IP from the persistent store.
 	 *
 	 * @param string $key
-	 * @return array{failCount: int, lastFailTime: int}
+	 * @return array
 	 */
 	protected function readThrottleRecord($key) {
 		$raw = $this->config->getAppValue('core', $key, '');
@@ -156,7 +143,7 @@ class LoginController extends Controller {
 	 * Persist an updated throttle record.
 	 *
 	 * @param string $key
-	 * @param array{failCount: int, lastFailTime: int} $record
+	 * @param array $record
 	 * @return void
 	 */
 	protected function writeThrottleRecord($key, array $record) {

--- a/core/Controller/LoginController.php
+++ b/core/Controller/LoginController.php
@@ -33,6 +33,7 @@ use OC_User;
 use OCP\AppFramework\Controller;
 use OCP\AppFramework\Http\RedirectResponse;
 use OCP\AppFramework\Http\TemplateResponse;
+use OCP\AppFramework\Utility\ITimeFactory;
 use OCP\License\ILicenseManager;
 use OCP\IConfig;
 use OCP\IRequest;
@@ -63,6 +64,28 @@ class LoginController extends Controller {
 	/** @var ILicenseManager */
 	private $licenseManager;
 
+	/** @var ITimeFactory */
+	private $timeFactory;
+
+	/**
+	 * Number of failed attempts from one IP before throttling starts.
+	 * Configurable via system value 'login_brute_force_max_attempts'.
+	 */
+	const BRUTE_FORCE_MAX_ATTEMPTS = 10;
+
+	/**
+	 * Rolling window in seconds: the attempt counter resets after this period
+	 * of inactivity. Configurable via system value 'login_brute_force_time_window'.
+	 */
+	const BRUTE_FORCE_TIME_WINDOW = 600;
+
+	/**
+	 * Maximum sleep penalty (in microseconds) applied after exceeding the
+	 * threshold. Caps the exponential back-off so legitimate users can still
+	 * recover via a valid password.  Default: 25 seconds.
+	 */
+	const BRUTE_FORCE_MAX_DELAY_US = 25000000;
+
 	/**
 	 * @param string $appName
 	 * @param IRequest $request
@@ -72,6 +95,8 @@ class LoginController extends Controller {
 	 * @param Session $userSession
 	 * @param IURLGenerator $urlGenerator
 	 * @param Manager $twoFactorManager
+	 * @param ILicenseManager $licenseManager
+	 * @param ITimeFactory $timeFactory
 	 */
 	public function __construct(
 		$appName,
@@ -82,7 +107,8 @@ class LoginController extends Controller {
 		Session $userSession,
 		IURLGenerator $urlGenerator,
 		Manager $twoFactorManager,
-		ILicenseManager $licenseManager
+		ILicenseManager $licenseManager,
+		ITimeFactory $timeFactory
 	) {
 		parent::__construct($appName, $request);
 		$this->userManager = $userManager;
@@ -92,6 +118,150 @@ class LoginController extends Controller {
 		$this->urlGenerator = $urlGenerator;
 		$this->twoFactorManager = $twoFactorManager;
 		$this->licenseManager = $licenseManager;
+		$this->timeFactory = $timeFactory;
+	}
+
+	/**
+	 * Returns the app-config key used to persist per-IP throttle data.
+	 * The IP is hashed so that raw addresses are not stored as plain text.
+	 *
+	 * @param string $ip
+	 * @return string
+	 */
+	protected function getThrottleKey($ip) {
+		return 'login_throttle_' . \hash('sha256', $ip);
+	}
+
+	/**
+	 * Read the current throttle record for an IP from the persistent store.
+	 *
+	 * @param string $key
+	 * @return array{failCount: int, lastFailTime: int}
+	 */
+	protected function readThrottleRecord($key) {
+		$raw = $this->config->getAppValue('core', $key, '');
+		if ($raw === '') {
+			return ['failCount' => 0, 'lastFailTime' => 0];
+		}
+		$data = \json_decode($raw, true);
+		if (!\is_array($data)
+			|| !isset($data['failCount'], $data['lastFailTime'])
+		) {
+			return ['failCount' => 0, 'lastFailTime' => 0];
+		}
+		return $data;
+	}
+
+	/**
+	 * Persist an updated throttle record.
+	 *
+	 * @param string $key
+	 * @param array{failCount: int, lastFailTime: int} $record
+	 * @return void
+	 */
+	protected function writeThrottleRecord($key, array $record) {
+		$this->config->setAppValue('core', $key, \json_encode($record));
+	}
+
+	/**
+	 * Apply a brute-force delay based on the current failure count.
+	 * Returns immediately when protection is disabled or below the threshold.
+	 *
+	 * @param string $ip  The remote client IP
+	 * @return void
+	 */
+	protected function throttleLogin($ip) {
+		if ($this->config->getSystemValue('login_brute_force_protection', true) === false) {
+			return;
+		}
+
+		$key = $this->getThrottleKey($ip);
+		$record = $this->readThrottleRecord($key);
+
+		$maxAttempts = (int) $this->config->getSystemValue(
+			'login_brute_force_max_attempts',
+			self::BRUTE_FORCE_MAX_ATTEMPTS
+		);
+		$timeWindow = (int) $this->config->getSystemValue(
+			'login_brute_force_time_window',
+			self::BRUTE_FORCE_TIME_WINDOW
+		);
+
+		$now = $this->timeFactory->getTime();
+
+		// If the last failure is outside the rolling window, the counter has
+		// naturally expired — treat this IP as clean.
+		if (($now - $record['lastFailTime']) >= $timeWindow) {
+			return;
+		}
+
+		$excess = $record['failCount'] - $maxAttempts;
+		if ($excess <= 0) {
+			return;
+		}
+
+		// Exponential back-off: 2^excess seconds, capped at MAX_DELAY_US.
+		$delayUs = (int) \min(
+			(2 ** $excess) * 1000000,
+			self::BRUTE_FORCE_MAX_DELAY_US
+		);
+		$this->applyDelay($delayUs);
+	}
+
+	/**
+	 * Increment the failure counter for this IP in the persistent store.
+	 *
+	 * @param string $ip
+	 * @return void
+	 */
+	protected function recordFailedLoginAttempt($ip) {
+		if ($this->config->getSystemValue('login_brute_force_protection', true) === false) {
+			return;
+		}
+
+		$key = $this->getThrottleKey($ip);
+		$record = $this->readThrottleRecord($key);
+
+		$timeWindow = (int) $this->config->getSystemValue(
+			'login_brute_force_time_window',
+			self::BRUTE_FORCE_TIME_WINDOW
+		);
+		$now = $this->timeFactory->getTime();
+
+		// Reset if the window has passed since the last failure.
+		if (($now - $record['lastFailTime']) >= $timeWindow) {
+			$record['failCount'] = 0;
+		}
+
+		$record['failCount']++;
+		$record['lastFailTime'] = $now;
+
+		$this->writeThrottleRecord($key, $record);
+	}
+
+	/**
+	 * Remove the throttle record for this IP upon successful authentication.
+	 *
+	 * @param string $ip
+	 * @return void
+	 */
+	protected function resetLoginThrottle($ip) {
+		if ($this->config->getSystemValue('login_brute_force_protection', true) === false) {
+			return;
+		}
+
+		$key = $this->getThrottleKey($ip);
+		$this->config->deleteAppValue('core', $key);
+	}
+
+	/**
+	 * Wrapper around usleep() to allow unit-test overriding.
+	 *
+	 * @param int $microseconds
+	 * @return void
+	 */
+	protected function applyDelay($microseconds) {
+		\usleep($microseconds);
 	}
 
 	/**
@@ -266,6 +436,13 @@ class LoginController extends Controller {
 	 */
 	public function tryLogin($user, $password, $redirect_url, $timezone = null, $remember_login = null) {
 		$originalUser = $user;
+		$ip = $this->request->getRemoteAddress();
+
+		// Apply a progressive delay when this IP has exceeded the failure
+		// threshold.  Legitimate users are unaffected until they exhaust the
+		// configurable number of free attempts.
+		$this->throttleLogin($ip);
+
 		// TODO: Add all the insane error handling
 		$loginResult = $this->userSession->login($user, $password);
 		if ($loginResult !== true && $this->config->getSystemValue('strict_login_enforced', false) !== true) {
@@ -277,6 +454,9 @@ class LoginController extends Controller {
 			}
 		}
 		if ($loginResult !== true) {
+			// Persist the failure so the delay grows on the next attempt.
+			$this->recordFailedLoginAttempt($ip);
+
 			$this->session->set('loginMessages', [
 				['invalidpassword'], []
 			]);
@@ -291,6 +471,10 @@ class LoginController extends Controller {
 			}
 			return new RedirectResponse($this->urlGenerator->linkToRoute('core.login.showLoginForm', $args));
 		}
+		// Successful login: clear the throttle record for this IP so a
+		// legitimately locked-out user is not penalised after recovery.
+		$this->resetLoginThrottle($ip);
+
 		/* @var $userObject IUser */
 		$userObject = $this->userSession->getUser();
 		// TODO: remove password checks from above and let the user session handle failures

--- a/core/Controller/LoginController.php
+++ b/core/Controller/LoginController.php
@@ -157,7 +157,7 @@ class LoginController extends Controller {
 	 * @param string $ip  The remote client IP
 	 * @return void
 	 */
-	protected function throttleLogin($ip) {
+	public function throttleLogin($ip) {
 		if ($this->config->getSystemValue('login_brute_force_protection', true) === false) {
 			return;
 		}
@@ -201,7 +201,7 @@ class LoginController extends Controller {
 	 * @param string $ip
 	 * @return void
 	 */
-	protected function recordFailedLoginAttempt($ip) {
+	public function recordFailedLoginAttempt($ip) {
 		if ($this->config->getSystemValue('login_brute_force_protection', true) === false) {
 			return;
 		}
@@ -232,7 +232,7 @@ class LoginController extends Controller {
 	 * @param string $ip
 	 * @return void
 	 */
-	protected function resetLoginThrottle($ip) {
+	public function resetLoginThrottle($ip) {
 		if ($this->config->getSystemValue('login_brute_force_protection', true) === false) {
 			return;
 		}

--- a/tests/Core/Controller/LoginControllerTest.php
+++ b/tests/Core/Controller/LoginControllerTest.php
@@ -27,6 +27,7 @@ use OC\Core\Controller\LoginController;
 use OC\User\Session;
 use OCP\AppFramework\Http\RedirectResponse;
 use OCP\AppFramework\Http\TemplateResponse;
+use OCP\AppFramework\Utility\ITimeFactory;
 use OCP\License\ILicenseManager;
 use OCP\IConfig;
 use OCP\IRequest;
@@ -55,6 +56,8 @@ class LoginControllerTest extends TestCase {
 	private $twoFactorManager;
 	/** @var ILicenseManager */
 	private $licenseManager;
+	/** @var ITimeFactory | \PHPUnit\Framework\MockObject\MockObject */
+	private $timeFactory;
 
 	public function setUp(): void {
 		parent::setUp();
@@ -70,6 +73,7 @@ class LoginControllerTest extends TestCase {
 			->disableOriginalConstructor()
 			->getMock();
 		$this->licenseManager = $this->createMock(ILicenseManager::class);
+		$this->timeFactory = $this->createMock(ITimeFactory::class);
 
 		$this->loginController = new LoginController(
 			'core',
@@ -80,7 +84,8 @@ class LoginControllerTest extends TestCase {
 			$this->userSession,
 			$this->urlGenerator,
 			$this->twoFactorManager,
-			$this->licenseManager
+			$this->licenseManager,
+			$this->timeFactory
 		);
 	}
 
@@ -468,7 +473,8 @@ class LoginControllerTest extends TestCase {
 				$this->userSession,
 				$this->urlGenerator,
 				$this->twoFactorManager,
-				$this->licenseManager
+				$this->licenseManager,
+				$this->timeFactory,
 			])
 			->getMock();
 		$this->loginController->expects($this->once())
@@ -524,8 +530,28 @@ class LoginControllerTest extends TestCase {
 		$this->userManager->expects($this->exactly($expectedGetByEmailCalls))
 			->method('getByEmail')->willReturn([]);
 
+		// Stub out brute-force throttle methods so they do not interfere with
+		// the strict config-mock expectations in this test.
+		$controller = $this->getMockBuilder(LoginController::class)
+			->setMethods(['throttleLogin', 'recordFailedLoginAttempt'])
+			->setConstructorArgs([
+				'core',
+				$this->request,
+				$this->userManager,
+				$this->config,
+				$this->session,
+				$this->userSession,
+				$this->urlGenerator,
+				$this->twoFactorManager,
+				$this->licenseManager,
+				$this->timeFactory,
+			])
+			->getMock();
+		$controller->expects($this->once())->method('throttleLogin');
+		$controller->expects($this->once())->method('recordFailedLoginAttempt');
+
 		$expected = new RedirectResponse($loginPageUrl);
-		$this->assertEquals($expected, $this->loginController->tryLogin($user, $password, '/foo'));
+		$this->assertEquals($expected, $controller->tryLogin($user, $password, '/foo'));
 	}
 
 	public function testLoginWithValidCredentials() {
@@ -554,7 +580,7 @@ class LoginControllerTest extends TestCase {
 		$expected = new RedirectResponse($indexPageUrl);
 
 		$this->loginController = $this->getMockBuilder(LoginController::class)
-			->setMethods(['getDefaultUrl'])
+			->setMethods(['getDefaultUrl', 'throttleLogin', 'resetLoginThrottle'])
 			->setConstructorArgs([
 				'core',
 				$this->request,
@@ -564,12 +590,15 @@ class LoginControllerTest extends TestCase {
 				$this->userSession,
 				$this->urlGenerator,
 				$this->twoFactorManager,
-				$this->licenseManager
+				$this->licenseManager,
+				$this->timeFactory,
 			])
 			->getMock();
 		$this->loginController->expects($this->once())
 			->method('getDefaultUrl')
 			->willReturn($indexPageUrl);
+		$this->loginController->expects($this->once())->method('throttleLogin');
+		$this->loginController->expects($this->once())->method('resetLoginThrottle');
 
 		$this->assertEquals($expected, $this->loginController->tryLogin($user, $password, null));
 	}
@@ -600,7 +629,7 @@ class LoginControllerTest extends TestCase {
 		$expected = new RedirectResponse($indexPageUrl);
 
 		$this->loginController = $this->getMockBuilder(LoginController::class)
-			->setMethods(['getDefaultUrl'])
+			->setMethods(['getDefaultUrl', 'throttleLogin', 'resetLoginThrottle'])
 			->setConstructorArgs([
 				'core',
 				$this->request,
@@ -610,12 +639,15 @@ class LoginControllerTest extends TestCase {
 				$this->userSession,
 				$this->urlGenerator,
 				$this->twoFactorManager,
-				$this->licenseManager
+				$this->licenseManager,
+				$this->timeFactory,
 			])
 			->getMock();
 		$this->loginController->expects($this->once())
 			->method('getDefaultUrl')
 			->willReturn($indexPageUrl);
+		$this->loginController->expects($this->once())->method('throttleLogin');
+		$this->loginController->expects($this->once())->method('resetLoginThrottle');
 
 		$this->assertEquals($expected, $this->loginController->tryLogin($user, $password, null, null, "1")); // "1" is expected as rememberMe value
 	}
@@ -650,10 +682,18 @@ class LoginControllerTest extends TestCase {
 			->with(\urldecode($originalUrl))
 			->will($this->returnValue($redirectUrl));
 
+		// Disable brute-force protection so the throttle helpers return
+		// immediately and do not require additional mock wiring.
+		$this->request->method('getRemoteAddress')->willReturn('127.0.0.1');
+		$this->config->method('getSystemValue')
+			->willReturnMap([
+				['login_brute_force_protection', true, false],
+			]);
+
 		$expected = new RedirectResponse(\urldecode($redirectUrl));
 		$this->assertEquals($expected, $this->loginController->tryLogin('Jane', $password, $originalUrl));
 	}
-	
+
 	public function testLoginWithTwoFactorEnforced() {
 		/** @var IUser | \PHPUnit\Framework\MockObject\MockObject $user */
 		$user = $this->createMock(IUser::class);
@@ -689,6 +729,14 @@ class LoginControllerTest extends TestCase {
 			->with('core.TwoFactorChallenge.selectChallenge')
 			->will($this->returnValue($challengeUrl));
 
+		// Disable brute-force protection so the throttle helpers return
+		// immediately and do not require additional mock wiring.
+		$this->request->method('getRemoteAddress')->willReturn('127.0.0.1');
+		$this->config->method('getSystemValue')
+			->willReturnMap([
+				['login_brute_force_protection', true, false],
+			]);
+
 		$expected = new RedirectResponse($challengeUrl);
 		$this->assertEquals($expected, $this->loginController->tryLogin('john@doe.com', $password, null));
 	}
@@ -707,7 +755,7 @@ class LoginControllerTest extends TestCase {
 				['john', 'just wrong']
 			)
 			->willReturn(false);
-		
+
 		$this->userManager->expects($this->once())
 			->method('getByEmail')
 			->with('john@doe.com')
@@ -718,7 +766,207 @@ class LoginControllerTest extends TestCase {
 			->with('core.login.showLoginForm', ['user' => 'john@doe.com'])
 			->will($this->returnValue(''));
 
+		// Disable brute-force protection so the throttle helpers return
+		// immediately and do not require additional mock wiring.
+		$this->request->method('getRemoteAddress')->willReturn('127.0.0.1');
+		$this->config->method('getSystemValue')
+			->willReturnMap([
+				['login_brute_force_protection', true, false],
+				['strict_login_enforced', false, false],
+			]);
+
 		$expected = new RedirectResponse('');
 		$this->assertEquals($expected, $this->loginController->tryLogin('john@doe.com', 'just wrong', null));
+	}
+
+	// -------------------------------------------------------------------------
+	// Brute-force throttle unit tests
+	// -------------------------------------------------------------------------
+
+	/**
+	 * Helper: build a LoginController that stubs applyDelay() so tests run
+	 * without actually sleeping, but all other throttle logic executes.
+	 *
+	 * @return LoginController|\PHPUnit\Framework\MockObject\MockObject
+	 */
+	private function buildThrottleController() {
+		return $this->getMockBuilder(LoginController::class)
+			->setMethods(['applyDelay'])
+			->setConstructorArgs([
+				'core',
+				$this->request,
+				$this->userManager,
+				$this->config,
+				$this->session,
+				$this->userSession,
+				$this->urlGenerator,
+				$this->twoFactorManager,
+				$this->licenseManager,
+				$this->timeFactory,
+			])
+			->getMock();
+	}
+
+	public function testThrottleLoginNoDelayBelowThreshold() {
+		$this->config->method('getSystemValue')
+			->willReturnMap([
+				['login_brute_force_protection', true, true],
+				['login_brute_force_max_attempts', LoginController::BRUTE_FORCE_MAX_ATTEMPTS, 10],
+				['login_brute_force_time_window', LoginController::BRUTE_FORCE_TIME_WINDOW, 600],
+			]);
+		$this->config->expects($this->once())
+			->method('getAppValue')
+			->willReturn(\json_encode(['failCount' => 5, 'lastFailTime' => 900]));
+		$this->timeFactory->method('getTime')->willReturn(1000); // within window
+
+		$controller = $this->buildThrottleController();
+		// applyDelay must NOT be called: failCount (5) <= max (10)
+		$controller->expects($this->never())->method('applyDelay');
+
+		$controller->throttleLogin('1.2.3.4');
+	}
+
+	public function testThrottleLoginDelayAppliedAboveThreshold() {
+		$this->config->method('getSystemValue')
+			->willReturnMap([
+				['login_brute_force_protection', true, true],
+				['login_brute_force_max_attempts', LoginController::BRUTE_FORCE_MAX_ATTEMPTS, 10],
+				['login_brute_force_time_window', LoginController::BRUTE_FORCE_TIME_WINDOW, 600],
+			]);
+		// failCount=12, excess=2 → delay = 2^2 * 1 000 000 = 4 000 000 µs
+		$this->config->expects($this->once())
+			->method('getAppValue')
+			->willReturn(\json_encode(['failCount' => 12, 'lastFailTime' => 900]));
+		$this->timeFactory->method('getTime')->willReturn(1000); // within window
+
+		$controller = $this->buildThrottleController();
+		$controller->expects($this->once())
+			->method('applyDelay')
+			->with(4000000);
+
+		$controller->throttleLogin('1.2.3.4');
+	}
+
+	public function testThrottleLoginNoDelayAfterWindowExpires() {
+		$this->config->method('getSystemValue')
+			->willReturnMap([
+				['login_brute_force_protection', true, true],
+				['login_brute_force_max_attempts', LoginController::BRUTE_FORCE_MAX_ATTEMPTS, 10],
+				['login_brute_force_time_window', LoginController::BRUTE_FORCE_TIME_WINDOW, 600],
+			]);
+		// failCount=99 but lastFailTime is outside the window
+		$this->config->expects($this->once())
+			->method('getAppValue')
+			->willReturn(\json_encode(['failCount' => 99, 'lastFailTime' => 1]));
+		$this->timeFactory->method('getTime')->willReturn(10000); // >> 601 seconds later
+
+		$controller = $this->buildThrottleController();
+		$controller->expects($this->never())->method('applyDelay');
+
+		$controller->throttleLogin('1.2.3.4');
+	}
+
+	public function testThrottleLoginDisabledByConfig() {
+		$this->config->method('getSystemValue')
+			->willReturnMap([
+				['login_brute_force_protection', true, false], // disabled
+			]);
+		// getAppValue should never be reached
+		$this->config->expects($this->never())->method('getAppValue');
+
+		$controller = $this->buildThrottleController();
+		$controller->expects($this->never())->method('applyDelay');
+
+		$controller->throttleLogin('1.2.3.4');
+	}
+
+	public function testRecordFailedLoginAttemptIncrementsCounter() {
+		$this->config->method('getSystemValue')
+			->willReturnMap([
+				['login_brute_force_protection', true, true],
+				['login_brute_force_time_window', LoginController::BRUTE_FORCE_TIME_WINDOW, 600],
+			]);
+		// Existing record: 3 failures, within the window
+		$this->config->expects($this->once())
+			->method('getAppValue')
+			->willReturn(\json_encode(['failCount' => 3, 'lastFailTime' => 950]));
+		$this->timeFactory->method('getTime')->willReturn(1000);
+
+		// Expect the incremented record to be persisted
+		$this->config->expects($this->once())
+			->method('setAppValue')
+			->with(
+				'core',
+				$this->stringContains('login_throttle_'),
+				$this->callback(function ($json) {
+					$data = \json_decode($json, true);
+					return $data['failCount'] === 4 && $data['lastFailTime'] === 1000;
+				})
+			);
+
+		$controller = $this->buildThrottleController();
+		$controller->recordFailedLoginAttempt('1.2.3.4');
+	}
+
+	public function testRecordFailedLoginAttemptResetsCounterOutsideWindow() {
+		$this->config->method('getSystemValue')
+			->willReturnMap([
+				['login_brute_force_protection', true, true],
+				['login_brute_force_time_window', LoginController::BRUTE_FORCE_TIME_WINDOW, 600],
+			]);
+		// Last failure was long ago
+		$this->config->expects($this->once())
+			->method('getAppValue')
+			->willReturn(\json_encode(['failCount' => 50, 'lastFailTime' => 1]));
+		$this->timeFactory->method('getTime')->willReturn(10000);
+
+		// Counter should reset to 1
+		$this->config->expects($this->once())
+			->method('setAppValue')
+			->with(
+				'core',
+				$this->stringContains('login_throttle_'),
+				$this->callback(function ($json) {
+					$data = \json_decode($json, true);
+					return $data['failCount'] === 1;
+				})
+			);
+
+		$controller = $this->buildThrottleController();
+		$controller->recordFailedLoginAttempt('1.2.3.4');
+	}
+
+	public function testResetLoginThrottleClearsRecord() {
+		$this->config->method('getSystemValue')
+			->willReturnMap([
+				['login_brute_force_protection', true, true],
+			]);
+		$this->config->expects($this->once())
+			->method('deleteAppValue')
+			->with('core', $this->stringContains('login_throttle_'));
+
+		$controller = $this->buildThrottleController();
+		$controller->resetLoginThrottle('1.2.3.4');
+	}
+
+	public function testThrottleDelayCapAtMaximum() {
+		$this->config->method('getSystemValue')
+			->willReturnMap([
+				['login_brute_force_protection', true, true],
+				['login_brute_force_max_attempts', LoginController::BRUTE_FORCE_MAX_ATTEMPTS, 10],
+				['login_brute_force_time_window', LoginController::BRUTE_FORCE_TIME_WINDOW, 600],
+			]);
+		// excess=100 → uncapped delay would be astronomical; capped at MAX_DELAY_US
+		$this->config->expects($this->once())
+			->method('getAppValue')
+			->willReturn(\json_encode(['failCount' => 110, 'lastFailTime' => 999]));
+		$this->timeFactory->method('getTime')->willReturn(1000);
+
+		$controller = $this->buildThrottleController();
+		$controller->expects($this->once())
+			->method('applyDelay')
+			->with(LoginController::BRUTE_FORCE_MAX_DELAY_US);
+
+		$controller->throttleLogin('1.2.3.4');
 	}
 }


### PR DESCRIPTION
## Summary
- `tryLogin()` had no rate limiting; CSRF token was reusable for unlimited attempts; zero throttle subscribers on the `user.loginfailed` event
- Adds per-IP exponential backoff: >10 failures within 600s → `2^excess` seconds sleep per attempt, capped at 25s
- Counter stored in `oc_appconfig`; reset on success; disableable via `login_brute_force_protection=false` in config.php

## Security Impact
**Medium** — unlimited credential stuffing / password spraying against the HTML login form

## Note
This PR touches the same files as `security/fix-login-user-enumeration` — merge this one first.

## Test plan
- [ ] 8 new tests cover: below-threshold no-delay, above-threshold exponential delay, expired-window reset, config-disabled, counter increment, counter reset, deletion on success, delay cap
- [ ] Existing tests stub the new throttle methods to preserve expectations
- [ ] Run `make test TEST_PHP_SUITE=core/Controller`

🤖 Generated with [Claude Code](https://claude.com/claude-code)