### PR TITLE
chore: set version string to 11.0.0-rc1

### DIFF
--- a/version.php
+++ b/version.php
@@ -28,7 +28,7 @@
 $OC_Version = [11, 0, 0, 0];
 
 // The human-readable string
-$OC_VersionString = '11.0.0-prealpha';
+$OC_VersionString = '11.0.0-rc1';
 
 $OC_VersionCanBeUpgradedFrom = [[8, 2, 11],[9, 0, 9],[9, 1]];
 


### PR DESCRIPTION
Bumps `$OC_VersionString` from `11.0.0-prealpha` to `11.0.0-rc1` for the first ownCloud 11 release candidate. The `v11.0.0-rc1` tag (used by the server-release build) is created from this commit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)