### PR TITLE
test: bump phpstan to major version 2

### DIFF
--- a/vendor-bin/phpstan/composer.json
+++ b/vendor-bin/phpstan/composer.json
@@ -1,5 +1,5 @@
 {
     "require": {
-        "phpstan/phpstan": "^1.12"
+        "phpstan/phpstan": "^2.2"
     }
 }


### PR DESCRIPTION
We are on PHP 8.3, so PHPstan major version 2 can be used.

I was surprised that it found no new issues in the code-base, but I guess that is Ok/good.