### PR TITLE
fix: render fix in config.sample

### DIFF
--- a/config/config.sample.php
+++ b/config/config.sample.php
@@ -1189,6 +1189,7 @@ $CONFIG = [
  * Redis Cluster support requires the php module phpredis in version 3.0.0 or higher.
  *
  * Available failover modes:
+ *
  *  - \RedisCluster::FAILOVER_NONE       - only send commands to primary nodes (default)
  *  - \RedisCluster::FAILOVER_ERROR      - failover to replicas for read commands if primary is unavailable
  *  - \RedisCluster::FAILOVER_DISTRIBUTE - randomly distribute read commands across primary and replica nodes


### PR DESCRIPTION
This is small render fix for config.sample.

With this, the list it will render as such (otherwise things get rendered in one line and not as list)

Post merging, I will do a config-to-docs run and add the change to the current docs-server PR of OC11 