### PR TITLE
chore(deps): bump guzzlehttp/guzzle to 7.14.2

### DIFF
--- a/changelog/unreleased/PHPdependencies20260225onward
+++ b/changelog/unreleased/PHPdependencies20260225onward
@@ -12,7 +12,7 @@ The following have been updated:
 
  * google/auth (v1.50.0 to v1.52.0)
 
- * guzzlehttp/guzzle (7.10.0 to 7.14.1)
+ * guzzlehttp/guzzle (7.10.0 to 7.14.2)
 
  * guzzlehttp/promises (2.3.0 to 2.5.1)
 
@@ -72,3 +72,4 @@ https://github.com/owncloud/core/pull/41666
 https://github.com/owncloud/core/pull/41670
 https://github.com/owncloud/core/pull/41677
 https://github.com/owncloud/core/pull/41681
+https://github.com/owncloud/core/pull/41691

--- a/composer.json
+++ b/composer.json
@@ -71,7 +71,7 @@
         "doctrine/dbal": "^3.10",
         "firebase/php-jwt": "^7.0",
         "google/apiclient": "^2.19",
-        "guzzlehttp/guzzle": "^7.11",
+        "guzzlehttp/guzzle": "^7.14",
         "icewind/smb": "^3.8",
         "icewind/streams": "0.7.8",
         "interfasys/lognormalizer": "^v1.0",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "9dc40cf1278269e0968ee0d1f6784397",
+    "content-hash": "d4d6a56d3742e1228faa50b61991bca4",
     "packages": [
         {
             "name": "bantu/ini-get-wrapper",
@@ -933,16 +933,16 @@
         },
         {
             "name": "guzzlehttp/guzzle",
-            "version": "7.14.1",
+            "version": "7.14.2",
             "source": {
                 "type": "git",
                 "url": "https://github.com/guzzle/guzzle.git",
-                "reference": "6b1d2429a2c312474c523aa9017fba0c07b5f4a0"
+                "reference": "fa88c57803501ad0770f5cddb1e60525d49da9a1"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/guzzle/guzzle/zipball/6b1d2429a2c312474c523aa9017fba0c07b5f4a0",
-                "reference": "6b1d2429a2c312474c523aa9017fba0c07b5f4a0",
+                "url": "https://api.github.com/repos/guzzle/guzzle/zipball/fa88c57803501ad0770f5cddb1e60525d49da9a1",
+                "reference": "fa88c57803501ad0770f5cddb1e60525d49da9a1",
                 "shasum": ""
             },
             "require": {
@@ -1041,7 +1041,7 @@
             ],
             "support": {
                 "issues": "https://github.com/guzzle/guzzle/issues",
-                "source": "https://github.com/guzzle/guzzle/tree/7.14.1"
+                "source": "https://github.com/guzzle/guzzle/tree/7.14.2"
             },
             "funding": [
                 {
@@ -1057,7 +1057,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2026-07-13T01:32:54+00:00"
+            "time": "2026-07-14T18:15:01+00:00"
         },
         {
             "name": "guzzlehttp/promises",


### PR DESCRIPTION
Addresses moderate security advisory GHSA-94pj-82f3-465w

https://github.com/guzzle/guzzle/security/advisories/GHSA-94pj-82f3-465w

https://github.com/guzzle/guzzle/releases/tag/7.14.2