### PR TITLE
fix: fix broken link in config.sample

### DIFF
--- a/config/config.sample.php
+++ b/config/config.sample.php
@@ -1229,7 +1229,7 @@ $CONFIG = [
 
 /**
  * Define connection options for memcached
- * For more details please see http://apprize.info/php/scaling/15.html
+ * For more details please see https://www.php.net/manual/en/memcached.constants.php
  */
 'memcached_options' => [
 	// Set timeouts to 50ms


### PR DESCRIPTION
The link provided to memcached options does no longer exists and needed to be updated.