### PR TITLE
fix(avatar): reject non-numeric crop coordinates

### DIFF
--- a/changelog/unreleased/41723
+++ b/changelog/unreleased/41723
@@ -1,0 +1,11 @@
+Bugfix: Reject non-numeric avatar crop coordinates
+
+Submitting a profile picture crop with empty or non-numeric coordinates hit the
+image cropping code with invalid values. On PHP 8 this raised a TypeError from
+round() and returned an HTTP 500; on PHP 7 it silently produced a broken crop.
+The client sends empty coordinates (crop[x]=&crop[y]=...) whenever the cropper
+failed to produce a selection. postCroppedAvatar now validates that all four
+coordinates are numeric and returns a clean HTTP 400 otherwise, instead of
+crashing.
+
+https://github.com/owncloud/core/issues/41723

--- a/changelog/unreleased/41723
+++ b/changelog/unreleased/41723
@@ -9,3 +9,4 @@ coordinates are numeric and returns a clean HTTP 400 otherwise, instead of
 crashing.
 
 https://github.com/owncloud/core/issues/41723
+https://github.com/owncloud/core/pull/41725

--- a/core/Controller/AvatarController.php
+++ b/core/Controller/AvatarController.php
@@ -325,7 +325,13 @@ class AvatarController extends Controller {
 			);
 		}
 
-		if (!isset($crop['x'], $crop['y'], $crop['w'], $crop['h'])) {
+		if (!isset($crop['x'], $crop['y'], $crop['w'], $crop['h'])
+			|| !\is_numeric($crop['x']) || !\is_numeric($crop['y'])
+			|| !\is_numeric($crop['w']) || !\is_numeric($crop['h'])
+		) {
+			// The client may submit empty coordinates (e.g. crop[x]=&crop[y]=...)
+			// when the cropper failed to produce a selection. Reject them here
+			// instead of letting round()/imagecreatetruecolor() fail later.
 			return new DataResponse(
 				['data' => ['message' => $this->l->t("No valid crop data provided")]],
 				Http::STATUS_BAD_REQUEST
@@ -343,7 +349,7 @@ class AvatarController extends Controller {
 		}
 
 		$image = new \OC_Image($tmpAvatar);
-		$image->crop($crop['x'], $crop['y'], \round($crop['w']), \round($crop['h']));
+		$image->crop((int)$crop['x'], (int)$crop['y'], (int)\round($crop['w']), (int)\round($crop['h']));
 		try {
 			$avatar = $this->avatarManager->getAvatar($userId);
 			$avatar->set($image);

--- a/tests/Core/Controller/AvatarControllerTest.php
+++ b/tests/Core/Controller/AvatarControllerTest.php
@@ -420,6 +420,34 @@ class AvatarControllerTest extends TestCase {
 	}
 
 	/**
+	 * Non-numeric crop coordinates must be rejected with a clean 400 instead of
+	 * reaching the image cropping code. jQuery serializes undefined cropper
+	 * coordinates as empty strings (crop[x]=&crop[y]=...), which are "set" but
+	 * not numeric; passing them to round()/imagecreatetruecolor() throws a
+	 * TypeError on PHP 8 (HTTP 500) or silently produces a broken crop on PHP 7.
+	 *
+	 * @dataProvider providesNonNumericCrop
+	 */
+	public function testPostCroppedAvatarNonNumericCrop($crop) {
+		// A valid tmp avatar is present, so we get past the tmpAvatar check and
+		// would reach the cropping code if the coordinates were not rejected.
+		$this->cache->expects($this->any())->method('get')->willReturn(\file_get_contents(\OC::$SERVERROOT.'/tests/data/testimage.jpg'));
+		$this->avatarManager->expects($this->any())->method('getAvatar')->willReturn($this->avatarMock);
+
+		$response = $this->avatarController->postCroppedAvatar($crop);
+
+		$this->assertEquals(Http::STATUS_BAD_REQUEST, $response->getStatus());
+	}
+
+	public function providesNonNumericCrop() {
+		return [
+			'empty strings (undefined jQuery coords)' => [['x' => '', 'y' => '', 'w' => '', 'h' => '']],
+			'non-numeric strings' => [['x' => 'a', 'y' => 'b', 'w' => 'c', 'h' => 'd']],
+			'mixed' => [['x' => 0, 'y' => 0, 'w' => '', 'h' => 10]],
+		];
+	}
+
+	/**
 	 * Test no tmp avatar to crop
 	 */
 	public function testPostCroppedAvatarNoTmpAvatar() {


### PR DESCRIPTION
## Summary

Hardens `postCroppedAvatar` against empty / non-numeric crop coordinates, fixing #41723 ("Cannot upload a profile picture").

## Root cause (reproduced end-to-end)

The reporter's failing `POST /avatar/cropped` is a downstream symptom of the Jcrop 2.0 asset-rename bug (fixed separately in #41724). When Jcrop fails to initialize, its `onChange`/`onSelect` callbacks never fire, so `$('#cropper').data()` has no `x/y/w/h`. Clicking "Choose as profile picture" then POSTs empty coordinates:

```
crop[x]=&crop[y]=&crop[w]=&crop[h]=
```

(verified with real jQuery 2.1.4). Server-side, `$crop = ['x'=>'','y'=>'','w'=>'','h'=>'']` passes the existing `=== null` and `isset()` guards, then reaches:

```php
$image->crop($crop['x'], $crop['y'], \round($crop['w']), \round($crop['h']));
```

- **PHP 8:** `round('')` throws `TypeError` → uncaught (the dispatcher only catches `\Exception`, not `\Error`) → **HTTP 500**, logged.
- **PHP 7** (reporter's `11.0.0-rc2` docker image): `round('')` returns `0.0`, `imagecreatetruecolor(0,0)` returns `false` → broken crop and a clean **HTTP 400** with nothing logged — exactly the reported symptom.

I reproduced both the 500 (PHP 8.3) and the empty-coord serialization against a live instance driving the real login → upload → crop flow.

## Fix

Validate that all four coordinates are numeric; return a clean `400 "No valid crop data provided"` otherwise, and cast to `int` before cropping.

## Testing

- New data-driven test `testPostCroppedAvatarNonNumericCrop` (empty strings, non-numeric strings, mixed) — fails with `TypeError` before the fix, passes after.
- Full `AvatarControllerTest` green (27 tests).
- Live-server verification: empty coords → clean 400 (no exception logged); valid coords → 200 success.

## Relationship to #41724

#41724 (Jcrop asset-path fix) resolves the user-facing bug by making the cropper work again. This PR is defense-in-depth so malformed crop data can never crash the endpoint regardless of client state or PHP version.

🤖 Generated with [Claude Code](https://claude.com/claude-code)