### PR TITLE
fix(backgroundjob): don't log ERROR for stale job rows of removed apps (#35589)

### DIFF
--- a/changelog/unreleased/35589
+++ b/changelog/unreleased/35589
@@ -1,0 +1,11 @@
+Bugfix: Stop logging ERROR for stale background job rows of removed apps
+
+The background-job runner logged an ERROR-level stack trace on every cron run
+for stale oc_jobs rows whose class no longer exists, left behind by removed or
+disabled apps. JobList::buildJob() now checks whether the class exists before
+logging: a class that exists but cannot be resolved as a service is still
+logged at ERROR as a genuine dependency-injection failure, while a class that
+no longer exists is logged once at DEBUG and the stale row is skipped.
+
+https://github.com/owncloud/core/issues/35589
+https://github.com/owncloud/core/pull/41644

--- a/lib/private/BackgroundJob/JobList.php
+++ b/lib/private/BackgroundJob/JobList.php
@@ -281,12 +281,21 @@ class JobList implements IJobList {
 				/** @var IJob $job */
 				$job = \OC::$server->query($row['class']);
 			} catch (QueryException $e) {
-				$this->logger->logException($e, ['app' => 'core']);
 				if (\class_exists($row['class'])) {
+					// The class exists but could not be resolved as a service:
+					// this is a genuine, actionable DI failure -> log at ERROR.
+					$this->logger->logException($e, ['app' => 'core']);
 					$class = $row['class'];
 					$job = new $class();
 				} else {
-					// job from disabled app or old version of an app, no need to do anything
+					// The class does not exist anymore (stale job row from a
+					// disabled/removed app or an old version). This is a benign,
+					// expected condition, so only log it at DEBUG instead of
+					// spamming an ERROR-level stack trace on every cron run.
+					$this->logger->debug(
+						'Background job class ' . $row['class'] . ' does not exist (stale job row), skipping',
+						['app' => 'core']
+					);
 					return null;
 				}
 			}

--- a/tests/lib/BackgroundJob/JobListTest.php
+++ b/tests/lib/BackgroundJob/JobListTest.php
@@ -285,9 +285,15 @@ class JobListTest extends TestCase {
 		$query->execute();
 	}
 
-	public function testUnknownJobLogsException() {
+	public function testUnknownJobDoesNotLogException() {
+		// A stale job row whose class no longer exists must NOT be logged at
+		// ERROR level via logException (see issue #35589). It is a benign,
+		// expected condition and is only logged at DEBUG instead.
 		$this->addWrongJob();
-		$this->logger->expects($this->once())->method('logException');
+		$this->logger->expects($this->never())->method('logException');
+		$this->logger->expects($this->atLeastOnce())
+			->method('debug')
+			->with($this->stringContains('wrong job title'), ['app' => 'core']);
 		$this->instance->listJobs(function () {
 		});
 		$this->clearJobsList();


### PR DESCRIPTION
## Summary

Fixes #35589 — the background-job runner logged an ERROR-level stack trace on **every cron run** for stale job rows whose class no longer exists (the "SyncJob does not exist" log spam).

`JobList::buildJob()` caught the `QueryException` from `\OC::$server->query($row['class'])` and **always** called `logException(..., ERROR)` before checking whether the class even exists. A stale `oc_jobs` row left behind by a removed or disabled app therefore produced a recurring ERROR-level stack trace, even though the job was correctly skipped (`return null`).

## Change

Check `class_exists()` **first** inside the catch:

- **Class exists but failed to resolve** as a service → genuine, actionable DI failure → still logged at ERROR via `logException()` (unchanged).
- **Class no longer exists** (stale row from a removed/disabled app or old version) → logged once at **DEBUG** with a concise message, then skipped.

Control flow and return values are unchanged (`new $class()` fallback when the class exists; `return null` for stale rows).

## Tests

Updates the existing `JobListTest::testUnknownJobLogsException` → `testUnknownJobDoesNotLogException`: a missing-class job must **not** call `logException` and instead logs at `debug`. (The old test asserted the now-removed ERROR behavior.)

> Tagged `@group DB` (existing class). `php -l` clean; full PHPUnit not run in the preparation environment.

> Note: `owncloud/core` is in maintenance mode; targets installations on classic ownCloud 10.x.

---

🤖 This PR was prepared by the Claude Code review agent from the analysis of #35589. Please review carefully before merging.
