### PR TITLE
fix: support federation between systems in subdirectories

### DIFF
--- a/apps/files_sharing/lib/External/Manager.php
+++ b/apps/files_sharing/lib/External/Manager.php
@@ -580,7 +580,7 @@ class Manager {
 				$remote .= ':' . $parsed_port;
 			}
 			if ($parsed_path !== null) {
-				$remote .= $parsed_path;
+				$remote .= \rtrim($parsed_path, '/');
 			}
 		} else {
 			$string_to_parse = 'http://' . $remote;
@@ -593,7 +593,7 @@ class Manager {
 					$remote .= ':' . $parsed_port;
 				}
 				if ($parsed_path !== null) {
-					$remote .= $parsed_path;
+					$remote .= \rtrim($parsed_path, '/');
 				}
 			}
 		}

--- a/apps/files_sharing/lib/External/Manager.php
+++ b/apps/files_sharing/lib/External/Manager.php
@@ -573,19 +573,27 @@ class Manager {
 	public function testRemoteUrl(IClientService $clientService, string $remote) {
 		$parsed_host = parse_url($remote, PHP_URL_HOST);
 		$parsed_port = parse_url($remote, PHP_URL_PORT);
+		$parsed_path = parse_url($remote, PHP_URL_PATH);
 		if (\is_string($parsed_host)) {
 			$remote = $parsed_host;
 			if ($parsed_port !== null) {
 				$remote .= ':' . $parsed_port;
 			}
+			if ($parsed_path !== null) {
+				$remote .= $parsed_path;
+			}
 		} else {
 			$string_to_parse = 'http://' . $remote;
 			$parsed_host = parse_url($string_to_parse, PHP_URL_HOST);
 			$parsed_port = parse_url($string_to_parse, PHP_URL_PORT);
+			$parsed_path = parse_url($string_to_parse, PHP_URL_PATH);
 			if (\is_string($parsed_host)) {
 				$remote = $parsed_host;
 				if ($parsed_port !== null) {
 					$remote .= ':' . $parsed_port;
+				}
+				if ($parsed_path !== null) {
+					$remote .= $parsed_path;
 				}
 			}
 		}

--- a/apps/files_sharing/tests/External/ManagerTest.php
+++ b/apps/files_sharing/tests/External/ManagerTest.php
@@ -434,7 +434,21 @@ class ManagerTest extends TestCase {
 		$this->assertArrayHasKey('user', $called[1]);
 	}
 
-	public function testRemoteWithValidHttps(): void {
+	public function providesRemoteAddress() {
+		return [
+			[
+				'owncloud.com',
+			],
+			[
+				'owncloud.com/cloud',
+			],
+		];
+	}
+
+	/**
+	 * @dataProvider providesRemoteAddress
+	 */
+	public function testRemoteWithValidHttps($remoteAddress): void {
 		$client = $this->getMockBuilder(IClient::class)
 			->disableOriginalConstructor()->getMock();
 		$response = $this->getMockBuilder(IResponse::class)
@@ -453,10 +467,13 @@ class ManagerTest extends TestCase {
 			->method('newClient')
 			->willReturn($client);
 
-		$this->assertEquals('https', $this->manager->testRemoteUrl($clientService, 'owncloud.com'));
+		$this->assertEquals('https', $this->manager->testRemoteUrl($clientService, $remoteAddress));
 	}
 
-	public function testRemoteWithWorkingHttp(): void {
+	/**
+	 * @dataProvider providesRemoteAddress
+	 */
+	public function testRemoteWithWorkingHttp($remoteAddress): void {
 		$client = $this->getMockBuilder(IClient::class)
 			->disableOriginalConstructor()->getMock();
 		$response = $this->getMockBuilder(IResponse::class)
@@ -475,7 +492,7 @@ class ManagerTest extends TestCase {
 			->method('newClient')
 			->willReturn($client);
 
-		$this->assertEquals('http', $this->manager->testRemoteUrl($clientService, 'owncloud.com'));
+		$this->assertEquals('http', $this->manager->testRemoteUrl($clientService, $remoteAddress));
 	}
 
 	public function testRemoteWithInvalidRemote(): void {

--- a/apps/files_sharing/tests/External/ManagerTest.php
+++ b/apps/files_sharing/tests/External/ManagerTest.php
@@ -442,6 +442,9 @@ class ManagerTest extends TestCase {
 			[
 				'owncloud.com/cloud',
 			],
+			[
+				'owncloud.com/cloud/',
+			],
 		];
 	}
 

--- a/changelog/unreleased/41599
+++ b/changelog/unreleased/41599
@@ -1,0 +1,10 @@
+Fix: support federation between systems in subdirectories
+
+If a federated server was installed in a subdirectory like:
+
+mydomain.com/cloud
+
+Then checks to see that the server is up and responding would fail.
+This problem has been corrected.
+
+https://github.com/owncloud/core/pull/41599


### PR DESCRIPTION
testRemoteUrl was only checking for a responding ownCloud at the provided host. But if the server is installed in a subdirectory then the requests were not sent there. For example:
- the cloud server is at http://mydomain.com/cloud
- testRemoteUrl checked for a repsonse from http://mydomain.com/status.php

Now it checks for a response from http://mydomain.com/cloud/status.php
