### PR TITLE
fix: handle deprecated code related to comments app

### DIFF
--- a/apps/comments/lib/Dav/CommentNode.php
+++ b/apps/comments/lib/Dav/CommentNode.php
@@ -228,8 +228,8 @@ class CommentNode implements \Sabre\DAV\INode, \Sabre\DAV\IProperties {
 
 		$result = [];
 		foreach ($properties as $property) {
-			$getter = $this->properties[$property];
-			if (\method_exists($this->comment, $getter)) {
+			$getter = $this->properties[$property] ?? null;
+			if (($getter !== null) && \method_exists($this->comment, $getter)) {
 				$result[$property] = $this->comment->$getter();
 			}
 		}

--- a/apps/comments/lib/Dav/EntityCollection.php
+++ b/apps/comments/lib/Dav/EntityCollection.php
@@ -171,7 +171,7 @@ class EntityCollection extends RootCollection implements IProperties {
 	 * @return bool
 	 */
 	public function setReadMarker($value) {
-		$dateTime = new \DateTime($value);
+		$dateTime = new \DateTime($value ?? 'now');
 		$user = $this->userSession->getUser();
 		$this->commentsManager->setReadMark($this->name, $this->id, $dateTime, $user);
 		return true;

--- a/apps/dav/lib/Server.php
+++ b/apps/dav/lib/Server.php
@@ -240,7 +240,7 @@ class Server {
 		$this->server->addPlugin(new PreviewPlugin(OC::$server->getTimeFactory(), OC::$server->getPreviewManager()));
 
 		$this->server->on('beforeMethod:PROPFIND', function (Request $request) use ($config) {
-			$depthHeader = strtolower($request->getHeader('depth'));
+			$depthHeader = strtolower((string) $request->getHeader('depth'));
 
 			if ($depthHeader === 'infinity' && !$config->getSystemValue('dav.propfind.depth_infinity', false)) {
 				throw new Exception\PreconditionFailed('Depth infinity not supported');

--- a/changelog/unreleased/41656
+++ b/changelog/unreleased/41656
@@ -1,0 +1,5 @@
+Bugfix: handle deprecated code related to comments app
+
+Code paths that caused deprecation warnings in PHP 8 have been corrected.
+
+https://github.com/owncloud/core/pull/41656


### PR DESCRIPTION
Code paths that caused deprecation warnings in PHP 8 have been corrected.

When running a comments app API acceptance test scenario locally, I got the following output:
```
$ make test-acceptance-api BEHAT_FEATURE=tests/acceptance/features/apiComments/comments.feature:9

  Scenario: Getting info of comments using files endpoint                                                 # /home/phil/git/owncloud/core/tests/acceptance/features/apiComments/comments.feature:9
[Fri Jun 26 21:11:37 2026] 127.0.0.1:40580 Accepted
[Fri Jun 26 21:11:37 2026] 127.0.0.1:40580 [201]: PUT /remote.php/dav/files/Alice/myFileToComment.txt
[Fri Jun 26 21:11:37 2026] 127.0.0.1:40580 Closing
    Given user "Alice" has uploaded file "filesForUpload/textfile.txt" to "/myFileToComment.txt"          # FeatureContext::userHasUploadedAFileTo()
[Fri Jun 26 21:11:37 2026] 127.0.0.1:40588 Accepted
[Fri Jun 26 21:11:37 2026] strtolower(): Passing null to parameter #1 ($string) of type string is deprecated at /home/phil/git/owncloud/core/apps/dav/lib/Server.php#243
[Fri Jun 26 21:11:37 2026] 127.0.0.1:40588 [207]: PROPFIND /remote.php/dav/files/Alice/myFileToComment.txt
[Fri Jun 26 21:11:37 2026] 127.0.0.1:40588 Closing
[Fri Jun 26 21:11:37 2026] 127.0.0.1:40594 Accepted
[Fri Jun 26 21:11:37 2026] DateTime::__construct(): Passing null to parameter #1 ($datetime) of type string is deprecated at /home/phil/git/owncloud/core/apps/comments/lib/Dav/EntityCollection.php#174
[Fri Jun 26 21:11:37 2026] 127.0.0.1:40594 [201]: POST /remote.php/dav/comments/files/2147484663
[Fri Jun 26 21:11:37 2026] 127.0.0.1:40594 Closing
    And user "Alice" has commented with content "My first comment" on file "/myFileToComment.txt"         # CommentsContext::userHasCommentedWithContentOnEntry()
[Fri Jun 26 21:11:37 2026] 127.0.0.1:40610 Accepted
[Fri Jun 26 21:11:37 2026] strtolower(): Passing null to parameter #1 ($string) of type string is deprecated at /home/phil/git/owncloud/core/apps/dav/lib/Server.php#243
[Fri Jun 26 21:11:37 2026] 127.0.0.1:40610 [207]: PROPFIND /remote.php/dav/files/Alice/myFileToComment.txt
[Fri Jun 26 21:11:37 2026] 127.0.0.1:40610 Closing
[Fri Jun 26 21:11:37 2026] 127.0.0.1:40612 Accepted
[Fri Jun 26 21:11:37 2026] Undefined array key "{http://owncloud.org/ns}actorDisplayName" at /home/phil/git/owncloud/core/apps/comments/lib/Dav/CommentNode.php#231
[Fri Jun 26 21:11:37 2026] method_exists(): Passing null to parameter #2 ($method) of type string is deprecated at /home/phil/git/owncloud/core/apps/comments/lib/Dav/CommentNode.php#232
[Fri Jun 26 21:11:37 2026] Undefined array key "{http://owncloud.org/ns}isUnread" at /home/phil/git/owncloud/core/apps/comments/lib/Dav/CommentNode.php#231
[Fri Jun 26 21:11:37 2026] method_exists(): Passing null to parameter #2 ($method) of type string is deprecated at /home/phil/git/owncloud/core/apps/comments/lib/Dav/CommentNode.php#232
[Fri Jun 26 21:11:37 2026] 127.0.0.1:40612 [207]: REPORT /remote.php/dav/comments/files/2147484663
[Fri Jun 26 21:11:37 2026] 127.0.0.1:40612 Closing
    And user "Alice" should have the following comments on file "/myFileToComment.txt"                    # CommentsContext::checkComments()
      | user  | comment          |
      | Alice | My first comment |
[Fri Jun 26 21:11:37 2026] 127.0.0.1:40614 Accepted
[Fri Jun 26 21:11:38 2026] 127.0.0.1:40614 [207]: PROPFIND /remote.php/dav/files/Alice/myFileToComment.txt
[Fri Jun 26 21:11:38 2026] 127.0.0.1:40614 Closing
    When user "Alice" gets the following properties of folder "/myFileToComment.txt" using the WebDAV API # WebDavPropertiesContext::userGetsPropertiesOfFolder()
      | propertyName       |
      | oc:comments-href   |
      | oc:comments-count  |
      | oc:comments-unread |
    Then the HTTP status code should be "201"                                                             # FeatureContext::thenTheHTTPStatusCodeShouldBe()
    And the single response should contain a property "oc:comments-count" with value "1"                  # WebDavPropertiesContext::theSingleResponseShouldContainAPropertyWithValue()
    And the single response should contain a property "oc:comments-unread" with value "0"                 # WebDavPropertiesContext::theSingleResponseShouldContainAPropertyWithValue()
    And the single response should contain a property "oc:comments-href" with value "%a_comment_url%"     # WebDavPropertiesContext::theSingleResponseShouldContainAPropertyWithValue()
```

There are 3 different deprecation warnings emitted. This PR fixes them:
```
strtolower(): Passing null to parameter #1 ($string) of type string is deprecated at /home/phil/git/owncloud/core/apps/dav/lib/Server.php#243
```

```
DateTime::__construct(): Passing null to parameter #1 ($datetime) of type string is deprecated at /home/phil/git/owncloud/core/apps/comments/lib/Dav/EntityCollection.php#174
```

```
method_exists(): Passing null to parameter #2 ($method) of type string is deprecated at /home/phil/git/owncloud/core/apps/comments/lib/Dav/CommentNode.php#232
```




