### PR TITLE
fix(integrity): clear stale per app results and use the local cache tier

### DIFF
--- a/changelog/unreleased/41735
+++ b/changelog/unreleased/41735
@@ -1,0 +1,11 @@
+Bugfix: Clear stale integrity check results when rescanning
+
+The code integrity checker stores one cache entry per checked scope, but a
+rescan only removed the entry holding the combined results. The per app entries
+had no expiry either, so a verdict about an app was cached indefinitely and was
+served even after the app had been repaired or replaced. Rescanning now clears
+all of them, the entries expire, and the results are kept in the host local
+cache tier - they describe the files on disk of one host and are of no use to
+another.
+
+https://github.com/owncloud/core/pull/41735

--- a/lib/private/IntegrityCheck/Checker.php
+++ b/lib/private/IntegrityCheck/Checker.php
@@ -55,6 +55,14 @@ use OCP\ILogger;
  */
 class Checker implements OnDiskHasher {
 	public const CACHE_KEY = 'oc.integritycheck.checker';
+
+	/**
+	 * The results describe the files on disk of this instance, so cached entries
+	 * have to expire for a node that never runs a check itself to notice a
+	 * repaired or replaced installation.
+	 */
+	public const CACHE_TTL = 24 * 3600;
+
 	/** @var EnvironmentHelper */
 	private $environmentHelper;
 	/** @var AppLocator */
@@ -104,7 +112,9 @@ class Checker implements OnDiskHasher {
 		$this->fileAccessHelper = $fileAccessHelper;
 		$this->appLocator = $appLocator;
 		$this->config = $config;
-		$this->cache = $cacheFactory ? $cacheFactory->create(self::CACHE_KEY) : new \OC\Memcache\NullCache();
+		$this->cache = $cacheFactory
+			? \OC\Memcache\LocalCacheFactory::create($cacheFactory, self::CACHE_KEY)
+			: new \OC\Memcache\NullCache();
 		$this->appManager = $appManager;
 		$this->tempManager = $tempManager;
 		$this->verifier = $verifier;
@@ -400,17 +410,21 @@ class Checker implements OnDiskHasher {
 
 		$this->setAppValue(self::CACHE_KEY, \json_encode($resultArray));
 		//Set cache for each app
-		$this->cache->set($scope, \json_encode($resultArray));
-		$this->cache->set(self::CACHE_KEY, \json_encode($resultArray));
+		$this->cache->set($scope, \json_encode($resultArray), self::CACHE_TTL);
+		$this->cache->set(self::CACHE_KEY, \json_encode($resultArray), self::CACHE_TTL);
 	}
 
 	/**
+	 * Clean previous results for a proper rescanning. Otherwise a stale verdict
+	 * would be served instead of the one the rescan is about to produce.
 	 *
-	 * Clean previous results for a proper rescanning. Otherwise
+	 * storeResults() writes one entry per scope in addition to CACHE_KEY, so the
+	 * whole prefix is cleared - removing CACHE_KEY alone left every per app entry
+	 * behind.
 	 */
 	private function cleanResults() {
 		$this->deleteAppValue(self::CACHE_KEY);
-		$this->cache->remove(self::CACHE_KEY);
+		$this->cache->clear();
 	}
 
 	/**

--- a/tests/lib/IntegrityCheck/CheckerTest.php
+++ b/tests/lib/IntegrityCheck/CheckerTest.php
@@ -27,11 +27,12 @@ use OC\IntegrityCheck\Helpers\EnvironmentHelper;
 use OC\IntegrityCheck\Helpers\FileAccessHelper;
 use OC\IntegrityCheck\Verifier\Verifier;
 use OC\IntegrityCheck\Verifier\VerificationResult;
+use OC\Memcache\ArrayCache;
 use OC\Memcache\NullCache;
 use OC\Memcache\Redis;
 use OCP\App\IAppManager;
-use OCP\ICacheFactory;
 use OCP\IConfig;
+use Test\Memcache\FixedCacheFactory;
 use Test\TestCase;
 
 /**
@@ -48,7 +49,7 @@ class CheckerTest extends TestCase {
 	private $fileAccessHelper;
 	/** @var IConfig | \PHPUnit\Framework\MockObject\MockObject */
 	private $config;
-	/** @var ICacheFactory | \PHPUnit\Framework\MockObject\MockObject */
+	/** @var FixedCacheFactory */
 	private $cacheFactory;
 	/** @var IAppManager | \PHPUnit\Framework\MockObject\MockObject */
 	private $appManager;
@@ -61,7 +62,7 @@ class CheckerTest extends TestCase {
 		$this->fileAccessHelper = $this->createMock(FileAccessHelper::class);
 		$this->appLocator = $this->createMock(AppLocator::class);
 		$this->config = $this->createMock(IConfig::class);
-		$this->cacheFactory = $this->createMock(ICacheFactory::class);
+		$this->cacheFactory = new FixedCacheFactory(new NullCache());
 		$this->appManager = $this->createMock(IAppManager::class);
 		$this->verifier = $this->createMock(Verifier::class);
 
@@ -87,12 +88,6 @@ class CheckerTest extends TestCase {
 			->method('getAllApps')
 			->willReturn([]);
 
-		$this->cacheFactory
-			->expects($this->any())
-			->method('create')
-			->with('oc.integritycheck.checker')
-			->willReturn(new NullCache());
-
 		$this->checker = new Checker(
 			$this->environmentHelper,
 			$this->fileAccessHelper,
@@ -103,6 +98,69 @@ class CheckerTest extends TestCase {
 			\OC::$server->getTempManager(),
 			$this->verifier
 		);
+
+		$this->assertSame([Checker::CACHE_KEY], $this->cacheFactory->getRequestedPrefixes());
+	}
+
+	/**
+	 * The results describe the files on disk of this host, so they belong in the
+	 * host local cache tier - not in a distributed one where another host could
+	 * hand back a verdict about an installation it cannot see.
+	 */
+	public function testUsesTheLocalCacheTier() {
+		$cacheFactory = $this->createMock(FixedCacheFactory::class);
+		$cacheFactory->expects($this->once())
+			->method('createLocal')
+			->with(Checker::CACHE_KEY)
+			->willReturn(new NullCache());
+		$cacheFactory->expects($this->never())->method('createDistributed');
+		$cacheFactory->expects($this->never())->method('create');
+
+		new Checker(
+			$this->environmentHelper,
+			$this->fileAccessHelper,
+			$this->appLocator,
+			$this->config,
+			$cacheFactory,
+			$this->appManager,
+			\OC::$server->getTempManager(),
+			$this->verifier
+		);
+	}
+
+	/**
+	 * storeResults() writes one entry per scope next to CACHE_KEY, and a rescan
+	 * has to invalidate all of them - removing CACHE_KEY alone left every per app
+	 * verdict cached forever.
+	 */
+	public function testRescanningDropsThePerAppResults() {
+		$cache = new ArrayCache();
+		$checker = new Checker(
+			$this->environmentHelper,
+			$this->fileAccessHelper,
+			$this->appLocator,
+			$this->config,
+			new FixedCacheFactory($cache),
+			$this->appManager,
+			\OC::$server->getTempManager(),
+			$this->verifier
+		);
+
+		$this->environmentHelper->method('getChannel')->willReturn('stable');
+		$this->environmentHelper->method('getServerRoot')->willReturn(\OC::$SERVERROOT);
+		$this->verifier->method('verify')->willReturn(VerificationResult::passed());
+
+		$cache->set('SomeApp', '{"SomeApp":[]}');
+		$cache->set('SomeOtherApp', '{"SomeOtherApp":[]}');
+		$cache->set(Checker::CACHE_KEY, '{"SomeApp":[]}');
+
+		$checker->runInstanceVerification();
+
+		// only the results of this run are left - the verification passed, so
+		// there is nothing to report
+		$this->assertNull($cache->get('SomeApp'));
+		$this->assertNull($cache->get('SomeOtherApp'));
+		$this->assertSame('[]', $cache->get(Checker::CACHE_KEY));
 	}
 
 	public function testIgnoredAppSignatureWithoutSignatureData() {
@@ -630,12 +688,7 @@ class CheckerTest extends TestCase {
 		$redisObj->method('get')
 			->with('SomeApp')
 			->willReturn('[]');
-		$cacheFactory = $this->createMock(ICacheFactory::class);
-		$cacheFactory
-			->expects($this->any())
-			->method('create')
-			->with('oc.integritycheck.checker')
-			->will($this->returnValue($redisObj));
+		$cacheFactory = new FixedCacheFactory($redisObj);
 		$checker = new Checker(
 			$this->environmentHelper,
 			$this->fileAccessHelper,
@@ -654,12 +707,7 @@ class CheckerTest extends TestCase {
 		$redisObj->method('get')
 			->with('SomeApp')
 			->willReturn(null);
-		$cacheFactory = $this->createMock(ICacheFactory::class);
-		$cacheFactory
-			->expects($this->any())
-			->method('create')
-			->with('oc.integritycheck.checker')
-			->will($this->returnValue($redisObj));
+		$cacheFactory = new FixedCacheFactory($redisObj);
 		$checker = new Checker(
 			$this->environmentHelper,
 			$this->fileAccessHelper,
@@ -702,10 +750,7 @@ class CheckerTest extends TestCase {
 				]
 			]));
 
-		$cacheFactory = $this->createMock(ICacheFactory::class);
-		$cacheFactory->expects($this->any())
-			->method('create')
-			->willReturn(new NullCache());
+		$cacheFactory = new FixedCacheFactory(new NullCache());
 
 		$checker = new Checker(
 			$this->environmentHelper,
@@ -732,10 +777,7 @@ class CheckerTest extends TestCase {
 			->with('core', 'oc.integritycheck.checker', '{}')
 			->willReturn('{}');
 
-		$cacheFactory = $this->createMock(ICacheFactory::class);
-		$cacheFactory->expects($this->any())
-			->method('create')
-			->willReturn(new NullCache());
+		$cacheFactory = new FixedCacheFactory(new NullCache());
 
 		$checker = new Checker(
 			$this->environmentHelper,
@@ -766,10 +808,7 @@ class CheckerTest extends TestCase {
 				]
 			]));
 
-		$cacheFactory = $this->createMock(ICacheFactory::class);
-		$cacheFactory->expects($this->any())
-			->method('create')
-			->willReturn(new NullCache());
+		$cacheFactory = new FixedCacheFactory(new NullCache());
 
 		$checker = new Checker(
 			$this->environmentHelper,


### PR DESCRIPTION
## Description

> ⚠️ **Stacked on #41734** (base is `perf/tier-host-local-caches`). Review/merge that first; the base flips to `master` once the stack lands.

Fixes a real invalidation bug in the code integrity checker and moves its cache to the local tier. The tier move alone would be hard to justify, so it is paired with the bug that shares its root cause.

**The bug:** `storeResults()` writes one cache entry **per checked scope** — `core`, plus one per app — with no TTL (`Checker.php:403`), while `cleanResults()` removed **only** `CACHE_KEY` (`:411-413`). The per-app entries were therefore **never invalidated**, cluster-wide, forever. A verdict about an app was cached indefinitely and kept being served after the app was repaired or replaced. Those stale verdicts are read via `getVerifiedAppsFromCache()` into `lib/private/legacy/app.php:808`, `settings/Controller/CheckSetupController.php:229-306` and `lib/private/TemplateLayout.php:69`.

**The fix** is one line: `cleanResults()` now calls `$this->cache->clear()` instead of `remove(self::CACHE_KEY)`. `ICache::clear($prefix = '')` is `@since 6.0.0` and prefix-scoped in every backend (Redis SCANs `prefix*`, APCu uses `APCUIterator`, ArrayCache truncates), so it drops the per-app keys *and* `CACHE_KEY` without touching other namespaces. This fixes local **and** distributed deployments.

Belt-and-braces: a `CACHE_TTL` (24 h) on the per-scope writes, so a node that never runs `cleanResults()` itself still notices a repaired installation.

**The tier move:** these results describe the files **on disk of one host** and are of no use to another — a second node consuming them is wrong even when nothing is malicious. `__construct` now uses `LocalCacheFactory`, keeping the existing null-factory branch.

Low-risk because `getResults()` already falls back to appconfig (`:378-385`), so `occ integrity:check-core` followed by a web request keeps working regardless of tier.

### Flagged but deliberately NOT fixed here

`storeResults():403` writes the whole `$resultArray` under the per-scope key, so `getVerifiedAppsFromCache()` returns a JSON **string** while the uncached `verifyAppSignature()` returns an **array**. `app.php:808`'s `empty($result)` then yields a different `level`/`removable` depending on cache warmth. That is an observable-semantics change and `CheckerTest.php:628-650` currently pins the string behaviour, so it belongs in its own PR.

## Related Issue

- Fixes n/a — found while auditing distributed-cache usage for GHSA-488r-cjpq-p3vc

## Motivation and Context

Per-app integrity verdicts were cached forever with no way to invalidate them, and they were shared between nodes that they do not describe.

## How Has This Been Tested?

- test environment: PHP 8.3.32, sqlite, plus a run with `memcache.local => APCu` + `memcache.distributed => Redis`.
- test case 1: `testRescanningDropsThePerAppResults()` — seeds `SomeApp`, `SomeOtherApp` and `CACHE_KEY` into an `ArrayCache`, runs `runInstanceVerification()`, asserts the per-app keys are gone and `CACHE_KEY` is `'[]'`. This is the test that justifies the PR.
- test case 2: `testUsesTheLocalCacheTier()`.
- test case 3: `tests/lib/IntegrityCheck/CheckerTest.php` builds a factory at six sites; all now use `FixedCacheFactory`, including the two that wrap `createMock(Redis::class)` and assert cache semantics (`testVerifyCachedAppSignatureCheck`, `testAppNotCachedSignatureCheck`) — so they keep asserting exactly what they asserted before. The prefix constraint that `->with('oc.integritycheck.checker')` used to pin is now covered by `getRequestedPrefixes()`. 193 tests, 417 assertions, all green.
- test case 4: **negative verification** — both new tests confirmed to fail with the source change reverted, then restored.
- test case 5: real-instance — seeded two stale per-app verdicts into APCu, ran `runInstanceVerification()`, confirmed both cleared, `redis KEYS *integritycheck* == 0`, TTL present at 86400 s.
- test case 6: full `tests/lib` — 7149 tests, 40221 assertions, no new failures. `make test-php-style` and phan clean.

## Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Database schema changes (next release will require increase of minor version instead of patch)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [ ] Tests only (no source changes)

## Checklist:

- [x] Code changes
- [x] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: n/a
- [x] Changelog item, see [TEMPLATE](https://github.com/owncloud/core/blob/master/changelog/TEMPLATE)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
