### PR TITLE
chore: add an empty line at the start of each list in changelogs

### DIFF
--- a/changelog/unreleased/PHPRemovedCodeOC11
+++ b/changelog/unreleased/PHPRemovedCodeOC11
@@ -1,6 +1,7 @@
 Change: Removed legacy and deprecated code from ownCloud 11
 
 The following have been removed:
+
  * class OC_DB
 
  * class OC_DB_StatementWrapper

--- a/changelog/unreleased/PHPdependencies20260225onward
+++ b/changelog/unreleased/PHPdependencies20260225onward
@@ -1,6 +1,7 @@
 Change: Update PHP dependencies
 
 The following have been updated:
+
  * doctrine/dbal (2.13.9 to 3.10.4)
 
  * google/apiclient (v2.19.0 to v2.19.3)


### PR DESCRIPTION
One more adjustment. There needs to be empty line above the first item in a list in a changelog entry.
Otherwise, the first list item is merged into the paragraph above.