### PR TITLE
perf(cache): keep host local asset and mimetype caches in the local tier

### DIFF
--- a/changelog/unreleased/41734
+++ b/changelog/unreleased/41734
@@ -1,0 +1,11 @@
+Change: Keep host local caches in the local cache tier
+
+The image paths of the active theme and the mimetype id map were stored in the
+distributed memory cache although both are derived from the files and the
+database of a single instance. They now use the host local cache tier and their
+entries expire, so a stale entry is scoped to one node and no longer lives
+forever. The repair step for mimetypes deletes rows from the mimetype table and
+now clears the mimetype cache afterwards, and occ upgrade clears both cache
+tiers instead of only the distributed one.
+
+https://github.com/owncloud/core/pull/41734

--- a/core/Command/Upgrade.php
+++ b/core/Command/Upgrade.php
@@ -30,6 +30,7 @@
 namespace OC\Core\Command;
 
 use OC\Console\TimestampFormatter;
+use OC\Memcache\LocalCacheFactory;
 use OC\Updater;
 use OCP\IConfig;
 use OCP\ILogger;
@@ -277,10 +278,10 @@ class Upgrade extends Command {
 			}
 
 			// Clear caches after successful upgrade.
-			// Caches were created before the upgrade, so the cache prefix will be the old one
-			// TODO: Note that only the "create" method is available in the interface. It isn't
-			// possible to create local or distributed caches explicitly
-			$this->cacheFactory->create()->clear();
+			// Caches were created before the upgrade, so the cache prefix will be the old one.
+			// Note that clearing the local cache only reaches the node running occ - other
+			// nodes rely on the TTLs the individual caches set on their entries.
+			$this->clearCaches();
 			return self::ERROR_SUCCESS;
 		} elseif ($this->config->getSystemValue('maintenance', false)) {
 			//Possible scenario: ownCloud core is updated but an app failed
@@ -294,6 +295,15 @@ class Upgrade extends Command {
 			$output->writeln('<info>ownCloud is already latest version</info>');
 			return self::ERROR_UP_TO_DATE;
 		}
+	}
+
+	/**
+	 * Clear both cache tiers - host local values (image paths, mime types, ...)
+	 * live in the local tier, everything else in the distributed one.
+	 */
+	private function clearCaches() {
+		$this->cacheFactory->create()->clear();
+		LocalCacheFactory::create($this->cacheFactory)->clear();
 	}
 
 	/**

--- a/lib/private/Files/Type/Loader.php
+++ b/lib/private/Files/Type/Loader.php
@@ -22,6 +22,7 @@
 namespace OC\Files\Type;
 
 use Doctrine\DBAL\Exception;
+use OC\Memcache\LocalCacheFactory;
 use OCP\Files\IMimeTypeLoader;
 use OCP\IDBConnection;
 use OCP\ICacheFactory;
@@ -37,6 +38,13 @@ use Doctrine\DBAL\Exception\UniqueConstraintViolationException;
 class Loader implements IMimeTypeLoader {
 	public const CACHE_PREFIX_FOR_ID = ':id:';
 	public const CACHE_PREFIX_FOR_MIME = ':mime:';
+
+	/**
+	 * The mimetype table only ever grows, so a cached entry cannot become
+	 * wrong - but reset() only clears the cache of the node it runs on, so
+	 * entries need to expire for the others to pick up a repair.
+	 */
+	public const CACHE_TTL = 24 * 3600;
 
 	/** @var IDBConnection */
 	private $dbConnection;
