### PR TITLE
fix(l10n): guard vsprintf against malformed translations (#41720)

### DIFF
--- a/changelog/unreleased/41720
+++ b/changelog/unreleased/41720
@@ -1,0 +1,12 @@
+Bugfix: Do not crash on malformed translations
+
+Changing the language (and any request that rendered a translated string with
+parameters) could return an HTTP 500 error. On PHP 8 vsprintf() throws a
+ValueError instead of returning false when a translation's format specifiers do
+not match the supplied arguments — a common result of translators turning "%s"
+into "% s" or "%S", or dropping a specifier. OC_L10N_String::__toString() did
+not guard against this, so a single malformed translation string in a shipped
+language file crashed the whole request. Such translations now fall back to the
+untranslated source text so the request still succeeds.
+
+https://github.com/owncloud/core/issues/41720

--- a/lib/private/legacy/l10n/string.php
+++ b/lib/private/legacy/l10n/string.php
@@ -65,7 +65,20 @@ class OC_L10N_String implements JsonSerializable {
 			return (string)$text;
 		}
 
-		return \vsprintf($text, $this->parameters);
+		try {
+			return \vsprintf($text, $this->parameters);
+		} catch (\ValueError $e) {
+			// A malformed translation (e.g. a translator turned "%s" into
+			// "% s" or "%S", or dropped a specifier) makes vsprintf() throw
+			// a ValueError on PHP 8. Rather than letting that bubble up as a
+			// 500, fall back to the untranslated source text so the request
+			// still succeeds. See https://github.com/owncloud/core/issues/41720
+			try {
+				return \vsprintf(\str_replace('%n', $this->count, $this->text), $this->parameters);
+			} catch (\ValueError $e) {
+				return (string)$this->text;
+			}
+		}
 	}
 
 	public function jsonSerialize(): string {

--- a/tests/lib/L10N/L10nTest.php
+++ b/tests/lib/L10N/L10nTest.php
@@ -56,6 +56,33 @@ class L10nTest extends TestCase {
 		self::assertEquals('malformed %', $lString->__toString());
 	}
 
+	/**
+	 * A translation whose format specifiers do not match the supplied
+	 * parameters must not crash. On PHP 8 vsprintf() throws a ValueError
+	 * for such mismatches (translators frequently mangle specifiers, e.g.
+	 * "%s" -> "% s" or "%S"). We must fall back to the untranslated text
+	 * instead of letting the ValueError bubble up as a 500. See #41720.
+	 *
+	 * @dataProvider providesMismatchedFormatTranslations
+	 */
+	public function testMismatchedFormatTranslationsDoNotThrow(string $translation, array $parameters): void {
+		$lMock = $this->createMock(L10N::class);
+		$lMock->method('getTranslations')->willReturn(['See %s' => $translation]);
+
+		$lString = new \OC_L10N_String($lMock, 'See %s', $parameters);
+		// Falls back to the untranslated source text rather than throwing.
+		self::assertEquals('See http://example.com', $lString->__toString());
+	}
+
+	public function providesMismatchedFormatTranslations(): array {
+		return [
+			// Unknown specifier "% S" produced by a translator (real case: lib/l10n/ug.json)
+			'unknown specifier' => ['% S', ['http://example.com']],
+			// More specifiers in the translation than parameters supplied
+			'too few arguments' => ['%s %s', ['http://example.com']],
+		];
+	}
+
 	public function testRussianPluralTranslations(): void {
 		$transFile = \OC::$SERVERROOT.'/tests/data/l10n/ru.json';
 		$l = new L10N($this->getFactory(), 'test', 'ru', [$transFile]);


### PR DESCRIPTION
## Description

`OC_L10N_String::__toString()` called `vsprintf()` unguarded. On **PHP 8** `vsprintf()` **throws a `ValueError`** — instead of returning `false` as it did on PHP 5/7 — whenever a translation's format specifiers do not match the supplied parameters. This is a common result of translators turning `%s` into `% s` or `%S`, or dropping a specifier (e.g. `lib/l10n/ug.json`: `See %s` → `% S گە قاراڭ`).

A single malformed string in a shipped language file therefore crashed the whole request with a **500**, e.g. `POST /settings/ajax/setlanguage.php` when a fresh user picked an affected language.

The fix wraps `vsprintf()` in `try/catch (\ValueError)` and falls back to substituting the parameters into the **untranslated source text** (and finally the raw source string) so the request succeeds instead of erroring out.

## Related Issue

- Fixes #41720

## Motivation and Context

This restores protection previously added on the 10.x branches (changelog #38103, commit `8d7670ee4a`) that was **never forward-ported** to master — `git merge-base --is-ancestor` confirms it is not an ancestor of the 11.0 branch.

The bug surfaced specifically in **11.0.0-rc2** because #41618 (merged between rc1 and rc2) fixed language resolution so non-English languages actually load for users, which exposes the malformed non-English strings that then crash `vsprintf`.

Note: the old 10.x form (`@\vsprintf(...)` + `=== false`) does **not** work on PHP 8, because `@` suppresses warnings, not `ValueError`. A `try/catch` is required.

## How Has This Been Tested?

- test environment: PHP 8.3, PHPUnit (`tests/lib/L10N/L10nTest.php`)
- Added data-driven `testMismatchedFormatTranslationsDoNotThrow` covering the unknown-specifier (`% S`) and too-few-arguments (`%s %s`) cases. It reproduces the `ValueError` at `string.php:68` on the unpatched code and passes after the fix.
- The pre-existing `testMalformedTranslations` never caught this because it used empty parameters, hitting the `count === 0` early return before `vsprintf`.
- `php -l lib/private/legacy/l10n/string.php` → no syntax errors.

## Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist:

- [x] Code changes
- [x] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: n/a
- [x] Changelog item, see [TEMPLATE](https://github.com/owncloud/core/blob/master/changelog/TEMPLATE)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
