### PR TITLE
fix(dav): honour the write hook veto on legacy chunked uploads [backport 10.16]

### DIFF
--- a/apps/dav/lib/Connector/Sabre/File.php
+++ b/apps/dav/lib/Connector/Sabre/File.php
@@ -553,7 +553,15 @@ class File extends Node implements IFile, IFileNode {
 			try {
 				$this->fileView->lockFile($targetPath, ILockingProvider::LOCK_SHARED);
 
-				$this->emitPreHooks($exists, $targetPath);
+				$run = $this->emitPreHooks($exists, $targetPath);
+				if ($run === false) {
+					// a hook (e.g. the blacklist check on the decoded target
+					// name) vetoed the write - abort before assembling the
+					// chunks into the final file
+					$this->fileView->unlockFile($targetPath, ILockingProvider::LOCK_SHARED);
+					$chunk_handler->cleanup();
+					throw new Forbidden('Writing the file was not allowed');
+				}
 				$this->fileView->changeLock($targetPath, ILockingProvider::LOCK_EXCLUSIVE);
 				/** @var \OC\Files\Storage\Storage $targetStorage */
 				list($targetStorage, $targetInternalPath) = $this->fileView->resolvePath($targetPath);

--- a/apps/dav/tests/unit/Connector/Sabre/FileTest.php
+++ b/apps/dav/tests/unit/Connector/Sabre/FileTest.php
@@ -681,6 +681,46 @@ class FileTest extends TestCase {
 	}
 
 	/**
+	 * A chunked upload whose assembled target name is blacklisted (e.g.
+	 * `.htaccess`) must be rejected, just like the non-chunked path. The
+	 * chunk names themselves (`.htaccess-chunking-...`) are not blacklisted,
+	 * so the guard has to fire on the decoded target name.
+	 */
+	public function testChunkedPutToBlacklistedNameIsForbidden() {
+		// wire the blacklist guard exactly as lib/kernel.php does at boot
+		// (setUp() clears all hooks, so it is not registered by default)
+		\OC_Hook::connect(
+			'OC_Filesystem',
+			'write',
+			'OC\Files\Filesystem',
+			'isForbiddenFileOrDir_Hook'
+		);
+
+		$_SERVER['HTTP_OC_CHUNKED'] = true;
+
+		$this->assertNull($this->doPut('/.htaccess-chunking-12345-2-0'));
+
+		$thrown = false;
+		try {
+			$this->doPut('/.htaccess-chunking-12345-2-1');
+		} catch (\Sabre\DAV\Exception\Forbidden $e) {
+			$thrown = true;
+		}
+		$this->assertTrue($thrown, 'Uploading a blacklisted .htaccess via chunking must be forbidden');
+
+		// The blacklisted target must never reach the storage backend - check
+		// the physical storage directly, because the file cache scanner skips
+		// blacklisted names and would hide a file that is actually on disk.
+		$view = Filesystem::getView();
+		list($storage, $internalPath) = $view->resolvePath('/.htaccess');
+		$this->assertFalse(
+			$storage->file_exists($internalPath),
+			'Blacklisted .htaccess must not be written to storage via chunked upload'
+		);
+		$this->assertEmpty($this->listPartFiles(), 'No stray part files');
+	}
+
+	/**
 	 * Test that putting a file triggers create hooks
 	 */
 	public function testPutSingleFileTriggersHooks() {

--- a/changelog/unreleased/41763
+++ b/changelog/unreleased/41763
@@ -1,0 +1,9 @@
+Change: Honour the write hook veto on legacy chunked WebDAV uploads
+
+The legacy WebDAV chunked upload path assembled the final file without
+respecting the pre-write hook result, so the filename blacklist that applies
+to ordinary uploads was not enforced for chunked uploads. The chunked
+assembly now aborts when a write hook vetoes the file, matching the
+non-chunked upload path.
+
+https://github.com/owncloud/core/pull/41763


### PR DESCRIPTION
Backport of #41762 to `10.16`.

## Summary

Make the legacy WebDAV chunked upload path honour the pre-write hook veto.

`createFileChunked()` in `apps/dav/lib/Connector/Sabre/File.php` called
`emitPreHooks()` but discarded its return value, then assembled the chunks into
the final file unconditionally. As a result the filename blacklist that applies
to ordinary uploads (enforced via the write hook) was not honoured for chunked
uploads — a name that is rejected on the normal `PUT` path could still be
written through the chunked path.

The chunked assembly now captures the hook result and aborts — unlock the
target, clean up the part files, and throw `Forbidden` — when a write hook
vetoes the file, mirroring the existing non-chunked `put()` path.

## Changes

- `apps/dav/lib/Connector/Sabre/File.php` — honour the `emitPreHooks()` veto in
  the chunked assembly path.
- `apps/dav/tests/unit/Connector/Sabre/FileTest.php` — add
  `testChunkedPutToBlacklistedNameIsForbidden()`, a regression test that pushes
  a blacklisted name via chunking and asserts it is rejected and never reaches
  the storage backend.

## Testing

- New regression test fails without the fix (the blacklisted file reaches
  storage) and passes with it.
- Full `apps/dav` Sabre connector suite: **456 tests, 1698 assertions — green.**
- `php-cs-fixer` reports no changes.
