### PR TITLE
test(user): cover HTML metacharacters in username validation

### DIFF
--- a/changelog/unreleased/username-metachar-regression-test
+++ b/changelog/unreleased/username-metachar-regression-test
@@ -1,4 +1,4 @@
-Tests: Cover HTML metacharacters in the username validation allow-list
+Change: Cover HTML metacharacters in the username validation allow-list
 
 The username allow-list in OC\User\Manager::createUser() already rejects every
 character outside "a-z", "A-Z", "0-9" and "+_.@-'", which blocks HTML and script

--- a/changelog/unreleased/username-metachar-regression-test
+++ b/changelog/unreleased/username-metachar-regression-test
@@ -1,0 +1,14 @@
+Tests: Cover HTML metacharacters in the username validation allow-list
+
+The username allow-list in OC\User\Manager::createUser() already rejects every
+character outside "a-z", "A-Z", "0-9" and "+_.@-'", which blocks HTML and script
+metacharacters from ever reaching a stored username. That behaviour was only
+covered by three generic invalid-character cases, none of which resembled an
+injection payload.
+
+The invalid-character data provider now also exercises quote, angle-bracket and
+full script-tag payloads, so any future relaxation of the allow-list that would
+let markup into a username fails the test suite instead of passing unnoticed.
+This is test-only coverage; no production behaviour changes.
+
+https://github.com/owncloud/core/pull/41738

--- a/tests/lib/User/ManagerTest.php
+++ b/tests/lib/User/ManagerTest.php
@@ -370,6 +370,11 @@ class ManagerTest extends TestCase {
 			['John#Smith'],
 			['John^Smith'],
 			['JohnSmith(CEO)'],
+			// HTML/script metacharacters must never reach a username
+			['"><script>alert(document.cookie)</script>'],
+			['<img src=x onerror=alert(1)>'],
+			['John<b>Smith'],
+			['John"Smith'],
 		];
 	}
 


### PR DESCRIPTION
## Summary

Adds regression coverage for HTML/script metacharacters in the username
validation allow-list. **Test-only — no production behaviour changes.**

`OC\User\Manager::createUser()` already rejects every character outside
`a-z`, `A-Z`, `0-9` and `+_.@-'`, so markup can never reach a stored
username. That guard was only exercised by three generic invalid-character
cases (`John#Smith`, `John^Smith`, `JohnSmith(CEO)`), none of which looked
like an injection payload. This extends the data provider so a future
relaxation of the allow-list fails the suite instead of passing unnoticed.

Added cases:

- `"><script>alert(document.cookie)</script>`
- `<img src=x onerror=alert(1)>`
- `John<b>Smith`
- `John"Smith`

## Background

This came out of triaging an external report claiming stored XSS via the
username field in `/settings/users`. The report did not reproduce: the
allow-list rejects the payload server-side at
`lib/private/User/Manager.php`, and the render sink in
`settings/js/users/users.js` uses jQuery `.text()` (`textContent`), so no
markup is interpretable. Both admin-panel and provisioning-API creation
paths funnel through the same `createUser()` method, so there is no
bypassing path.

No fix was required. These tests exist so that conclusion stays true.

## Testing

```
$ phpunit -c tests/phpunit-autotest.xml --filter testUsernameHasInvalidChars
OK (7 tests, 14 assertions)

$ phpunit -c tests/phpunit-autotest.xml tests/lib/User/ManagerTest.php
OK (42 tests, 95 assertions)
```

Both new payloads confirmed rejected by the existing regex; full
`ManagerTest` green with no regressions.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
