### PR TITLE
fix(occ): don't let one broken command make occ unusable (#33895)

### DIFF
--- a/lib/private/Console/Application.php
+++ b/lib/private/Console/Application.php
@@ -167,17 +167,31 @@ class Application {
 
 	private function loadCommandsFromInfoXml($commands) {
 		foreach ($commands as $command) {
+			// A single broken command (unknown class, failing constructor,
+			// etc.) must never abort loading or render occ unusable - skip it,
+			// log a warning, and continue with the remaining commands.
 			try {
-				$c = \OC::$server->query($command);
-			} catch (QueryException $e) {
-				if (\class_exists($command)) {
-					$c = new $command();
-				} else {
-					throw new \Exception("Console command '$command' is unknown and could not be loaded");
+				try {
+					$c = \OC::$server->query($command);
+				} catch (QueryException $e) {
+					if (\class_exists($command)) {
+						$c = new $command();
+					} else {
+						throw new \Exception("Console command '$command' is unknown and could not be loaded");
+					}
 				}
-			}
 
-			$this->application->addCommand($c);
+				$this->application->addCommand($c);
+			} catch (\Throwable $e) {
+				\OC::$server->getLogger()->warning(
+					"Console command '{command}' could not be loaded and was skipped: {message}",
+					[
+						'command' => $command,
+						'message' => $e->getMessage(),
+						'app' => 'core',
+					]
+				);
+			}
 		}
 	}
 }

--- a/tests/lib/Console/ApplicationTest.php
+++ b/tests/lib/Console/ApplicationTest.php
@@ -1,0 +1,78 @@
+<?php
+/**
+ * This file is licensed under the Affero General Public License version 3 or
+ * later.
+ * See the COPYING-README file.
+ */
+
+namespace Test\Console;
+
+use OC\Console\Application;
+use Symfony\Component\Console\Command\Command;
+use Test\TestCase;
+
+/**
+ * A minimal, dependency-free console command used as the "valid" command in
+ * the resilience test. It must be resolvable both via the DI container
+ * (\OC::$server->query()) and via `new $command()`.
+ */
+class ValidStubCommand extends Command {
+	protected function configure() {
+		$this->setName('test:valid-stub-command');
+	}
+}
+
+/**
+ * A fake Symfony application that just records the commands it is asked to
+ * register, so the test can assert which commands survived loading without
+ * needing a real Symfony Application instance.
+ */
+class RecordingApplication {
+	public $registered = [];
+
+	public function addCommand($command) {
+		$this->registered[] = $command;
+	}
+}
+
+/**
+ * @group DB
+ *
+ * Requires the ownCloud test bootstrap (\OC::$server must be available for the
+ * logger and the DI container). It does NOT require a database connection, but
+ * is tagged @group DB so it only runs in the bootstrapped suite where
+ * \OC::$server is wired up.
+ */
+class ApplicationTest extends TestCase {
+	/**
+	 * Core guarantee for issue #33895: a single broken app-provided command
+	 * (here an unknown/non-existent class name, which today reaches the
+	 * `throw new \Exception(...)` path) must NOT abort loading or kill occ.
+	 * The broken command is skipped (and logged) while every other valid
+	 * command is still registered.
+	 */
+	public function testBrokenCommandDoesNotAbortLoading() {
+		// Build an Application without running its constructor so we don't need
+		// a real Symfony Application / OC_Defaults / version string here.
+		$reflection = new \ReflectionClass(Application::class);
+		$application = $reflection->newInstanceWithoutConstructor();
+
+		// Inject a fake Symfony application that just records added commands.
+		$symfonyApplication = new RecordingApplication();
+		self::invokePrivate($application, 'application', [$symfonyApplication]);
+
+		$commands = [
+			// Broken: unknown class -> throws inside the loop. Must be skipped.
+			'OC\\This\\Command\\Does\\Not\\Exist',
+			// Valid: must still be registered despite the broken one above.
+			ValidStubCommand::class,
+		];
+
+		// The method must NOT throw despite the broken command.
+		self::invokePrivate($application, 'loadCommandsFromInfoXml', [$commands]);
+
+		// The valid command was still registered.
+		$this->assertCount(1, $symfonyApplication->registered);
+		$this->assertInstanceOf(ValidStubCommand::class, $symfonyApplication->registered[0]);
+	}
+}


### PR DESCRIPTION
## Summary

Fixes #33895 — a single broken console command could make **all** of `occ` unusable.

`OC\Console\Application::loadCommandsFromInfoXml()` loaded each app-provided command and let any failure propagate out of `occ`. The existing `try/catch` only handled `QueryException` (falling back to `new $command()` or throwing for an unknown class), so:

- a command class that no longer exists, or
- a command whose constructor throws — e.g. an `ArgumentCountError` or any other PHP `\Error`/`\Throwable` that is **not** a `QueryException`

bubbled all the way up and **aborted the entire command loader**. The practical impact: one broken app makes `occ` unable to run *any* command — including the `maintenance:*` / `upgrade` / repair commands an administrator needs to recover from that very situation.

## Change

Wrap each per-command load in an outer `try/catch (\Throwable)`:

- A broken command is now **logged** via `ILogger::warning` (with the command name and error message) and **skipped**, and the loop continues loading the remaining commands.
- The existing `query` → `new $command()` → unknown-class logic is preserved **byte-for-byte** as the inner block, so the normal/success path registers exactly the same commands as before. The outer catch only changes behavior when a command actually fails.
- `\Throwable` is used deliberately so it covers both `\Exception` and `\Error` (the `ArgumentCountError`-style constructor failures this issue is about).

## Why this is safe

- No new code-execution path is introduced — `new $command()` was already present; this only broadens *error tolerance* around it.
- Failures are not swallowed silently — each is logged with enough context (command name + message) for an admin to find and fix the offending app.
- Identical behavior when nothing is broken.

## Tests

Adds `tests/lib/Console/ApplicationTest.php` (`testBrokenCommandDoesNotAbortLoading`): given a command list containing a broken (unknown-class) command followed by a valid one, `loadCommandsFromInfoXml()` must not throw and the valid command must still be registered.

> Tagged `@group DB` because it relies on the ownCloud test bootstrap (`\OC::$server` for the logger); it does not need an actual DB connection. `php -l` clean; the full PHPUnit suite was not run in the preparation environment.

> Note: `owncloud/core` is in maintenance mode; this targets installations still on classic ownCloud 10.x. Labelled `junior job` / `sev3-medium` on the issue.

---

🤖 This PR was prepared by the Claude Code review agent from the analysis of #33895. Please review carefully before merging.
