### PR TITLE
test: report and fix deprecations emitted by PHP unit tests

### DIFF
--- a/lib/private/DB/PostgreSqlMigrator.php
+++ b/lib/private/DB/PostgreSqlMigrator.php
@@ -42,7 +42,9 @@ class PostgreSqlMigrator extends Migrator {
 					}
 					$fromDefault = $column->fromColumn->getDefault();
 					$toDefault = $column->column->getDefault();
-					$fromDefault = \trim($fromDefault, "()");
+					if (\is_string($fromDefault)) {
+						$fromDefault = \trim($fromDefault, "()");
+					}
 
 					// by intention usage of !=
 					return $fromDefault != $toDefault;

--- a/tests/lib/SetupTest.php
+++ b/tests/lib/SetupTest.php
@@ -145,6 +145,13 @@ class SetupTest extends \Test\TestCase {
 		\touch($htaccessFile);
 		\chmod($htaccessFile, 0400);
 		\OC::$SERVERROOT = \OC::$SERVERROOT . '/tests/data';
+		$this->config
+			->expects($this->exactly(2))
+			->method('getSystemValue')
+			->willReturnOnConsecutiveCalls(
+				'https://www.example.com/owncloud',
+				'/'
+			);
 		try {
 			$this->setupClass->updateHtaccess($this->config);
 		} catch (\Exception $e) {
@@ -167,6 +174,12 @@ class SetupTest extends \Test\TestCase {
 		@\mkdir($htaccessFile);
 		
 		\OC::$SERVERROOT = \OC::$SERVERROOT . '/tests/data';
+		$this->config
+			->expects($this->exactly(1))
+			->method('getSystemValue')
+			->willReturnOnConsecutiveCalls(
+				'https://www.example.com/owncloud'
+			);
 		try {
 			$this->setupClass->updateHtaccess($this->config);
 		} catch (\Exception $e) {
@@ -183,6 +196,13 @@ class SetupTest extends \Test\TestCase {
 		\touch($htaccessFile);
 		\chmod($htaccessFile, 0700);
 		\OC::$SERVERROOT = \OC::$SERVERROOT . '/tests/data';
+		$this->config
+			->expects($this->exactly(2))
+			->method('getSystemValue')
+			->willReturnOnConsecutiveCalls(
+				'https://www.example.com/owncloud',
+				'/'
+			);
 		try {
 			$this->setupClass->updateHtaccess($this->config);
 		} catch (\Exception $e) {

--- a/tests/phpunit-autotest.xml
+++ b/tests/phpunit-autotest.xml
@@ -4,6 +4,7 @@
 		 failOnWarning="true"
 		 timeoutForSmallTests="900" timeoutForMediumTests="900"
 		 timeoutForLargeTests="900"
+		 convertDeprecationsToExceptions="true"
 		 xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/9.5/phpunit.xsd">
 	<coverage>
 		<include>


### PR DESCRIPTION
Set convertDeprecationsToExceptions to true in PHP unit tests, so that we know if any code is executed that is deprecated in the running PHP version.

The following deprecation warning were emitted:

```
1) Test\DB\DBSchemaTest::testSchema
trim(): Passing null to parameter #1 ($string) of type string is deprecated

/home/runner/work/core/core/lib/private/DB/PostgreSqlMigrator.php:45
/home/runner/work/core/core/lib/private/DB/PostgreSqlMigrator.php:39
/home/runner/work/core/core/lib/private/DB/Migrator.php:175
/home/runner/work/core/core/lib/private/DB/Migrator.php:80
/home/runner/work/core/core/lib/private/DB/MDB2SchemaManager.php:111
/home/runner/work/core/core/tests/lib/DB/DBSchemaTest.php:71
/home/runner/work/core/core/tests/lib/DB/DBSchemaTest.php:58
```
The column default value may be null, (or some other non-string value).
The `trim` is only relevant if the value is a string, so only do it on strings.


```
1) Test\SetupTest::testCannotUpdateHtaccess
parse_url(): Passing null to parameter #1 ($url) of type string is deprecated

/home/phil/git/owncloud/core/lib/private/Setup.php:462
/home/phil/git/owncloud/core/tests/lib/SetupTest.php:149

2) Test\SetupTest::testHtaccessIsFolder
parse_url(): Passing null to parameter #1 ($url) of type string is deprecated

/home/phil/git/owncloud/core/lib/private/Setup.php:462
/home/phil/git/owncloud/core/tests/lib/SetupTest.php:171

3) Test\SetupTest::testUpdateHtaccess
parse_url(): Passing null to parameter #1 ($url) of type string is deprecated

/home/phil/git/owncloud/core/lib/private/Setup.php:462
/home/phil/git/owncloud/core/tests/lib/SetupTest.php:187
```

These are testing updating of the `.htaccess` file in different scenarios. The underlying code calls `getSystemValue` at various places. In real-life those calls should return either an actual value or the default empty string. We can avoid the `null` problem in the tests by appropriately mocking the `getSystemValue` calls.

I was pleasantly surprised; I thought that there would be many places in the code that passed `int` `null` and so on to functions that now expect a string.