### PR TITLE
fix: add dist URLs for icewind/smb and icewind/streams to avoid intermittent Codeberg git failures

### DIFF
--- a/composer.lock
+++ b/composer.lock
@@ -1268,6 +1268,12 @@
                 "url": "https://codeberg.org/icewind/SMB",
                 "reference": "97063a63b44edc6554966f6121679506b8d85103"
             },
+            "dist": {
+                "type": "zip",
+                "url": "https://codeberg.org/icewind/SMB/archive/97063a63b44edc6554966f6121679506b8d85103.zip",
+                "reference": "97063a63b44edc6554966f6121679506b8d85103",
+                "shasum": "978ab879866b09bcee82c8cf5b4c105ac29e2da0"
+            },
             "require": {
                 "icewind/streams": ">=0.7.3",
                 "php": ">=8.2"
@@ -1304,6 +1310,12 @@
                 "type": "git",
                 "url": "https://codeberg.org/icewind/streams",
                 "reference": "cb2bd3ed41b516efb97e06e8da35a12ef58ba48b"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://codeberg.org/icewind/streams/archive/cb2bd3ed41b516efb97e06e8da35a12ef58ba48b.zip",
+                "reference": "cb2bd3ed41b516efb97e06e8da35a12ef58ba48b",
+                "shasum": "378a5605644b6dd2f38a0be39e7b8cf7c711455a"
             },
             "require": {
                 "php": ">=7.1"


### PR DESCRIPTION
## Summary

- Both `icewind/smb` and `icewind/streams` had empty `dist: {}` entries in `composer.lock`, forcing Composer to always `git clone` from Codeberg
- Git clone operations are sensitive to intermittent connectivity; zip downloads are far more resilient
- Adds Codeberg archive zip URLs with SHA1 checksums so `composer install --prefer-dist` fetches a zip instead of cloning

Fixes #41563

## Root cause

Packagist crawls these packages but cannot auto-populate `dist` URLs because Codeberg's Forgejo instance doesn't expose GitHub-style API zipball endpoints. All other packages have `dist` entries pointing to GitHub/Packagist CDN zips — only the `icewind/*` packages were missing them.

## Fix

Added `dist` blocks to the two affected entries in `composer.lock` using Codeberg's own deterministic archive endpoint (`/archive/<sha>.zip`). The SHA references match the existing `source` entries exactly, so the installed code is identical.

## Test plan

- [ ] CI `composer install --prefer-dist` should no longer need to `git clone` from Codeberg for these two packages
- [ ] Verify CI passes without Codeberg git connectivity

🤖 Generated with [Claude Code](https://claude.com/claude-code)