### PR TITLE
feat(cache): expose createLocal() on ICacheFactory

### DIFF
--- a/changelog/unreleased/41753
+++ b/changelog/unreleased/41753
@@ -1,0 +1,13 @@
+Change: Expose createLocal() on ICacheFactory
+
+The cache factory has always been able to hand out a cache from the host local
+tier, but the method was missing from the public ICacheFactory interface, so
+core had to ask for it defensively and apps had no way to use it at all. It is
+now part of the interface, which lets values that are only meaningful on the
+machine that produced them be kept out of the cache shared between the nodes of
+an installation.
+
+Note for app developers: a class implementing OCP\ICacheFactory has to declare
+createLocal() from this release on.
+
+https://github.com/owncloud/core/pull/41753

--- a/lib/private/App/AppManager.php
+++ b/lib/private/App/AppManager.php
@@ -31,8 +31,7 @@
 namespace OC\App;
 
 use OC_App;
-use OC\Memcache\ArrayCache;
-use OC\Memcache\NullCache;
+use OC\Memcache\LocalCacheFactory;
 use OC\Installer;
 use OCP\App\AppNotFoundException;
 use OCP\App\IAppManager;
@@ -120,14 +119,9 @@ class AppManager implements IAppManager {
 		$this->dispatcher = $dispatcher;
 		$this->config = $config;
 
-		// TODO we have no public API for this
-		if (\method_exists($this->memCacheFactory, 'createLocal')) {
-			/* @phan-suppress-next-line PhanUndeclaredMethod */
-			$this->appInfo = $this->memCacheFactory->createLocal('app-info');
-		}
-		if ($this->appInfo === null || $this->appInfo instanceof NullCache) {
-			$this->appInfo = new ArrayCache('app-info');
-		}
+		// app info describes the apps installed on this machine, so it belongs in
+		// the host local tier
+		$this->appInfo = LocalCacheFactory::create($this->memCacheFactory, 'app-info');
 	}
 
 	/**

--- a/lib/private/Memcache/LocalCacheFactory.php
+++ b/lib/private/Memcache/LocalCacheFactory.php
@@ -33,9 +33,8 @@ use OCP\ICacheFactory;
  * consume what any single node (or anything else able to talk to the backend)
  * wrote there.
  *
- * ICacheFactory does not declare createLocal(), so the tier is requested
- * defensively and a request scoped ArrayCache is used whenever a usable local
- * cache cannot be obtained.
+ * A request scoped ArrayCache is used whenever a usable local cache cannot be
+ * obtained.
  *
  * @package OC\Memcache
  */
