### PR TITLE
test: use phpunit 12 for assertions in acceptance tests

### DIFF
--- a/vendor-bin/behat/composer.json
+++ b/vendor-bin/behat/composer.json
@@ -11,7 +11,7 @@
         "symfony/translation": "^5.4",
         "sabre/xml": "^2.2",
         "guzzlehttp/guzzle": "^7.15",
-        "phpunit/phpunit": "^9.6",
+        "phpunit/phpunit": "^12.5",
         "laminas/laminas-ldap": "^2.20",
         "helmich/phpunit-json-assert": "^3.5"
     }


### PR DESCRIPTION
The phpunit assertions are used in some acceptance tests. Update from PHPunit 9 to 12. Major version 12 is the version of PHPunit that was released with PHP 8.3.
