### PR TITLE
chore(ci): switch off fail-fast for PHP unit workflow jobs

### DIFF
--- a/.github/workflows/php-unit.yml
+++ b/.github/workflows/php-unit.yml
@@ -14,7 +14,7 @@ jobs:
     name: PHP Unit
     runs-on: ubuntu-latest
     strategy:
-      fail-fast: true
+      fail-fast: false
       matrix:
         php: ${{ fromJSON(inputs.php-versions) }}
         database: [sqlite]


### PR DESCRIPTION
The PHP unit test jobs all take about the same time. It seems unfortunate to cancel the other jobs when one of them has errors. Letting the other jobs finish will not take much extra CI time. And it is sometimes useful to have all the results:

- if one of the jobs failed due to a CI infrastrucutre issue
- if a database-related test fails, then see the result on other databases

Opinions welcome.