### PR TITLE
chore: fix format of PHP dependency changelog

### DIFF
--- a/changelog/unreleased/PHPdependencies20260225onward
+++ b/changelog/unreleased/PHPdependencies20260225onward
@@ -1,19 +1,19 @@
 Change: Update PHP dependencies
 
 The following have been updated:
-- doctrine/dbal (2.13.9 to 3.10.4)
-- google/apiclient (v2.19.0 to v2.19.3)
-- google/apiclient-services (v0.435.0 to v0.441.1)
-- google/auth (v1.50.0 to v1.50.1)
-- guzzlehttp/psr7 (2.8.0 to 2.10.4)
-- guzzlehttp/guzzle (7.10.0 to 7.11.0)
-- guzzlehttp/promises (2.3.0 to 2.4.1)
-- laravel/serializable-closure (v2.0.10 to v2.0.13)
-- phpseclib/phpseclib (3.0.49 to 3.0.50)
-- pimple/pimple (3.6.1 to 3.6.2)
-- sabre/vobject (4.5.8 to 4.6.0)
-- symfony/deprecation-contracts (v3.6.0 to v3.7.0)
-- symfony/mailer (v7.4.6 to v7.4.12)
+ * doctrine/dbal (2.13.9 to 3.10.4)
+ * google/apiclient (v2.19.0 to v2.19.3)
+ * google/apiclient-services (v0.435.0 to v0.441.1)
+ * google/auth (v1.50.0 to v1.50.1)
+ * guzzlehttp/psr7 (2.8.0 to 2.10.4)
+ * guzzlehttp/guzzle (7.10.0 to 7.11.0)
+ * guzzlehttp/promises (2.3.0 to 2.4.1)
+ * laravel/serializable-closure (v2.0.10 to v2.0.13)
+ * phpseclib/phpseclib (3.0.49 to 3.0.50)
+ * pimple/pimple (3.6.1 to 3.6.2)
+ * sabre/vobject (4.5.8 to 4.6.0)
+ * symfony/deprecation-contracts (v3.6.0 to v3.7.0)
+ * symfony/mailer (v7.4.6 to v7.4.12)
 
 https://github.com/owncloud/core/pull/41450
 https://github.com/owncloud/core/pull/41477


### PR DESCRIPTION
The existing list, starting each list item with a dash, gets all merged together and wrapped into a paragraph by the `calens` bot that generates the full changelog:
https://github.com/owncloud/core/pull/41593/changes#r3370831449

I think that a list should use an asterisk rather than a dash at each line, like:
https://github.com/restic/restic/blob/master/changelog/0.9.0_2018-05-21/issue-1665

This PR fixes the format of the PHP dependencies changelog item.