### PR TITLE
ci: always start mariadb service for federated tests

### DIFF
--- a/.github/workflows/acceptance.yml
+++ b/.github/workflows/acceptance.yml
@@ -86,7 +86,7 @@ jobs:
     services:
       mysql:
         image: >-
-          ${{ (startsWith(matrix.database,'mysql:') || startsWith(matrix.database,'mariadb:')) && matrix.database || '' }}
+          ${{ case(startsWith(matrix.database,'mysql:') || startsWith(matrix.database,'mariadb:'), matrix.database, inputs.federated-folder != '', 'mariadb:10.6', '') }}
         env:
           MYSQL_ROOT_PASSWORD: password
           MYSQL_DATABASE: owncloud
@@ -100,7 +100,7 @@ jobs:
         ports:
           - 3306:3306
       postgres:
-        image: ${{ startsWith(matrix.database,'postgres:') && matrix.database || '' }}
+        image: ${{ case(startsWith(matrix.database,'postgres:'), matrix.database, '') }}
         env:
           POSTGRES_DB: owncloud
           POSTGRES_USER: owncloud


### PR DESCRIPTION
For federated tests, we always us mariadb for the federated server, the same as was done in the drone configs. So for federated tests, start the mariadb service even if the local system will be using PostgreSQL.

This allows test workflows with PostgreSQL database selected for the local system-under-test database, and also a federated server, to work. PR #41745 and #41746 demonstrate that the acceptance tests pass for that configuration.

This is the same sort of fix as was done in https://github.com/owncloud/reusable-workflows/pull/86
