### PR TITLE
fix(sharing): show original file owner in reshare panel

### DIFF
--- a/changelog/unreleased/30394
+++ b/changelog/unreleased/30394
@@ -1,0 +1,11 @@
+Bugfix: Show original file owner in the reshare panel
+
+The share panel's reshare banner showed only the direct sharer of a
+reshare, not the original file owner, even though the OCS reshare response
+already carried the file-owner fields. We've surfaced those fields so the
+panel now shows "Shared with you by {sharer} (on behalf of {fileOwner})"
+(and the group-share equivalent) when the file owner differs from the direct
+sharer. When they match or the owner is absent, the previous wording is kept.
+
+https://github.com/owncloud/core/issues/30394
+https://github.com/owncloud/core/pull/41640

--- a/core/js/sharedialogresharerinfoview.js
+++ b/core/js/sharedialogresharerinfoview.js
@@ -72,22 +72,52 @@
 
 			var reshareTemplate = this.template();
 			var ownerDisplayName = this.model.getReshareOwnerDisplayname();
+			var fileOwner = this.model.getReshareFileOwner();
+			var fileOwnerDisplayName = this.model.getReshareFileOwnerDisplayname();
+			// Only mention the original file owner when it is known and
+			// differs from the direct sharer. Otherwise keep the previous
+			// single-owner wording to avoid a regression.
+			var hasDistinctFileOwner = !_.isUndefined(fileOwner)
+				&& fileOwner !== this.model.getReshareOwner();
 			var sharedByText = '';
 			if (this.model.getReshareType() === OC.Share.SHARE_TYPE_GROUP) {
-				sharedByText = t(
-					'core',
-					'Shared with you and the group {group} by {owner}',
-					{
-						group: this.model.getReshareWithDisplayName(),
-						owner: ownerDisplayName
-					}
-				);
+				if (hasDistinctFileOwner) {
+					sharedByText = t(
+						'core',
+						'Shared with you and the group {group} by {owner} (on behalf of {fileOwner})',
+						{
+							group: this.model.getReshareWithDisplayName(),
+							owner: ownerDisplayName,
+							fileOwner: fileOwnerDisplayName
+						}
+					);
+				} else {
+					sharedByText = t(
+						'core',
+						'Shared with you and the group {group} by {owner}',
+						{
+							group: this.model.getReshareWithDisplayName(),
+							owner: ownerDisplayName
+						}
+					);
+				}
 			}  else {
-				sharedByText = t(
-					'core',
-					'Shared with you by {owner}',
-					{ owner: ownerDisplayName }
-				);
+				if (hasDistinctFileOwner) {
+					sharedByText = t(
+						'core',
+						'Shared with you by {owner} (on behalf of {fileOwner})',
+						{
+							owner: ownerDisplayName,
+							fileOwner: fileOwnerDisplayName
+						}
+					);
+				} else {
+					sharedByText = t(
+						'core',
+						'Shared with you by {owner}',
+						{ owner: ownerDisplayName }
+					);
+				}
 			}
 
 			this.$el.html(reshareTemplate({

--- a/core/js/shareitemmodel.js
+++ b/core/js/shareitemmodel.js
@@ -31,6 +31,8 @@
 	 * @property {number} share_type
 	 * @property {string} share_with
 	 * @property {string} displayname_owner
+	 * @property {string} uid_file_owner
+	 * @property {string} displayname_file_owner
 	 * @property {number} permissions
 	 * @property {OC.Share.Types.ShareAttribute[]} attributes
 	 */
@@ -372,6 +374,20 @@
 		 */
 		getReshareOwnerDisplayname: function() {
 			return this.get('reshare').displayname_owner;
+		},
+
+		/**
+		 * @returns {string}
+		 */
+		getReshareFileOwner: function() {
+			return this.get('reshare').uid_file_owner;
+		},
+
+		/**
+		 * @returns {string}
+		 */
+		getReshareFileOwnerDisplayname: function() {
+			return this.get('reshare').displayname_file_owner;
 		},
 
 		/**

--- a/core/js/tests/specs/sharedialogviewSpec.js
+++ b/core/js/tests/specs/sharedialogviewSpec.js
@@ -969,6 +969,56 @@ describe('OC.Share.ShareDialogView', function() {
 			dialog.render();
 			expect(dialog.$el.find('.resharerInfoView .reshare').length).toEqual(0);
 		});
+		it('shows original file owner for single user reshare when it differs from the sharer', function() {
+			shareModel.set({
+				reshare: {
+					uid_owner: 'user1',
+					displayname_owner: 'User One',
+					uid_file_owner: 'owner1',
+					displayname_file_owner: 'File Owner',
+					share_type: OC.Share.SHARE_TYPE_USER
+				},
+				shares: [],
+				permissions: OC.PERMISSION_READ
+			});
+			dialog.render();
+			expect(dialog.$el.find('.resharerInfoView .reshare').length).toEqual(1);
+			expect(dialog.$el.find('.resharerInfoView .reshare').text().trim()).toEqual('Shared with you by User One (on behalf of File Owner)');
+		});
+		it('shows original file owner for group reshare when it differs from the sharer', function() {
+			shareModel.set({
+				reshare: {
+					uid_owner: 'user1',
+					displayname_owner: 'User One',
+					uid_file_owner: 'owner1',
+					displayname_file_owner: 'File Owner',
+					share_with: 'group2',
+					share_with_displayname: 'Group Two',
+					share_type: OC.Share.SHARE_TYPE_GROUP
+				},
+				shares: [],
+				permissions: OC.PERMISSION_READ
+			});
+			dialog.render();
+			expect(dialog.$el.find('.resharerInfoView .reshare').length).toEqual(1);
+			expect(dialog.$el.find('.resharerInfoView .reshare').text().trim()).toEqual('Shared with you and the group Group Two by User One (on behalf of File Owner)');
+		});
+		it('does not mention file owner when it equals the sharer', function() {
+			shareModel.set({
+				reshare: {
+					uid_owner: 'user1',
+					displayname_owner: 'User One',
+					uid_file_owner: 'user1',
+					displayname_file_owner: 'User One',
+					share_type: OC.Share.SHARE_TYPE_USER
+				},
+				shares: [],
+				permissions: OC.PERMISSION_READ
+			});
+			dialog.render();
+			expect(dialog.$el.find('.resharerInfoView .reshare').length).toEqual(1);
+			expect(dialog.$el.find('.resharerInfoView .reshare').text().trim()).toEqual('Shared with you by User One');
+		});
 	});
 	describe('tabs', function() {
 		beforeEach(function() {


### PR DESCRIPTION
## Summary

Fixes #30394.

The share panel's reshare banner showed only the **direct sharer** of a reshare, not the **original file owner** — even though the OCS reshare response already carries `uid_file_owner` / `displayname_file_owner`. The frontend simply discarded those fields.

This surfaces them:
- `core/js/shareitemmodel.js` — add `getReshareFileOwner()` / `getReshareFileOwnerDisplayname()` getters for the already-present fields.
- `core/js/sharedialogresharerinfoview.js` — when the file owner is known **and differs** from the direct sharer, render `Shared with you by {owner} (on behalf of {fileOwner})` (and the group-share equivalent). When the file owner equals the sharer or is absent, the previous wording is kept unchanged — no regression for ordinary shares.

Frontend-only; **no API change** (the backend already exposes the data).

## Tests

Added three cases to `core/js/tests/specs/sharedialogviewSpec.js`:
- single-user reshare with a distinct file owner → both names shown
- group reshare with a distinct file owner → both names shown
- file owner equals sharer → original single-owner text (regression guard)

> ⚠️ JS unit tests were not executed in the automated environment (karma/node_modules not installed); the specs pass `node -c` syntax checks. Please let CI run the karma suite.

## Notes
- Display names are rendered via `t()` which auto-escapes placeholders, matching the existing escaping — no XSS regression, and no data is exposed that wasn't already delivered to this user.

🤖 Generated with [Claude Code](https://claude.com/claude-code)