### PR TITLE
fix(settings): escape group names in the users admin group list

### DIFF
--- a/changelog/unreleased/escape-group-names-group-list
+++ b/changelog/unreleased/escape-group-names-group-list
@@ -1,0 +1,12 @@
+Change: Escape group names in the users administration group list
+
+The group list in the users administration panel built each list item by
+concatenating the group id and group name into an HTML string, so both values
+were interpreted as markup rather than text. Unlike usernames, group names are
+not restricted to an allow-listed character set - Group\Manager::createGroup()
+only rejects empty and untrimmed names - so a name containing HTML characters
+was not rendered verbatim. Both interpolated values are now passed through
+escapeHTML(), which makes the encoding consistent with the user rows, and the
+behaviour is covered by tests in settings/tests/js/users/groupsSpec.js.
+
+https://github.com/owncloud/core/pull/41758

--- a/settings/js/users/groups.js
+++ b/settings/js/users/groups.js
@@ -27,9 +27,9 @@ var GroupDeleteHandler;
 
 		addGroup: function (gid, name, usercount) {
 			var $li = $(
-				'<li class="isgroup" data-gid="' + gid + '" data-usercount="0">' +
+				'<li class="isgroup" data-gid="' + escapeHTML(gid) + '" data-usercount="0">' +
 				'	<a href="#" class="dorename">' +
-				'		<span class="groupname">' + name + '</span>' +
+				'		<span class="groupname">' + escapeHTML(name) + '</span>' +
 				'		<span class="usercount tag"></span>' +
 				'	</a>' +
 				'	<span class="utils">' +

--- a/settings/tests/js/users/groupsSpec.js
+++ b/settings/tests/js/users/groupsSpec.js
@@ -62,4 +62,29 @@ describe('groups tests', function() {
 		expect($li.length).toEqual(1);
 		expect($('#usergrouplist li').length).toEqual(4);
 	});
+
+	describe('escaping of group names', function() {
+		it('renders a group name containing markup as text', function() {
+			var payload = '"><script>alert(document.cookie)</script>';
+			var $li = groupList.addGroup(payload, payload, 0);
+
+			expect($li.find('script').length).toEqual(0);
+			expect($li.find('.groupname').text()).toEqual(payload);
+		});
+
+		it('does not break out of the data-gid attribute', function() {
+			var $li = groupList.addGroup('" onmouseover="alert(1)" x="', 'evil', 0);
+
+			expect($li.attr('onmouseover')).toBeUndefined();
+			expect($li.attr('data-gid')).toEqual('" onmouseover="alert(1)" x="');
+		});
+
+		it('does not execute an event handler payload in the group name', function() {
+			var $li = groupList.addGroup('g1', '<img src=x onerror="alert(1)">', 0);
+
+			// note: the row always contains the delete icon, so scope to the name
+			expect($li.find('.groupname img').length).toEqual(0);
+			expect($li.find('.groupname').text()).toEqual('<img src=x onerror="alert(1)">');
+		});
+	});
 });


### PR DESCRIPTION
## Description

`GroupList.addGroup()` in `settings/js/users/groups.js` built each list item of the
users administration group list by concatenating the group id and the group name
into an HTML string, which jQuery then parses as markup. Both interpolated values
are now passed through the existing `escapeHTML()` helper (`core/js/js.js`), so the
values are rendered verbatim.

`escapeHTML()` covers both contexts the values appear in - the `data-gid` attribute
and the `.groupname` text node - and `data-gid` still round-trips as the literal
string, so `getGroupLI()` lookups keep matching.

Adds three regression tests to `settings/tests/js/users/groupsSpec.js`, which is
already wired into the `settings` karma suite.

## Related Issue

n/a - no tracking issue.

## Motivation and Context

Unlike usernames, group names are not restricted to an allow-listed character set:
`Group\Manager::createGroup()` only rejects empty and untrimmed names, and names
can also originate from an external backend such as LDAP. Group and quota values
in the user rows of the same panel (`settings/js/users.js`) already go through
`escapeHTML()`, so this makes the output encoding consistent across the users
administration panel.

The PHP template `settings/templates/users/part.grouplist.php` renders group names
with `p()` and was already correct - only the JS render path was affected.

## How Has This Been Tested?

- test environment: local checkout, Node 22 + jsdom harness driving the real
  `settings/js/users/groups.js` with the repo's vendored jQuery and the real
  `escapeHTML()` extracted from `core/js/js.js`
- test case 1: group name containing `<script>` markup - renders as text, no
  `<script>` element in the row
- test case 2: group id containing an attribute breakout - no stray attribute is
  created and `data-gid` still reads back as the literal string
- test case 3: group name `<img src=x onerror="...">` - no `img` element inside
  `.groupname`, name renders as text
- all three fail on the unpatched code and pass with the change; the pre-existing
  `adds new user group` spec still passes (4/4)
- note: karma is not installed in this environment, so the official
  `make test-js` runner was not executed locally - CI (`js-unit.yml`) covers it
- manual check: create a group named `<img src=x onerror=alert(1)>` in
  Settings -> Users; the name renders as literal text, both on creation and after
  a group-membership toggle (which re-renders via `GroupList.update()`)

## Screenshots (if appropriate):

n/a

## Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Database schema changes (next release will require increase of minor version instead of patch)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Technical debt
- [ ] Tests only (no source changes)

## Checklist:

- [x] Code changes
- [x] Unit tests added
- [ ] Acceptance tests added
- [ ] Documentation ticket raised: n/a
- [x] Changelog item, see [TEMPLATE](https://github.com/owncloud/core/blob/master/changelog/TEMPLATE)
