### PR TITLE
fix(js-tests): fix test isolation bugs exposed by Jasmine 5 random ordering

### DIFF
--- a/apps/files/tests/js/fileactionsmenuSpec.js
+++ b/apps/files/tests/js/fileactionsmenuSpec.js
@@ -93,6 +93,7 @@ describe('OCA.Files.FileActionsMenu tests', function() {
 		fileActions = null;
 		fileList.destroy();
 		fileList = undefined;
+		OC.hideMenus();
 		menu.remove();
 		$('#dir, #permissions, #filestable').remove();
 	});

--- a/apps/files_sharing/tests/js/appSpec.js
+++ b/apps/files_sharing/tests/js/appSpec.js
@@ -58,14 +58,18 @@ describe('OCA.Sharing.App tests', function() {
 	});
 	describe('file actions', function() {
 		var oldLegacyFileActions;
+		var oldFileActions;
 
 		beforeEach(function() {
 			oldLegacyFileActions = window.FileActions;
 			window.FileActions = new OCA.Files.FileActions();
+			oldFileActions = OCA.Files.fileActions;
+			OCA.Files.fileActions = new OCA.Files.FileActions();
 		});
 
 		afterEach(function() {
 			window.FileActions = oldLegacyFileActions;
+			OCA.Files.fileActions = oldFileActions;
 		});
 		it('provides default file actions', function() {
 			_.each([fileListIn, fileListOut], function(fileList) {

--- a/apps/systemtags/tests/js/systemtagsinfoviewSpec.js
+++ b/apps/systemtags/tests/js/systemtagsinfoviewSpec.js
@@ -53,6 +53,7 @@ describe('OCA.SystemTags.SystemTagsInfoView tests', function() {
 		var allTagsCollection;
 		beforeEach(function() {
 			allTagsCollection = view._inputView.collection;
+			allTagsCollection.reset();
 
 			allTagsCollection.add([
 				{id: '1', name: 'test1'},
@@ -67,6 +68,9 @@ describe('OCA.SystemTags.SystemTagsInfoView tests', function() {
 				{id: '3', name: 'test3'}
 			]);
 			view.render();
+		});
+		afterEach(function() {
+			allTagsCollection.reset();
 		});
 		it('add tag to list view', function() {
 			view.selectedTagsCollection.add([{id: '4', name: 'test4'}]);

--- a/changelog/unreleased/41616
+++ b/changelog/unreleased/41616
@@ -1,0 +1,10 @@
+Bugfix: Fix JS test isolation bugs exposed by Jasmine 5 random test ordering
+
+Several JS test specs left shared singleton state dirty between tests,
+causing intermittent failures when Jasmine 5 ran tests in random order.
+Fixed OC._currentMenu leak in fileactionsmenuSpec, stale OCA.Files.fileActions
+reference causing infinite recursion in files_sharing/appSpec, and stale
+models in the OC.SystemTags.collection singleton in systemtagsinfoviewSpec
+and systemtagsinputfieldSpec.
+
+https://github.com/owncloud/core/pull/41616

--- a/core/js/tests/specs/systemtags/systemtagsinputfieldSpec.js
+++ b/core/js/tests/specs/systemtags/systemtagsinputfieldSpec.js
@@ -339,6 +339,7 @@ describe('OC.SystemTags.SystemTagsInputField tests', function() {
 					new OC.SystemTags.SystemTagModel({id: '3', name: 'test3', userAssignable: false, canAssign: false}),
 					new OC.SystemTags.SystemTagModel({id: '4', name: 'test4', userAssignable: false, canAssign: true})
 				];
+				view.collection.reset();
 			});
 			afterEach(function() {
 				fetchStub.restore();
@@ -522,6 +523,7 @@ describe('OC.SystemTags.SystemTagsInputField tests', function() {
 					new OC.SystemTags.SystemTagModel({id: '3', name: 'test3', userAssignable: false, canAssign: false}),
 					new OC.SystemTags.SystemTagModel({id: '4', name: 'test4', userAssignable: false, canAssign: true})
 				];
+				view.collection.reset();
 				view.render();
 			});
 			afterEach(function() {


### PR DESCRIPTION
## Summary

- **`fileactionsmenuSpec.js`**: Call `OC.hideMenus()` in `afterEach` to clear `OC._currentMenu` before `menu.remove()`, preventing a double `slideUp` in subsequent tests
- **`files_sharing/appSpec.js`**: Save and restore `OCA.Files.fileActions` in the `file actions` describe so stale `_onActionsUpdated` handlers from `files/appSpec.js` don't fire with `fileList=null` causing infinite recursion
- **`systemtagsinfoviewSpec.js`**: Reset `allTagsCollection` (the `OC.SystemTags.collection` singleton) in `beforeEach`/`afterEach` of the `events` describe so name mutations (e.g. `set('name', 'test1_renamed')`) don't persist into other test suites
- **`systemtagsinputfieldSpec.js`**: Call `view.collection.reset()` in both the `as admin` and `as user` `initSelection` `beforeEach` blocks so Backbone's silent ignore of duplicate-id `add()` calls doesn't leave stale/renamed models in the singleton

## Root cause

Jasmine 5 (bumped in #41615) runs tests in random order by default. This exposed pre-existing test isolation bugs where shared singleton state (`OC._currentMenu`, `OCA.Files.fileActions`, `OC.SystemTags.collection`) was left dirty between tests.

## Test plan

- [x] Verified with 25 consecutive successful karma runs under Jasmine 5 random ordering (`FirefoxHeadless`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)