### PR TITLE
chore(changelog): fix prefix in changelog entry for #41599

### DIFF
--- a/changelog/unreleased/41599
+++ b/changelog/unreleased/41599
@@ -1,4 +1,4 @@
-Fix: support federation between systems in subdirectories
+Bugfix: support federation between systems in subdirectories
 
 If a federated server was installed in a subdirectory like:
 


### PR DESCRIPTION
## Summary

Corrects the changelog entry for #41599 (`changelog/unreleased/41599`) — changes the prefix from `Fix:` to `Bugfix:` to match the required calens format.

## Test plan
- [ ] `make test-php-style` / calens validation passes with the corrected prefix
