### PR TITLE
fix(docs): point go.php help links at the latest server docs

### DIFF
--- a/changelog/unreleased/41688
+++ b/changelog/unreleased/41688
@@ -8,3 +8,4 @@ a non-existent version path and 404'd. The version segment now defaults to
 'latest'; callers may still pass an explicit published version.
 
 https://github.com/owncloud/docs/issues/5132
+https://github.com/owncloud/core/pull/41688

--- a/changelog/unreleased/docs-go-php-latest
+++ b/changelog/unreleased/docs-go-php-latest
@@ -1,0 +1,10 @@
+Bugfix: Point documentation help links at the latest server docs
+
+Contextual documentation links (setup checks, help & tips, app info.xml keys)
+were built as /server/<version>/go.php?to=<key> using the running server's
+concrete version, e.g. /server/10.16/. The documentation site publishes the
+current stable release only under /server/latest/, so those links resolved to
+a non-existent version path and 404'd. The version segment now defaults to
+'latest'; callers may still pass an explicit published version.
+
+https://github.com/owncloud/docs/issues/5132

--- a/lib/private/legacy/defaults.php
+++ b/lib/private/legacy/defaults.php
@@ -46,7 +46,6 @@ class OC_Defaults {
 	private $defaultiTunesAppId;
 	private $defaultAndroidClientUrl;
 	private $defaultDocBaseUrl;
-	private $defaultDocVersion;
 	private $defaultSlogan;
 	private $defaultLogoClaim;
 	private $defaultMailHeaderColor;
@@ -58,8 +57,6 @@ class OC_Defaults {
 	public function __construct() {
 		$this->l = \OC::$server->getL10N('lib');
 		$this->config = \OC::$server->getConfig();
-		$version = \OCP\Util::getVersion();
-
 		$this->defaultEntity = 'ownCloud'; /* e.g. company name, used for footers and copyright notices */
 		$this->defaultName = 'ownCloud'; /* short name, used when referring to the software */
 		$this->defaultTitle = 'ownCloud'; /* can be a longer name, for titles */
@@ -69,7 +66,6 @@ class OC_Defaults {
 		$this->defaultiTunesAppId = '1359583808';
 		$this->defaultAndroidClientUrl = 'https://play.google.com/store/apps/details?id=com.owncloud.android';
 		$this->defaultDocBaseUrl = 'https://doc.owncloud.com';
-		$this->defaultDocVersion = $version[0] . '.' . $version[1]; // used to generate doc links
 		$this->defaultSlogan = $this->l->t('A safe home for all your data');
 		$this->defaultLogoClaim = '';
 		$this->defaultMailHeaderColor = '#041e42'; /* header color of mail notifications */
@@ -285,18 +281,18 @@ class OC_Defaults {
 
 	/**
 	 * @param string $key
-	 * @param string|null $ocVersion ownCloud version to look for in the docs. Defaults to the version of this onwCloud instance
+	 * @param string|null $ocVersion ownCloud version to look for in the docs.
+	 *        Defaults to 'latest'. The documentation site publishes the current
+	 *        stable release only under /server/latest/ (older minor versions
+	 *        such as 10.16 have no dedicated path), so a concrete version would
+	 *        404. Callers may still pass an explicit published version.
 	 */
 	public function buildDocLinkToKey($key, $ocVersion = null) {
 		if ($this->themeExist('buildDocLinkToKey')) {
 			return $this->theme->buildDocLinkToKey($key);
 		}
 
-		if ($ocVersion) {
-			$version = $ocVersion;
-		} else {
-			$version = $this->defaultDocVersion;
-		}
+		$version = $ocVersion ?: 'latest';
 
 		return $this->getDocBaseUrl() . '/server/' . $version . '/go.php?to=' . $key;
 	}

--- a/tests/acceptance/features/bootstrap/WebUIHelpAndTipsContext.php
+++ b/tests/acceptance/features/bootstrap/WebUIHelpAndTipsContext.php
@@ -58,13 +58,9 @@ class WebUIHelpAndTipsContext extends RawMinkContext implements Context {
 	 * @throws Exception
 	 */
 	protected function generateHelpLinks(string $to):string {
-		$version = SetupHelper::getSystemConfigValue(
-			'version',
-			$this->featureContext->getStepLineRef()
-		);
-		$version = \explode(".", $version);
-		$version = $version[0] . "." . $version[1];
-		return "https://doc.owncloud.com/server/$version/go.php?to=$to";
+		// Doc links always point at the 'latest' server docs; the documentation
+		// site publishes the current stable only under /server/latest/.
+		return "https://doc.owncloud.com/server/latest/go.php?to=$to";
 	}
 
 	/**


### PR DESCRIPTION
## Description

`OC_Defaults::buildDocLinkToKey()` builds contextual documentation links as `/server/<version>/go.php?to=<key>`, deriving `<version>` from the running server's concrete version (e.g. `/server/10.16/`). The documentation site publishes the current stable release **only** under `/server/latest/` — there is no `/server/10.16/` path — so these links resolve to a non-existent version segment and 404.

This defaults the version segment to `latest`. An explicit `$ocVersion` argument is still honored for callers that pass a specific published version. The now-unused `defaultDocVersion` property (and its `Util::getVersion()` computation) is removed, and the help & tips acceptance helper is updated to reconstruct the same `latest` URL so it keeps matching the UI.

Verified:
```
https://doc.owncloud.com/server/10.16/... → 404   (concrete version, what we emitted)
https://doc.owncloud.com/server/latest/... → 200   (what we emit now)
```

## Related Issue

- Fixes owncloud/docs#5132

This is the source-side companion to the docs-side fix (a static `go.php` redirector on the now-static GitHub Pages docs site, owncloud/docs-monorepo PR — the docs site has no PHP, so it also honors the legacy `go.php?to=` shape and remaps unpublished versions to `latest`). This core change stops generating the dead version segment for future releases.

## Motivation and Context

Every doc deep-link surfaced to admins/users (setup checks, help & tips, per-app `info.xml` documentation keys) is currently broken. This fixes them at the source.

## How Has This Been Tested?

- `php -l` on both changed files (clean).
- Confirmed `defaultDocVersion` has no remaining references in `lib/` or `tests/`.
- Verified on production that the concrete-version path 404s and the `latest` path returns 200.
- The `WebUIHelpAndTipsContext` acceptance helper now reconstructs the `latest` URL, matching what the UI renders.

## Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist:

- [x] Code changes
- [ ] Unit tests added
- [x] Acceptance tests added <!-- existing acceptance helper updated to match -->
- [x] Documentation ticket raised: owncloud/docs#5132
- [x] Changelog item, see [TEMPLATE](https://github.com/owncloud/core/blob/master/changelog/TEMPLATE)
