### PR TITLE
docs(changelog): add entry for the PHP 8.3 migration

### DIFF
--- a/changelog/unreleased/41449
+++ b/changelog/unreleased/41449
@@ -1,0 +1,8 @@
+Change: Raise minimum PHP version to 8.3
+
+The minimum required PHP version is now 8.3. Numerous PHP 8.x deprecation
+warnings were resolved across the codebase, the mail subsystem was migrated
+to symfony/mailer, the unused ext-apc requirement was dropped, and the PHP
+version check now runs early in lib/base.php.
+
+https://github.com/owncloud/core/pull/41449


### PR DESCRIPTION
Adds the missing calens changelog entry for the PHP 8.3 migration merged in #41449.

The two existing PHP-related entries (`PHPRemovedCodeOC11`, `PHPdependencies20260225onward`) cover removed legacy code and dependency bumps, but not the core migration itself — namely that the minimum required PHP version is now 8.3.

🤖 Generated with [Claude Code](https://claude.com/claude-code)