### PR TITLE
test: use phan major version 6 code analysis

### DIFF
--- a/changelog/unreleased/41650
+++ b/changelog/unreleased/41650
@@ -1,0 +1,10 @@
+Change: use phan major version 6 code analysis
+
+Now that PHP 7 support has been dropped, we can use the latest release of the
+phan code analyser.
+
+Patch releases before 6.0.7 had a problem with the function signatures for some
+Redis methods. That was corrected in https://github.com/phan/phan/pull/5546 and
+released in phan version 6.0.7. So that version is required as the minimum here.
+
+https://github.com/owncloud/core/pull/41650

--- a/lib/private/User/DeletedUser.php
+++ b/lib/private/User/DeletedUser.php
@@ -22,7 +22,6 @@
 namespace OC\User;
 
 use OC\Files\Cache\Storage;
-use OC\Hooks\Emitter;
 use OCP\IURLGenerator;
 use OCP\IUser;
 use OCP\IConfig;

--- a/lib/private/User/DeletedUser.php
+++ b/lib/private/User/DeletedUser.php
@@ -33,8 +33,7 @@ use OCP\Files\NotFoundException;
  * This class is intended to be used internally.
  */
 class DeletedUser implements IUser {
-	/** @var Emitter */
-	private $emitter;
+	private Manager $emitter;
 	/** @var IConfig */
 	private $config;
 	/** @var IURLGenerator */

--- a/vendor-bin/phan/composer.json
+++ b/vendor-bin/phan/composer.json
@@ -1,5 +1,5 @@
 {
     "require": {
-        "phan/phan": "^5.5"
+        "phan/phan": "^6.0.7"
     }
 }


### PR DESCRIPTION
Now that PHP 7 support has been dropped, we can use the latest release of the phan code analyser.

Patch releases before 6.0.7 had a problem with the function signatures for some Redis methods. That was corrected in https://github.com/phan/phan/pull/5546 and released in phan version 6.0.7. So that version is required as the minimum here.

`phan` v6 reported:
```
php -d zend.enable_gc=0 vendor-bin/phan/vendor/bin/phan --config-file .phan/config.php --require-config-exists -p
   analyze ████████████████████████████████████████████████████████████ 100.0% 1017MB/1017MB
lib/private/User/DeletedUser.php:119 PhanUndeclaredMethod Call to undeclared method \OC\Hooks\Emitter::emit
lib/private/User/DeletedUser.php:155 PhanUndeclaredMethod Call to undeclared method \OC\Hooks\Emitter::emit
```

Actually the object is a `Manager` not just an `Emitter`. `Manager` implements `Emitter` (through a few layers of inheritance), and `Manager` has an `emit` method. I have changed the declaration of `$emitter` and that makes `phan` happy. It also looks correct, only a `Manager` object is ever written to `$emitter`