### PR TITLE
ci: add calens validation job to CI workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -27,3 +27,13 @@ jobs:
     uses: ./.github/workflows/php-unit.yml
     with:
       php-versions: '["8.3"]'
+
+  calens:
+    name: Changelog lint
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+
+      - name: Validate changelog entries
+        uses: actionhippie/calens@0b8ceba55a72f5ef8b7d910698fcd28be8bb8c19 # v1.13.4

--- a/changelog/unreleased/41597
+++ b/changelog/unreleased/41597
@@ -1,4 +1,4 @@
-Fix: Adjust code to avoid PHP8 messages
+Bugfix: Adjust code to avoid PHP8 messages
 
 Avoid trying to access array offset on false in the encryption storage wrapper.
 


### PR DESCRIPTION
## Summary

Add a `Changelog lint` CI job that runs [calens](https://github.com/actionhippie/calens) on every PR and master push. This catches malformed changelog entries in `changelog/unreleased/` before they can block the auto-changelog generation workflow on master (as happened in https://github.com/owncloud/core/actions/runs/27135471818).

## Changes

- New `calens` job in `.github/workflows/ci.yml`
- Uses `actionhippie/calens@0b8ceba55a72f5ef8b7d910698fcd28be8bb8c19` (v1.13.4) — SHA-pinned to match the pin already used in the reusable `calens.yml` workflow
- Runs on both PRs and master pushes via the existing `on:` trigger block

## Test plan

- [ ] The "Changelog lint" check appears and passes on this PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)