### PR TITLE
test: run acceptance tests with postgres 10.21

### DIFF
--- a/.github/workflows/acceptance.yml
+++ b/.github/workflows/acceptance.yml
@@ -86,7 +86,7 @@ jobs:
     services:
       mysql:
         image: >-
-          ${{ (startsWith(matrix.database,'mysql:') || startsWith(matrix.database,'mariadb:')) && matrix.database || '' }}
+          ${{ case(startsWith(matrix.database,'mysql:') || startsWith(matrix.database,'mariadb:'), matrix.database, inputs.federated-folder != '', 'mariadb:10.6', '') }}
         env:
           MYSQL_ROOT_PASSWORD: password
           MYSQL_DATABASE: owncloud
@@ -100,7 +100,7 @@ jobs:
         ports:
           - 3306:3306
       postgres:
-        image: ${{ startsWith(matrix.database,'postgres:') && matrix.database || '' }}
+        image: ${{ case(startsWith(matrix.database,'postgres:'), matrix.database, '') }}
         env:
           POSTGRES_DB: owncloud
           POSTGRES_USER: owncloud

--- a/.github/workflows/acceptance.yml
+++ b/.github/workflows/acceptance.yml
@@ -10,7 +10,7 @@ on:
         description: JSON array of databases
         required: false
         type: string
-        default: '["mariadb:10.6"]'
+        default: '["postgres:10.21"]'
       test-suites:
         description: JSON array of acceptance test suite names
         required: false

--- a/.github/workflows/php-unit.yml
+++ b/.github/workflows/php-unit.yml
@@ -31,7 +31,7 @@ jobs:
     services:
       mysql:
         image: >-
-          ${{ (startsWith(matrix.database,'mysql:') || startsWith(matrix.database,'mariadb:')) && matrix.database || '' }}
+          ${{ case(startsWith(matrix.database,'mysql:') || startsWith(matrix.database,'mariadb:'), matrix.database, '') }}
         env:
           MYSQL_ROOT_PASSWORD: password
           MYSQL_DATABASE: owncloud
@@ -45,7 +45,7 @@ jobs:
         ports:
           - 3306:3306
       postgres:
-        image: ${{ startsWith(matrix.database,'postgres:') && matrix.database || '' }}
+        image: ${{ case(startsWith(matrix.database,'postgres:'), matrix.database, '') }}
         env:
           POSTGRES_DB: owncloud
           POSTGRES_USER: owncloud


### PR DESCRIPTION
That version is also used in a unit test workflow. This is a single-use PR to run the tests to check
that the API is working fine with PostgreSQL.
