### PR TITLE
fix(js-tests): reset collection in tag actions beforeEach to prevent flaky test

### DIFF
--- a/core/js/tests/specs/systemtags/systemtagsinputfieldSpec.js
+++ b/core/js/tests/specs/systemtags/systemtagsinputfieldSpec.js
@@ -65,6 +65,7 @@ describe('OC.SystemTags.SystemTagsInputField tests', function() {
 				var $el = view.$el.find('input');
 				$el.val('1');
 
+				view.collection.reset();
 				view.collection.add([
 					new OC.SystemTags.SystemTagModel({id: '1', name: 'abc'}),
 					new OC.SystemTags.SystemTagModel({id: '2', name: 'def'}),
@@ -243,6 +244,7 @@ describe('OC.SystemTags.SystemTagsInputField tests', function() {
 			beforeEach(function() {
 				opts = select2Stub.getCall(0).args[0];
 
+				view.collection.reset();
 				view.collection.add([
 					new OC.SystemTags.SystemTagModel({id: '1', name: 'abc'}),
 				]);
@@ -373,6 +375,7 @@ describe('OC.SystemTags.SystemTagsInputField tests', function() {
 				fetchStub = sinon.stub(OC.SystemTags.SystemTagsCollection.prototype, 'fetch');
 				opts = select2Stub.getCall(0).args[0];
 
+				view.collection.reset();
 				view.collection.add([
 					new OC.SystemTags.SystemTagModel({id: '1', name: 'abc'}),
 					new OC.SystemTags.SystemTagModel({id: '2', name: 'def'}),
@@ -558,6 +561,7 @@ describe('OC.SystemTags.SystemTagsInputField tests', function() {
 				view.render();
 				opts = select2Stub.getCall(0).args[0];
 
+				view.collection.reset();
 				view.collection.add([
 					new OC.SystemTags.SystemTagModel({id: '1', name: 'abc'}),
 					new OC.SystemTags.SystemTagModel({id: '2', name: 'def'}),


### PR DESCRIPTION
## Summary

- Jasmine 5.x randomises test execution order by default (unlike Jasmine 2.x, which ran tests in declaration order)
- `OC.SystemTags.collection` is a process-wide singleton; a test that adds `{id: '1', name: 'test1'}` can leave that model in the collection
- Backbone's `Collection.add()` silently ignores models whose `id` already exists — so the 'tag actions' `beforeEach` adding `{id: '1', name: 'abc'}` was a no-op when the slot was already occupied
- The rename-form test then read the stale `'test1'` name instead of `'abc'` → `Expected 'test1' to equal 'abc'`

Fix: add an explicit `view.collection.reset()` at the top of the nested `beforeEach` so the state is clean regardless of which test ran before.

Observed failing in PR #41609 (a `composer.lock`-only change) because that PR's CI happened to get a random seed that exposed the ordering bug.

## Test plan

- [ ] `make test-js` passes consistently across multiple runs (no seed-dependent failures in `systemtagsinputfieldSpec.js`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)