### PR TITLE
fix(routing): request legacy ajax endpoints through the front controller

### DIFF
--- a/apps/files_external/js/gdrive.js
+++ b/apps/files_external/js/gdrive.js
@@ -1,6 +1,6 @@
 $(document).ready(function() {
 	var backendId = 'googledrive';
-	var backendUrl = OC.generateUrl('apps/files_external/ajax/oauth2.php');
+	var backendUrl = OC.generateUrl('/index.php/apps/files_external/ajax/oauth2.php');
 
 	function generateUrl($tr) {
 		// no mapping between client ID and Google 'project', so we always load the same URL

--- a/apps/files_sharing/js/public.js
+++ b/apps/files_sharing/js/public.js
@@ -228,7 +228,7 @@ OCA.Sharing.PublicApp = {
 				urlSpec.x = Math.ceil(urlSpec.x);
 				urlSpec.y = Math.ceil(urlSpec.y);
 				urlSpec.t = $('#dirToken').val();
-				return OC.generateUrl('/apps/files_sharing/ajax/publicpreview.php?') + $.param(urlSpec);
+				return OC.generateUrl('/index.php/apps/files_sharing/ajax/publicpreview.php') + '?' + $.param(urlSpec);
 			};
 
 			this.fileList.updateEmptyContent = function () {

--- a/apps/files_trashbin/js/filelist.js
+++ b/apps/files_trashbin/js/filelist.js
@@ -275,7 +275,7 @@
 		},
 
 		generatePreviewUrl: function(urlSpec) {
-			return OC.generateUrl('/apps/files_trashbin/ajax/preview.php?') + $.param(urlSpec);
+			return OC.generateUrl('/index.php/apps/files_trashbin/ajax/preview.php') + '?' + $.param(urlSpec);
 		},
 
 		getDownloadUrl: function() {

--- a/changelog/unreleased/41743
+++ b/changelog/unreleased/41743
@@ -1,0 +1,18 @@
+Bugfix: Request legacy ajax endpoints through the front controller
+
+The front controller rewrite only forwards a request to index.php when the
+requested path does not exist on disk. Five javascript call sites requested a url
+that was itself a real file, so the web server executed the script directly,
+without the bootstrap index.php would have performed, and the request died with a
+fatal error (HTTP 500): changing the personal language, the share dialog e-mail
+lookup, the Google Drive OAuth entry point, and the trashbin and public link
+preview thumbnails.
+
+All five now build their url with an explicit /index.php/ prefix so that the
+request no longer matches a file on disk and reaches the router. The prefix has
+to be part of the url literal because OC.generateUrl() omits /index.php when
+mod_rewrite is active, which is how four of the five came to request the shadowed
+url in the first place.
+
+https://github.com/owncloud/core/issues/41740
+https://github.com/owncloud/core/pull/41743

--- a/core/js/sharedialogmailview.js
+++ b/core/js/sharedialogmailview.js
@@ -208,7 +208,7 @@
 						if (this.xhr != null)
 							this.xhr.abort();
 
-						var xhr = $.get(OC.generateUrl('core/ajax/share.php'), {
+						var xhr = $.get(OC.generateUrl('/index.php/core/ajax/share.php'), {
 							'fetch' : 'getShareWithEmail',
 							'search': query.term
 						}).done(function(result) {

--- a/settings/js/panels/profile.js
+++ b/settings/js/panels/profile.js
@@ -213,7 +213,7 @@ $(document).ready(function () {
 		// Serialize the data
 		var post = $("#languageinput").serialize();
 		// Ajax foo
-		$.post('ajax/setlanguage.php', post, function (data) {
+		$.post(OC.generateUrl('/index.php/settings/ajax/setlanguage.php'), post, function (data) {
 			if (data.status === "success") {
 				location.reload();
 			}


### PR DESCRIPTION
## Description

Minimal fix for #41740 — **5 files, 5 lines**, no route or test-fixture changes.

The front controller rewrite generated by `\OC\Setup::updateHtaccess()` only
forwards a request to `index.php` when the requested path does **not** exist on
disk:

```apache
RewriteCond %{REQUEST_FILENAME} !-f
RewriteRule . index.php [PT,E=PATH_INFO:$1]
```

Five javascript call sites requested a url that **is** a real file. Apache
therefore executed those scripts directly, without the bootstrap `index.php`
would have performed, and each request died with a fatal error → HTTP 500.

Each call site was audited by executing the *shipped* `OC.generateUrl()` /
`OC.filePath()` with a real runtime config (`modRewriteWorking:true`,
`oc_webroot:""`) to get the url the browser actually requests, then probing that
url with an authenticated admin session on a pristine
`owncloud/server:11.0.0-rc2`:

| broken feature | call site | requested url | fatal error |
| --- | --- | --- | --- |
| change personal language | `settings/js/panels/profile.js:216` | `/settings/ajax/setlanguage.php` | `Class "OC" not found` |
| share dialog e-mail lookup | `core/js/sharedialogmailview.js:211` | `/core/ajax/share.php` | `Class "OC" not found` |
| Google Drive OAuth entry point | `apps/files_external/js/gdrive.js:3` | `/apps/files_external/ajax/oauth2.php` | `Class "OCP\JSON" not found` |
| trashbin preview thumbnails | `apps/files_trashbin/js/filelist.js:278` | `/apps/files_trashbin/ajax/preview.php` | `Class "OC_Util" not found` |
| public link preview thumbnails | `apps/files_sharing/js/public.js:231` | `/apps/files_sharing/ajax/publicpreview.php` | `Class "OCP\JSON" not found` |

## What this changes

All five now build their url with an explicit `/index.php/` prefix, so the
request no longer matches a file on disk and reaches the router.

**The prefix has to be part of the url literal.** `OC.generateUrl()` omits
`/index.php` when `modRewriteWorking` is set (`core/js/js.js`), which is exactly
how four of these five came to request the shadowed url in the first place — the
obvious `OC.generateUrl('/core/ajax/share.php')` silently produces the broken
form.

`settings/js/panels/profile.js` is the odd one out: it posted the **relative**
path `'ajax/setlanguage.php'`, which the browser resolved against
`/settings/personal`. It never went through `OC.generateUrl()` at all.

Not touched: `apps/files_sharing/js/public.js:157,164` also point at
`publicpreview.php` but use `OC.filePath()`, which already injects `/index.php/`
for non-core app `.php` files — those were never broken.

## Verification

Measured on a freshly installed, pristine `owncloud/server:11.0.0-rc2`
(`htaccess.RewriteBase => '/'`, stock `.htaccess`) with an authenticated admin
session — an authenticated session is what distinguishes "the script ran" from
the router's `302 → /login`:

| endpoint | before | after |
| --- | --- | --- |
| change language | **500** | **200** `{"status":"success","message":"Language changed"}`, persists `admin\|core\|lang\|de` |
| `core/ajax/share` (getItem) | **500** | **200** |
| `files_external/ajax/oauth2` | **500** | **200** |
| trashbin preview, real trashed file | **500** | **200**, returns PNG image data |
| trashbin preview, no `file` param | **500** | **400** — the script's own validation, i.e. it bootstrapped |

No jasmine spec or acceptance test asserts any of these five urls
(`tests/acceptance/features/bootstrap/Sharing.php:3487` already uses the
`/index.php/` form), so no test changes are needed.

## Relationship to #41742

This PR fixes the reported breakage and nothing else, so it is small enough to
review at a glance and to backport.

It does **not** remove the underlying bug class: the route urls still resolve to
files on disk, so those routes remain unreachable at their own declared urls, and
the next author who writes the obvious `OC.generateUrl('/core/ajax/share.php')`
will reintroduce exactly this bug.

**#41742 is stacked on this branch** and removes the shadowing itself: route urls
lose the `.php` suffix, the remaining `OC.filePath()` call sites move to
`OC.generateUrl()`, five long-dead routes go away, and a bundle-wide guard test
fails if any route url resolves to a file on disk. It also drops the
`/index.php/` prefixes this PR adds — with the shadowing gone they are no longer
needed. Merge order: this PR first, then #41742 (or just #41742 if you prefer to
take the whole thing at once).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
