### PR TITLE
fix(preview): do not trust cached binary paths from the distributed cache

### DIFF
--- a/changelog/unreleased/41732
+++ b/changelog/unreleased/41732
@@ -1,0 +1,9 @@
+Security: Do not trust cached binary paths
+
+The paths of the helper binaries used to render previews - ffmpeg, avconv and
+AtomicParsley - were cached in the distributed memory cache and used without
+being checked, then interpolated unquoted into the shell commands built from
+them. A cached path is now stored in the host local cache tier only, is
+validated before it is used, and is quoted when the command line is assembled.
+
+https://github.com/owncloud/core/pull/41732

--- a/lib/private/Memcache/LocalCacheFactory.php
+++ b/lib/private/Memcache/LocalCacheFactory.php
@@ -1,0 +1,64 @@
+<?php
+/**
+ * @author Thomas Müller <thomas.mueller@tmit.eu>
+ *
+ * @copyright Copyright (c) 2026, ownCloud GmbH
+ * @license AGPL-3.0
+ *
+ * This code is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License, version 3,
+ * as published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License, version 3,
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>
+ *
+ */
+
+namespace OC\Memcache;
+
+use OCP\ICache;
+use OCP\ICacheFactory;
+
+/**
+ * Resolves a cache from the host local tier of an ICacheFactory.
+ *
+ * Values which are only meaningful on the machine which produced them - resolved
+ * binary paths, theme asset paths, integrity check verdicts - must not be stored
+ * in the distributed tier: it is reachable over the network and every node would
+ * consume what any single node (or anything else able to talk to the backend)
+ * wrote there.
+ *
+ * ICacheFactory does not declare createLocal(), so the tier is requested
+ * defensively and a request scoped ArrayCache is used whenever a usable local
+ * cache cannot be obtained.
+ *
+ * @package OC\Memcache
+ */
+class LocalCacheFactory {
+	/**
+	 * Create a cache in the host local tier of $factory, never returning a
+	 * NullCache: when no local memcache is configured the returned cache is
+	 * request scoped rather than a no-op, so the caller still benefits from
+	 * caching within a single request.
+	 *
+	 * @param ICacheFactory $factory
+	 * @param string $prefix
+	 * @return ICache
+	 */
+	public static function create(ICacheFactory $factory, $prefix = '') {
+		$cache = null;
+		if (\method_exists($factory, 'createLocal')) {
+			/* @phan-suppress-next-line PhanUndeclaredMethod */
+			$cache = $factory->createLocal($prefix);
+		}
+		if (!$cache instanceof ICache || $cache instanceof NullCache) {
+			$cache = new ArrayCache($prefix);
+		}
+		return $cache;
+	}
+}

