### PR TITLE
build: update minimum version of nodejs and yarn

### DIFF
--- a/build/package.json
+++ b/build/package.json
@@ -51,8 +51,8 @@
     "qs": "6.7.3"
   },
   "engines": {
-    "node": ">= 14.17.0",
-    "yarn": ">= 1.0.0"
+    "node": ">= 18.20.0",
+    "yarn": ">= 1.22.0"
   },
   "scripts": {
     "clean-modules": "modclean -r --patterns=\"default:safe,owncloud:basic\"",


### PR DESCRIPTION
We can no longer build with nodejs v14. node-release, one of the dependencies, requires at least nodejs v18.

nodejs v22 is the oldest release series that is still supported, so it would be nice to require that as a minimum.
But the GitHub workflow runner seems to have nodejs 18 already installed, so allow that.

yarn v1 still has version 1.22.x that works with all current nodejs releases. So require that as a minimum.

Trying to build with nodejs v14 gives:

```
error node-releases@2.0.47: The engine "node" is incompatible with this module. Expected version ">=18". Got "14.21.3"
error Found incompatible module.
```
