### PR TITLE
test: remove mentions of Oracle from the acceptance tests

### DIFF
--- a/tests/acceptance/features/apiTrashbin/trashbinFilesFoldersOc10Issue23151.feature
+++ b/tests/acceptance/features/apiTrashbin/trashbinFilesFoldersOc10Issue23151.feature
@@ -12,8 +12,8 @@ Feature: files and folders exist in the trashbin after being deleted
   # On a very slow system, the file deletes might all happen in different seconds.
   # But on "reasonable" systems, some of the files will be deleted in the same second,
   # thus testing the required behavior.
-  # Note: skipOnDbOracle because Oracle is slow and so "close together in time" does not really happen
-  @issue-23151 @skipOnDbOracle
+  # Pgsql database can have different sorting, so allow this scenario to be skipped on that
+  @issue-23151 @skipOnDbPgsql
   Scenario Outline: trashbin can store two files with the same name but different origins when the files are deleted close together in time
     Given using <dav-path> DAV path
     And user "Alice" has created folder "/folderA"

--- a/tests/acceptance/features/cliExternalStorage/filesExternalWebdavOwncloud.feature
+++ b/tests/acceptance/features/cliExternalStorage/filesExternalWebdavOwncloud.feature
@@ -11,7 +11,7 @@ Feature: using files external service with storage as webdav_owncloud
     And user "Alice" has created folder "TestMnt"
     And using server "LOCAL"
 
-  @issue-38165 @skipOnDbOracle
+  @issue-38165
   Scenario: creating a webdav_owncloud external storage
     When the administrator creates an external mount point with the following configuration about user "Alice" using the occ command
       | host                   | %remote_server%    |
@@ -28,7 +28,7 @@ Feature: using files external service with storage as webdav_owncloud
       | ok     | 0    |         |
     And as "admin" folder "TestMountPoint" should exist
 
-  @skipOnEncryption @issue-encryption-181 @skipOnDbOracle @issue-38165
+  @skipOnEncryption @issue-encryption-181 @issue-38165
   Scenario: using webdav_owncloud as external storage
     Given the administrator has created an external mount point with the following configuration about user "Alice" using the occ command
       | host                   | %remote_server%    |

--- a/tests/acceptance/features/webUIWebdavLocks/unlock.feature
+++ b/tests/acceptance/features/webUIWebdavLocks/unlock.feature
@@ -120,8 +120,8 @@ Feature: Unlock locked files and folders
       | shared    |
 
   # This scenario depends on the order of locks displayed on the UI.
-  # Pgsql and Oracle database can have different sorting, so allow this scenario to be skipped on those
-  @skipOnFIREFOX @files_sharing-app-required @skipOnLDAP @skipOnDbPgsql @skipOnDbOracle
+  # Pgsql database can have different sorting, so allow this scenario to be skipped on that
+  @skipOnFIREFOX @files_sharing-app-required @skipOnLDAP @skipOnDbPgsql
   Scenario: deleting the first one of multiple shared locks on the webUI
     Given these users have been created without skeleton files:
       | username  |
@@ -161,8 +161,8 @@ Feature: Unlock locked files and folders
     And 2 locks should be reported for folder "FOLDER_TO_SHARE" of user "receiver2" by the WebDAV API
 
   # This scenario depends on the order of locks displayed on the UI.
-  # Pgsql and Oracle database can have different sorting, so allow this scenario to be skipped on those
-  @skipOnFIREFOX @files_sharing-app-required @skipOnLDAP @skipOnDbPgsql @skipOnDbOracle
+  # Pgsql database can have different sorting, so allow this scenario to be skipped on that
+  @skipOnFIREFOX @files_sharing-app-required @skipOnLDAP @skipOnDbPgsql
   Scenario: deleting the second one of multiple shared locks on the webUI
     Given these users have been created without skeleton files:
       | username  |
@@ -202,8 +202,8 @@ Feature: Unlock locked files and folders
     And 2 locks should be reported for folder "FOLDER_TO_SHARE" of user "receiver2" by the WebDAV API
 
   # This scenario depends on the order of locks displayed on the UI.
-  # Pgsql and Oracle database can have different sorting, so allow this scenario to be skipped on those
-  @skipOnFIREFOX @files_sharing-app-required @skipOnLDAP @skipOnDbPgsql @skipOnDbOracle
+  # Pgsql database can have different sorting, so allow this scenario to be skipped on that
+  @skipOnFIREFOX @files_sharing-app-required @skipOnLDAP @skipOnDbPgsql
   Scenario: deleting the last one of multiple shared locks on the webUI
     Given these users have been created without skeleton files:
       | username  |


### PR DESCRIPTION
Oracle is no longer supported, so remove mentions from the acceptance tests. Also update places where test scenarios need to be skipped on PostgreSQL. Maintaining these skipOnDbPgsql means that we can reliably run the acceptance tests on PostgreSQL without getting flaky false-negatives.