@@ -51,11 +50,7 @@ class LocalCacheFactory {
 	 * @return ICache
 	 */
 	public static function create(ICacheFactory $factory, $prefix = '') {
-		$cache = null;
-		if (\method_exists($factory, 'createLocal')) {
-			/* @phan-suppress-next-line PhanUndeclaredMethod */
-			$cache = $factory->createLocal($prefix);
-		}
+		$cache = $factory->createLocal($prefix);
 		if (!$cache instanceof ICache || $cache instanceof NullCache) {
 			$cache = new ArrayCache($prefix);
 		}

--- a/lib/public/ICacheFactory.php
+++ b/lib/public/ICacheFactory.php
@@ -41,6 +41,23 @@ interface ICacheFactory {
 	public function create($prefix = '');
 
 	/**
+	 * Get a memory cache instance in the host local tier
+	 *
+	 * Unlike the cache returned by create(), this cache is not shared between the
+	 * nodes of an installation. Values which are only meaningful on the machine
+	 * which produced them - resolved paths on disk, results of inspecting the
+	 * local installation - belong here and not in the shared cache, where every
+	 * node would consume what any single node wrote.
+	 *
+	 * All entries added trough the cache instance will be namespaced by $prefix to prevent collisions between apps
+	 *
+	 * @param string $prefix
+	 * @return \OCP\ICache
+	 * @since 11.0.0
+	 */
+	public function createLocal($prefix = '');
+
+	/**
 	 * Check if any memory cache backend is available
 	 *
 	 * @return bool

--- a/tests/lib/Memcache/LocalCacheFactoryTest.php
+++ b/tests/lib/Memcache/LocalCacheFactoryTest.php
@@ -77,20 +77,12 @@ class LocalCacheFactoryTest extends TestCase {
 		$this->assertNull($factory->createDistributed('test')->get('key'));
 	}
 
-	public function testFallsBackWhenCreateLocalIsNotImplemented(): void {
-		// ICacheFactory does not declare createLocal(), so a bare interface
-		// mock has no such method
-		$factory = $this->createMock(ICacheFactory::class);
-
-		$this->assertInstanceOf(ArrayCache::class, LocalCacheFactory::create($factory, 'test'));
-	}
-
 	/**
 	 * @dataProvider unusableLocalCacheProvider
 	 * @param mixed $returnValue
 	 */
 	public function testFallsBackWhenCreateLocalReturnsSomethingUnusable($returnValue): void {
-		$factory = $this->createMock(FixedCacheFactory::class);
+		$factory = $this->createMock(ICacheFactory::class);
 		$factory->method('createLocal')->willReturn($returnValue);
 
 		$this->assertInstanceOf(ArrayCache::class, LocalCacheFactory::create($factory, 'test'));
@@ -101,6 +93,17 @@ class LocalCacheFactoryTest extends TestCase {
 			'null' => [null],
 			'a NullCache' => [new NullCache('test')],
 		];
+	}
+
+	/**
+	 * The helper calls createLocal() unconditionally, which is only safe as long
+	 * as every ICacheFactory has to provide it.
+	 */
+	public function testTheLocalTierIsPartOfThePublicApi(): void {
+		$this->assertTrue(
+			(new \ReflectionClass(ICacheFactory::class))->hasMethod('createLocal'),
+			'ICacheFactory declares createLocal()'
+		);
 	}
 
 	public function testPassesThroughThePrefix(): void {


### PR DESCRIPTION
## Description

> ♻️ **Recreated against `master`.** This supersedes #41737, which was merged into its stacked base branch
> (`refactor/drop-storage-id-distributed-cache`) rather than into `master`, so the change never reached master.
> This PR carries the identical diff, rebased onto current `master` and re-verified.

Adds `createLocal($prefix = '')` to `OCP\ICacheFactory` with `@since 11.0.0`.

`OC\Memcache\Factory` has offered a host-local tier since it was written, but the public interface only ever declared `create()` — which is an **alias for the distributed tier**. So core had to reach for the local tier through `method_exists()` plus a phan suppression, and apps could not use it at all. That gap is the reason the values behind #41732 were in the wrong tier to begin with.

With the method declared, this PR also:

- drops the `method_exists` branch and the `@phan-suppress` from `LocalCacheFactory` (the `NullCache`/null guard **stays** — an installation with no `memcache.local` still gets a request-scoped cache rather than no caching);
- retires the last `// TODO we have no public API for this` at `AppManager.php:123`, which now just calls `LocalCacheFactory::create(...)`, dropping two now-unused imports.

### The BC question, stated plainly

Adding a method to a published interface is a **hard BC break** for any third-party class implementing it — fatal at declaration time, not a deprecation warning. In-tree there is exactly one implementer (`Factory.php:35`) plus the test double, but the marketplace cannot be grepped.

The mitigating facts: 11.0.0 is at **rc2, i.e. pre-GA**, which is the cheapest window this change will ever have; `@since 11.0.0` precedent already exists (`lib/public/IUser.php:39`); and `build/OCPSinceChecker.php` only blacklists `9.2`, so the tag passes CI. The changelog entry calls the break out explicitly for app developers.

This is deliberately **last and separate** so that the security fix in #41732 could never be blocked by an API debate. The rest of the series (#41732, #41733, #41734) is already in `master`; #41735 and #41736 are still open, but this PR does not depend on either of them — the four files it touches are untouched by both.

## Related Issue

- Fixes n/a — final step of the GHSA-488r-cjpq-p3vc hardening series

## Motivation and Context

Core needed the local cache tier and had to reach for it defensively; apps could not reach it at all.

## How Has This Been Tested?

- test environment: PHP 8.3.32, sqlite, plus a run with `memcache.local => APCu` + `memcache.distributed => Redis`.
- test case 1: `tests/lib/Memcache/LocalCacheFactoryTest.php` proves the change is **behaviour-neutral** — real `Factory` with `memcache.local` unset still yields an `ArrayCache` and never the distributed instance; `createLocal` returning `null` or a `NullCache` still falls back. New `testTheLocalTierIsPartOfThePublicApi()` guards the declaration itself.
- test case 2: **negative verification** — reverting `ICacheFactory.php` makes the suite fail (1 failure + 2 mock errors), confirming the tests actually depend on the new declaration; then restored and green.
- test case 3: `build/OCPSinceChecker.php` passes with the new `@since 11.0.0` tag.
- test case 4: implementer audit — `Factory` and the `FixedCacheFactory` double are the only in-tree implementers and both already declared `createLocal`; `createMock(ICacheFactory::class)` sites pick the new method up automatically, so `ManagerTest` (37 tests) and `ServerTest` (105 tests) stay green.
- test case 5: real-instance — `createLocal()` returns `OC\Memcache\APCu`, `create()` returns `OC\Memcache\Redis`, `LocalCacheFactory::create()` resolves to APCu.
- test case 6: re-verified after the rebase onto current `master` (`ef90ee8295`) — the staged diff is byte-identical to the previously-reviewed commit; `tests/lib/Memcache` 88 tests green, `tests/lib/App` 162 tests green, `php-cs-fixer` clean, `OCPSinceChecker` passes. (`AppTest::testBuildAppNamespaceInfoXml` fails identically on unmodified `master`, i.e. pre-existing and unrelated.)
- test case 7: full `tests/lib` — 7149 tests, 40221 assertions, no new failures. `make test-php-style` clean; **phan reports 0 issues in core**, confirming both suppressions removed by this series were the only ones needed.

## Types of changes

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Database schema changes (next release will require increase of minor version instead of patch)
- [x] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Technical debt
- [ ] Tests only (no source changes)

## Checklist:

- [x] Code changes
- [x] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: n/a
- [x] Changelog item, see [TEMPLATE](https://github.com/owncloud/core/blob/master/changelog/TEMPLATE)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

