### PR TITLE
fix: normalise trashbin-original-location PROPFIND response (full-ci)

### DIFF
--- a/apps/dav/lib/TrashBin/AbstractTrashBinNode.php
+++ b/apps/dav/lib/TrashBin/AbstractTrashBinNode.php
@@ -110,7 +110,7 @@ abstract class AbstractTrashBinNode implements ITrashBinNode {
 			$originalPath = $location . '/' . $originalPath;
 		}
 
-		return $originalPath;
+		return ltrim($originalPath, '/');
 	}
 
 	public function getDeleteTimestamp() : int {

--- a/changelog/unreleased/41649
+++ b/changelog/unreleased/41649
@@ -1,0 +1,8 @@
+Bugfix: normalise trashbin original-location PROPFIND response
+
+In certain situations the trashbin original-location in a PROPFIND response
+contained a leading slash. This change ensures that a relative path (without
+a leading slash) is always returned.
+
+https://github.com/owncloud/core/issues/39337
+https://github.com/owncloud/core/pull/41649

--- a/tests/acceptance/features/apiTrashbin/trashbinDelete.feature
+++ b/tests/acceptance/features/apiTrashbin/trashbinDelete.feature
@@ -38,10 +38,10 @@ Feature: files and folders can be deleted from the trashbin
     And user "Alice" has deleted file "/PARENT/CHILD/child.txt"
     When user "Alice" deletes the file with original path "textfile1.txt" from the trashbin using the trashbin API
     Then the HTTP status code should be "204"
-    And as "Alice" the file with original path "/textfile1.txt" should not exist in the trashbin
-    But as "Alice" the file with original path "/textfile0.txt" should exist in the trashbin
-    And as "Alice" the file with original path "/PARENT/parent.txt" should exist in the trashbin
-    And as "Alice" the file with original path "/PARENT/CHILD/child.txt" should exist in the trashbin
+    And as "Alice" the file with original path "textfile1.txt" should not exist in the trashbin
+    But as "Alice" the file with original path "textfile0.txt" should exist in the trashbin
+    And as "Alice" the file with original path "PARENT/parent.txt" should exist in the trashbin
+    And as "Alice" the file with original path "PARENT/CHILD/child.txt" should exist in the trashbin
     Examples:
       | dav-path |
       | new      |
@@ -60,10 +60,10 @@ Feature: files and folders can be deleted from the trashbin
     When user "Alice" deletes the file with original path "/PARENT/textfile0.txt" from the trashbin using the trashbin API
     And user "Alice" deletes the file with original path "/PARENT/CHILD/child.txt" from the trashbin using the trashbin API
     Then the HTTP status code of responses on all endpoints should be "204"
-    And as "Alice" the file with original path "/PARENT/textfile0.txt" should not exist in the trashbin
-    And as "Alice" the file with original path "/PARENT/CHILD/child.txt" should not exist in the trashbin
-    But as "Alice" the file with original path "/textfile0.txt" should exist in the trashbin
-    And as "Alice" the file with original path "/PARENT/child.txt" should exist in the trashbin
+    And as "Alice" the file with original path "PARENT/textfile0.txt" should not exist in the trashbin
+    And as "Alice" the file with original path "PARENT/CHILD/child.txt" should not exist in the trashbin
+    But as "Alice" the file with original path "textfile0.txt" should exist in the trashbin
+    And as "Alice" the file with original path "PARENT/child.txt" should exist in the trashbin
     Examples:
       | dav-path |
       | new      |
@@ -78,10 +78,10 @@ Feature: files and folders can be deleted from the trashbin
     And user "Alice" has deleted file "/PARENT/CHILD/child.txt"
     When user "Brian" tries to delete the file with original path "textfile1.txt" from the trashbin of user "Alice" using the trashbin API
     Then the HTTP status code should be "<status-code>"
-    And as "Alice" the file with original path "/textfile1.txt" should exist in the trashbin
-    And as "Alice" the file with original path "/textfile0.txt" should exist in the trashbin
-    And as "Alice" the file with original path "/PARENT/parent.txt" should exist in the trashbin
-    And as "Alice" the file with original path "/PARENT/CHILD/child.txt" should exist in the trashbin
+    And as "Alice" the file with original path "textfile1.txt" should exist in the trashbin
+    And as "Alice" the file with original path "textfile0.txt" should exist in the trashbin
+    And as "Alice" the file with original path "PARENT/parent.txt" should exist in the trashbin
+    And as "Alice" the file with original path "PARENT/CHILD/child.txt" should exist in the trashbin
     Examples:
       | dav-path | status-code |
       | new      | 401         |
@@ -96,10 +96,10 @@ Feature: files and folders can be deleted from the trashbin
     And user "Alice" has deleted file "/PARENT/CHILD/child.txt"
     When user "Brian" tries to delete the file with original path "textfile1.txt" from the trashbin of user "Alice" using the password "invalid" and the trashbin API
     Then the HTTP status code should be "401"
-    And as "Alice" the file with original path "/textfile1.txt" should exist in the trashbin
-    And as "Alice" the file with original path "/textfile0.txt" should exist in the trashbin
-    And as "Alice" the file with original path "/PARENT/parent.txt" should exist in the trashbin
-    And as "Alice" the file with original path "/PARENT/CHILD/child.txt" should exist in the trashbin
+    And as "Alice" the file with original path "textfile1.txt" should exist in the trashbin
+    And as "Alice" the file with original path "textfile0.txt" should exist in the trashbin
+    And as "Alice" the file with original path "PARENT/parent.txt" should exist in the trashbin
+    And as "Alice" the file with original path "PARENT/CHILD/child.txt" should exist in the trashbin
     Examples:
       | dav-path |
       | new      |
@@ -114,10 +114,10 @@ Feature: files and folders can be deleted from the trashbin
     And user "Alice" has deleted file "/PARENT/CHILD/child.txt"
     When user "Brian" tries to delete the file with original path "textfile1.txt" from the trashbin of user "Alice" using the password "" and the trashbin API
     Then the HTTP status code should be "401"
-    And as "Alice" the file with original path "/textfile1.txt" should exist in the trashbin
-    And as "Alice" the file with original path "/textfile0.txt" should exist in the trashbin
-    And as "Alice" the file with original path "/PARENT/parent.txt" should exist in the trashbin
-    And as "Alice" the file with original path "/PARENT/CHILD/child.txt" should exist in the trashbin
+    And as "Alice" the file with original path "textfile1.txt" should exist in the trashbin
+    And as "Alice" the file with original path "textfile0.txt" should exist in the trashbin
+    And as "Alice" the file with original path "PARENT/parent.txt" should exist in the trashbin
+    And as "Alice" the file with original path "PARENT/CHILD/child.txt" should exist in the trashbin
     Examples:
       | dav-path |
       | new      |
@@ -133,11 +133,11 @@ Feature: files and folders can be deleted from the trashbin
     And user "Alice" has deleted folder "/FOLDER"
     When user "Alice" deletes the folder with original path "/PARENT" from the trashbin using the trashbin API
     Then the HTTP status code should be "204"
-    And as "Alice" the file with original path "/PARENT/parent.txt" should not exist in the trashbin
-    And as "Alice" the file with original path "/PARENT/CHILD/child.txt" should not exist in the trashbin
-    And as "Alice" the folder with original path "/PARENT/CHILD/" should not exist in the trashbin
-    But as "Alice" the file with original path "/FOLDER/parent.txt" should exist in the trashbin
-    And as "Alice" the file with original path "/FOLDER/CHILD/child.txt" should exist in the trashbin
+    And as "Alice" the file with original path "PARENT/parent.txt" should not exist in the trashbin
+    And as "Alice" the file with original path "PARENT/CHILD/child.txt" should not exist in the trashbin
+    And as "Alice" the folder with original path "PARENT/CHILD/" should not exist in the trashbin
+    But as "Alice" the file with original path "FOLDER/parent.txt" should exist in the trashbin
+    And as "Alice" the file with original path "FOLDER/CHILD/child.txt" should exist in the trashbin
     Examples:
       | dav-path |
       | new      |
@@ -153,11 +153,11 @@ Feature: files and folders can be deleted from the trashbin
     And user "Alice" has deleted folder "/FOLDER"
     When user "Alice" deletes the folder with original path "/PARENT/CHILD" from the trashbin using the trashbin API
     Then the HTTP status code should be "204"
-    And as "Alice" the file with original path "/PARENT/CHILD/child.txt" should not exist in the trashbin
-    And as "Alice" the folder with original path "/PARENT/CHILD/" should not exist in the trashbin
-    But as "Alice" the file with original path "/PARENT/parent.txt" should exist in the trashbin
-    And as "Alice" the file with original path "/FOLDER/parent.txt" should exist in the trashbin
-    And as "Alice" the file with original path "/FOLDER/CHILD/child.txt" should exist in the trashbin
+    And as "Alice" the file with original path "PARENT/CHILD/child.txt" should not exist in the trashbin
+    And as "Alice" the folder with original path "PARENT/CHILD/" should not exist in the trashbin
+    But as "Alice" the file with original path "PARENT/parent.txt" should exist in the trashbin
+    And as "Alice" the file with original path "FOLDER/parent.txt" should exist in the trashbin
+    And as "Alice" the file with original path "FOLDER/CHILD/child.txt" should exist in the trashbin
     Examples:
       | dav-path |
       | new      |

--- a/tests/acceptance/features/apiTrashbin/trashbinFilesFolders.feature
+++ b/tests/acceptance/features/apiTrashbin/trashbinFilesFolders.feature
@@ -13,7 +13,7 @@ Feature: files and folders exist in the trashbin after being deleted
     Given using <dav-path> DAV path
     When user "Alice" deletes file "/textfile0.txt" using the WebDAV API
     Then the HTTP status code should be "204"
-    And as "Alice" file "/textfile0.txt" should exist in the trashbin
+    And as "Alice" file "textfile0.txt" should exist in the trashbin
     But as "Alice" file "/textfile0.txt" should not exist
     Examples:
       | dav-path |
@@ -25,7 +25,7 @@ Feature: files and folders exist in the trashbin after being deleted
     And user "Alice" has created folder "/tmp"
     When user "Alice" deletes folder "/tmp" using the WebDAV API
     Then the HTTP status code should be "204"
-    And as "Alice" folder "/tmp" should exist in the trashbin
+    And as "Alice" folder "tmp" should exist in the trashbin
     Examples:
       | dav-path |
       | new      |
@@ -37,8 +37,8 @@ Feature: files and folders exist in the trashbin after being deleted
     And user "Alice" has moved file "/textfile0.txt" to "/new-folder/new-file.txt"
     When user "Alice" deletes file "/new-folder/new-file.txt" using the WebDAV API
     Then the HTTP status code should be "204"
-    And as "Alice" the file with original path "/new-folder/new-file.txt" should exist in the trashbin
-    And as "Alice" file "/new-file.txt" should exist in the trashbin
+    And as "Alice" the file with original path "new-folder/new-file.txt" should exist in the trashbin
+    And as "Alice" file "new-file.txt" should exist in the trashbin
     But as "Alice" file "/new-folder/new-file.txt" should not exist
     Examples:
       | dav-path |
@@ -53,8 +53,8 @@ Feature: files and folders exist in the trashbin after being deleted
     And user "Alice" has shared folder "/shared" with user "Brian"
     When user "Alice" deletes file "/shared/shared_file.txt" using the WebDAV API
     Then the HTTP status code should be "204"
-    And as "Alice" the file with original path "/shared/shared_file.txt" should exist in the trashbin
-    And as "Alice" file "/shared_file.txt" should exist in the trashbin
+    And as "Alice" the file with original path "shared/shared_file.txt" should exist in the trashbin
+    And as "Alice" file "shared_file.txt" should exist in the trashbin
     But as "Alice" file "/shared/shared_file.txt" should not exist
     Examples:
       | dav-path |
@@ -69,7 +69,7 @@ Feature: files and folders exist in the trashbin after being deleted
     And user "Alice" has shared folder "/shared" with user "Brian"
     When user "Alice" deletes folder "/shared" using the WebDAV API
     Then the HTTP status code should be "204"
-    And as "Alice" the folder with original path "/shared" should exist in the trashbin
+    And as "Alice" the folder with original path "shared" should exist in the trashbin
     Examples:
       | dav-path |
       | new      |
@@ -96,11 +96,11 @@ Feature: files and folders exist in the trashbin after being deleted
       | /folderC/textfile0.txt |
       | /folderD/textfile0.txt |
     Then the HTTP status code of responses on all endpoints should be "204"
-    And as "Alice" the folder with original path "/folderA/textfile0.txt" should exist in the trashbin
-    And as "Alice" the folder with original path "/folderB/textfile0.txt" should exist in the trashbin
-    And as "Alice" the folder with original path "/folderC/textfile0.txt" should exist in the trashbin
-    And as "Alice" the folder with original path "/folderD/textfile0.txt" should exist in the trashbin
-    And as "Alice" the folder with original path "/textfile0.txt" should exist in the trashbin
+    And as "Alice" the folder with original path "folderA/textfile0.txt" should exist in the trashbin
+    And as "Alice" the folder with original path "folderB/textfile0.txt" should exist in the trashbin
+    And as "Alice" the folder with original path "folderC/textfile0.txt" should exist in the trashbin
+    And as "Alice" the folder with original path "folderD/textfile0.txt" should exist in the trashbin
+    And as "Alice" the folder with original path "textfile0.txt" should exist in the trashbin
     Examples:
       | dav-path |
       | new      |
@@ -116,9 +116,9 @@ Feature: files and folders exist in the trashbin after being deleted
     And user "Alice" deletes file "/folderB/textfile0.txt" using the WebDAV API
     And user "Alice" deletes file "/textfile0.txt" using the WebDAV API
     Then the HTTP status code of responses on all endpoints should be "204"
-    And as "Alice" the folder with original path "/folderA/textfile0.txt" should exist in the trashbin
-    And as "Alice" the folder with original path "/folderB/textfile0.txt" should exist in the trashbin
-    And as "Alice" the folder with original path "/textfile0.txt" should exist in the trashbin
+    And as "Alice" the folder with original path "folderA/textfile0.txt" should exist in the trashbin
+    And as "Alice" the folder with original path "folderB/textfile0.txt" should exist in the trashbin
+    And as "Alice" the folder with original path "textfile0.txt" should exist in the trashbin
     Examples:
       | dav-path |
       | new      |
@@ -131,7 +131,7 @@ Feature: files and folders exist in the trashbin after being deleted
     And user "Alice" has moved file "/textfile0.txt" to "/local_storage/tmp/textfile0.txt"
     When user "Alice" deletes folder "/local_storage/tmp" using the WebDAV API
     Then the HTTP status code should be "204"
-    And as "Alice" the folder with original path "/local_storage/tmp" should exist in the trashbin
+    And as "Alice" the folder with original path "local_storage/tmp" should exist in the trashbin
     Examples:
       | dav-path |
       | new      |
@@ -250,7 +250,7 @@ Feature: files and folders exist in the trashbin after being deleted
     And user "<username>" has uploaded file with content "to delete" to "/textfile0.txt"
     When user "<username>" deletes file "/textfile0.txt" using the WebDAV API
     Then the HTTP status code should be "204"
-    And as "<username>" file "/textfile0.txt" should exist in the trashbin
+    And as "<username>" file "textfile0.txt" should exist in the trashbin
     But as "<username>" file "/textfile0.txt" should not exist
     Examples:
       | dav-path | username |
@@ -280,9 +280,9 @@ Feature: files and folders exist in the trashbin after being deleted
     And user "Alice" has uploaded file "filesForUpload/textfile.txt" to "/new-folder/new-file.txt"
     When user "Alice" deletes folder "/new-folder" using the WebDAV API
     Then the HTTP status code should be "204"
-    And as "Alice" the file with original path "/new-folder/new-file.txt" should exist in the trashbin
-    And as "Alice" the folder with original path "/new-folder" should exist in the trashbin
-    And as "Alice" file "/new-folder/new-file.txt" should exist in the trashbin
+    And as "Alice" the file with original path "new-folder/new-file.txt" should exist in the trashbin
+    And as "Alice" the folder with original path "new-folder" should exist in the trashbin
+    And as "Alice" file "new-folder/new-file.txt" should exist in the trashbin
     But as "Alice" file "/new-folder/new-file.txt" should not exist
     Examples:
       | dav-path |

--- a/tests/acceptance/features/apiTrashbin/trashbinFilesFoldersOc10Issue23151.feature
+++ b/tests/acceptance/features/apiTrashbin/trashbinFilesFoldersOc10Issue23151.feature
@@ -37,7 +37,7 @@ Feature: files and folders exist in the trashbin after being deleted
 #    And as "Alice" the folder with original path "/folderB/textfile0.txt" should not exist in the trashbin
 #    And as "Alice" the folder with original path "/folderC/textfile0.txt" should not exist in the trashbin
 #    And as "Alice" the folder with original path "/folderD/textfile0.txt" should not exist in the trashbin
-    And as "Alice" the folder with original path "/textfile0.txt" should exist in the trashbin
+    And as "Alice" the folder with original path "textfile0.txt" should exist in the trashbin
     Examples:
       | dav-path |
       | new      |

--- a/tests/acceptance/features/apiTrashbin/trashbinSharingToRoot.feature
+++ b/tests/acceptance/features/apiTrashbin/trashbinSharingToRoot.feature
@@ -15,7 +15,7 @@ Feature: using trashbin together with sharing
     And user "Brian" has moved folder "/shared" to "/renamed_shared"
     When user "Brian" deletes folder "/renamed_shared" using the WebDAV API
     Then the HTTP status code should be "204"
-    And as "Brian" the folder with original path "/renamed_shared" should not exist in the trashbin
+    And as "Brian" the folder with original path "renamed_shared" should not exist in the trashbin
     Examples:
       | dav-path |
       | new      |
@@ -30,8 +30,8 @@ Feature: using trashbin together with sharing
     And user "Brian" has moved file "/shared" to "/renamed_shared"
     When user "Brian" deletes file "/renamed_shared/shared_file.txt" using the WebDAV API
     Then the HTTP status code should be "204"
-    And as "Brian" the file with original path "/renamed_shared/shared_file.txt" should exist in the trashbin
-    And as "Alice" the file with original path "/shared/shared_file.txt" should exist in the trashbin
+    And as "Brian" the file with original path "renamed_shared/shared_file.txt" should exist in the trashbin
+    And as "Alice" the file with original path "shared/shared_file.txt" should exist in the trashbin
     Examples:
       | dav-path |
       | new      |
@@ -49,9 +49,9 @@ Feature: using trashbin together with sharing
     And user "Alice" has shared folder "/shared" with group "grp1"
     When user "Brian" deletes file "/shared/shared_file.txt" using the WebDAV API
     Then the HTTP status code should be "204"
-    And as "Brian" the file with original path "/shared/shared_file.txt" should exist in the trashbin
-    And as "Alice" the file with original path "/shared/shared_file.txt" should exist in the trashbin
-    And as "Carol" the file with original path "/shared/shared_file.txt" should not exist in the trashbin
+    And as "Brian" the file with original path "shared/shared_file.txt" should exist in the trashbin
+    And as "Alice" the file with original path "shared/shared_file.txt" should exist in the trashbin
+    And as "Carol" the file with original path "shared/shared_file.txt" should not exist in the trashbin
     Examples:
       | dav-path |
       | new      |
@@ -69,9 +69,9 @@ Feature: using trashbin together with sharing
     And user "Alice" has shared folder "/shared" with group "grp1"
     When user "Alice" deletes file "/shared/shared_file.txt" using the WebDAV API
     Then the HTTP status code should be "204"
-    And as "Alice" the file with original path "/shared/shared_file.txt" should exist in the trashbin
-    And as "Brian" the file with original path "/shared/shared_file.txt" should not exist in the trashbin
-    And as "Carol" the file with original path "/shared/shared_file.txt" should not exist in the trashbin
+    And as "Alice" the file with original path "shared/shared_file.txt" should exist in the trashbin
+    And as "Brian" the file with original path "shared/shared_file.txt" should not exist in the trashbin
+    And as "Carol" the file with original path "shared/shared_file.txt" should not exist in the trashbin
     Examples:
       | dav-path |
       | new      |
@@ -90,9 +90,9 @@ Feature: using trashbin together with sharing
     And user "Alice" has shared folder "/shared" with group "grp1"
     When user "Brian" deletes folder "/shared/sub" using the WebDAV API
     Then the HTTP status code should be "204"
-    And as "Brian" the file with original path "/shared/sub/shared_file.txt" should exist in the trashbin
-    And as "Alice" the file with original path "/shared/sub/shared_file.txt" should exist in the trashbin
-    And as "Carol" the file with original path "/shared/sub/shared_file.txt" should not exist in the trashbin
+    And as "Brian" the file with original path "shared/sub/shared_file.txt" should exist in the trashbin
+    And as "Alice" the file with original path "shared/sub/shared_file.txt" should exist in the trashbin
+    And as "Carol" the file with original path "shared/sub/shared_file.txt" should not exist in the trashbin
     Examples:
       | dav-path |
       | new      |
@@ -111,9 +111,9 @@ Feature: using trashbin together with sharing
     And user "Alice" has shared folder "/shared" with group "grp1"
     When user "Alice" deletes folder "/shared/sub" using the WebDAV API
     Then the HTTP status code should be "204"
-    And as "Alice" the file with original path "/shared/sub/shared_file.txt" should exist in the trashbin
-    And as "Brian" the file with original path "/shared/sub/shared_file.txt" should not exist in the trashbin
-    And as "Carol" the file with original path "/shared/sub/shared_file.txt" should not exist in the trashbin
+    And as "Alice" the file with original path "shared/sub/shared_file.txt" should exist in the trashbin
+    And as "Brian" the file with original path "shared/sub/shared_file.txt" should not exist in the trashbin
+    And as "Carol" the file with original path "shared/sub/shared_file.txt" should not exist in the trashbin
     Examples:
       | dav-path |
       | new      |
@@ -127,11 +127,11 @@ Feature: using trashbin together with sharing
     And user "Alice" has shared folder "/shared" with user "Brian"
     And user "Brian" has moved file "/shared" to "/renamed_shared"
     And user "Brian" has deleted file "/renamed_shared/shared_file.txt"
-    When user "Brian" restores the file with original path "/renamed_shared/shared_file.txt" using the trashbin API
+    When user "Brian" restores the file with original path "renamed_shared/shared_file.txt" using the trashbin API
     Then the HTTP status code should be "201"
     And the following headers should match these regular expressions for user "Brian"
       | ETag | /^"[a-f0-9:\.]{1,32}"$/ |
-    And as "Brian" the file with original path "/renamed_shared/shared_file.txt" should not exist in the trashbin
+    And as "Brian" the file with original path "renamed_shared/shared_file.txt" should not exist in the trashbin
     And user "Brian" should see the following elements
       | /renamed_shared/                |
       | /renamed_shared/shared_file.txt |
@@ -149,9 +149,9 @@ Feature: using trashbin together with sharing
     And as "Alice" folder "/shareFolderParent" should exist
     And user "Alice" has uploaded file "filesForUpload/textfile.txt" to "/textfile0.txt"
     And user "Alice" has deleted file "/textfile0.txt"
-    When user "Alice" restores the file with original path "/textfile0.txt" to "/shareFolderParent/textfile0.txt" using the trashbin API
+    When user "Alice" restores the file with original path "textfile0.txt" to "/shareFolderParent/textfile0.txt" using the trashbin API
     Then the HTTP status code should be "403"
-    And as "Alice" the file with original path "/textfile0.txt" should exist in the trashbin
+    And as "Alice" the file with original path "textfile0.txt" should exist in the trashbin
     And as "Alice" file "/shareFolderParent/textfile0.txt" should not exist
     And as "Brian" file "/shareFolderParent/textfile0.txt" should not exist
     Examples:
@@ -168,9 +168,9 @@ Feature: using trashbin together with sharing
     And user "Alice" has uploaded file "filesForUpload/textfile.txt" to "/textfile0.txt"
     And as "Alice" folder "/shareFolderParent/shareFolderChild" should exist
     And user "Alice" has deleted file "/textfile0.txt"
-    When user "Alice" restores the file with original path "/textfile0.txt" to "/shareFolderParent/shareFolderChild/textfile0.txt" using the trashbin API
+    When user "Alice" restores the file with original path "textfile0.txt" to "/shareFolderParent/shareFolderChild/textfile0.txt" using the trashbin API
     Then the HTTP status code should be "403"
-    And as "Alice" the file with original path "/textfile0.txt" should exist in the trashbin
+    And as "Alice" the file with original path "textfile0.txt" should exist in the trashbin
     And as "Alice" file "/shareFolderParent/shareFolderChild/textfile0.txt" should not exist
     And as "Brian" file "/shareFolderParent/shareFolderChild/textfile0.txt" should not exist
     Examples:

--- a/tests/acceptance/features/apiTrashbin/trashbinSharingToShares.feature
+++ b/tests/acceptance/features/apiTrashbin/trashbinSharingToShares.feature
@@ -18,7 +18,7 @@ Feature: using trashbin together with sharing
     And user "Brian" has moved folder "/Shares/shared" to "/Shares/renamed_shared"
     When user "Brian" deletes folder "/Shares/renamed_shared" using the WebDAV API
     Then the HTTP status code should be "204"
-    And as "Brian" the folder with original path "/Shares/renamed_shared" should not exist in the trashbin
+    And as "Brian" the folder with original path "Shares/renamed_shared" should not exist in the trashbin
     Examples:
       | dav-path |
       | new      |
@@ -34,8 +34,8 @@ Feature: using trashbin together with sharing
     And user "Brian" has moved file "/Shares/shared" to "/Shares/renamed_shared"
     When user "Brian" deletes file "/Shares/renamed_shared/shared_file.txt" using the WebDAV API
     Then the HTTP status code should be "204"
-    And as "Brian" the file with original path "/Shares/renamed_shared/shared_file.txt" should exist in the trashbin
-    And as "Alice" the file with original path "/shared/shared_file.txt" should exist in the trashbin
+    And as "Brian" the file with original path "Shares/renamed_shared/shared_file.txt" should exist in the trashbin
+    And as "Alice" the file with original path "shared/shared_file.txt" should exist in the trashbin
     Examples:
       | dav-path |
       | new      |
@@ -55,9 +55,9 @@ Feature: using trashbin together with sharing
     And user "Carol" has accepted share "/Shares/shared" offered by user "Alice"
     When user "Brian" deletes file "/Shares/shared/shared_file.txt" using the WebDAV API
     Then the HTTP status code should be "204"
-    And as "Brian" the file with original path "/Shares/shared/shared_file.txt" should exist in the trashbin
-    And as "Alice" the file with original path "/shared/shared_file.txt" should exist in the trashbin
-    And as "Carol" the file with original path "/Shares/shared/shared_file.txt" should not exist in the trashbin
+    And as "Brian" the file with original path "Shares/shared/shared_file.txt" should exist in the trashbin
+    And as "Alice" the file with original path "shared/shared_file.txt" should exist in the trashbin
+    And as "Carol" the file with original path "Shares/shared/shared_file.txt" should not exist in the trashbin
     Examples:
       | dav-path |
       | new      |
@@ -77,9 +77,9 @@ Feature: using trashbin together with sharing
     And user "Carol" has accepted share "/Shares/shared" offered by user "Alice"
     When user "Alice" deletes file "/shared/shared_file.txt" using the WebDAV API
     Then the HTTP status code should be "204"
-    And as "Alice" the file with original path "/shared/shared_file.txt" should exist in the trashbin
-    And as "Brian" the file with original path "/Shares/shared/shared_file.txt" should not exist in the trashbin
-    And as "Carol" the file with original path "/Shares/shared/shared_file.txt" should not exist in the trashbin
+    And as "Alice" the file with original path "shared/shared_file.txt" should exist in the trashbin
+    And as "Brian" the file with original path "Shares/shared/shared_file.txt" should not exist in the trashbin
+    And as "Carol" the file with original path "Shares/shared/shared_file.txt" should not exist in the trashbin
     Examples:
       | dav-path |
       | new      |
@@ -100,9 +100,9 @@ Feature: using trashbin together with sharing
     And user "Carol" has accepted share "/Shares/shared" offered by user "Alice"
     When user "Brian" deletes file "/Shares/shared/sub/shared_file.txt" using the WebDAV API
     Then the HTTP status code should be "204"
-    And as "Brian" the file with original path "/Shares/shared/sub/shared_file.txt" should exist in the trashbin
-    And as "Alice" the file with original path "/shared/sub/shared_file.txt" should exist in the trashbin
-    And as "Carol" the file with original path "/Shares/sub/shared/shared_file.txt" should not exist in the trashbin
+    And as "Brian" the file with original path "Shares/shared/sub/shared_file.txt" should exist in the trashbin
+    And as "Alice" the file with original path "shared/sub/shared_file.txt" should exist in the trashbin
+    And as "Carol" the file with original path "Shares/sub/shared/shared_file.txt" should not exist in the trashbin
     Examples:
       | dav-path |
       | new      |
@@ -123,9 +123,9 @@ Feature: using trashbin together with sharing
     And user "Carol" has accepted share "/Shares/shared" offered by user "Alice"
     When user "Alice" deletes file "/shared/sub/shared_file.txt" using the WebDAV API
     Then the HTTP status code should be "204"
-    And as "Alice" the file with original path "/shared/sub/shared_file.txt" should exist in the trashbin
-    And as "Brian" the file with original path "/Shares/shared/sub/shared_file.txt" should not exist in the trashbin
-    And as "Carol" the file with original path "/Shares/shared/sub/shared_file.txt" should not exist in the trashbin
+    And as "Alice" the file with original path "shared/sub/shared_file.txt" should exist in the trashbin
+    And as "Brian" the file with original path "Shares/shared/sub/shared_file.txt" should not exist in the trashbin
+    And as "Carol" the file with original path "Shares/shared/sub/shared_file.txt" should not exist in the trashbin
     Examples:
       | dav-path |
       | new      |
@@ -140,11 +140,11 @@ Feature: using trashbin together with sharing
     And user "Brian" has accepted share "/shared" offered by user "Alice"
     And user "Brian" has moved folder "/Shares/shared" to "/Shares/renamed_shared"
     And user "Brian" has deleted file "/Shares/renamed_shared/shared_file.txt"
-    When user "Brian" restores the file with original path "/Shares/renamed_shared/shared_file.txt" using the trashbin API
+    When user "Brian" restores the file with original path "Shares/renamed_shared/shared_file.txt" using the trashbin API
     Then the HTTP status code should be "201"
     And the following headers should match these regular expressions for user "Brian"
       | ETag | /^"[a-f0-9:\.]{1,32}"$/ |
-    And as "Brian" the file with original path "/Shares/renamed_shared/shared_file.txt" should not exist in the trashbin
+    And as "Brian" the file with original path "Shares/renamed_shared/shared_file.txt" should not exist in the trashbin
     And user "Brian" should see the following elements
       | /Shares/renamed_shared/                |
       | /Shares/renamed_shared/shared_file.txt |
@@ -162,9 +162,9 @@ Feature: using trashbin together with sharing
     And user "Alice" has accepted share "/shareFolderParent" offered by user "Brian"
     And as "Alice" folder "/Shares/shareFolderParent" should exist
     And user "Alice" has deleted file "/textfile0.txt"
-    When user "Alice" restores the file with original path "/textfile0.txt" to "/Shares/shareFolderParent/textfile0.txt" using the trashbin API
+    When user "Alice" restores the file with original path "textfile0.txt" to "/Shares/shareFolderParent/textfile0.txt" using the trashbin API
     Then the HTTP status code should be "403"
-    And as "Alice" the file with original path "/textfile0.txt" should exist in the trashbin
+    And as "Alice" the file with original path "textfile0.txt" should exist in the trashbin
     And as "Alice" file "/Shares/shareFolderParent/textfile0.txt" should not exist
     And as "Brian" file "/shareFolderParent/textfile0.txt" should not exist
     Examples:
@@ -181,9 +181,9 @@ Feature: using trashbin together with sharing
     And user "Alice" has accepted share "/shareFolderParent" offered by user "Brian"
     And as "Alice" folder "/Shares/shareFolderParent/shareFolderChild" should exist
     And user "Alice" has deleted file "/textfile0.txt"
-    When user "Alice" restores the file with original path "/textfile0.txt" to "/Shares/shareFolderParent/shareFolderChild/textfile0.txt" using the trashbin API
+    When user "Alice" restores the file with original path "textfile0.txt" to "/Shares/shareFolderParent/shareFolderChild/textfile0.txt" using the trashbin API
     Then the HTTP status code should be "403"
-    And as "Alice" the file with original path "/textfile0.txt" should exist in the trashbin
+    And as "Alice" the file with original path "textfile0.txt" should exist in the trashbin
     And as "Alice" file "/Shares/shareFolderParent/shareFolderChild/textfile0.txt" should not exist
     And as "Brian" file "/shareFolderParent/shareFolderChild/textfile0.txt" should not exist
     Examples:

--- a/tests/acceptance/features/apiTrashbin/trashbinSkip.feature
+++ b/tests/acceptance/features/apiTrashbin/trashbinSkip.feature
@@ -33,9 +33,9 @@ Feature: files and folders can be deleted completely skipping the trashbin
     Then the HTTP status code of responses on all endpoints should be "204"
     And as "Alice" file "sample.txt" should exist in the trashbin
     And as "Alice" file "sample.py" should exist in the trashbin
-    But as "Alice" the file with original path "/sample.dat" should not exist in the trashbin
-    And as "Alice" the file with original path "/sample.php" should not exist in the trashbin
-    And as "Alice" the file with original path "/sample.go" should not exist in the trashbin
+    But as "Alice" the file with original path "sample.dat" should not exist in the trashbin
+    And as "Alice" the file with original path "sample.php" should not exist in the trashbin
+    And as "Alice" the file with original path "sample.go" should not exist in the trashbin
     Examples:
       | dav-path |
       | new      |
@@ -61,11 +61,11 @@ Feature: files and folders can be deleted completely skipping the trashbin
       | PARENT/sample.go  |
       | PARENT/sample.py  |
     Then the HTTP status code of responses on all endpoints should be "204"
-    And as "Alice" the file with original path "/PARENT/sample.txt" should exist in the trashbin
-    And as "Alice" the file with original path "/PARENT/sample.py" should exist in the trashbin
-    But as "Alice" the file with original path "/PARENT/sample.dat" should not exist in the trashbin
-    And as "Alice" the file with original path "/PARENT/sample.php" should not exist in the trashbin
-    And as "Alice" the file with original path "/PARENT/sample.go" should not exist in the trashbin
+    And as "Alice" the file with original path "PARENT/sample.txt" should exist in the trashbin
+    And as "Alice" the file with original path "PARENT/sample.py" should exist in the trashbin
+    But as "Alice" the file with original path "PARENT/sample.dat" should not exist in the trashbin
+    And as "Alice" the file with original path "PARENT/sample.php" should not exist in the trashbin
+    And as "Alice" the file with original path "PARENT/sample.go" should not exist in the trashbin
     Examples:
       | dav-path |
       | new      |
@@ -101,16 +101,16 @@ Feature: files and folders can be deleted completely skipping the trashbin
       | sample.PY  |
       | sample.py  |
     Then the HTTP status code of responses on all endpoints should be "204"
-    And as "Alice" the file with original path "/sample.TXT" should exist in the trashbin
-    And as "Alice" the file with original path "/sample.txt" should exist in the trashbin
-    And as "Alice" the file with original path "/sample.PY" should exist in the trashbin
-    And as "Alice" the file with original path "/sample.py" should exist in the trashbin
-    But as "Alice" the file with original path "/sample.DAT" should not exist in the trashbin
-    And as "Alice" the file with original path "/sample.dat" should not exist in the trashbin
-    And as "Alice" the file with original path "/sample.PHP" should not exist in the trashbin
-    And as "Alice" the file with original path "/sample.php" should not exist in the trashbin
-    And as "Alice" the file with original path "/sample.GO" should not exist in the trashbin
-    And as "Alice" the file with original path "/sample.go" should not exist in the trashbin
+    And as "Alice" the file with original path "sample.TXT" should exist in the trashbin
+    And as "Alice" the file with original path "sample.txt" should exist in the trashbin
+    And as "Alice" the file with original path "sample.PY" should exist in the trashbin
+    And as "Alice" the file with original path "sample.py" should exist in the trashbin
+    But as "Alice" the file with original path "sample.DAT" should not exist in the trashbin
+    And as "Alice" the file with original path "sample.dat" should not exist in the trashbin
+    And as "Alice" the file with original path "sample.PHP" should not exist in the trashbin
+    And as "Alice" the file with original path "sample.php" should not exist in the trashbin
+    And as "Alice" the file with original path "sample.GO" should not exist in the trashbin
+    And as "Alice" the file with original path "sample.go" should not exist in the trashbin
     Examples:
       | dav-path |
       | new      |
@@ -197,8 +197,8 @@ Feature: files and folders can be deleted completely skipping the trashbin
     And user "Alice" has uploaded file with content "sample delete file 2" to "PARENT/sample.dat"
     When user "Alice" deletes file "PARENT/sample.dat" using the WebDAV API
     Then the HTTP status code should be "204"
-    And as "Alice" the file with original path "/PARENT" should not exist in the trashbin
-    And as "Alice" the file with original path "/PARENT/sample.dat" should not exist in the trashbin
+    And as "Alice" the file with original path "PARENT" should not exist in the trashbin
+    And as "Alice" the file with original path "PARENT/sample.dat" should not exist in the trashbin
     Examples:
       | dav-path |
       | new      |

--- a/tests/acceptance/features/apiTrashbinRestore/trashbinRestore.feature
+++ b/tests/acceptance/features/apiTrashbinRestore/trashbinRestore.feature
@@ -17,11 +17,11 @@ Feature: Restore deleted files/folders
     And user "Alice" has uploaded file with content "text file 1" to "/textfile1.txt"
     And user "Alice" has deleted file "/textfile0.txt"
     And as "Alice" file "/textfile0.txt" should exist in the trashbin
-    When user "Alice" restores the file with original path "/textfile0.txt" using the trashbin API
+    When user "Alice" restores the file with original path "textfile0.txt" using the trashbin API
     Then the HTTP status code should be "201"
     And the following headers should match these regular expressions for user "Alice"
       | ETag | /^"[a-f0-9:\.]{1,32}"$/ |
-    And as "Alice" the file with original path "/textfile0.txt" should not exist in the trashbin
+    And as "Alice" the file with original path "textfile0.txt" should not exist in the trashbin
     And the content of file "/textfile0.txt" for user "Alice" should be "file to delete"
     And user "Alice" should see the following elements
       | /FOLDER/           |
@@ -40,9 +40,9 @@ Feature: Restore deleted files/folders
     And user "Alice" has created folder "/new-folder"
     And user "Alice" has moved file "/textfile0.txt" to "/new-folder/new-file.txt"
     And user "Alice" has deleted file "/new-folder/new-file.txt"
-    When user "Alice" restores the file with original path "/new-folder/new-file.txt" using the trashbin API
+    When user "Alice" restores the file with original path "new-folder/new-file.txt" using the trashbin API
     Then the HTTP status code should be "201"
-    And as "Alice" the file with original path "/new-folder/new-file.txt" should not exist in the trashbin
+    And as "Alice" the file with original path "new-folder/new-file.txt" should not exist in the trashbin
     And as "Alice" file "/new-folder/new-file.txt" should exist
     And the content of file "/new-folder/new-file.txt" for user "Alice" should be "file to delete"
     Examples:
@@ -57,10 +57,10 @@ Feature: Restore deleted files/folders
     And user "Alice" has moved file "/textfile0.txt" to "/new-folder/new-file.txt"
     And user "Alice" has deleted file "/new-folder/new-file.txt"
     And user "Alice" has deleted folder "/new-folder"
-    When user "Alice" restores the folder with original path "/new-folder" using the trashbin API
-    And user "Alice" restores the file with original path "/new-folder/new-file.txt" using the trashbin API
+    When user "Alice" restores the folder with original path "new-folder" using the trashbin API
+    And user "Alice" restores the file with original path "new-folder/new-file.txt" using the trashbin API
     Then the HTTP status code should be "201"
-    And as "Alice" the file with original path "/new-folder/new-file.txt" should not exist in the trashbin
+    And as "Alice" the file with original path "new-folder/new-file.txt" should not exist in the trashbin
     And as "Alice" file "/new-folder/new-file.txt" should exist
     And the content of file "/new-folder/new-file.txt" for user "Alice" should be "file to delete"
     Examples:
@@ -74,7 +74,7 @@ Feature: Restore deleted files/folders
     And user "Alice" has created folder "/PARENT"
     And user "Alice" has created folder "/PARENT/CHILD"
     And user "Alice" has uploaded file with content "to delete" to "<delete-path>"
-    And user "Alice" has deleted file "<delete-path>"
+    And user "Alice" has deleted file "/<delete-path>"
     When user "Alice" restores the file with original path "<delete-path>" to "<restore-path>" using the trashbin API
     Then the HTTP status code should be "201"
     And the following headers should match these regular expressions for user "Alice"
@@ -84,13 +84,13 @@ Feature: Restore deleted files/folders
     And as "Alice" file "<delete-path>" should not exist
     And the content of file "<restore-path>" for user "Alice" should be "to delete"
     Examples:
-      | dav-path | delete-path             | restore-path         |
-      | old      | /PARENT/parent.txt      | parent.txt           |
-      | new      | /PARENT/parent.txt      | parent.txt           |
-      | old      | /PARENT/CHILD/child.txt | child.txt            |
-      | new      | /PARENT/CHILD/child.txt | child.txt            |
-      | old      | /textfile0.txt          | PARENT/textfile0.txt |
-      | new      | /textfile0.txt          | PARENT/textfile0.txt |
+      | dav-path | delete-path            | restore-path         |
+      | old      | PARENT/parent.txt      | parent.txt           |
+      | new      | PARENT/parent.txt      | parent.txt           |
+      | old      | PARENT/CHILD/child.txt | child.txt            |
+      | new      | PARENT/CHILD/child.txt | child.txt            |
+      | old      | textfile0.txt          | PARENT/textfile0.txt |
+      | new      | textfile0.txt          | PARENT/textfile0.txt |
 
   @skipOnOcV10 @issue-35974 @skipOnOcV11
   Scenario Outline: restoring a file to an already existing path overrides the file
@@ -98,15 +98,15 @@ Feature: Restore deleted files/folders
     And using <dav-path> DAV path
     And user "Alice" has created folder "/PARENT"
     And user "Alice" has uploaded file with content "PARENT file content" to <upload-path>
-    And user "Alice" has deleted file <delete-path>
+    And user "Alice" has deleted file "/<delete-path>"
     When user "Alice" restores the file with original path <delete-path> to <upload-path> using the trashbin API
     Then the HTTP status code should be "204"
     And as "Alice" file <upload-path> should exist
     And the content of file <upload-path> for user "Alice" should be "file to delete"
     Examples:
       | dav-path | upload-path                | delete-path        |
-      | old      | "/PARENT/textfile0.txt"    | "/textfile0.txt"   |
-      | new      | "/PARENT/textfile0.txt"    | "/textfile0.txt"   |
+      | old      | "/PARENT/textfile0.txt"    | "textfile0.txt"    |
+      | new      | "/PARENT/textfile0.txt"    | "textfile0.txt"    |
       | old      | "/PARENT/.hiddenfile0.txt" | ".hiddenfile0.txt" |
       | new      | "/PARENT/.hiddenfile0.txt" | ".hiddenfile0.txt" |
 
@@ -118,11 +118,11 @@ Feature: Restore deleted files/folders
     And user "Alice" has deleted file "/new-folder/new-file.txt"
     And user "Alice" has deleted folder "/new-folder"
     When user "Alice" creates folder "/new-folder" using the WebDAV API
-    And user "Alice" restores the file with original path "/new-folder/new-file.txt" using the trashbin API
+    And user "Alice" restores the file with original path "new-folder/new-file.txt" using the trashbin API
     Then the HTTP status code should be "201"
     And the following headers should match these regular expressions for user "Alice"
       | ETag | /^"[a-f0-9:\.]{1,32}"$/ |
-    And as "Alice" the file with original path "/new-folder/new-file.txt" should not exist in the trashbin
+    And as "Alice" the file with original path "new-folder/new-file.txt" should not exist in the trashbin
     And as "Alice" file "/new-folder/new-file.txt" should exist
     And the content of file "/new-folder/new-file.txt" for user "Alice" should be "file to delete"
     Examples:
@@ -138,11 +138,11 @@ Feature: Restore deleted files/folders
     And user "Alice" has moved file "/textfile0.txt" to "/local_storage/tmp/textfile0.txt"
     And user "Alice" has deleted file "/local_storage/tmp/textfile0.txt"
     And as "Alice" the folder with original path "/local_storage/tmp/textfile0.txt" should exist in the trashbin
-    When user "Alice" restores the folder with original path "/local_storage/tmp/textfile0.txt" using the trashbin API
+    When user "Alice" restores the folder with original path "local_storage/tmp/textfile0.txt" using the trashbin API
     Then the HTTP status code should be "201"
     And the following headers should match these regular expressions for user "Alice"
       | ETag | /^"[a-f0-9:\.]{1,32}"$/ |
-    And as "Alice" the folder with original path "/local_storage/tmp/textfile0.txt" should not exist in the trashbin
+    And as "Alice" the folder with original path "local_storage/tmp/textfile0.txt" should not exist in the trashbin
     And the content of file "/local_storage/tmp/textfile0.txt" for user "Alice" should be "file to delete"
     And user "Alice" should see the following elements
       | /local_storage/                  |
@@ -162,9 +162,9 @@ Feature: Restore deleted files/folders
     And user "Alice" has uploaded chunk file "1" of "1" with "AA" to "/local_storage/tmp/textfile0.txt"
     And user "Alice" has deleted file "/local_storage/tmp/textfile0.txt"
     And as "Alice" the folder with original path "/local_storage/tmp/textfile0.txt" should exist in the trashbin
-    When user "Alice" restores the folder with original path "/local_storage/tmp/textfile0.txt" using the trashbin API
+    When user "Alice" restores the folder with original path "local_storage/tmp/textfile0.txt" using the trashbin API
     Then the HTTP status code should be "201"
-    And as "Alice" the folder with original path "/local_storage/tmp/textfile0.txt" should not exist in the trashbin
+    And as "Alice" the folder with original path "local_storage/tmp/textfile0.txt" should not exist in the trashbin
     And the content of file "/local_storage/tmp/textfile0.txt" for user "Alice" should be "AA"
 
   @local_storage @files_external-app-required @skipOnEncryptionType:user-keys @encryption-issue-42 @skip_on_objectstore @newChunking
@@ -177,10 +177,10 @@ Feature: Restore deleted files/folders
       | number | content |
       | 1      | AA      |
     And user "Alice" has deleted file "/local_storage/tmp/textfile0.txt"
-    And as "Alice" the folder with original path "/local_storage/tmp/textfile0.txt" should exist in the trashbin
-    When user "Alice" restores the folder with original path "/local_storage/tmp/textfile0.txt" using the trashbin API
+    And as "Alice" the folder with original path "local_storage/tmp/textfile0.txt" should exist in the trashbin
+    When user "Alice" restores the folder with original path "local_storage/tmp/textfile0.txt" using the trashbin API
     Then the HTTP status code should be "201"
-    And as "Alice" the folder with original path "/local_storage/tmp/textfile0.txt" should not exist in the trashbin
+    And as "Alice" the folder with original path "local_storage/tmp/textfile0.txt" should not exist in the trashbin
     And the content of file "/local_storage/tmp/textfile0.txt" for user "Alice" should be "AA"
 
   @smokeTest
@@ -188,9 +188,9 @@ Feature: Restore deleted files/folders
     Given using <dav-path> DAV path
     And user "Brian" has been created with default attributes and without skeleton files
     And user "Alice" has deleted file "/textfile0.txt"
-    When user "Brian" tries to restore the file with original path "/textfile0.txt" from the trashbin of user "Alice" using the trashbin API
+    When user "Brian" tries to restore the file with original path "textfile0.txt" from the trashbin of user "Alice" using the trashbin API
     Then the HTTP status code should be "<status-code>"
-    And as "Alice" the folder with original path "/textfile0.txt" should exist in the trashbin
+    And as "Alice" the folder with original path "textfile0.txt" should exist in the trashbin
     And user "Alice" should not see the following elements
       | /textfile0.txt |
     Examples:
@@ -203,9 +203,9 @@ Feature: Restore deleted files/folders
     Given using <dav-path> DAV path
     And user "Brian" has been created with default attributes and without skeleton files
     And user "Alice" has deleted file "/textfile0.txt"
-    When user "Alice" tries to restore the file with original path "/textfile0.txt" from the trashbin of user "Alice" using the password "invalid" and the trashbin API
+    When user "Alice" tries to restore the file with original path "textfile0.txt" from the trashbin of user "Alice" using the password "invalid" and the trashbin API
     Then the HTTP status code should be "401"
-    And as "Alice" the folder with original path "/textfile0.txt" should exist in the trashbin
+    And as "Alice" the folder with original path "textfile0.txt" should exist in the trashbin
     And user "Alice" should not see the following elements
       | /textfile0.txt |
     Examples:
@@ -218,9 +218,9 @@ Feature: Restore deleted files/folders
     Given using <dav-path> DAV path
     And user "Brian" has been created with default attributes and without skeleton files
     And user "Alice" has deleted file "/textfile0.txt"
-    When user "Alice" tries to restore the file with original path "/textfile0.txt" from the trashbin of user "Alice" using the password "" and the trashbin API
+    When user "Alice" tries to restore the file with original path "textfile0.txt" from the trashbin of user "Alice" using the password "" and the trashbin API
     Then the HTTP status code should be "401"
-    And as "Alice" the folder with original path "/textfile0.txt" should exist in the trashbin
+    And as "Alice" the folder with original path "textfile0.txt" should exist in the trashbin
     And user "Alice" should not see the following elements
       | /textfile0.txt |
     Examples:
@@ -255,9 +255,9 @@ Feature: Restore deleted files/folders
     And user "Alice" has created folder "/new-folder/folder1/folder2/"
     And user "Alice" has moved file "/textfile0.txt" to "/new-folder/folder1/folder2/new-file.txt"
     And user "Alice" has deleted file "/new-folder/folder1/folder2/new-file.txt"
-    When user "Alice" restores the file with original path "/new-folder/folder1/folder2/new-file.txt" using the trashbin API
+    When user "Alice" restores the file with original path "new-folder/folder1/folder2/new-file.txt" using the trashbin API
     Then the HTTP status code should be "201"
-    And as "Alice" the file with original path "/new-folder/folder1/folder2/new-file.txt" should not exist in the trashbin
+    And as "Alice" the file with original path "new-folder/folder1/folder2/new-file.txt" should not exist in the trashbin
     And as "Alice" file "/new-folder/folder1/folder2/new-file.txt" should exist
     And the content of file "/new-folder/folder1/folder2/new-file.txt" for user "Alice" should be "file to delete"
     Examples:
@@ -273,9 +273,9 @@ Feature: Restore deleted files/folders
     And user "Alice" has created folder "/new-folder/folder1/folder2/"
     And user "Alice" has moved file "/textfile0.txt" to "/new-folder/folder1/folder2/new-file.txt"
     And user "Alice" has deleted folder "/new-folder/"
-    When user "Alice" restores the folder with original path "/new-folder/" using the trashbin API
+    When user "Alice" restores the folder with original path "new-folder/" using the trashbin API
     Then the HTTP status code should be "201"
-    And as "Alice" the file with original path "/new-folder/folder1/folder2/new-file.txt" should not exist in the trashbin
+    And as "Alice" the file with original path "new-folder/folder1/folder2/new-file.txt" should not exist in the trashbin
     And as "Alice" file "/new-folder/folder1/folder2/new-file.txt" should exist
     And the content of file "/new-folder/folder1/folder2/new-file.txt" for user "Alice" should be "file to delete"
     Examples:
@@ -291,13 +291,13 @@ Feature: Restore deleted files/folders
     And user "Alice" has created folder "/new-folder/folder1/folder2"
     And user "Alice" has moved file "/textfile0.txt" to "/new-folder/folder1/folder2/new-file.txt"
     And user "Alice" has deleted folder "/new-folder"
-    When user "Alice" restores the folder with original path "/new-folder/folder1" to "/folder1" using the trashbin API
+    When user "Alice" restores the folder with original path "new-folder/folder1" to "/folder1" using the trashbin API
     Then the HTTP status code should be "201"
-    And as "Alice" the file with original path "/new-folder/folder1/folder2/new-file.txt" should not exist in the trashbin
-    And as "Alice" the folder with original path "/new-folder/folder1" should not exist in the trashbin
+    And as "Alice" the file with original path "new-folder/folder1/folder2/new-file.txt" should not exist in the trashbin
+    And as "Alice" the folder with original path "new-folder/folder1" should not exist in the trashbin
     And as "Alice" file "/folder1/folder2/new-file.txt" should exist
     And the content of file "/folder1/folder2/new-file.txt" for user "Alice" should be "file to delete"
-    But as "Alice" the folder with original path "/new-folder" should exist in the trashbin
+    But as "Alice" the folder with original path "new-folder" should exist in the trashbin
     Examples:
       | dav-path |
       | old      |
@@ -312,12 +312,12 @@ Feature: Restore deleted files/folders
     And user "Alice" has moved file "/textfile0.txt" to "/new-folder/folder1/folder2/new-file.txt"
     And user "Alice" has uploaded file with content "to delete" to "/new-folder/folder1/folder2/not-restored.txt"
     And user "Alice" has deleted folder "/new-folder/"
-    When user "Alice" restores the file with original path "/new-folder/folder1/folder2/new-file.txt" to "new-file.txt" using the trashbin API
+    When user "Alice" restores the file with original path "new-folder/folder1/folder2/new-file.txt" to "new-file.txt" using the trashbin API
     Then the HTTP status code should be "201"
-    And as "Alice" the file with original path "/new-folder/folder1/folder2/new-file.txt" should not exist in the trashbin
+    And as "Alice" the file with original path "new-folder/folder1/folder2/new-file.txt" should not exist in the trashbin
     And as "Alice" file "/new-file.txt" should exist
     And the content of file "/new-file.txt" for user "Alice" should be "file to delete"
-    But as "Alice" the file with original path "/new-folder/folder1/folder2/not-restored.txt" should exist in the trashbin
+    But as "Alice" the file with original path "new-folder/folder1/folder2/not-restored.txt" should exist in the trashbin
     Examples:
       | dav-path |
       | old      |
@@ -336,14 +336,14 @@ Feature: Restore deleted files/folders
       | .hidden_file         |
       | /FOLDER/.hidden_file |
     When user "Alice" restores the following files with original path
-      | path                 |
-      | .hidden_file         |
-      | /FOLDER/.hidden_file |
+      | path                |
+      | .hidden_file        |
+      | FOLDER/.hidden_file |
     Then the HTTP status code of responses on all endpoints should be "201"
     And as "Alice" the files with following original paths should not exist in the trashbin
-      | path                 |
-      | .hidden_file         |
-      | /FOLDER/.hidden_file |
+      | path                |
+      | .hidden_file        |
+      | FOLDER/.hidden_file |
     And as "Alice" the following files should exist
       | path                 |
       | .hidden_file         |
@@ -442,11 +442,11 @@ Feature: Restore deleted files/folders
     And user "Alice" has created folder "/parent_folder/sub"
     And user "Alice" has uploaded file with content "parent text" to "/parent_folder/sub/parent.txt"
     And user "Alice" has deleted folder "parent_folder"
-    When user "Alice" restores the folder with original path "/parent_folder/sub/parent.txt" to "parent.txt" using the trashbin API
+    When user "Alice" restores the folder with original path "parent_folder/sub/parent.txt" to "parent.txt" using the trashbin API
     Then the HTTP status code should be "201"
     And the following headers should match these regular expressions for user "Alice"
       | ETag | /^"[a-f0-9:\.]{1,32}"$/ |
-    And as "Alice" the file with original path "/parent_folder/sub/parent.txt" should not exist in the trashbin
+    And as "Alice" the file with original path "parent_folder/sub/parent.txt" should not exist in the trashbin
     And the content of file "parent.txt" for user "Alice" should be "parent text"
     Examples:
       | dav-path |
@@ -460,9 +460,9 @@ Feature: Restore deleted files/folders
     And user "Alice" has created folder "/parent_folder/sub"
     And user "Alice" has uploaded file with content "parent text" to "/parent_folder/sub/parent.txt"
     And user "Alice" has deleted folder "parent_folder"
-    When user "Alice" restores the folder with original path "/parent_folder/sub/parent.txt" to "/parent_folder/sub/parent.txt" using the trashbin API
+    When user "Alice" restores the folder with original path "parent_folder/sub/parent.txt" to "/parent_folder/sub/parent.txt" using the trashbin API
     Then the HTTP status code should be "409"
-    And as "Alice" the file with original path "/parent_folder/sub/parent.txt" should exist in the trashbin
+    And as "Alice" the file with original path "parent_folder/sub/parent.txt" should exist in the trashbin
     And user "Alice" should not see the following elements
       | /parent_folder/               |
       | /parent_folder/sub/           |
@@ -481,11 +481,11 @@ Feature: Restore deleted files/folders
     And user "Alice" has deleted folder "parent_folder"
     And user "Alice" has created folder "/parent_folder"
     And user "Alice" has created folder "/parent_folder/sub"
-    When user "Alice" restores the folder with original path "/parent_folder/sub/parent.txt" using the trashbin API
+    When user "Alice" restores the folder with original path "parent_folder/sub/parent.txt" using the trashbin API
     Then the HTTP status code should be "201"
     And the following headers should match these regular expressions for user "Alice"
       | ETag | /^"[a-f0-9:\.]{1,32}"$/ |
-    And as "Alice" the file with original path "/parent_folder/sub/parent.txt" should not exist in the trashbin
+    And as "Alice" the file with original path "parent_folder/sub/parent.txt" should not exist in the trashbin
     And the content of file "/parent_folder/sub/parent.txt" for user "Alice" should be "parent text"
     And user "Alice" should see the following elements
       | /parent_folder/               |
@@ -503,9 +503,9 @@ Feature: Restore deleted files/folders
     And user "Alice" has created folder "/parent_folder/sub"
     And user "Alice" has uploaded file with content "parent text" to "/parent_folder/sub/parent.txt"
     And user "Alice" has deleted folder "parent_folder"
-    When user "Alice" restores the folder with original path "/parent_folder/sub/parent.txt" without specifying the destination using the trashbin API
+    When user "Alice" restores the folder with original path "parent_folder/sub/parent.txt" without specifying the destination using the trashbin API
     Then the HTTP status code should be "400"
-    And as "Alice" the file with original path "/parent_folder/sub/parent.txt" should exist in the trashbin
+    And as "Alice" the file with original path "parent_folder/sub/parent.txt" should exist in the trashbin
     And user "Alice" should not see the following elements
       | /parent_folder/               |
       | /parent_folder/sub/           |
@@ -552,24 +552,24 @@ Feature: Restore deleted files/folders
       | /fo.xyz   |
       | /fo.exe   |
     When user "Alice" restores the following folders with original path
-      | path      |
-      | /fo.      |
-      | /fo.1     |
-      | /fo...1.. |
-      | /...      |
-      | /..fo     |
-      | /fo.xyz   |
-      | /fo.exe   |
+      | path     |
+      | fo.      |
+      | fo.1     |
+      | fo...1.. |
+      | ...      |
+      | ..fo     |
+      | fo.xyz   |
+      | fo.exe   |
     Then the HTTP status code of responses on all endpoints should be "201"
     And as "Alice" the folders with following original paths should not exist in the trashbin
-      | path      |
-      | /fo.      |
-      | /fo.1     |
-      | /fo...1.. |
-      | /...      |
-      | /..fo     |
-      | /fo.xyz   |
-      | /fo.exe   |
+      | path     |
+      | fo.      |
+      | fo.1     |
+      | fo...1.. |
+      | ...      |
+      | ..fo     |
+      | fo.xyz   |
+      | fo.exe   |
     But as "Alice" the following folders should exist
       | path      |
       | /fo.      |

--- a/tests/acceptance/features/bootstrap/TrashbinContext.php
+++ b/tests/acceptance/features/bootstrap/TrashbinContext.php
@@ -723,11 +723,12 @@ class TrashbinContext implements Context {
 	 *
 	 * @param string|null $user
 	 * @param string|null $originalPath
+	 * @param bool $checkRelativeAndAbsolutePath
 	 *
 	 * @return bool
 	 * @throws Exception
 	 */
-	private function isInTrash(?string $user, ?string $originalPath):bool {
+	private function isInTrash(?string $user, ?string $originalPath, bool $checkRelativeAndAbsolutePath = false):bool {
 		$techPreviewHadToBeEnabled = $this->occContext->enableDAVTechPreview();
 		$res = $this->featureContext->getResponse();
 		$listing = $this->listTrashbinFolder($user);
@@ -737,12 +738,16 @@ class TrashbinContext implements Context {
 			$this->occContext->disableDAVTechPreview();
 		}
 
-		// we don't care if the test step writes a leading "/" or not
-		$originalPath = \ltrim($originalPath, '/');
-
 		foreach ($listing as $entry) {
-			if ($entry['original-location'] !== null && \ltrim($entry['original-location'], '/') === $originalPath) {
-				return true;
+			if (\array_key_exists('original-location', $entry)) {
+				// First check if the normally-expected relative path matches the desired one
+				if ($entry['original-location'] === ltrim($originalPath, '/')) {
+					return true;
+				}
+				// If we have been requested to also check for the absolute path, then do that.
+				if ($checkRelativeAndAbsolutePath && $entry['original-location'] === '/' . ltrim($originalPath, '/')) {
+					return true;
+				}
 			}
 		}
 		return false;
@@ -957,7 +962,7 @@ class TrashbinContext implements Context {
 	 */
 	public function elementInTrashHasBeenRestored(string $user, string $originalPath):void {
 		$this->restoreElement($user, $originalPath);
-		if ($this->isInTrash($user, $originalPath)) {
+		if ($this->isInTrash($user, $originalPath, true)) {
 			throw new Exception("File previously located at $originalPath is still in the trashbin");
 		}
 	}
@@ -1017,8 +1022,12 @@ class TrashbinContext implements Context {
 		string $originalPath
 	):void {
 		$user = $this->featureContext->getActualUsername($user);
+		// The step may pass a relative path (no leading slash) or an absolute path
+		// The Trashbin API should always return a relative path. But to be sure here
+		// we check that the element is not in the trashbin under either path form
+		// by passing boolean "true" in the 3rd parameter.
 		Assert::assertFalse(
-			$this->isInTrash($user, $originalPath),
+			$this->isInTrash($user, $originalPath, true),
 			"File previously located at $originalPath was found in the trashbin of user $user"
 		);
 	}


### PR DESCRIPTION
In certain situations the trashbin original-location in a PROPFIND response
contained a leading slash. This change ensures that a relative path (without
a leading slash) is always returned.

https://github.com/owncloud/core/issues/39337
https://github.com/owncloud/core/pull/41649

Fixes #39337 

The test code changes related to this issue from old PR #39336 have also been reverted in this PR.
The test code checks for an exact match to the original-location specified in the test steps.
For test steps that check that an element does NOT exist in the trashbin, the test steps check the trashbin for both forms of original-location (relative and absolute path). That is a double-check to make sure that no unexpected stuff is left in the trashbin.