### PR TITLE
ci(acceptance): do not cancel sibling suites on the first failure

### DIFF
--- a/.github/workflows/acceptance.yml
+++ b/.github/workflows/acceptance.yml
@@ -77,7 +77,7 @@ jobs:
     permissions:
       contents: read
     strategy:
-      fail-fast: true
+      fail-fast: false
       matrix:
         php: ${{ fromJSON(inputs.php-versions) }}
         database: ${{ fromJSON(inputs.databases) }}


### PR DESCRIPTION
Each acceptance test workflow runs different test scenarios. If one acceptance test suite fails, we still want to see the results of the other test suites.

This is similar to what was done in https://github.com/owncloud/reusable-workflows/pull/90

