### PR TITLE
chore: remove msteamsbridge config sample (app archived)

### DIFF
--- a/changelog/unreleased/41668
+++ b/changelog/unreleased/41668
@@ -1,0 +1,8 @@
+Change: Remove msteamsbridge config sample
+
+The owncloud/msteamsbridge integration app is being archived and is no
+longer maintained. Its Microsoft Teams Bridge config sample block has been
+removed from config.apps.sample.php so the config-to-docs sync no longer
+re-adds the parameters to the admin documentation.
+
+https://github.com/owncloud/core/pull/41668

--- a/config/config.apps.sample.php
+++ b/config/config.apps.sample.php
@@ -317,25 +317,6 @@ $CONFIG = [
 'wopi.business-flow.enabled' => 'no',
 
 /**
- * App: Microsoft Teams Bridge
- *
- * Possible key: `msteamsbridge` ARRAY
- *
- * Subkey: `loginButtonName` STRING
- */
-
-/**
- * Login Button Label
- * This key is necessary for security reasons. Users will be asked to click a login
- * button each time when accessing the ownCloud app after a fresh start of their
- * Microsoft Teams app or after idle time. This behavior is by design. The button
- * name can be freely set based on your requirements.
- */
-'msteamsbridge' => [
-   "loginButtonName" => "Login to ownCloud with Azure AD",
-],
-
-/**
  * App: OpenID Connect (OIDC)
  *
  * Possible key: `openid-connect` ARRAY


### PR DESCRIPTION
The `owncloud/msteamsbridge` integration app is being archived and is no longer maintained (heads-up: owncloud/docs#5125).

This removes the **Microsoft Teams Bridge** (`msteamsbridge`) config sample block from `config/config.apps.sample.php`.

### Why this belongs in core
`config.apps.sample.php` is the source that the [config-to-docs](https://github.com/owncloud/config-to-docs) tool converts into the admin documentation page `config_apps_sample_php_parameters.adoc`. The docs cleanup in owncloud/docs-server#1561 removed the rendered block from that generated `.adoc`, but everything below its `// header end do not delete or edit this line` marker is generated — so without removing the source here, the next config-to-docs sync would re-add the Teams Bridge parameters.

### Changes
- Remove the `App: Microsoft Teams Bridge` comment block and the `'msteamsbridge' => ['loginButtonName' => ...]` array from `config/config.apps.sample.php`.

### Verification
- `php -l config/config.apps.sample.php` → no syntax errors.
- `grep -i msteams config/config.apps.sample.php` → 0 matches after the change.

Related: owncloud/docs#5125, owncloud/docs-server#1561

🤖 Generated with [Claude Code](https://claude.com/claude-code)
