### PR TITLE
fix(sharing): enforce the read permission in the public preview endpoint (full-ci)

### DIFF
--- a/apps/files_sharing/ajax/publicpreview.php
+++ b/apps/files_sharing/ajax/publicpreview.php
@@ -62,6 +62,15 @@ try {
 	exit;
 }
 
+// a share without the read permission - like an upload only ("file drop") share - must not
+// expose any file content, nor whether a given file name exists. Sending back 404 the same
+// way ShareController::downloadShare() does.
+if (($linkedItem->getPermissions() & \OCP\Constants::PERMISSION_READ) === 0) {
+	\OC_Response::setStatus(\OC_Response::STATUS_NOT_FOUND);
+	\OCP\Util::writeLog('core-preview', 'Share does not grant read permission', \OCP\Util::DEBUG);
+	exit;
+}
+
 $userId = $linkedItem->getShareOwner();
 if ($userId === null) {
 	\OC_Response::setStatus(\OC_Response::STATUS_INTERNAL_SERVER_ERROR);

--- a/changelog/unreleased/41751
+++ b/changelog/unreleased/41751
@@ -1,0 +1,8 @@
+Security: Enforce the read permission in the public share preview endpoint
+
+The public share preview endpoint resolved the share by token and rendered the
+requested file without consulting the share's permission bitmask. It now returns
+404 when the share does not carry the read permission, which makes it consistent
+with ShareController::downloadShare() and the public WebDAV route.
+
+https://github.com/owncloud/core/pull/41751

--- a/tests/acceptance/features/apiSharePublicLink1/accessToPublicLinkShare.feature
+++ b/tests/acceptance/features/apiSharePublicLink1/accessToPublicLinkShare.feature
@@ -59,6 +59,31 @@ Feature: accessing a public link share
     Then the HTTP status code of responses on all endpoints should be "200"
 
 
+  Scenario: Access to the preview of a file in an upload-only public link share is not allowed
+    Given the administrator has enabled DAV tech_preview
+    And user "Alice" has created folder "FOLDER"
+    And user "Alice" has uploaded file "filesForUpload/testavatar.jpg" to "FOLDER/testavatar.jpg"
+    And user "Alice" has created a public link share with settings
+      | path        | /FOLDER         |
+      | permissions | uploadwriteonly |
+    When the public accesses the preview of file "testavatar.jpg" from the last shared public link using the sharing API
+    Then the HTTP status code should be "404"
+
+
+  Scenario: Access to the preview in an upload-only public link share does not disclose whether a file exists
+    Given the administrator has enabled DAV tech_preview
+    And user "Alice" has created folder "FOLDER"
+    And user "Alice" has uploaded file "filesForUpload/testavatar.jpg" to "FOLDER/testavatar.jpg"
+    And user "Alice" has created a public link share with settings
+      | path        | /FOLDER         |
+      | permissions | uploadwriteonly |
+    When the public accesses the preview of the following files from the last shared public link using the sharing API
+      | path               |
+      | testavatar.jpg     |
+      | thisWillNeverExist |
+    Then the HTTP status code of responses on all endpoints should be "404"
+
+
   Scenario Outline: Request to non-existent public link
     When a user requests "<endpoint>" with "<method>" and no authentication
     Then the HTTP status code should be "404"


### PR DESCRIPTION
## Description

The public share preview endpoint (`apps/files_sharing/ajax/publicpreview.php`) resolved the share by token and rendered the requested file without ever consulting the share's permission bitmask. It now returns `404` when the share does not carry `PERMISSION_READ`.

This makes the endpoint consistent with the two sibling paths that serve content from a public link, both of which already enforced the read bit:

- `ShareController::downloadShare()` — `apps/files_sharing/lib/Controllers/ShareController.php:434`
- the public WebDAV route, via the `PermissionsMask` storage wrapper — `apps/dav/appinfo/v1/publicwebdav.php:88`

The check is deliberately placed *before* any file name is resolved, so the response does not vary with the requested name.

## Related Issue

n/a — reported privately.

## Motivation and Context

`publicpreview.php` was the only content-serving public-link path without a permission check, so its behaviour diverged from `downloadShare()` and public WebDAV for shares that do not grant read access.

## How Has This Been Tested?

- test environment: PHP 8.3.32, local checkout
- `php -l apps/files_sharing/ajax/publicpreview.php` — no syntax errors
- `php-cs-fixer` with the ownCloud coding standard — 0 of 1 files fixable
- `apps/files_sharing/tests/Controllers/ShareControllerTest.php` — 12 tests, 45 assertions, OK
- Permission matrix reviewed: `create`-only (4) → `404`; `read` (1), `read`+`create` (5), `change` (15) and `all` (31) are unaffected, so the four pre-existing scenarios that expect `200` from this endpoint still hold
- Two acceptance scenarios added in `tests/acceptance/features/apiSharePublicLink1/accessToPublicLinkShare.feature`, covering an `uploadwriteonly` public link share. These run in CI (this PR is titled `full-ci` so the `apiSharePublicLink1` suite executes); they were not run locally as no server is available in that environment.

## Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Database schema changes (next release will require increase of minor version instead of patch)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [ ] Tests only (no source changes)

## Checklist:

- [x] Code changes
- [ ] Unit tests added
- [x] Acceptance tests added
- [ ] Documentation ticket raised: <link>
- [x] Changelog item, see [TEMPLATE](https://github.com/owncloud/core/blob/master/changelog/TEMPLATE)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
