### PR TITLE
fix(navigation): hide app icon when app not enabled for the user

### DIFF
--- a/changelog/unreleased/41717
+++ b/changelog/unreleased/41717
@@ -1,0 +1,9 @@
+Bugfix: Hide navigation icon for apps not enabled for the user
+
+Apps that were enabled only for a specific group still showed their navigation
+icon in the top-left app menu for every user, including users who were not in
+that group. Clicking the icon then bounced the user back to the Files app. The
+navigation manager now skips apps that are not enabled for the current user,
+mirroring the per-user check already used for the web navigation entry.
+
+https://github.com/owncloud/core/issues/41717

--- a/lib/private/NavigationManager.php
+++ b/lib/private/NavigationManager.php
@@ -142,6 +142,11 @@ class NavigationManager implements INavigationManager {
 			return;
 		}
 		foreach ($this->appManager->getInstalledApps() as $app) {
+			// skip apps that are not enabled for the current user, e.g. apps
+			// that are only enabled for a specific group the user is not in
+			if (!$this->appManager->isEnabledForUser($app)) {
+				continue;
+			}
 			// load plugins and collections from info.xml
 			$info = $this->appManager->getAppInfo($app);
 			if (!isset($info['navigation'])) {

--- a/tests/lib/NavigationManagerTest.php
+++ b/tests/lib/NavigationManagerTest.php
@@ -182,6 +182,7 @@ class NavigationManagerTest extends TestCase {
 		});
 
 		$appManager->expects($this->once())->method('getInstalledApps')->willReturn(['test']);
+		$appManager->method('isEnabledForUser')->with('test')->willReturn(true);
 		$appManager->expects($this->once())->method('getAppInfo')->with('test')->willReturn($config);
 		$l10nFac->expects($this->exactly(\count($expected)))->method('get')->with('test')->willReturn($l);
 		$urlGenerator->method('imagePath')->willReturnCallback(static function ($appName, $file) {
@@ -204,6 +205,30 @@ class NavigationManagerTest extends TestCase {
 
 		$entries = $navigationManager->getAll();
 		$this->assertEquals($expected, $entries);
+	}
+
+	public function testAppNotEnabledForUserIsNotShown(): void {
+		$appManager = $this->createMock(IAppManager::class);
+		$urlGenerator = $this->createMock(IURLGenerator::class);
+		$l10nFac = $this->createMock(IFactory::class);
+		$userSession = $this->createMock(IUserSession::class);
+		$groupManager = $this->createMock(IGroupManager::class);
+		$systemConfig = $this->createMock(IConfig::class);
+
+		$appManager->expects($this->once())->method('getInstalledApps')->willReturn(['test']);
+		// the app is installed (e.g. enabled only for a specific group) but not
+		// enabled for the current user - its navigation entry must be skipped
+		$appManager->method('isEnabledForUser')->with('test')->willReturn(false);
+		$appManager->expects($this->never())->method('getAppInfo');
+
+		$user = $this->createMock(IUser::class);
+		$user->method('getUID')->willReturn('user001');
+		$userSession->method('getUser')->willReturn($user);
+		$groupManager->method('isAdmin')->willReturn(false);
+
+		$navigationManager = new NavigationManager($appManager, $urlGenerator, $l10nFac, $userSession, $groupManager, $systemConfig);
+
+		$this->assertEquals([], $navigationManager->getAll());
 	}
 
 	public function providesNavigationConfig(): array {


### PR DESCRIPTION
## Description

Fixes #41717

When an app is enabled only for a specific group (via the admin apps UI), its navigation icon in the top-left app menu was shown to **every** user — including users not in that group. Clicking the icon then bounced the non-member back to the Files app.

### Root cause

`OC\NavigationManager::init()` built the app menu entries by iterating `getInstalledApps()` (all non-disabled apps, including group-restricted ones) and its only filter was the `admin` role check. It never called `isEnabledForUser()`. Since a group-enabled app's `enabled` value is a JSON group array (not `'no'`), it survives the "installed" filter and its icon was emitted for all users.

Notably, the special-case `web` nav item (`suppressWebNavItem()`) already did the correct per-user `isEnabledForUser('web')` check — that gate was simply missing from the main app loop.

### Fix

Skip apps that are not enabled for the current user in the navigation build loop, mirroring the existing web check.

## Tests

- Added `testAppNotEnabledForUserIsNotShown` — fails before the fix, passes after.
- Updated the existing `testWithAppManager` mocks to account for the new `isEnabledForUser` call.
- All `NavigationManagerTest` cases pass (11 tests, 49 assertions).

## Note

The follow-up comment on the issue about `files_texteditor` is a separate, correct behavior — those apps have no own `<navigation>` entry and integrate into Files, so they are unaffected. This change targets apps with their own navigation icon, like Notes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)