### PR TITLE
chore: add empty lines between items in a changelog entry

### DIFF
--- a/changelog/unreleased/PHPRemovedCodeOC11
+++ b/changelog/unreleased/PHPRemovedCodeOC11
@@ -1,17 +1,27 @@
 Change: Removed legacy and deprecated code from ownCloud 11
 
 The following have been removed:
-- class OC_DB
-- class OC_DB_StatementWrapper
-- class OC_Group_Backend
-- class OC_Group_Database
-- class OC_OCS_Result
-- class \OCP\DB
-- class MDBSchemaWriter
-- interface OC_Group_Interface
-- interface OC_User_Interface
-- method MDB2SchemaManager::getDbStructure()
-- method MDB2SchemaManager::generateChangeScript()
+ * class OC_DB
+
+ * class OC_DB_StatementWrapper
+
+ * class OC_Group_Backend
+
+ * class OC_Group_Database
+
+ * class OC_OCS_Result
+
+ * class \OCP\DB
+
+ * class MDBSchemaWriter
+
+ * interface OC_Group_Interface
+
+ * interface OC_User_Interface
+
+ * method MDB2SchemaManager::getDbStructure()
+
+ * method MDB2SchemaManager::generateChangeScript()
 
 https://github.com/owncloud/core/pull/41455
 https://github.com/owncloud/core/pull/41458

--- a/changelog/unreleased/PHPdependencies20260225onward
+++ b/changelog/unreleased/PHPdependencies20260225onward
@@ -2,17 +2,29 @@ Change: Update PHP dependencies
 
 The following have been updated:
  * doctrine/dbal (2.13.9 to 3.10.4)
+
  * google/apiclient (v2.19.0 to v2.19.3)
+
  * google/apiclient-services (v0.435.0 to v0.441.1)
+
  * google/auth (v1.50.0 to v1.50.1)
+
  * guzzlehttp/psr7 (2.8.0 to 2.10.4)
+
  * guzzlehttp/guzzle (7.10.0 to 7.11.0)
+
  * guzzlehttp/promises (2.3.0 to 2.4.1)
+
  * laravel/serializable-closure (v2.0.10 to v2.0.13)
+
  * phpseclib/phpseclib (3.0.49 to 3.0.50)
+
  * pimple/pimple (3.6.1 to 3.6.2)
+
  * sabre/vobject (4.5.8 to 4.6.0)
+
  * symfony/deprecation-contracts (v3.6.0 to v3.7.0)
+
  * symfony/mailer (v7.4.6 to v7.4.12)
 
 https://github.com/owncloud/core/pull/41450


### PR DESCRIPTION
When there is a list in the text of a changelog entry, the `calens` bot is still merging and wrapping the whole list into a single paragraph.

Separate the items with empty lines. Hopefully that will be the last thing that we need to do to get the changelog output format correct.