### PR TITLE
fix(occ): pass empty string instead of null to user search in home list commands

### DIFF
--- a/changelog/unreleased/41630
+++ b/changelog/unreleased/41630
@@ -1,0 +1,10 @@
+Bugfix: Fix user:home:list-dirs and user:home:list-users crashing on PHP 8
+
+The occ commands user:home:list-dirs and user:home:list-users --all passed
+null as the search pattern to IUserManager::search() to mean "all users".
+On PHP 8 the null reached Connection::escapeLikeParameter(string $param) and
+raised a TypeError, aborting the command. Both commands now pass the empty
+string, which is the established "match all" sentinel used by every other
+caller.
+
+https://github.com/owncloud/core/issues/41630

--- a/core/Command/User/HomeListDirs.php
+++ b/core/Command/User/HomeListDirs.php
@@ -52,7 +52,7 @@ class HomeListDirs extends Base {
 			$output->writeln('<info>We detected that the instance is running on a S3 primary object storage, home directories might not be accurate</info>');
 		}
 
-		$users = $this->userManager->search(null);
+		$users = $this->userManager->search('');
 		$homePaths = [];
 		foreach ($users as $user) {
 			$home = $user->getHome();

--- a/core/Command/User/HomeListUsers.php
+++ b/core/Command/User/HomeListUsers.php
@@ -79,7 +79,7 @@ class HomeListUsers extends Base {
 				$output->writeln('<error>--all and path option cannot be given together</error>');
 				return 1;
 			}
-			$users = $this->userManager->search(null, null, null, true);
+			$users = $this->userManager->search('', null, null, true);
 			$outputData = [];
 			foreach ($users as $user) {
 				$home = $user->getHome();

--- a/tests/Core/Command/User/HomeListDirsTest.php
+++ b/tests/Core/Command/User/HomeListDirsTest.php
@@ -70,7 +70,10 @@ class HomeListDirsTest extends TestCase {
 		$user2Mock = $this->createMock(IUser::class);
 		$user2Mock->method('getHome')->willReturn("$homePath/user2");
 
-		$this->userManager->method('search')->willReturn([$user1Mock, $user2Mock]);
+		$this->userManager->expects($this->once())
+			->method('search')
+			->with($this->identicalTo(''))
+			->willReturn([$user1Mock, $user2Mock]);
 		$this->commandTester->execute([]);
 		$output = $this->commandTester->getDisplay();
 		$this->assertStringContainsString($homePath, $output);

--- a/tests/Core/Command/User/HomeListUsersTest.php
+++ b/tests/Core/Command/User/HomeListUsersTest.php
@@ -114,7 +114,10 @@ class HomeListUsersTest extends TestCase {
 			->getMock();
 		$userObject->method('getHome')->willReturn($path . '/' . $uid);
 		$userObject->method('getUID')->willReturn($uid);
-		$this->userManager->method('search')->willReturn([$uid => $userObject]);
+		$this->userManager->expects($this->once())
+			->method('search')
+			->with($this->identicalTo(''), null, null, true)
+			->willReturn([$uid => $userObject]);
 
 		$this->commandTester->execute(['--all' => true]);
 		$output = $this->commandTester->getDisplay();


### PR DESCRIPTION
## Summary

`occ user:home:list-dirs` (and `user:home:list-users --all`) crash on PHP 8 with:

```
TypeError: OC\DB\Connection::escapeLikeParameter(): Argument #1 ($param)
must be of type string, null given
```

### Root cause

Both commands passed `null` as the search pattern to `IUserManager::search()` to mean "all users":

- `core/Command/User/HomeListDirs.php:55` — `search(null)`
- `core/Command/User/HomeListUsers.php:82` — `search(null, null, null, true)`

The `null` flows through `Manager::search()` → `AccountMapper::search()` → `Connection::escapeLikeParameter(string $param)`. On older PHP it was silently coerced to `''`; PHP 8's strict scalar type hint rejects it and raises a `TypeError`. (The Docker reference in the issue is incidental — it's a PHP-version difference, not a container one.)

The correct "match all" sentinel is the **empty string** `''`, which `UserSearch::isSearchable()` explicitly treats as searchable and which every other caller in the codebase already uses (`ListUsers`, `ScanFiles`, `Scan`, `Principal`).

### Fix

Pass `''` instead of `null` at both call sites.

### Tests

Updated `HomeListDirsTest` and `HomeListUsersTest` to assert the search pattern is `identicalTo('')` (strict — loose `with('')` would pass against `null` since `'' == null` in PHP). Both tests fail against the old code and pass after the fix.

Fixes #41630

🤖 Generated with [Claude Code](https://claude.com/claude-code)