@@ -55,7 +63,7 @@ class Loader implements IMimeTypeLoader {
 	 */
 	public function __construct(IDBConnection $dbConnection, ICacheFactory $cacheFactory) {
 		$this->dbConnection = $dbConnection;
-		$this->memcache = $cacheFactory->create('mimetypes');
+		$this->memcache = LocalCacheFactory::create($cacheFactory, 'mimetypes');
 		$this->mimetypes = [];
 		$this->mimetypeIds = [];
 	}
@@ -171,8 +179,8 @@ class Loader implements IMimeTypeLoader {
 		$r->free();
 
 		// update cache
-		$this->memcache->set(self::CACHE_PREFIX_FOR_ID . $row['id'], $mimetype);
-		$this->memcache->set(self::CACHE_PREFIX_FOR_MIME . $mimetype, $row['id']);
+		$this->memcache->set(self::CACHE_PREFIX_FOR_ID . $row['id'], $mimetype, self::CACHE_TTL);
+		$this->memcache->set(self::CACHE_PREFIX_FOR_MIME . $mimetype, $row['id'], self::CACHE_TTL);
 
 		// update local vars
 		$this->mimetypes[$row['id']] = $mimetype;
@@ -232,8 +240,8 @@ class Loader implements IMimeTypeLoader {
 			$id = $row['id'];
 
 			// update cache
-			$this->memcache->set(self::CACHE_PREFIX_FOR_ID . $row['id'], $row['mimetype']);
-			$this->memcache->set(self::CACHE_PREFIX_FOR_MIME . $row['mimetype'], $row['id']);
+			$this->memcache->set(self::CACHE_PREFIX_FOR_ID . $row['id'], $row['mimetype'], self::CACHE_TTL);
+			$this->memcache->set(self::CACHE_PREFIX_FOR_MIME . $row['mimetype'], $row['id'], self::CACHE_TTL);
 
 			// update local vars
 			$this->mimetypes[$row['id']] = $row['mimetype'];
@@ -266,8 +274,8 @@ class Loader implements IMimeTypeLoader {
 			$mimetype = $row['mimetype'];
 
 			// update cache
-			$this->memcache->set(self::CACHE_PREFIX_FOR_ID . $row['id'], $row['mimetype']);
-			$this->memcache->set(self::CACHE_PREFIX_FOR_MIME . $row['mimetype'], $row['id']);
+			$this->memcache->set(self::CACHE_PREFIX_FOR_ID . $row['id'], $row['mimetype'], self::CACHE_TTL);
+			$this->memcache->set(self::CACHE_PREFIX_FOR_MIME . $row['mimetype'], $row['id'], self::CACHE_TTL);
 
 			// update local vars
 			$this->mimetypes[$row['id']] = $row['mimetype'];

--- a/lib/private/Repair.php
+++ b/lib/private/Repair.php
@@ -126,7 +126,7 @@ class Repair implements IOutput {
 	 */
 	public static function getRepairSteps() {
 		return [
-			new RepairMimeTypes(\OC::$server->getConfig()),
+			new RepairMimeTypes(\OC::$server->getConfig(), \OC::$server->getMimeTypeLoader()),
 			new RepairMismatchFileCachePath(
 				\OC::$server->getDatabaseConnection(),
 				\OC::$server->getMimeTypeLoader(),

--- a/lib/private/Repair/RepairMimeTypes.php
+++ b/lib/private/Repair/RepairMimeTypes.php
@@ -29,6 +29,7 @@
 
 namespace OC\Repair;
 
+use OCP\Files\IMimeTypeLoader;
 use OCP\Migration\IOutput;
 use OCP\Migration\IRepairStep;
 
@@ -39,15 +40,22 @@ class RepairMimeTypes implements IRepairStep {
 	protected $config;
 
 	/**
+	 * @var IMimeTypeLoader
+	 */
+	protected $mimeTypeLoader;
+
+	/**
 	 * @var int
 	 */
 	protected $folderMimeTypeId;
 
 	/**
 	 * @param \OCP\IConfig $config
+	 * @param IMimeTypeLoader|null $mimeTypeLoader
 	 */
-	public function __construct($config) {
+	public function __construct($config, IMimeTypeLoader $mimeTypeLoader = null) {
 		$this->config = $config;
+		$this->mimeTypeLoader = $mimeTypeLoader ?? \OC::$server->getMimeTypeLoader();
 	}
 
 	public function getName() {
@@ -313,12 +321,15 @@ class RepairMimeTypes implements IRepairStep {
 	 */
 	public function run(IOutput $out) {
 		$ocVersionFromBeforeUpdate = $this->config->getSystemValue('version', '0.0.0');
+		$repaired = false;
 
 		// NOTE TO DEVELOPERS: when adding new mime types, please make sure to
 		// add a version comparison to avoid doing it every time
 
 		// only update mime types if necessary as it can be expensive
 		if (\version_compare($ocVersionFromBeforeUpdate, '8.2.0', '<')) {
+			$repaired = true;
+
 			$this->fixOfficeMimeTypes();
 			$out->info('Fixed office mime types');
 
@@ -346,6 +357,7 @@ class RepairMimeTypes implements IRepairStep {
 
 		// Mimetype updates from #19272
 		if (\version_compare($ocVersionFromBeforeUpdate, '8.2.0.8', '<')) {
+			$repaired = true;
 			$this->introduceJavaMimeType();
 			$out->info('Fixed java/class mime types');
 
@@ -360,8 +372,17 @@ class RepairMimeTypes implements IRepairStep {
 		}
 
 		if (\version_compare($ocVersionFromBeforeUpdate, '9.0.0.10', '<')) {
+			$repaired = true;
 			$this->introduceRichDocumentsMimeTypes();
 			$out->info('Fixed richdocuments additional office mime types');
+		}
+
+		if ($repaired) {
+			// rows have been inserted into and deleted from the mimetypes table,
+			// so anything holding on to the old id <-> mimetype mapping has to
+			// let go of it
+			$this->mimeTypeLoader->reset();
+			$out->info('Cleared the mime type cache');
 		}
 	}
 }

--- a/lib/private/URLGenerator.php
+++ b/lib/private/URLGenerator.php
@@ -32,8 +32,10 @@
 namespace OC;
 
 use OC\Helper\EnvironmentHelper;
+use OC\Memcache\LocalCacheFactory;
 use OCP\Theme\ITheme;
 use OC_Defaults;
+use OCP\ICache;
 use OCP\ICacheFactory;
 use OCP\IConfig;
 use OCP\IURLGenerator;
@@ -44,10 +46,18 @@ use RuntimeException;
  * Class to generate URLs
  */
 class URLGenerator implements IURLGenerator {
+	/**
+	 * Image paths depend on the server root and the theme, so they are cached
+	 * per node. The TTL only exists as a safety net - nothing invalidates these
+	 * entries, so without it a moved installation would keep serving the old
+	 * paths for the lifetime of the cache.
+	 */
+	private const IMAGE_PATH_TTL = 24 * 3600;
+
 	/** @var IConfig */
 	private $config;
-	/** @var ICacheFactory */
-	private $cacheFactory;
+	/** @var ICache */
+	private $imagePathCache;
 	/** @var IRouter */
 	private $router;
 	/** @var ITheme */
@@ -69,7 +79,7 @@ class URLGenerator implements IURLGenerator {
 		EnvironmentHelper $environmentHelper
 	) {
 		$this->config = $config;
-		$this->cacheFactory = $cacheFactory;
+		$this->imagePathCache = LocalCacheFactory::create($cacheFactory, 'imagePath');
 		$this->router = $router;
 		$this->environmentHelper = $environmentHelper;
 		$this->theme = \OC_Util::getTheme();
@@ -159,16 +169,15 @@ class URLGenerator implements IURLGenerator {
 	 * Returns the path to the image.
 	 */
 	public function imagePath($app, $image) {
-		$cache = $this->cacheFactory->create('imagePath');
 		$cacheKey = $this->theme->getName().'-'.$app.'-'.$image;
-		if ($key = $cache->get($cacheKey)) {
+		if ($key = $this->imagePathCache->get($cacheKey)) {
 			return $key;
 		}
 
 		$path = $this->getImagePath($app, $image);
 
 		if ($path !== '' && $path !== null) {
-			$cache->set($cacheKey, $path);
+			$this->imagePathCache->set($cacheKey, $path, self::IMAGE_PATH_TTL);
 			return $path;
 		} else {
 			throw new RuntimeException(

--- a/tests/lib/Files/Type/LoaderTest.php
+++ b/tests/lib/Files/Type/LoaderTest.php
@@ -23,8 +23,8 @@ namespace Test\Files\Type;
 
 use OC\Files\Type\Loader;
 use OCP\IDBConnection;
-use OCP\ICacheFactory;
 use OCP\ICache;
+use Test\Memcache\FixedCacheFactory;
 
 class LoaderTest extends \Test\TestCase {
 	/** @var IDBConnection */
@@ -33,16 +33,15 @@ class LoaderTest extends \Test\TestCase {
 	protected $loader;
 	/** @var ICache */
 	protected $memcache;
+	/** @var FixedCacheFactory */
+	protected $cacheFactory;
 
 	protected function setUp(): void {
 		$this->memcache = $this->createMock(ICache::class);
-		$cacheFactoryMock = $this->createMock(ICacheFactory::class);
-		$cacheFactoryMock->expects($this->once())
-			->method('create')
-			->willReturn($this->memcache);
+		$this->cacheFactory = new FixedCacheFactory($this->memcache);
 
 		$this->db = \OC::$server->getDatabaseConnection();
-		$this->loader = new Loader($this->db, $cacheFactoryMock);
+		$this->loader = new Loader($this->db, $this->cacheFactory);
 	}
 
 	protected function tearDown(): void {
@@ -98,5 +97,38 @@ class LoaderTest extends \Test\TestCase {
 		$mimetypeId2 = $this->loader->getId('testing/mymimetype');
 
 		$this->assertEquals($mimetypeId, $mimetypeId2);
+	}
+
+	/**
+	 * The mimetype map is derived from the database of this instance, so it
+	 * belongs in the local tier - not in a distributed cache that anything able
+	 * to reach it could remap.
+	 */
+	public function testUsesTheLocalCacheTier() {
+		$cacheFactory = $this->createMock(FixedCacheFactory::class);
+		$cacheFactory->expects($this->once())
+			->method('createLocal')
+			->with('mimetypes')
+			->willReturn($this->createMock(ICache::class));
+		$cacheFactory->expects($this->never())->method('createDistributed');
+		$cacheFactory->expects($this->never())->method('create');
+
+		new Loader($this->db, $cacheFactory);
+	}
+
+	/**
+	 * Nothing invalidates the cache of the other nodes, so entries have to
+	 * expire on their own.
+	 */
+	public function testCachedEntriesExpire() {
+		$this->memcache->expects($this->atLeastOnce())
+			->method('set')
+			->with(
+				$this->anything(),
+				$this->anything(),
+				Loader::CACHE_TTL
+			);
+
+		$this->loader->getId('testing/mymimetype');
 	}
 }

--- a/tests/lib/Repair/RepairMimeTypesTest.php
+++ b/tests/lib/Repair/RepairMimeTypesTest.php
@@ -51,7 +51,7 @@ class RepairMimeTypesTest extends TestCase {
 
 		$this->storage = new Temporary([]);
 
-		$this->repair = new RepairMimeTypes($config);
+		$this->repair = new RepairMimeTypes($config, $this->mimetypeLoader);
 	}
 
 	protected function tearDown(): void {
@@ -459,6 +459,45 @@ class RepairMimeTypesTest extends TestCase {
 		$this->assertNull($this->getMimeTypeIdFromDB('application/x-font-ttf'));
 		$this->assertNull($this->getMimeTypeIdFromDB('font'));
 		$this->assertNull($this->getMimeTypeIdFromDB('font/opentype'));
+	}
+
+	/**
+	 * The repair step deletes rows from the mimetypes table, so it has to drop
+	 * the id <-> mimetype mapping the loader caches - otherwise the mapping of
+	 * a deleted mimetype survives the repair.
+	 */
+	public function testMimeTypeCacheIsResetAfterRepair() {
+		/** @var IMimeTypeLoader | MockObject $loader */
+		$loader = $this->createMock(IMimeTypeLoader::class);
+		$loader->expects($this->once())->method('reset');
+
+		/** @var IConfig | MockObject $config */
+		$config = $this->createMock(IConfig::class);
+		$config->method('getSystemValue')->with('version')->willReturn('8.0.0.0');
+
+		/** @var IOutput | MockObject $outputMock */
+		$outputMock = $this->createMock(IOutput::class);
+
+		(new RepairMimeTypes($config, $loader))->run($outputMock);
+	}
+
+	/**
+	 * Nothing was changed, so there is no reason to throw the mimetype cache of
+	 * every node away.
+	 */
+	public function testMimeTypeCacheIsKeptWhenNothingIsRepaired() {
+		/** @var IMimeTypeLoader | MockObject $loader */
+		$loader = $this->createMock(IMimeTypeLoader::class);
+		$loader->expects($this->never())->method('reset');
+
+		/** @var IConfig | MockObject $config */
+		$config = $this->createMock(IConfig::class);
+		$config->method('getSystemValue')->with('version')->willReturn('10.0.0.0');
+
+		/** @var IOutput | MockObject $outputMock */
+		$outputMock = $this->createMock(IOutput::class);
+
+		(new RepairMimeTypes($config, $loader))->run($outputMock);
 	}
 
 	/**

--- a/tests/lib/UrlGeneratorTest.php
+++ b/tests/lib/UrlGeneratorTest.php
@@ -8,11 +8,12 @@
 
 namespace Test;
 use OC\Helper\EnvironmentHelper;
+use OC\Memcache\ArrayCache;
 use OC\URLGenerator;
-use OCP\ICacheFactory;
 use OCP\IConfig;
 use OCP\IURLGenerator;
 use OCP\Route\IRouter;
+use Test\Memcache\FixedCacheFactory;
 
 /**
  * Class UrlGeneratorTest
@@ -26,10 +27,14 @@ class UrlGeneratorTest extends TestCase {
 	/** @var EnvironmentHelper | \PHPUnit\Framework\MockObject\MockObject */
 	private $environmentHelper;
 
+	/** @var ArrayCache */
+	private $imagePathCache;
+
 	public function setUp(): void {
 		parent::setUp();
 		$config = $this->createMock(IConfig::class);
-		$cacheFactory = $this->createMock(ICacheFactory::class);
+		$this->imagePathCache = new ArrayCache();
+		$cacheFactory = new FixedCacheFactory($this->imagePathCache);
 		$this->router = $this->createMock(IRouter::class);
 		$this->environmentHelper = $this->createMock(EnvironmentHelper::class);
 		$this->urlGenerator = new URLGenerator(
@@ -140,5 +145,61 @@ class UrlGeneratorTest extends TestCase {
 			["/apps/index.php", "http://localhost/owncloud/apps/index.php"],
 			["apps/index.php", "http://localhost/owncloud/apps/index.php"],
 		];
+	}
+
+	public function testImagePathIsCached() {
+		$this->environmentHelper->expects($this->any())
+			->method('getWebRoot')
+			->willReturn('/owncloud');
+		$this->environmentHelper->expects($this->any())
+			->method('getServerRoot')
+			->willReturn(\OC::$SERVERROOT);
+
+		$path = $this->urlGenerator->imagePath('', 'favicon.png');
+		$this->assertEquals('/owncloud/core/img/favicon.png', $path);
+
+		// the theme name is part of the key, so that switching themes does not
+		// serve the paths of the previous one
+		$theme = \OC_Util::getTheme()->getName();
+		$this->assertEquals($path, $this->imagePathCache->get($theme . '--favicon.png'));
+
+		// a second call is served from the cache - proven by handing out a
+		// value the filesystem would never produce
+		$this->imagePathCache->set($theme . '--favicon.png', '/from/the/cache.png');
+		$this->assertEquals('/from/the/cache.png', $this->urlGenerator->imagePath('', 'favicon.png'));
+	}
+
+	/**
+	 * Image paths are host local, so they must not be stored in the distributed
+	 * cache where another host - or anything else reaching it - could serve them
+	 * back.
+	 */
+	public function testImagePathsUseTheLocalCacheTier() {
+		$cacheFactory = $this->createMock(FixedCacheFactory::class);
+		$cacheFactory->expects($this->once())
+			->method('createLocal')
+			->with('imagePath')
+			->willReturn(new ArrayCache());
+		$cacheFactory->expects($this->never())->method('createDistributed');
+		$cacheFactory->expects($this->never())->method('create');
+
+		new URLGenerator(
+			$this->createMock(IConfig::class),
+			$cacheFactory,
+			$this->router,
+			$this->environmentHelper
+		);
+	}
+
+	public function testImagePathThrowsForMissingImage() {
+		$this->environmentHelper->expects($this->any())
+			->method('getWebRoot')
+			->willReturn('/owncloud');
+		$this->environmentHelper->expects($this->any())
+			->method('getServerRoot')
+			->willReturn(\OC::$SERVERROOT);
+
+		$this->expectException(\RuntimeException::class);
+		$this->urlGenerator->imagePath('', 'this-image-does-not-exist.gif');
 	}
 }


### PR DESCRIPTION
## Description

> ⚠️ **Stacked on #41732** (base is `fix/ghsa-488r-findbinarypath-cache-poisoning`, which introduces `LocalCacheFactory` and the `FixedCacheFactory` test double). Review/merge that one first; the base flips to `master` once it lands.

Moves two host-local caches out of the distributed tier and into the local one, and adds the TTLs and the invalidation that makes doing so correct.

**`URLGenerator::imagePath()`** — the cache is now resolved **once in the constructor** instead of calling `create()` on every invocation (`:162`), and entries get a 24 h TTL (they were unbounded). Local tiering here is *strictly* better than what we had: these entries are **never invalidated anywhere today** and the key embeds the theme name, so staleness becomes node-scoped and dies with the worker instead of persisting cluster-wide forever. Measured 0.019 ms → 0.0027 ms per call, ~60 icons per page, so the cache is well worth keeping — just not in the shared tier.

**`Files\Type\Loader`** — same tier move plus a `CACHE_TTL` applied at all six `set()` sites, which were unbounded. Worth keeping too: a 500-file listing costs 1.98 ms uncached vs 0.375 ms cached. `reset()` keeps clearing its own cache; that method exists to repair *this* process's view after a parallel-scan unique-constraint race (`Files/Cache/Scanner.php:474`, which clears its in-memory arrays right there), so local scope is the correct scope. Today's behaviour — one scanner losing a race nukes every node's mimetype map — is over-broad.

**Latent bug fixed here because it is what makes the tiering defensible:** `Repair\RepairMimeTypes` **deletes rows** from `*PREFIX*mimetypes` with no cache invalidation at all, so a deleted mimetype's id→name mapping survived the repair. It now takes an optional `IMimeTypeLoader` (defaulted, so third-party construction keeps working) and calls `->reset()` at the end of `run()` — but only when something was actually repaired, so a no-op upgrade doesn't throw every node's map away. Single construction site `lib/private/Repair.php:129` updated.

**`core/Command/Upgrade.php`** — the blanket `create()->clear()` only ever reached the distributed tier. It now clears both, and the stale TODO is rewritten. Residual limit stated plainly in the code comment: clearing local from CLI only clears the node running `occ`, so bounded staleness now comes from the new TTLs plus worker restarts. That is exactly why the TTLs are in *this* PR and not a follow-up.

Untouched on purpose: the **locking** cache (2.96 ms DB vs 0.023 ms memcache per file — 130×) and everything genuinely cluster-shared.

## Related Issue

- Fixes n/a — follow-up hardening from the GHSA-488r-cjpq-p3vc investigation

## Motivation and Context

Host-local values in a network-reachable, protocol-injectable backend are a standing supply of write primitives like the one in #41732. Neither of these two needs to be shared between nodes, and moving them also makes their staleness bounded rather than permanent.

## How Has This Been Tested?

- test environment: PHP 8.3.32, sqlite, plus a run with `memcache.local => APCu` + `memcache.distributed => Redis` — CI sets no `memcache.*` and is blind to tiering. (Note for anyone reproducing: `OC\Memcache\APCu::isAvailable()` gates on the ini key **`apc.enable_cli`**, not `apcu.enable_cli`, or the local tier silently degrades to `NullCache` on CLI.)
- test case 1: `tests/lib/Files/Type/LoaderTest.php` — the old `->expects($this->once())->method('create')` mock is replaced with `FixedCacheFactory`; new `testUsesTheLocalCacheTier()` (asserts `createLocal('mimetypes')` once, `create`/`createDistributed` never) and `testCachedEntriesExpire()` (asserts `set()` receives `Loader::CACHE_TTL`).
- test case 2: `tests/lib/UrlGeneratorTest.php` — new `testImagePathIsCached()` (asserts the resolved path, that the theme name is part of the key, and that a planted value is served on the second call), `testImagePathsUseTheLocalCacheTier()`, `testImagePathThrowsForMissingImage()`.
- test case 3: `tests/lib/Repair/RepairMimeTypesTest.php` — `testMimeTypeCacheIsResetAfterRepair()` (version 8.0.0.0 → `reset()` once) and `testMimeTypeCacheIsKeptWhenNothingIsRepaired()` (version 10.0.0.0 → never).
- test case 4: **negative verification** — each new test was re-run with the source change temporarily reverted and confirmed to fail (3 failures), then restored. A test that passes either way proves nothing.
- test case 5: real-instance A/B — after the change `imagePath` and `mimetypes` keys exist **only** in APCu, with `redis KEYS` returning **0** for both namespaces; icons and mimetypes still resolve correctly.
- test case 6: full `tests/lib` — 7149 tests, 40221 assertions, no new failures. `make test-php-style` and phan clean.

## Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Database schema changes (next release will require increase of minor version instead of patch)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Technical debt
- [ ] Tests only (no source changes)

## Checklist:

- [x] Code changes
- [x] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: n/a
- [x] Changelog item, see [TEMPLATE](https://github.com/owncloud/core/blob/master/changelog/TEMPLATE)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
