### PR TITLE
fix: add missing space to mail footer signature delimiter

### DIFF
--- a/changelog/unreleased/41364
+++ b/changelog/unreleased/41364
@@ -1,0 +1,8 @@
+Bugfix: Add missing space to mail footer signature delimiter
+
+We've fixed the signature delimiter in the email footer templates. The delimiter
+on the first line was missing the trailing space required by the signature block
+convention (RFC 3676), so mail clients were unable to recognize and collapse the
+signature. The delimiter is now correctly written as "-- " (dash-dash-space).
+
+https://github.com/owncloud/core/issues/41364

--- a/changelog/unreleased/41617
+++ b/changelog/unreleased/41617
@@ -6,3 +6,4 @@ convention (RFC 3676), so mail clients were unable to recognize and collapse the
 signature. The delimiter is now correctly written as "-- " (dash-dash-space).
 
 https://github.com/owncloud/core/issues/41364
+https://github.com/owncloud/core/pull/41617

--- a/core/templates/html.mail.footer.php
+++ b/core/templates/html.mail.footer.php
@@ -1,4 +1,4 @@
---<br>
+-- <br>
 <?php p($theme->getName()); ?> -
 <?php p($theme->getSlogan()); ?>
 <br><a href="<?php p($theme->getBaseUrl()); ?>"><?php p($theme->getBaseUrl());?></a>

--- a/core/templates/plain.mail.footer.php
+++ b/core/templates/plain.mail.footer.php
@@ -1,4 +1,4 @@
---
+-- 
 <?php p($theme->getName() . ' - ' . $theme->getSlogan()); ?>
 <?php
 p("\n" . $theme->getBaseUrl());


### PR DESCRIPTION
### Description

The signature delimiter on the first line of the mail footer templates was missing the trailing space required by the [signature block convention](https://en.wikipedia.org/wiki/Signature_block) (RFC 3676). The delimiter must be exactly `-- ` (dash-dash-**space**) followed by a line break for mail clients to recognize and collapse the signature.

- `core/templates/plain.mail.footer.php`: `--` → `-- `
- `core/templates/html.mail.footer.php`: `--<br>` → `-- <br>`

### How was this tested?

- Verified the exact bytes of line 1 in both files (`cat -A` shows `-- $` and `-- <br>$`).
- Confirmed `php-cs-fixer` does **not** strip the trailing space: although the coding standard enables `no_trailing_whitespace` and these templates are not excluded, line 1 is an inline-HTML token (`T_INLINE_HTML`) which the rule does not touch — dry-run reports 0 of 2 files to fix.
- `php -l` passes on both templates.

Fixes #41364

🤖 Generated with [Claude Code](https://claude.com/claude-code)