### PR TITLE
chore(deps): update PHP dependencies

### DIFF
--- a/changelog/unreleased/PHPdependencies20260225onward
+++ b/changelog/unreleased/PHPdependencies20260225onward
@@ -2,13 +2,13 @@ Change: Update PHP dependencies
 
 The following have been updated:
 
- * doctrine/dbal (2.13.9 to 3.10.4)
+ * doctrine/dbal (2.13.9 to 3.10.6)
 
  * firebase/php-jwt (7.0.5 to 7.1.0)
 
  * google/apiclient (v2.19.0 to v2.19.4)
 
- * google/apiclient-services (v0.435.0 to v0.449.0)
+ * google/apiclient-services (v0.435.0 to v0.451.0)
 
  * google/auth (v1.50.0 to v1.52.0)
 
@@ -18,7 +18,7 @@ The following have been updated:
 
  * guzzlehttp/psr7 (2.8.0 to 2.13.0)
 
- * laravel/serializable-closure (v2.0.10 to v2.0.13)
+ * laravel/serializable-closure (v2.0.10 to v2.0.15)
 
  * league/mime-type-detection (1.16.0 to 1.17.0)
 
@@ -74,3 +74,4 @@ https://github.com/owncloud/core/pull/41677
 https://github.com/owncloud/core/pull/41681
 https://github.com/owncloud/core/pull/41691
 https://github.com/owncloud/core/pull/41697
+https://github.com/owncloud/core/pull/41709

--- a/composer.lock
+++ b/composer.lock
@@ -293,16 +293,16 @@
         },
         {
             "name": "doctrine/dbal",
-            "version": "3.10.5",
+            "version": "3.10.6",
             "source": {
                 "type": "git",
                 "url": "https://github.com/doctrine/dbal.git",
-                "reference": "95d84866bf3c04b2ddca1df7c049714660959aef"
+                "reference": "c95589d775a0b2e543467d40f8c3ecccf586f2b4"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/doctrine/dbal/zipball/95d84866bf3c04b2ddca1df7c049714660959aef",
-                "reference": "95d84866bf3c04b2ddca1df7c049714660959aef",
+                "url": "https://api.github.com/repos/doctrine/dbal/zipball/c95589d775a0b2e543467d40f8c3ecccf586f2b4",
+                "reference": "c95589d775a0b2e543467d40f8c3ecccf586f2b4",
                 "shasum": ""
             },
             "require": {
@@ -387,7 +387,7 @@
             ],
             "support": {
                 "issues": "https://github.com/doctrine/dbal/issues",
-                "source": "https://github.com/doctrine/dbal/tree/3.10.5"
+                "source": "https://github.com/doctrine/dbal/tree/3.10.6"
             },
             "funding": [
                 {
@@ -403,7 +403,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2026-02-24T08:03:57+00:00"
+            "time": "2026-07-21T12:57:49+00:00"
         },
         {
             "name": "doctrine/deprecations",
@@ -827,16 +827,16 @@
         },
         {
             "name": "google/apiclient-services",
-            "version": "v0.449.0",
+            "version": "v0.451.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/googleapis/google-api-php-client-services.git",
-                "reference": "7e7fbc0e503655d4e7d41b297e0def347a34e026"
+                "reference": "81162a54400a4bd7ec20f107a4798c49b1b37e02"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/googleapis/google-api-php-client-services/zipball/7e7fbc0e503655d4e7d41b297e0def347a34e026",
-                "reference": "7e7fbc0e503655d4e7d41b297e0def347a34e026",
+                "url": "https://api.github.com/repos/googleapis/google-api-php-client-services/zipball/81162a54400a4bd7ec20f107a4798c49b1b37e02",
+                "reference": "81162a54400a4bd7ec20f107a4798c49b1b37e02",
                 "shasum": ""
             },
             "require": {
@@ -865,9 +865,9 @@
             ],
             "support": {
                 "issues": "https://github.com/googleapis/google-api-php-client-services/issues",
-                "source": "https://github.com/googleapis/google-api-php-client-services/tree/v0.449.0"
+                "source": "https://github.com/googleapis/google-api-php-client-services/tree/v0.451.0"
             },
-            "time": "2026-07-01T01:48:37+00:00"
+            "time": "2026-07-19T01:14:24+00:00"
         },
         {
             "name": "google/auth",
@@ -1821,16 +1821,16 @@
         },
         {
             "name": "laravel/serializable-closure",
-            "version": "v2.0.13",
+            "version": "v2.0.15",
             "source": {
                 "type": "git",
                 "url": "https://github.com/laravel/serializable-closure.git",
-                "reference": "b566ee0dd251f3c4078bed003a7ce015f5ea6dce"
+                "reference": "dccd8bcb851bb03fcc005df650b708b57cc52661"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/laravel/serializable-closure/zipball/b566ee0dd251f3c4078bed003a7ce015f5ea6dce",
-                "reference": "b566ee0dd251f3c4078bed003a7ce015f5ea6dce",
+                "url": "https://api.github.com/repos/laravel/serializable-closure/zipball/dccd8bcb851bb03fcc005df650b708b57cc52661",
+                "reference": "dccd8bcb851bb03fcc005df650b708b57cc52661",
                 "shasum": ""
             },
             "require": {
@@ -1878,7 +1878,7 @@
                 "issues": "https://github.com/laravel/serializable-closure/issues",
                 "source": "https://github.com/laravel/serializable-closure"
             },
-            "time": "2026-04-16T14:03:50+00:00"
+            "time": "2026-07-21T16:49:22+00:00"
         },
         {
             "name": "league/flysystem",
@@ -7814,9 +7814,9 @@
         "ext-simplexml": "*",
         "ext-zip": "*"
     },
-    "platform-dev": [],
+    "platform-dev": {},
     "platform-overrides": {
         "php": "8.3"
     },
-    "plugin-api-version": "2.6.0"
+    "plugin-api-version": "2.9.0"
 }


### PR DESCRIPTION
- Upgrading doctrine/dbal (3.10.5 to 3.10.6) https://github.com/doctrine/dbal/releases#release-3.10.6
- Upgrading google/apiclient-services (v0.449.0 to v0.451.0) https://packagist.org/packages/google/apiclient-services#v0.451.0
- Upgrading laravel/serializable-closure (v2.0.13 to v2.0.15) https://github.com/laravel/serializable-closure/releases/tag/v2.0.15
