### PR TITLE
fix: don't cache the 'en' language fallback on anonymous pages (#41618)

### DIFF
--- a/changelog/unreleased/41618
+++ b/changelog/unreleased/41618
@@ -1,0 +1,11 @@
+Bugfix: Honor language on anonymous pages
+
+Anonymous pages (the login page and the password-protected public share page)
+always rendered in English even when default_language was configured or the
+browser sent a matching Accept-Language header, while authenticated pages were
+translated correctly. The language factory cached the "en" last-resort fallback
+as the per-request language, which then short-circuited every later lookup
+before default_language or Accept-Language could be consulted. The fallback is
+no longer cached, so anonymous pages honor default_language and Accept-Language.
+
+https://github.com/owncloud/core/issues/41618

--- a/lib/private/L10N/Factory.php
+++ b/lib/private/L10N/Factory.php
@@ -251,9 +251,12 @@ class Factory implements IFactory {
 			}
 		}
 
-		if ($app === null && !$this->requestLanguage) {
-			$this->requestLanguage = 'en';
-		}
+		// Do NOT cache the 'en' last-resort fallback in requestLanguage: doing so
+		// poisons the per-request Factory singleton so that a later findLanguage()
+		// returns 'en' before ever consulting default_language or Accept-Language.
+		// This broke anonymous pages (login / public-share password page) whenever
+		// the first no-app lookup ran without a visible Accept-Language header
+		// (e.g. the header not forwarded by the web server) — see issue #41618.
 		return 'en'; // Last try: English
 	}
 

--- a/tests/lib/L10N/FactoryTest.php
+++ b/tests/lib/L10N/FactoryTest.php
@@ -271,6 +271,56 @@ class FactoryTest extends TestCase {
 	}
 
 	/**
+	 * Regression test for #41618: on an anonymous request the first no-app
+	 * findLanguage() falls through to the 'en' last-resort fallback (no
+	 * Accept-Language match, no default_language yet). This must NOT poison the
+	 * per-request Factory singleton — a later findLanguage() has to re-evaluate
+	 * default_language instead of short-circuiting on a cached 'en'.
+	 */
+	public function testFindLanguageDoesNotCacheFallbackAcrossAnonymousLookups(): void {
+		$factory = $this->getFactory(['languageExists']);
+
+		// Only the second lookup resolves a language (default_language 'de').
+		$factory
+			->expects($this->once())
+			->method('languageExists')
+			->with(null, 'de')
+			->willReturn(true);
+
+		// installed=true and getUser()=null on both lookups (anonymous). The
+		// first lookup sees no default_language, the second one does.
+		$this->config
+			->expects($this->exactly(4))
+			->method('getSystemValue')
+			->withConsecutive(
+				['installed', false],
+				['default_language', false],
+				['installed', false],
+				['default_language', false],
+			)
+			->willReturnOnConsecutiveCalls(true, false, true, 'de');
+		$this->userSession
+			->expects($this->exactly(2))
+			->method('getUser')
+			->willReturn(null);
+
+		// Accept-Language header is not forwarded (e.g. official Docker/Apache
+		// image), so the first lookup can only reach the 'en' fallback.
+		$this->request
+			->expects($this->once())
+			->method('getHeader')
+			->with('ACCEPT_LANGUAGE')
+			->willReturn('');
+
+		// First lookup: nothing matchable -> last-resort 'en'.
+		$this->assertSame('en', $factory->findLanguage(), 'First lookup falls back to en');
+		// The fallback must not have been cached.
+		$this->assertSame('', self::invokePrivate($factory, 'requestLanguage'), 'Fallback en is not cached');
+		// Second lookup: default_language is now honored instead of cached 'en'.
+		$this->assertSame('de', $factory->findLanguage(), 'Second lookup honors default_language');
+	}
+
+	/**
 	 * @dataProvider dataFindAvailableLanguages
 	 *
 	 * @param string|null $app

--- a/tests/lib/L10N/FactoryTest.php
+++ b/tests/lib/L10N/FactoryTest.php
@@ -404,8 +404,13 @@ class FactoryTest extends TestCase {
 			[null, 'de', null, ['de'], 'de', 'de'],
 			[null, 'de,en', null, ['de'], 'de', 'de'],
 			[null, 'de-DE,en-US;q=0.8,en;q=0.6', null, ['de'], 'de', 'de'],
-			// Language is not available
-			[null, 'de', null, ['ru'], 'en', 'en'],
+			// No matchable language and 'en' is neither requested nor available →
+			// last-resort 'en' is returned but must NOT be cached as the request
+			// language (caching it would defeat default_language on a later lookup
+			// — see issue #41618).
+			[null, 'de', null, ['ru'], 'en', ''],
+			// 'en' is explicitly requested AND available → a real match, which IS
+			// cached as the request language (correct behavior, not the #41618 bug).
 			[null, 'de,en', null, ['ru', 'en'], 'en', 'en'],
 			[null, 'de-DE,en-US;q=0.8,en;q=0.6', null, ['ru', 'en'], 'en', 'en'],
 			// Language is available, but request language is set


### PR DESCRIPTION
## Problem

Anonymous pages — the login page and the password-protected public-share page — always render in English, even when `default_language` is configured or the browser sends a matching `Accept-Language` header. Authenticated pages render in the correct language. Fixes #41618.

## Root cause

`OC\L10N\Factory` is a per-request singleton. `findLanguage()` short-circuits on a non-empty `$requestLanguage` (and `languageExists(_, 'en')` is always true). When the first no-app `findLanguage()` runs without a usable `Accept-Language` match — e.g. the header isn't forwarded by the web server, as in the official Docker/Apache image — `setLanguageFromRequest()` caches the `'en'` last-resort fallback into `$requestLanguage`:

```php
if ($app === null && !$this->requestLanguage) {
    $this->requestLanguage = 'en';
}
return 'en';
```

Every later lookup on that request then returns `'en'` *before* `default_language` (step 3) or `Accept-Language` (step 4) is ever consulted. Authenticated requests are unaffected because they seed `$requestLanguage` from the stored user language first.

The original triage hypothesis (guest layout not consulting `findLanguage()`) was **refuted** while tracing the code — `layout.guest.php` / `TemplateLayout` *do* call `findLanguage()`; the defect is the poisoned cache.

## Fix

Stop caching the `'en'` fallback in `setLanguageFromRequest()`. `default_language` and `Accept-Language` are then re-evaluated on subsequent lookups, so anonymous pages honor both. Single-file behavioral change in `lib/private/L10N/Factory.php`.

## Tests

`tests/lib/L10N/FactoryTest.php`: the `dataSetLanguageFromRequest` rows that previously enshrined the `'en'` caching (no-app, no available match) now assert the fallback is **returned** (`'en'`) but **not stored** (`requestLanguage` stays `''`) — which is exactly the regression guard for this bug.

Verified locally: `php -l` clean on both files. Full suite runs in CI (`Test (Linux)`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
