### PR TITLE
fix: Adjust code to avoid PHP8 messages

### DIFF
--- a/apps/federation/lib/DbHandler.php
+++ b/apps/federation/lib/DbHandler.php
@@ -293,6 +293,9 @@ class DbHandler {
 	 * @return string
 	 */
 	protected function normalizeUrl($url) {
+		if ($url === null) {
+			$url = '';
+		}
 		$normalized = $url;
 
 		if (\strpos($url, 'https://') === 0) {

--- a/changelog/unreleased/41597
+++ b/changelog/unreleased/41597
@@ -1,0 +1,7 @@
+Fix: Adjust code to avoid PHP8 messages
+
+Avoid trying to access array offset on false in the encryption storage wrapper.
+
+Handle passing null to normalizeUrl in the federation DbHandler.
+
+https://github.com/owncloud/core/pull/41597

--- a/lib/private/Files/Storage/Wrapper/Encryption.php
+++ b/lib/private/Files/Storage/Wrapper/Encryption.php
@@ -472,7 +472,7 @@ class Encryption extends Wrapper {
 					if (!empty($encryptionModuleId)) {
 						$encryptionModule = $this->encryptionManager->getEncryptionModule($encryptionModuleId);
 						$shouldEncrypt = true;
-					} elseif (empty($encryptionModuleId) && $info['encrypted'] === true) {
+					} elseif ($info !== false && $info->isEncrypted()) {
 						// we come from a old installation. No header and/or no module defined
 						// but the file is encrypted. In this case we need to use the
 						// OC_DEFAULT_MODULE to read the file


### PR DESCRIPTION
fix: avoid trying to access array offset on false

This fixes log file messages like:
```
{"reqId":"rRziQ2UaFono1r96TEdK","level":3,"time":"2026-05-19T12:44:35+00:00","remoteAddr":"::1",
"user":"Brian","app":"PHP","method":"PUT",
"url":"\/server\/remote.php\/webdav\/textfile0.txt-chunking-42-3-2",
"message":"Trying to access array offset on false at
\/var\/www\/html\/server\/lib\/private\/Files\/Storage\/Wrapper\/Encryption.php#475"}
```

fix: handle passing null to normalizeUrl
This will fix log file messages like
```
{"reqId":"oAKAHIupnZUz4ujYoFqY","level":3,"time":"2026-05-19T12:46:31+00:00","remoteAddr":"::1",
"user":"--","app":"PHP","method":"POST",
"url":"\/server\/ocs\/v1.php\/apps\/federation\/api\/v1\/request-shared-secret",
"message":"strpos(): Passing null to parameter https://github.com/owncloud/core/pull/1 ($haystack) of type string is deprecated
at \/var\/www\/html\/server\/apps\/federation\/lib\/DbHandler.php#298"}
```