### PR TITLE
test: do not start federated server as a PHP dev server

### DIFF
--- a/tests/acceptance/run.sh
+++ b/tests/acceptance/run.sh
@@ -771,7 +771,7 @@ function teardown() {
 declare -x TEST_SERVER_URL
 declare -x TEST_SERVER_FED_URL
 declare -x TEST_WITH_PHPDEVSERVER
-[[ -z "${TEST_SERVER_URL}" && -z "${TEST_SERVER_FED_URL}" ]] && TEST_WITH_PHPDEVSERVER="true"
+[[ -z "${TEST_SERVER_URL}" ]] && TEST_WITH_PHPDEVSERVER="true"
 
 if [ -z "${IPV4_URL}" ]
 then
@@ -836,14 +836,7 @@ else
 	PHPPID=$!
 	echo ${PHPPID}
 
-	PORT_FED=$((8180 + ${EXECUTOR_NUMBER}))
-	echo ${PORT_FED}
-	php -S localhost:${PORT_FED} -t ../.. &
-	PHPPID_FED=$!
-	echo ${PHPPID_FED}
-
 	export TEST_SERVER_URL="http://localhost:${PORT}"
-	export TEST_SERVER_FED_URL="http://localhost:${PORT_FED}"
 
 	# The endpoint to use to do occ commands via the testing app
 	TESTING_APP_URL="${TEST_SERVER_URL}/ocs/v2.php/apps/testing/api/v1/"


### PR DESCRIPTION
We can run some acceptance test scenario(s) directly from the command line without having to set up Apache etc. The run.sh script will start a PHP dev server, and that is easy for checking scenarios during development.

The current run.sh script starts 2 PHP dev servers. The 2nd one was supposed to be for use in test scenarios for federation.

But the 2nd PHP dev server was started with the same code, database and data directory as the 1st one. That causes lots of problems with the 2 attempted instances of ownCloud Classic getting very confused about which users, files etc exist.

This PR removes the startup of the 2nd PHP dev server. If a developer needs to run federated scenarios locally, then they need to fully set up a separate Federated server that uses different database tables, data storage directory etc.

I can now run a scenario with a 1-line command such as:

```
make test-acceptance-api BEHAT_FEATURE=tests/acceptance/features/apiComments/comments.feature:9
```

If I run the PHP dev server manually in another terminal window with:
`php -S localhost:8080 -t /home/phil/git/owncloud/core`

Then I can run a test scenario with:
```
make test-acceptance-api BEHAT_FEATURE=tests/acceptance/features/apiComments/comments.feature:9 TEST_SERVER_URL=http://localhost:8080
```

Specifying `TEST_SERVER_URL` in the `make` command means that the script does not start the PHP dev server, it assumes that the code is already being served by something at `TEST_SERVER_URL`