### PR TITLE
fix: encode search highlights returned as a DAV property

### DIFF
--- a/apps/dav/lib/Connector/Sabre/FilesSearchReportPlugin.php
+++ b/apps/dav/lib/Connector/Sabre/FilesSearchReportPlugin.php
@@ -183,7 +183,11 @@ class FilesSearchReportPlugin extends ServerPlugin {
 			$this->server->getPropertiesByNode($propFind, $node);
 			// assuming we only have one entry in the highlights array
 			if (isset($paths[$path]->highlights[0]) && \in_array(self::REPORT_HIGHLIGHTS, $requestedProps)) {
-				$propFind->set(self::REPORT_HIGHLIGHTS, \str_replace(["\r\n", "\r", "\n"], '<br/>', $paths[$path]->highlights[0]));
+				// the highlight is built from file content, so it has to be encoded
+				// before the line breaks are turned into markup - encoding
+				// afterwards would mangle the <br/> we inject here on purpose
+				$highlight = \htmlspecialchars($paths[$path]->highlights[0], ENT_QUOTES, 'UTF-8');
+				$propFind->set(self::REPORT_HIGHLIGHTS, \str_replace(["\r\n", "\r", "\n"], '<br/>', $highlight));
 			}
 			if (isset($paths[$path]->score) && \in_array(self::REPORT_SCORE, $requestedProps)) {
 				$propFind->set(self::REPORT_SCORE, $paths[$path]->score);

--- a/apps/dav/tests/unit/Connector/Sabre/FilesSearchReportPluginTest.php
+++ b/apps/dav/tests/unit/Connector/Sabre/FilesSearchReportPluginTest.php
@@ -292,6 +292,87 @@ class FilesSearchReportPluginTest extends \Test\TestCase {
 		}
 	}
 
+	public function highlightsEscapingProvider() {
+		return [
+			[
+				'<script>alert(1)</script>',
+				'&lt;script&gt;alert(1)&lt;/script&gt;',
+			],
+			[
+				'<img src=x onerror="alert(1)">',
+				'&lt;img src=x onerror=&quot;alert(1)&quot;&gt;',
+			],
+			// the newline substitution still has to produce a real <br/>
+			[
+				"first<script>alert(1)</script>\nsecond",
+				'first&lt;script&gt;alert(1)&lt;/script&gt;<br/>second',
+			],
+			// an already encoded fragment must survive as-is, single encoding only
+			[
+				'harmless &amp; encoded',
+				'harmless &amp;amp; encoded',
+			],
+		];
+	}
+
+	/**
+	 * The highlight fragment is built from attacker controlled file content and is
+	 * handed out as an HTML bearing property (this code deliberately injects
+	 * <br/>), so a client rendering it as HTML must not be able to execute script.
+	 *
+	 * @dataProvider highlightsEscapingProvider
+	 */
+	public function testOnReportEscapesHighlights($highlight, $expected) {
+		$base = '/remote.php/dav/files/user';
+		$nodePath = '/';
+		$path = "{$base}{$nodePath}";
+		$resultPath = '/hit0';
+
+		$parameters = new SearchRequest();
+		$parameters->properties = ['{http://owncloud.org/ns}search-highlights'];
+		$parameters->searchInfo = ['pattern' => 'hit', 'limit' => 1];
+
+		$node = $this->createMock(Directory::class);
+		$node->method('getPath')->willReturn($nodePath);
+
+		$this->searchService->method('searchPaged')
+			->will($this->returnCallback(function () use ($resultPath, $highlight) {
+				$mock = $this->createMock(ResultFile::class);
+				$mock->path = $resultPath;
+				$mock->highlights = [$highlight];
+				return [$mock];
+			}));
+
+		$this->tree->method('getMultipleNodes')
+			->will($this->returnCallback(function ($paths) {
+				$nodes = [];
+				foreach ($paths as $nodePath) {
+					$nodes[$nodePath] = $this->createMock(Node::class);
+				}
+				return $nodes;
+			}));
+
+		$responses = [];
+		$this->server->expects($this->once())
+			->method('generateMultiStatus')
+			->will($this->returnCallback(function ($responsesArg) use (&$responses) {
+				foreach ($responsesArg as $responseArg) {
+					$responses[] = $responseArg;
+				}
+			}));
+
+		$this->setupBaseTreeNode($path, $node);
+		$this->plugin->initialize($this->server);
+
+		$this->plugin->onReport(FilesSearchReportPlugin::REPORT_NAME, $parameters, $path);
+
+		$this->assertCount(1, $responses);
+		$this->assertSame(
+			$expected,
+			$responses[0][200]['{http://owncloud.org/ns}search-highlights']
+		);
+	}
+
 	private function getSearchList($search, $numberOfItems) {
 		$results = [];
 		$pathParts = [];

--- a/changelog/unreleased/41760
+++ b/changelog/unreleased/41760
@@ -1,0 +1,13 @@
+Security: Encode search highlights before they are returned as a DAV property
+
+The search-highlights property of the files search REPORT returned the
+elasticsearch highlight fragment unencoded. The fragment is built from
+file content, so a user who shared a crafted file could place arbitrary
+markup in the property value. The property deliberately carries HTML -
+line breaks are substituted with <br/> - so a client rendering it as
+HTML would execute the injected markup.
+
+The fragment is now HTML-encoded before the line break substitution,
+which keeps the intended <br/> markup intact.
+
+https://github.com/owncloud/core/pull/41760


### PR DESCRIPTION
## Description

The `search-highlights` property of the files search `REPORT` returned the elasticsearch highlight fragment unencoded. That fragment is built from file content, so a user who shared a crafted file could place arbitrary markup into the property value. The property deliberately carries HTML — line breaks are substituted with `<br/>` — so a client rendering it as HTML would execute the injected markup.

The fragment is now encoded before the line break substitution. **The order matters:** encoding afterwards would also escape the `<br/>` injected here on purpose.

```php
$highlight = \htmlspecialchars($paths[$path]->highlights[0], ENT_QUOTES, 'UTF-8');
$propFind->set(self::REPORT_HIGHLIGHTS, \str_replace(["\r\n", "\r", "\n"], '<br/>', $highlight));
```

## Related Issue

- Fixes OC10-124
- Companion PR (primary fix): owncloud/search_elastic#348

## Motivation and Context

This is the second egress channel for the same fragment. owncloud/search_elastic#348 sets `'encoder' => 'html'` on the highlight query, so with that PR in place the value already arrives encoded — but this change keeps the property safe **independently of which search backend produced it**, and independently of that app's version.

Scope, stated precisely rather than overclaimed: I verified with a live `XMLWriter` run that Sabre already XML-escapes property text, so this was **not** an exploitable XML-transport hole. The value semantically carries HTML, so this is hardening of an HTML-bearing property, not a second active XSS.

## How Has This Been Tested?

- **test environment:** PHP 8.3.32, PHPUnit 9.6.35.
- **new test:** `testOnReportEscapesHighlights`, a 4-case data provider covering `<script>`, `<img onerror>`, a payload combined with a newline (asserting the intended `<br/>` still comes through as real markup), and an already-encoded fragment (asserting single encoding only). Written test-first — all 4 cases failed before the fix.
- **regression:** `apps/dav/tests/unit/Connector/` → OK, 466 tests / 1720 assertions. `FilesSearchReportPluginTest` alone → OK, 22 tests / 208 assertions; the pre-existing highlight assertion still passes because its fixture has nothing to escape.
- **style:** `php-cs-fixer` on both changed files → 0 of 2 files to fix.

## Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist:

- [x] Code changes
- [x] Unit tests added
- [ ] Acceptance tests added — covered in the companion search_elastic PR, which owns the rendering path
- [x] Changelog item (`changelog/unreleased/41760`)

> Note: the changelog file is named for the anticipated PR number — rename if this lands as a different number.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