--- a/lib/private/Preview/Movie.php
+++ b/lib/private/Preview/Movie.php
@@ -97,10 +97,7 @@ class Movie implements IProvider2 {
 			if (\strtolower($suffix) === '.mp4') {
 				$tmpFolder = \OC::$server->getTempManager()->getTemporaryFolder();
 				$tmpBase = $tmpFolder.'/Cover';
-				$cmd = self::$atomicParsleyBinary . ' ' .
-					\escapeshellarg($absPath).
-					' --extractPixToPath ' . \escapeshellarg($tmpBase) .
-					' > /dev/null 2>&1';
+				$cmd = self::buildAtomicParsleyCommand($absPath, $tmpBase);
 
 				\exec($cmd, $output, $returnCode);
 
@@ -121,6 +118,47 @@ class Movie implements IProvider2 {
 	}
 
 	/**
+	 * Build the AtomicParsley command line used to extract cover artwork.
+	 *
+	 * The binary is escaped just like every other part of the command line: it
+	 * originates from OC_Helper::findBinaryPath() and must never be interpolated
+	 * into a shell string unquoted.
+	 *
+	 * @param string $absPath
+	 * @param string $tmpBase
+	 * @return string
+	 */
+	private static function buildAtomicParsleyCommand($absPath, $tmpBase) {
+		return \escapeshellarg(self::$atomicParsleyBinary) . ' ' .
+			\escapeshellarg($absPath) .
+			' --extractPixToPath ' . \escapeshellarg($tmpBase) .
+			' > /dev/null 2>&1';
+	}
+
+	/**
+	 * Build the avconv/ffmpeg command line used to grab a single frame.
+	 *
+	 * @param string $absPath
+	 * @param int $second
+	 * @param string $tmpPath
+	 * @return string
+	 */
+	private static function buildMovieCommand($absPath, $second, $tmpPath) {
+		if (self::$avconvBinary) {
+			return \escapeshellarg(self::$avconvBinary) . ' -y -ss ' . \escapeshellarg($second) .
+				' -i ' . \escapeshellarg($absPath) .
+				' -an -f mjpeg -vframes 1 -vsync 1 ' . \escapeshellarg($tmpPath) .
+				' > /dev/null 2>&1';
+		}
+
+		return \escapeshellarg(self::$ffmpegBinary) . ' -y -ss ' . \escapeshellarg($second) .
+			' -i ' . \escapeshellarg($absPath) .
+			' -f mjpeg -vframes 1' .
+			' ' . \escapeshellarg($tmpPath) .
+			' > /dev/null 2>&1';
+	}
+
+	/**
 	 * @param $absPath
 	 * @param $second
 	 * @return bool|string
@@ -128,18 +166,7 @@ class Movie implements IProvider2 {
 	private function generateFromMovie($absPath, $second) {
 		$tmpPath = \OC::$server->getTempManager()->getTemporaryFile();
 
-		if (self::$avconvBinary) {
-			$cmd = self::$avconvBinary . ' -y -ss ' . \escapeshellarg($second) .
-				' -i ' . \escapeshellarg($absPath) .
-				' -an -f mjpeg -vframes 1 -vsync 1 ' . \escapeshellarg($tmpPath) .
-				' > /dev/null 2>&1';
-		} else {
-			$cmd = self::$ffmpegBinary . ' -y -ss ' . \escapeshellarg($second) .
-				' -i ' . \escapeshellarg($absPath) .
-				' -f mjpeg -vframes 1' .
-				' ' . \escapeshellarg($tmpPath) .
-				' > /dev/null 2>&1';
-		}
+		$cmd = self::buildMovieCommand($absPath, $second, $tmpPath);
 
 		\exec($cmd, $output, $returnCode);
 

--- a/lib/private/legacy/helper.php
+++ b/lib/private/legacy/helper.php
@@ -519,32 +519,82 @@ class OC_Helper {
 	}
 
 	/**
+	 * Sentinel stored in the cache to remember that a program could not be
+	 * found, so the (comparatively expensive) lookup is not repeated. It is
+	 * distinguishable from a cache miss, which yields null.
+	 */
+	private const BINARY_NOT_FOUND = false;
+
+	/**
+	 * Number of seconds a resolved binary path is cached for
+	 */
+	private const BINARY_PATH_TTL = 300;
+
+	/**
 	 * Try to find a program
 	 *
 	 * @param string $program
 	 * @return null|string
 	 */
 	public static function findBinaryPath($program) {
-		$memcache = \OC::$server->getMemCacheFactory()->create('findBinaryPath');
-		if ($memcache->hasKey($program)) {
-			return $memcache->get($program);
+		// host local tier only: a binary path is meaningful for this machine
+		// alone and ends up in a shell command, so it must not be read from a
+		// cache which other hosts - or anything able to reach the cache
+		// backend - can write to.
+		$memcache = \OC\Memcache\LocalCacheFactory::create(
+			\OC::$server->getMemCacheFactory(),
+			'findBinaryPath'
+		);
+
+		$cached = $memcache->get($program);
+		if ($cached === self::BINARY_NOT_FOUND) {
+			return null;
 		}
+		// never hand out a cached path without checking it still describes the
+		// program which was asked for
+		if ($cached !== null && self::isUsableBinaryPath($program, $cached)) {
+			return $cached;
+		}
+
 		$result = null;
 		if (self::is_function_enabled('exec')) {
 			$exeSniffer = new ExecutableFinder();
 			// Returns null if nothing is found
 			$result = $exeSniffer->find($program);
-			#if (empty($result)) {
-			#	$command = 'find ' . self::getCleanedPath(\getenv('PATH')) . ' -name ' . \escapeshellarg($program) . ' 2> /dev/null';
-			#	\exec($command, $output, $returnCode);
-			#	if (\count($output) > 0) {
-			#		$result = \escapeshellcmd($output[0]);
-			#	}
-			#}
 		}
-		// store the value for 5 minutes
-		$memcache->set($program, $result, 300);
+		if (!self::isUsableBinaryPath($program, $result)) {
+			$result = null;
+		}
+
+		$memcache->set(
+			$program,
+			$result === null ? self::BINARY_NOT_FOUND : $result,
+			self::BINARY_PATH_TTL
+		);
 		return $result;
+	}
+
+	/**
+	 * Check that a path really is the executable of the requested program.
+	 *
+	 * @param string $program the program which was looked up
+	 * @param mixed $path the path to check
+	 * @return bool
+	 */
+	private static function isUsableBinaryPath($program, $path) {
+		if (!\is_string($path) || $path === '') {
+			return false;
+		}
+		// a NUL byte truncates the value for any C level consumer and makes
+		// escapeshellarg() throw
+		if (\strpos($path, "\0") !== false) {
+			return false;
+		}
+		if (\basename($path) !== $program) {
+			return false;
+		}
+		// is_executable() alone is not enough: it is also true for directories
+		return \is_file($path) && \is_executable($path);
 	}
 
 	/**

--- a/tests/lib/Memcache/FixedCacheFactory.php
+++ b/tests/lib/Memcache/FixedCacheFactory.php
@@ -1,0 +1,77 @@
+<?php
+/**
+ * @author Thomas Müller <thomas.mueller@tmit.eu>
+ *
+ * @copyright Copyright (c) 2026, ownCloud GmbH
+ * @license AGPL-3.0
+ *
+ * This code is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License, version 3,
+ * as published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License, version 3,
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>
+ *
+ */
+
+namespace Test\Memcache;
+
+use OCP\ICache;
+use OCP\ICacheFactory;
+
+/**
+ * An ICacheFactory handing out one and the same cache for every tier, so a test
+ * can observe what the code under test stored.
+ *
+ * \OC\Memcache\Factory returns a fresh cache instance per call, which makes the
+ * cache contents invisible to a test unless the factory is replaced.
+ */
+class FixedCacheFactory implements ICacheFactory {
+	/** @var ICache */
+	private $cache;
+
+	/** @var string[] the prefixes this factory was asked for */
+	private $prefixes = [];
+
+	public function __construct(ICache $cache) {
+		$this->cache = $cache;
+	}
+
+	public function create($prefix = '') {
+		$this->prefixes[] = $prefix;
+		return $this->cache;
+	}
+
+	public function createLocal($prefix = '') {
+		$this->prefixes[] = $prefix;
+		return $this->cache;
+	}
+
+	public function createDistributed($prefix = '') {
+		$this->prefixes[] = $prefix;
+		return $this->cache;
+	}
+
+	public function createLocking($prefix = '') {
+		$this->prefixes[] = $prefix;
+		return $this->cache;
+	}
+
+	public function isAvailable() {
+		return true;
+	}
+
+	/**
+	 * The prefixes this factory handed out a cache for, in call order.
+	 *
+	 * @return string[]
+	 */
+	public function getRequestedPrefixes() {
+		return $this->prefixes;
+	}
+}

--- a/tests/lib/Memcache/LocalCacheFactoryTest.php
+++ b/tests/lib/Memcache/LocalCacheFactoryTest.php
@@ -1,0 +1,113 @@
+<?php
+/**
+ * @author Thomas Müller <thomas.mueller@tmit.eu>
+ *
+ * @copyright Copyright (c) 2026, ownCloud GmbH
+ * @license AGPL-3.0
+ *
+ * This code is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License, version 3,
+ * as published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License, version 3,
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>
+ *
+ */
+namespace Test\Memcache;
+
+use OC\Memcache\ArrayCache;
+use OC\Memcache\Factory;
+use OC\Memcache\LocalCacheFactory;
+use OC\Memcache\NullCache;
+use OCP\ICache;
+use OCP\ICacheFactory;
+use OCP\ILogger;
+use Test\TestCase;
+
+class LocalCacheFactoryTest extends TestCase {
+	/** @var ILogger */
+	private $logger;
+
+	protected function setUp(): void {
+		parent::setUp();
+		$this->logger = $this->createMock(ILogger::class);
+	}
+
+	public function testUsesTheLocalTier(): void {
+		$factory = new Factory(
+			'prefix',
+			$this->logger,
+			ArrayCache::class,
+			NullCache::class,
+			null
+		);
+
+		$cache = LocalCacheFactory::create($factory, 'test');
+
+		$this->assertInstanceOf(ArrayCache::class, $cache);
+	}
+
+	/**
+	 * The distributed tier must not be used as a fallback: that is exactly the
+	 * trust boundary this helper exists to keep.
+	 */
+	public function testNeverFallsBackToTheDistributedTier(): void {
+		$factory = new Factory(
+			'prefix',
+			$this->logger,
+			null,
+			ArrayCache::class,
+			null
+		);
+		// no local cache configured, so the local tier is a NullCache ...
+		$this->assertInstanceOf(NullCache::class, $factory->createLocal('test'));
+
+		// ... and the helper substitutes a request scoped cache instead
+		$cache = LocalCacheFactory::create($factory, 'test');
+		$this->assertInstanceOf(ArrayCache::class, $cache);
+
+		// prove it is not the distributed instance by writing through it
+		$cache->set('key', 'value');
+		$this->assertSame('value', $cache->get('key'));
+		$this->assertNull($factory->createDistributed('test')->get('key'));
+	}
+
+	public function testFallsBackWhenCreateLocalIsNotImplemented(): void {
+		// ICacheFactory does not declare createLocal(), so a bare interface
+		// mock has no such method
+		$factory = $this->createMock(ICacheFactory::class);
+
+		$this->assertInstanceOf(ArrayCache::class, LocalCacheFactory::create($factory, 'test'));
+	}
+
+	/**
+	 * @dataProvider unusableLocalCacheProvider
+	 * @param mixed $returnValue
+	 */
+	public function testFallsBackWhenCreateLocalReturnsSomethingUnusable($returnValue): void {
+		$factory = $this->createMock(FixedCacheFactory::class);
+		$factory->method('createLocal')->willReturn($returnValue);
+
+		$this->assertInstanceOf(ArrayCache::class, LocalCacheFactory::create($factory, 'test'));
+	}
+
+	public function unusableLocalCacheProvider() {
+		return [
+			'null' => [null],
+			'a NullCache' => [new NullCache('test')],
+		];
+	}
+
+	public function testPassesThroughThePrefix(): void {
+		$factory = new FixedCacheFactory($this->createMock(ICache::class));
+
+		LocalCacheFactory::create($factory, 'some-prefix');
+
+		$this->assertSame(['some-prefix'], $factory->getRequestedPrefixes());
+	}
+}

--- a/tests/lib/Preview/MovieCommandTest.php
+++ b/tests/lib/Preview/MovieCommandTest.php
@@ -1,0 +1,190 @@
+<?php
+/**
+ * @author Thomas Müller <thomas.mueller@tmit.eu>
+ *
+ * @copyright Copyright (c) 2026, ownCloud GmbH
+ * @license AGPL-3.0
+ *
+ * This code is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License, version 3,
+ * as published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License, version 3,
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>
+ *
+ */
+
+namespace Test\Preview;
+
+use OC\Preview\Movie;
+use Test\TestCase;
+
+/**
+ * The binaries used by the Movie provider come from OC_Helper::findBinaryPath(),
+ * i.e. from a cache. These tests pin that they are quoted before ending up in a
+ * shell command, independently of whether ffmpeg is installed.
+ *
+ * @package Test\Preview
+ */
+class MovieCommandTest extends TestCase {
+	/** @var array */
+	private $binaries = [];
+
+	protected function setUp(): void {
+		parent::setUp();
+		$this->binaries = [
+			Movie::$avconvBinary,
+			Movie::$ffmpegBinary,
+			Movie::$atomicParsleyBinary,
+		];
+		Movie::$avconvBinary = null;
+		Movie::$ffmpegBinary = null;
+		Movie::$atomicParsleyBinary = null;
+	}
+
+	protected function tearDown(): void {
+		list(
+			Movie::$avconvBinary,
+			Movie::$ffmpegBinary,
+			Movie::$atomicParsleyBinary
+		) = $this->binaries;
+		parent::tearDown();
+	}
+
+	private function buildMovieCommand($absPath, $second, $tmpPath) {
+		return self::invokePrivate(
+			Movie::class,
+			'buildMovieCommand',
+			[$absPath, $second, $tmpPath]
+		);
+	}
+
+	private function buildAtomicParsleyCommand($absPath, $tmpBase) {
+		return self::invokePrivate(
+			Movie::class,
+			'buildAtomicParsleyCommand',
+			[$absPath, $tmpBase]
+		);
+	}
+
+	public function testFfmpegBinaryIsQuoted(): void {
+		Movie::$ffmpegBinary = '/usr/bin/ffmpeg';
+
+		$cmd = $this->buildMovieCommand('/tmp/in.mp4', 5, '/tmp/out.jpg');
+
+		$this->assertStringStartsWith(\escapeshellarg('/usr/bin/ffmpeg') . ' ', $cmd);
+	}
+
+	public function testAvconvBinaryIsQuoted(): void {
+		Movie::$avconvBinary = '/usr/bin/avconv';
+
+		$cmd = $this->buildMovieCommand('/tmp/in.mp4', 5, '/tmp/out.jpg');
+
+		$this->assertStringStartsWith(\escapeshellarg('/usr/bin/avconv') . ' ', $cmd);
+	}
+
+	public function testAvconvTakesPrecedenceOverFfmpeg(): void {
+		Movie::$avconvBinary = '/usr/bin/avconv';
+		Movie::$ffmpegBinary = '/usr/bin/ffmpeg';
+
+		$cmd = $this->buildMovieCommand('/tmp/in.mp4', 5, '/tmp/out.jpg');
+
+		$this->assertStringStartsWith(\escapeshellarg('/usr/bin/avconv') . ' ', $cmd);
+		$this->assertStringNotContainsString('ffmpeg', $cmd);
+	}
+
+	public function testAtomicParsleyBinaryIsQuoted(): void {
+		Movie::$atomicParsleyBinary = '/usr/bin/AtomicParsley';
+
+		$cmd = $this->buildAtomicParsleyCommand('/tmp/in.mp4', '/tmp/Cover');
+
+		$this->assertStringStartsWith(\escapeshellarg('/usr/bin/AtomicParsley') . ' ', $cmd);
+	}
+
+	/**
+	 * A hostile binary value must end up as a single quoted token, so the shell
+	 * treats it as one (non-existing) command name instead of parsing the
+	 * payload.
+	 *
+	 * @dataProvider hostileBinaryProvider
+	 */
+	public function testHostileBinaryIsQuotedAsOneToken(string $binary): void {
+		Movie::$ffmpegBinary = $binary;
+		$ffmpegCmd = $this->buildMovieCommand('/tmp/in.mp4', 5, '/tmp/out.jpg');
+		Movie::$ffmpegBinary = null;
+
+		Movie::$avconvBinary = $binary;
+		$avconvCmd = $this->buildMovieCommand('/tmp/in.mp4', 5, '/tmp/out.jpg');
+		Movie::$avconvBinary = null;
+
+		Movie::$atomicParsleyBinary = $binary;
+		$atomicParsleyCmd = $this->buildAtomicParsleyCommand('/tmp/in.mp4', '/tmp/Cover');
+
+		foreach ([$ffmpegCmd, $avconvCmd, $atomicParsleyCmd] as $cmd) {
+			$this->assertStringStartsWith(\escapeshellarg($binary) . ' ', $cmd);
+		}
+	}
+
+	public function hostileBinaryProvider() {
+		return [
+			'command chaining' => ['/usr/bin/ffmpeg; id'],
+			'background' => ['/usr/bin/ffmpeg & id'],
+			'pipe' => ['/usr/bin/ffmpeg | id'],
+			'subshell' => ['/usr/bin/ffmpeg $(id)'],
+			'backticks' => ['/usr/bin/ffmpeg `id`'],
+			'newline' => ["/usr/bin/ffmpeg\nid"],
+			'quote break out' => ["/usr/bin/ffmpeg' ; id ; '"],
+		];
+	}
+
+	/**
+	 * The end to end proof: hand the built command to a real shell and verify
+	 * the payload appended to the binary does not run.
+	 *
+	 * @dataProvider commandBuilderProvider
+	 */
+	public function testInjectedPayloadIsNotExecutedByTheShell(string $builder): void {
+		$marker = \OC::$server->getTempManager()->getTemporaryFile();
+		// the temp manager creates the file - the payload would re-create it
+		\unlink($marker);
+
+		$payload = '/usr/bin/ffmpeg; touch ' . \escapeshellarg($marker);
+		Movie::$ffmpegBinary = $payload;
+		Movie::$atomicParsleyBinary = $payload;
+
+		if ($builder === 'movie') {
+			$cmd = $this->buildMovieCommand('/tmp/in.mp4', 5, '/tmp/out.jpg');
+		} else {
+			$cmd = $this->buildAtomicParsleyCommand('/tmp/in.mp4', '/tmp/Cover');
+		}
+
+		\exec($cmd, $output, $returnCode);
+
+		$this->assertFileDoesNotExist($marker, 'the injected command must not run');
+		$this->assertNotSame(0, $returnCode, 'the bogus binary must not be found');
+	}
+
+	public function commandBuilderProvider() {
+		return [
+			'ffmpeg/avconv' => ['movie'],
+			'AtomicParsley' => ['atomicParsley'],
+		];
+	}
+
+	/**
+	 * Quoting the binary also fixes paths containing spaces, which used to
+	 * break the command.
+	 */
+	public function testBinaryPathWithSpacesIsUsable(): void {
+		Movie::$ffmpegBinary = '/opt/my apps/bin/ffmpeg';
+
+		$cmd = $this->buildMovieCommand('/tmp/in.mp4', 5, '/tmp/out.jpg');
+
+		$this->assertStringStartsWith("'/opt/my apps/bin/ffmpeg' ", $cmd);
+	}
+}

--- a/tests/lib/legacy/HelperTest.php
+++ b/tests/lib/legacy/HelperTest.php
@@ -2,9 +2,93 @@
 
 namespace Test\legacy;
 
+use OC\Memcache\ArrayCache;
+use Test\Memcache\FixedCacheFactory;
 use Test\TestCase;
 
 class HelperTest extends TestCase {
+	/** @var ArrayCache */
+	private $cache;
+
+	protected function setUp(): void {
+		parent::setUp();
+		$this->cache = new ArrayCache('findBinaryPath');
+		$this->overwriteService('MemCacheFactory', new FixedCacheFactory($this->cache));
+	}
+
+	protected function tearDown(): void {
+		$this->restoreService('MemCacheFactory');
+		parent::tearDown();
+	}
+
+	/**
+	 * A value read back from the cache must not be handed out just because it
+	 * is there - a cache an attacker can write to would otherwise hand a
+	 * chosen string to the shell commands built from it.
+	 *
+	 * @dataProvider poisonedBinaryPathProvider
+	 * @param mixed $poisoned
+	 */
+	public function testFindBinaryPathRejectsPoisonedCacheEntry($poisoned): void {
+		$this->cache->set('ffmpeg', $poisoned);
+
+		$this->assertNotSame(
+			$poisoned,
+			\OC_Helper::findBinaryPath('ffmpeg'),
+			'a rejected cache entry must never be returned'
+		);
+		// the bad entry has been replaced by whatever was resolved (or the
+		// not-found sentinel), so it cannot be served again
+		$this->assertNotSame($poisoned, $this->cache->get('ffmpeg'));
+	}
+
+	public function poisonedBinaryPathProvider() {
+		return [
+			'appended command' => ['/usr/bin/ffmpeg;touch /tmp/oc-pwned'],
+			'bare command' => ['; id'],
+			'command substitution' => ['$(id)'],
+			'does not exist' => ['/nonexistent/ffmpeg'],
+			'not executable' => ['/etc/passwd'],
+			// is_executable() is true for directories, so is_file() is required
+			'directory' => ['/usr/bin'],
+			'a different binary' => ['/usr/bin/env'],
+			'nul byte' => ["/usr/bin/ffmpeg\0/evil"],
+			'empty' => [''],
+			'not a string' => [['/usr/bin/ffmpeg']],
+			'boolean true' => [true],
+		];
+	}
+
+	public function testFindBinaryPathUsesValidCachedValue(): void {
+		// PHP_BINARY is guaranteed to exist and be executable
+		$program = \basename(PHP_BINARY);
+		$this->cache->set($program, PHP_BINARY);
+
+		$this->assertSame(PHP_BINARY, \OC_Helper::findBinaryPath($program));
+	}
+
+	public function testFindBinaryPathCachesMissWithoutRepeatedLookup(): void {
+		$program = 'oc-definitely-no-such-binary';
+
+		$this->assertNull(\OC_Helper::findBinaryPath($program));
+		// a miss is remembered, so it is distinguishable from "not looked up yet"
+		$this->assertTrue($this->cache->hasKey($program));
+		$this->assertNull(\OC_Helper::findBinaryPath($program));
+	}
+
+	/**
+	 * A legacy null entry - what the previous implementation stored for a miss -
+	 * must not be mistaken for a usable path.
+	 */
+	public function testFindBinaryPathHandlesLegacyNullCacheEntry(): void {
+		$this->cache->set('ffmpeg', null);
+
+		$result = \OC_Helper::findBinaryPath('ffmpeg');
+		$this->assertTrue($result === null || \is_file($result));
+		// the entry has been rewritten, so the legacy value heals itself
+		$this->assertNotNull($this->cache->get('ffmpeg'));
+	}
+
 	/**
 	 * @dataProvider getCleanedPathProvider
 	 */


### PR DESCRIPTION
## Description

`OC_Helper::findBinaryPath()` cached the resolved path of a helper binary in the **distributed** memory cache and returned it unvalidated. `OC\Preview\Movie` then interpolated that value **unquoted** into the shell string handed to `exec()` — only the surrounding arguments were escaped. Anything able to write to the distributed cache (e.g. Redis reached through SSRF / CRLF protocol smuggling) could therefore choose what gets executed the next time any user triggers a video thumbnail.

The root cause is a **trust-tier mismatch** rather than "memcache is unsafe": `ICacheFactory::create()` aliases `createDistributed()` (`lib/private/Memcache/Factory.php:164`), so a host-specific value — a path on the local filesystem — was stored behind a network socket speaking an injectable protocol. The `md5(instanceId-version-serverRoot)` prefix is derivation, not secrecy.

Three layers of fix, so no single one has to be perfect:

1. **Right tier.** New `OC\Memcache\LocalCacheFactory` resolves the cache from the host-local tier, removing the remote write primitive entirely. It never returns a `NullCache`: with `memcache.local` unset the value would otherwise not be cached at all, so a request-scoped `ArrayCache` is substituted. This generalises the inline precedent at `AppManager.php:123-129`.
2. **Validate on read and on write.** New `isUsableBinaryPath()` rejects non-strings, empty values and NUL bytes, requires `basename($path) === $program`, and requires **both** `is_file()` and `is_executable()`. `is_executable()` alone is not enough — `is_executable('/tmp')` is `true`, so a poisoned *directory* path would pass. Validation runs on the cache-hit path too, so a stale or poisoned entry falls through and is overwritten.
3. **Escape at the sink.** `escapeshellarg()` is applied to the binary in the extracted `buildMovieCommand()` / `buildAtomicParsleyCommand()`. Quoting is the semantically correct operation for a single path token, and it additionally *fixes* a pre-existing bug: a binary in a path containing spaces never worked. Escaping happens at the sink rather than at assignment because the three statics are `public static` and settable by anything.

`hasKey()` + `get()` also collapses into a single `get()` with an explicit `false` sentinel — halves the cache ops, removes the hasKey/get race, and preserves negative caching, which matters because `avconv`/`AtomicParsley` are normally absent and a miss costs 0.8–0.9 ms. Legacy `null` entries read as a miss and self-heal.

### Reviewer notes

- `escapeshellarg()` would break a caller who stuffed *binary + flags* into one of the statics. Nothing in core does (only `PreviewManager.php:389/393/397` and `MovieTest.php:39-40` assign them), but this is a one-line downgrade to `escapeshellcmd` if you disagree. Note the "escapeshellcmd preserves Windows backslash paths" argument does not apply — Windows is hard-blocked at `lib/base.php:22`.
- **Out of scope, deliberately:** `lib/private/Preview/Office.php:60` has the same raw-binary-into-`shell_exec` shape, but `$this->cmd` is admin-config-sourced — a different trust tier. Mixing tiers in a security PR seemed wrong; happy to file a follow-up.
- **Accepted cost:** on an instance that configures only `memcache.distributed`, this cache degrades to request-scoped — worst case ~2.5 ms once per request that renders a video preview. Instances following the documented `memcache.local` recommendation get hits that are ~70× cheaper than before (APCu 0.00033 ms vs a loopback Redis RTT floor of 0.0216 ms).

## Related Issue

- Fixes GHSA-488r-cjpq-p3vc

## Motivation and Context

Command execution reachable by anyone who can write to the distributed cache. PR #41376 closed the autoloader sink for this same primitive; this sink is independent of it.

## How Has This Been Tested?

- test environment: PHP 8.3.32, sqlite, plus a second run with `memcache.local => APCu` and `memcache.distributed => Redis` (Redis 7 in Docker) — CI configures no `memcache.*` at all and is therefore blind to tiering.
- test case 1: `tests/lib/legacy/HelperTest.php` — 19 tests. A `@dataProvider` of payloads each asserted rejected *and* asserted to be replaced in the cache: `/usr/bin/php;touch /tmp/x`, `; id`, `/nonexistent/php`, `/etc/passwd` (exists, not executable), **`/usr/bin` (directory)**, `/usr/bin/curl` (executable, wrong basename), NUL-embedded, non-string types. Plus: a valid cached path is served from cache, and a missing binary is negative-cached.
- test case 2: new `tests/lib/Preview/MovieCommandTest.php` — 14 tests. Plain `Test\TestCase`, so unlike `MovieTest.php` it runs without ffmpeg installed and covers the AtomicParsley branch that is dead in CI today. Asserts each of the three command builders quotes the binary and that no metacharacter escapes.
- test case 3: real-instance poisoning A/B. After the change `findBinaryPath` writes **only** to APCu — `redis KEYS *findBinaryPath* == 0`. Planting each payload above into the local tier: every one rejected, path correctly re-resolved, poisoned entry overwritten. Setting a static to `/opt/my apps/avconv;touch /tmp/pwned` yields `'/opt/my apps/avconv;touch /tmp/pwned' -y -ss '5' ...` — one quoted token, injection inert.
- test case 4: full `tests/lib` — 7149 tests, 40221 assertions, no new failures. `make test-php-style` and phan clean on the touched files.

## Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Database schema changes (next release will require increase of minor version instead of patch)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [ ] Tests only (no source changes)

## Checklist:

- [x] Code changes
- [x] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: n/a
- [x] Changelog item, see [TEMPLATE](https://github.com/owncloud/core/blob/master/changelog/TEMPLATE)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
