### PR TITLE
test: enhance the Storage directory test output

### DIFF
--- a/tests/lib/Files/Storage/Storage.php
+++ b/tests/lib/Files/Storage/Storage.php
@@ -66,17 +66,51 @@ abstract class Storage extends \Test\TestCase {
 	 * @dataProvider directoryProvider
 	 */
 	public function testDirectories($directory) {
-		$this->assertFalse($this->instance->file_exists('/' . $directory));
+		$this->assertFalse(
+			$this->instance->file_exists('/' . $directory),
+			"The folder '$directory' already exists at the start of the test"
+		);
 
-		$this->assertTrue($this->instance->mkdir('/' . $directory));
+		$this->assertTrue(
+			$this->instance->mkdir('/' . $directory),
+			"The folder '$directory' could not be created"
+		);
 
-		$this->assertTrue($this->instance->file_exists('/' . $directory));
-		$this->assertTrue($this->instance->is_dir('/' . $directory));
-		$this->assertFalse($this->instance->is_file('/' . $directory));
-		$this->assertEquals('dir', $this->instance->filetype('/' . $directory));
-		$this->assertEquals(0, $this->instance->filesize('/' . $directory));
-		$this->assertTrue($this->instance->isReadable('/' . $directory));
-		$this->assertTrue($this->instance->isUpdatable('/' . $directory));
+		$this->assertTrue(
+			$this->instance->file_exists('/' . $directory),
+			"The folder '$directory' does not exist"
+		);
+		$this->assertTrue(
+			$this->instance->is_dir('/' . $directory),
+			"The folder '$directory' is not a directory"
+		);
+		$this->assertFalse(
+			$this->instance->is_file('/' . $directory),
+			"The folder '$directory' is actually a file"
+		);
+		$fileType = $this->instance->filetype('/' . $directory);
+		if ($fileType === false) {
+			$this->fail("The file type of folder '$directory' could not be determined");
+		}
+		$this->assertEquals(
+			'dir',
+			$fileType,
+			"The folder '$directory' is file type $fileType, not 'dir'"
+		);
+		$fileSize = $this->instance->filesize('/' . $directory);
+		$this->assertEquals(
+			0,
+			$fileSize,
+			"The empty folder '$directory' has non-zero size " . (string) $fileSize
+		);
+		$this->assertTrue(
+			$this->instance->isReadable('/' . $directory),
+			"The folder '$directory' is not readable"
+		);
+		$this->assertTrue(
+			$this->instance->isUpdatable('/' . $directory),
+			"The folder '$directory' is not updatable"
+		);
 
 		$dh = $this->instance->opendir('/');
 		$content = [];
@@ -87,13 +121,25 @@ abstract class Storage extends \Test\TestCase {
 		}
 		$this->assertEquals([$directory], $content);
 
-		$this->assertFalse($this->instance->mkdir('/' . $directory)); //can't create existing folders
-		$this->assertTrue($this->instance->rmdir('/' . $directory));
+		$this->assertFalse(
+			$this->instance->mkdir('/' . $directory),
+			"The folder '$directory' could be created again when it already exists"
+		); //can't create existing folders
+		$this->assertTrue(
+			$this->instance->rmdir('/' . $directory),
+			"The folder '$directory' could not be deleted"
+		);
 
 		$this->wait();
-		$this->assertFalse($this->instance->file_exists('/' . $directory));
+		$this->assertFalse(
+			$this->instance->file_exists('/' . $directory),
+			"The folder '$directory' still exists after deleting it"
+		);
 
-		$this->assertFalse($this->instance->rmdir('/' . $directory)); //can't remove non existing folders
+		$this->assertFalse(
+			$this->instance->rmdir('/' . $directory),
+			"The folder '$directory' could be deleted again even though it was just deleted"
+		); //can't remove non-existing folders
 
 		$dh = $this->instance->opendir('/');
 		$content = [];


### PR DESCRIPTION
This unit test has a lot of assertions about the directory-under-test as it is created, deleted etc. Currently, if the test fails then there is just a message like "Failed asserting that false is true."

This change adds descriptive messages for each unit test assertion. That will make it easier to know at which step the test failed.

Test change only, changelog is not required.

I was looking at unit test results of https://github.com/owncloud/files_external_s3/pull/1048
https://github.com/owncloud/files_external_s3/actions/runs/29474921414/job/87545790764?pr=1048

Results like this are not helpful:
```
1) OCA\Files_External\Tests\Storage\Amazons3Test::testDirectories with data set #0 ('folder')
Failed asserting that false is true.

/home/runner/work/files_external_s3/files_external_s3/tests/lib/Files/Storage/Storage.php:91
```
