### PR TITLE
chore: bump version string to 11.0.0-rc3

### DIFF
--- a/version.php
+++ b/version.php
@@ -28,7 +28,7 @@
 $OC_Version = [11, 0, 0, 0];
 
 // The human-readable string
-$OC_VersionString = '11.0.0-rc2';
+$OC_VersionString = '11.0.0-rc3';
 
 $OC_VersionCanBeUpgradedFrom = [[8, 2, 11],[9, 0, 9],[9, 1]];
 


### PR DESCRIPTION
Bump `$OC_VersionString` from 11.0.0-rc2 to 11.0.0-rc3 for the upcoming 11.0.0-rc3 release. The code ($OC_Version) is unchanged; this only updates the human-readable version string reported by the server.

🤖 Generated with [Claude Code](https://claude.com/claude-code)