### PR TITLE
fix(settings): load renamed Jcrop 2.0 assets for avatar cropper

### DIFF
--- a/changelog/unreleased/avatar-cropper-jcrop-path
+++ b/changelog/unreleased/avatar-cropper-jcrop-path
@@ -8,4 +8,7 @@ template still referenced the old paths. The script therefore failed to load,
 the plugin never registered on jQuery, and the cropper could not be shown. The
 template now loads the renamed Jcrop assets.
 
-https://github.com/owncloud/core/pull/38666
+Original Jcrop PR: https://github.com/owncloud/core/pull/38666
+
+https://github.com/owncloud/core/issues/41723
+https://github.com/owncloud/core/pull/41724

--- a/changelog/unreleased/avatar-cropper-jcrop-path
+++ b/changelog/unreleased/avatar-cropper-jcrop-path
@@ -1,0 +1,11 @@
+Bugfix: Fix avatar cropper broken by Jcrop 2.0 file rename
+
+Uploading a non-square profile picture opened a cropper that immediately failed
+with "$cropperImage.Jcrop is not a function". Bumping the Jcrop dependency from
+0.9.12 to 2.0.4 renamed its distribution files from js/jquery.Jcrop.js and
+css/jquery.Jcrop.css to js/Jcrop.js and css/Jcrop.css, but the personal profile
+template still referenced the old paths. The script therefore failed to load,
+the plugin never registered on jQuery, and the cropper could not be shown. The
+template now loads the renamed Jcrop assets.
+
+https://github.com/owncloud/core/pull/38666

--- a/settings/templates/panels/personal/profile.php
+++ b/settings/templates/panels/personal/profile.php
@@ -3,8 +3,8 @@ script('settings', 'panels/profile');
 vendor_script('strengthify/jquery.strengthify');
 vendor_style('strengthify/strengthify');
 if ($_['enableAvatars']) {
-	vendor_script('jcrop/js/jquery.Jcrop');
-	vendor_style('jcrop/css/jquery.Jcrop');
+	vendor_script('jcrop/js/Jcrop');
+	vendor_style('jcrop/css/Jcrop');
 }
 ?>
 <?php if ($_['enableAvatars']): ?>


### PR DESCRIPTION
## Summary

Fixes the avatar cropper, which broke with `$cropperImage.Jcrop is not a function` when uploading a non-square profile picture.

## Root cause

PR #38666 bumped `@bower_components/jcrop` from **0.9.12 → 2.0.4**. Jcrop 2.0 renamed its distribution files:

- `js/jquery.Jcrop.js` → `js/Jcrop.js`
- `css/jquery.Jcrop.css` → `css/Jcrop.css`

But `settings/templates/panels/personal/profile.php` still referenced the old paths via `vendor_script`/`vendor_style`. The script 404'd, `$.fn.Jcrop` was never registered on jQuery, and cropping threw `$cropperImage.Jcrop is not a function` (`profile.js:93`).

## Fix

Point the template at the renamed Jcrop assets.

## Compatibility

The Jcrop 2.0.4 **JS API is backward-compatible** with `profile.js`'s usage — `onChange`, `onSelect`, `setSelect`, `aspectRatio`, `boxWidth`, `boxHeight` are all still supported through 2.0.4's `legacyHandlers` shim, which invokes the callback with the unscaled `{x, y, w, h}` coords that `saveCoords`/`sendCropData` expect. `Jcrop.gif` is referenced relative to the CSS and ships in the 2.0.4 package. So this is purely a filename-path break, not an API break.

🤖 Generated with [Claude Code](https://claude.com/claude-code)