### PR TITLE
chore(deps-dev): revert bump jasmine-core from 5.1.1 to 6.3.0 in /build

### DIFF
--- a/build/package.json
+++ b/build/package.json
@@ -36,7 +36,7 @@
   },
   "devDependencies": {
     "handlebars": "^4.7.9",
-    "jasmine-core": "^6.3.0",
+    "jasmine-core": "^5.1.1",
     "jasmine-sinon": "^0.4.0",
     "karma": "^6.4.4",
     "karma-coverage": "*",

--- a/build/yarn.lock
+++ b/build/yarn.lock
@@ -1016,10 +1016,10 @@ istanbul-reports@^3.0.5:
     html-escaper "^2.0.0"
     istanbul-lib-report "^3.0.0"
 
-jasmine-core@^6.3.0:
-  version "6.3.0"
-  resolved "https://registry.yarnpkg.com/jasmine-core/-/jasmine-core-6.3.0.tgz#ff8e4e771a4c8e7bebd0966bc4625f000f78fa84"
-  integrity sha512-eMm5qBovNjNoGOcgE/W207+wrcK5zrQv0Rg/rWGboUJUmZp0dFCpHTyjpuDAfCwRCqg7f9U2q2jtv/aUuzdCQg==
+jasmine-core@^5.1.1:
+  version "5.1.1"
+  resolved "https://registry.yarnpkg.com/jasmine-core/-/jasmine-core-5.1.1.tgz#38b6ccfbe60aa2a863cf441751d9639b5a571edc"
+  integrity sha512-UrzO3fL7nnxlQXlvTynNAenL+21oUQRlzqQFsA2U11ryb4+NLOCOePZ70PTojEaUKhiFugh7dG0Q+I58xlPdWg==
 
 jasmine-sinon@^0.4.0:
   version "0.4.0"


### PR DESCRIPTION
…(#41621)

This reverts commit 9d20f45fa67fb3acfa2270ec2006a27130adfa9e.

The Java Script tests were failing in that PR, but it got merged. So needs to be reverted.