### PR TITLE
chore(deps): bump PHP dependencies to close published advisories [10.16]

### DIFF
--- a/changelog/unreleased/PHPdependencies20260821
+++ b/changelog/unreleased/PHPdependencies20260821
@@ -1,0 +1,33 @@
+Security: Update PHP dependencies to close published advisories
+
+The 10.16 branch had not seen a dependency update since the 10.16.4 release, and
+several bundled packages were carrying published advisories. They have been
+updated to versions that are not affected:
+
+- guzzlehttp/guzzle (7.10.0 to 7.15.3)
+- guzzlehttp/promises (2.3.0 to 2.5.2)
+- guzzlehttp/psr7 (2.8.0 to 2.13.0)
+- phpseclib/phpseclib (3.0.52 to 3.0.56)
+- rhukster/dom-sanitizer (dev-main to 1.0.14)
+- symfony/polyfill-php80 (v1.33.0 to v1.37.0)
+- symfony/routing (v5.4.52 to v5.4.53)
+
+This closes sixteen advisories: CVE-2026-69246, CVE-2026-69245, CVE-2026-67354,
+CVE-2026-67355, CVE-2026-67353, CVE-2026-67339, CVE-2026-59883, CVE-2026-55767
+and CVE-2026-55568 in guzzlehttp/guzzle; CVE-2026-59882, CVE-2026-55766,
+CVE-2026-48998 and CVE-2026-49214 in guzzlehttp/psr7; CVE-2026-55599 in
+phpseclib/phpseclib; CVE-2026-48784 in symfony/routing; and CVE-2026-40301 in
+rhukster/dom-sanitizer.
+
+rhukster/dom-sanitizer was required as "dev-main", an unversioned branch pin.
+Such a pin carries no version number, so vulnerability scanners cannot match it
+against advisory ranges and silently report nothing for the package. It is now
+required as a tagged release, which both applies the CVE-2026-40301 fix and makes
+the dependency visible to scanners.
+
+firebase/php-jwt remains at 6.10.0 and is still affected by CVE-2025-45769 (low,
+weak encryption). The advisory is only fixed in 7.0.0, and every 7.x release
+requires PHP 8.0 or later, so it cannot be applied to the 10.16 line, which
+supports PHP 7.4.
+
+https://github.com/owncloud/core/pull/41784

--- a/composer.json
+++ b/composer.json
@@ -86,7 +86,7 @@
         "phpseclib/phpseclib": "^3.0",
         "pimple/pimple": "^3.5",
         "punic/punic": "^3.8",
-        "rhukster/dom-sanitizer": "dev-main",
+        "rhukster/dom-sanitizer": "^1.0.10",
         "sabre/dav": "^4.4",
         "sabre/http": "^5.1",
         "sabre/vobject": "^4.5",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "d75b7ae1ae621dbe24a44199ec6482f4",
+    "content-hash": "e06dd3a57a69977de8cd37a8c54286d8",
     "packages": [
         {
             "name": "bantu/ini-get-wrapper",
@@ -1015,25 +1015,26 @@
         },
         {
             "name": "guzzlehttp/guzzle",
-            "version": "7.10.0",
+            "version": "7.15.3",
             "source": {
                 "type": "git",
                 "url": "https://github.com/guzzle/guzzle.git",
-                "reference": "b51ac707cfa420b7bfd4e4d5e510ba8008e822b4"
+                "reference": "ae311b8f045ea93ce7b1c9cdb7cec06c53f944bc"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/guzzle/guzzle/zipball/b51ac707cfa420b7bfd4e4d5e510ba8008e822b4",
-                "reference": "b51ac707cfa420b7bfd4e4d5e510ba8008e822b4",
+                "url": "https://api.github.com/repos/guzzle/guzzle/zipball/ae311b8f045ea93ce7b1c9cdb7cec06c53f944bc",
+                "reference": "ae311b8f045ea93ce7b1c9cdb7cec06c53f944bc",
                 "shasum": ""
             },
             "require": {
                 "ext-json": "*",
-                "guzzlehttp/promises": "^2.3",
-                "guzzlehttp/psr7": "^2.8",
+                "guzzlehttp/promises": "^2.5.2",
+                "guzzlehttp/psr7": "^2.13",
                 "php": "^7.2.5 || ^8.0",
                 "psr/http-client": "^1.0",
-                "symfony/deprecation-contracts": "^2.2 || ^3.0"
+                "symfony/deprecation-contracts": "^2.5 || ^3.0",
+                "symfony/polyfill-php80": "^1.25"
             },
             "provide": {
                 "psr/http-client-implementation": "1.0"
@@ -1041,9 +1042,10 @@
             "require-dev": {
                 "bamarni/composer-bin-plugin": "^1.8.2",
                 "ext-curl": "*",
-                "guzzle/client-integration-tests": "3.0.2",
+                "guzzle/client-integration-tests": "3.0.3",
+                "guzzlehttp/test-server": "^0.7",
                 "php-http/message-factory": "^1.1",
-                "phpunit/phpunit": "^8.5.39 || ^9.6.20",
+                "phpunit/phpunit": "^8.5.52 || ^9.6.34",
                 "psr/log": "^1.1 || ^2.0 || ^3.0"
             },
             "suggest": {
@@ -1121,7 +1123,7 @@
             ],
             "support": {
                 "issues": "https://github.com/guzzle/guzzle/issues",
-                "source": "https://github.com/guzzle/guzzle/tree/7.10.0"
+                "source": "https://github.com/guzzle/guzzle/tree/7.15.3"
             },
             "funding": [
                 {
@@ -1137,28 +1139,29 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2025-08-23T22:36:01+00:00"
+            "time": "2026-08-05T19:48:21+00:00"
         },
         {
             "name": "guzzlehttp/promises",
-            "version": "2.3.0",
+            "version": "2.5.2",
             "source": {
                 "type": "git",
                 "url": "https://github.com/guzzle/promises.git",
-                "reference": "481557b130ef3790cf82b713667b43030dc9c957"
+                "reference": "2823687acff28b2dbe67b2508a6b300e2c3fa4ce"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/guzzle/promises/zipball/481557b130ef3790cf82b713667b43030dc9c957",
-                "reference": "481557b130ef3790cf82b713667b43030dc9c957",
+                "url": "https://api.github.com/repos/guzzle/promises/zipball/2823687acff28b2dbe67b2508a6b300e2c3fa4ce",
+                "reference": "2823687acff28b2dbe67b2508a6b300e2c3fa4ce",
                 "shasum": ""
             },
             "require": {
-                "php": "^7.2.5 || ^8.0"
+                "php": "^7.2.5 || ^8.0",
+                "symfony/deprecation-contracts": "^2.5 || ^3.0"
             },
             "require-dev": {
                 "bamarni/composer-bin-plugin": "^1.8.2",
-                "phpunit/phpunit": "^8.5.44 || ^9.6.25"
+                "phpunit/phpunit": "^8.5.52 || ^9.6.34"
             },
             "type": "library",
             "extra": {
@@ -1204,7 +1207,7 @@
             ],
             "support": {
                 "issues": "https://github.com/guzzle/promises/issues",
-                "source": "https://github.com/guzzle/promises/tree/2.3.0"
+                "source": "https://github.com/guzzle/promises/tree/2.5.2"
             },
             "funding": [
                 {
@@ -1220,27 +1223,29 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2025-08-22T14:34:08+00:00"
+            "time": "2026-08-05T19:30:54+00:00"
         },
         {
             "name": "guzzlehttp/psr7",
-            "version": "2.8.0",
+            "version": "2.13.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/guzzle/psr7.git",
-                "reference": "21dc724a0583619cd1652f673303492272778051"
+                "reference": "dad89620b7a6edb60c15858442eb2e408b45d8f4"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/guzzle/psr7/zipball/21dc724a0583619cd1652f673303492272778051",
-                "reference": "21dc724a0583619cd1652f673303492272778051",
+                "url": "https://api.github.com/repos/guzzle/psr7/zipball/dad89620b7a6edb60c15858442eb2e408b45d8f4",
+                "reference": "dad89620b7a6edb60c15858442eb2e408b45d8f4",
                 "shasum": ""
             },
             "require": {
                 "php": "^7.2.5 || ^8.0",
                 "psr/http-factory": "^1.0",
                 "psr/http-message": "^1.1 || ^2.0",
-                "ralouphie/getallheaders": "^3.0"
+                "ralouphie/getallheaders": "^3.0",
+                "symfony/deprecation-contracts": "^2.5 || ^3.0",
+                "symfony/polyfill-php80": "^1.25"
             },
             "provide": {
                 "psr/http-factory-implementation": "1.0",
@@ -1248,8 +1253,9 @@
             },
             "require-dev": {
                 "bamarni/composer-bin-plugin": "^1.8.2",
-                "http-interop/http-factory-tests": "0.9.0",
-                "phpunit/phpunit": "^8.5.44 || ^9.6.25"
+                "http-interop/http-factory-tests": "1.1.0",
+                "jshttp/mime-db": "1.54.0.1",
+                "phpunit/phpunit": "^8.5.52 || ^9.6.34"
             },
             "suggest": {
                 "laminas/laminas-httphandlerrunner": "Emit PSR-7 responses"
@@ -1320,7 +1326,7 @@
             ],
             "support": {
                 "issues": "https://github.com/guzzle/psr7/issues",
-                "source": "https://github.com/guzzle/psr7/tree/2.8.0"
+                "source": "https://github.com/guzzle/psr7/tree/2.13.0"
             },
             "funding": [
                 {
@@ -1336,7 +1342,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2025-08-23T21:21:41+00:00"
+            "time": "2026-07-16T22:23:49+00:00"
         },
         {
             "name": "icewind/smb",
@@ -2630,16 +2636,16 @@
         },
         {
             "name": "phpseclib/phpseclib",
-            "version": "3.0.52",
+            "version": "3.0.56",
             "source": {
                 "type": "git",
                 "url": "https://github.com/phpseclib/phpseclib.git",
-                "reference": "2adaefc83df2ec548558307690f376dd7d4f4fce"
+                "reference": "7adbbe38cde25e2df2116dbf2673c407e24fa305"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/phpseclib/phpseclib/zipball/2adaefc83df2ec548558307690f376dd7d4f4fce",
-                "reference": "2adaefc83df2ec548558307690f376dd7d4f4fce",
+                "url": "https://api.github.com/repos/phpseclib/phpseclib/zipball/7adbbe38cde25e2df2116dbf2673c407e24fa305",
+                "reference": "7adbbe38cde25e2df2116dbf2673c407e24fa305",
                 "shasum": ""
             },
             "require": {
@@ -2720,7 +2726,7 @@
             ],
             "support": {
                 "issues": "https://github.com/phpseclib/phpseclib/issues",
-                "source": "https://github.com/phpseclib/phpseclib/tree/3.0.52"
+                "source": "https://github.com/phpseclib/phpseclib/tree/3.0.56"
             },
             "funding": [
                 {
@@ -2736,7 +2742,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2026-04-27T07:02:15+00:00"
+            "time": "2026-08-03T04:36:50+00:00"
         },
         {
             "name": "pimple/pimple",
@@ -3281,16 +3287,16 @@
         },
         {
             "name": "rhukster/dom-sanitizer",
-            "version": "dev-main",
+            "version": "1.0.14",
             "source": {
                 "type": "git",
                 "url": "https://github.com/rhukster/dom-sanitizer.git",
-                "reference": "0794d8deff97b8227727df6d6ccd844b8c30c887"
+                "reference": "4292aa3daa34e0aefb80db06d1811cf0fd14b3d8"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/rhukster/dom-sanitizer/zipball/0794d8deff97b8227727df6d6ccd844b8c30c887",
-                "reference": "0794d8deff97b8227727df6d6ccd844b8c30c887",
+                "url": "https://api.github.com/repos/rhukster/dom-sanitizer/zipball/4292aa3daa34e0aefb80db06d1811cf0fd14b3d8",
+                "reference": "4292aa3daa34e0aefb80db06d1811cf0fd14b3d8",
                 "shasum": ""
             },
             "require": {
@@ -3301,7 +3307,6 @@
             "require-dev": {
                 "phpunit/phpunit": "^9"
             },
-            "default-branch": true,
             "type": "library",
             "autoload": {
                 "psr-4": {
@@ -3321,9 +3326,9 @@
             "description": "A simple but effective DOM/SVG/MathML Sanitizer for PHP 7.4+",
             "support": {
                 "issues": "https://github.com/rhukster/dom-sanitizer/issues",
-                "source": "https://github.com/rhukster/dom-sanitizer/tree/main"
+                "source": "https://github.com/rhukster/dom-sanitizer/tree/1.0.14"
             },
-            "time": "2025-11-30T01:09:58+00:00"
+            "time": "2026-08-10T22:54:15+00:00"
         },
         {
             "name": "sabre/dav",
@@ -4178,16 +4183,16 @@
         },
         {
             "name": "symfony/polyfill-php80",
-            "version": "v1.33.0",
+            "version": "v1.37.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/polyfill-php80.git",
-                "reference": "0cc9dd0f17f61d8131e7df6b84bd344899fe2608"
+                "reference": "dfb55726c3a76ea3b6459fcfda1ec2d80a682411"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/polyfill-php80/zipball/0cc9dd0f17f61d8131e7df6b84bd344899fe2608",
-                "reference": "0cc9dd0f17f61d8131e7df6b84bd344899fe2608",
+                "url": "https://api.github.com/repos/symfony/polyfill-php80/zipball/dfb55726c3a76ea3b6459fcfda1ec2d80a682411",
+                "reference": "dfb55726c3a76ea3b6459fcfda1ec2d80a682411",
                 "shasum": ""
             },
             "require": {
@@ -4238,7 +4243,7 @@
                 "shim"
             ],
             "support": {
-                "source": "https://github.com/symfony/polyfill-php80/tree/v1.33.0"
+                "source": "https://github.com/symfony/polyfill-php80/tree/v1.37.0"
             },
             "funding": [
                 {
@@ -4258,7 +4263,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2025-01-02T08:10:11+00:00"
+            "time": "2026-04-10T16:19:22+00:00"
         },
         {
             "name": "symfony/process",
@@ -4328,16 +4333,16 @@
         },
         {
             "name": "symfony/routing",
-            "version": "v5.4.52",
+            "version": "v5.4.53",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/routing.git",
-                "reference": "275b31328b2e58cab004be0cf086380e2a5c5ee7"
+                "reference": "f4ca0c533854c26e3b27e981da760807f89e1a42"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/routing/zipball/275b31328b2e58cab004be0cf086380e2a5c5ee7",
-                "reference": "275b31328b2e58cab004be0cf086380e2a5c5ee7",
+                "url": "https://api.github.com/repos/symfony/routing/zipball/f4ca0c533854c26e3b27e981da760807f89e1a42",
+                "reference": "f4ca0c533854c26e3b27e981da760807f89e1a42",
                 "shasum": ""
             },
             "require": {
@@ -4398,7 +4403,7 @@
                 "url"
             ],
             "support": {
-                "source": "https://github.com/symfony/routing/tree/v5.4.52"
+                "source": "https://github.com/symfony/routing/tree/v5.4.53"
             },
             "funding": [
                 {
@@ -4418,7 +4423,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2026-04-16T14:40:03+00:00"
+            "time": "2026-05-22T19:02:28+00:00"
         },
         {
             "name": "symfony/service-contracts",
@@ -7634,7 +7639,6 @@
     "aliases": [],
     "minimum-stability": "stable",
     "stability-flags": {
-        "rhukster/dom-sanitizer": 20,
         "roave/security-advisories": 20
     },
     "prefer-stable": false,


### PR DESCRIPTION
Backports the dependency updates that `master` already has to the `10.16` branch,
for the 10.16.5 release (OC10-149).

### Why

The `10.16` branch has had no dependency update since the 10.16.4 release commit
(`852062dd`, 2026-07-29). An inventory of `owncloud/server:10.16.4` matched
against the GitHub Advisory Database found **sixteen** published advisories
against `lib/composer` alone. `master` is already clean — this brings `10.16`
in line.

| Package | Was | Now | Advisories closed |
|---|---|---|---|
| guzzlehttp/guzzle | 7.10.0 | 7.15.3 | 9 (incl. CVE-2026-69246, **HIGH**) |
| guzzlehttp/psr7 | 2.8.0 | 2.13.0 | 4 |
| phpseclib/phpseclib | 3.0.52 | 3.0.56 | 1 |
| symfony/routing | v5.4.52 | v5.4.53 | 1 |
| rhukster/dom-sanitizer | `dev-main` | 1.0.14 | 1 |
| guzzlehttp/promises | 2.3.0 | 2.5.2 | — (transitive) |
| symfony/polyfill-php80 | v1.33.0 | v1.37.0 | — (transitive) |

CVE-2026-69246 is the one currently suppressed in
`owncloud-docker/server`'s `v22.04/10.16.4/.trivyignore`; this lets that
suppression be dropped for the 10.16.5 image.

### The dom-sanitizer pin is also a scanner blind spot

`rhukster/dom-sanitizer` was required as `"dev-main"`. A branch pin resolves to a
commit and carries **no version number**, so no advisory version range can ever
match it — Trivy and every other range-based scanner have silently reported
nothing for this package in every scan we have ever run. The 10.16.4 image ships
commit `0794d8de` (2025-11-30), which is five commits behind tag `1.0.10` and
therefore affected by CVE-2026-40301.

Requiring `^1.0.10` fixes the vulnerability *and* makes the dependency visible to
scanners. Note `master` still has the `dev-main` pin, so 11.x has the same blind
spot — a separate PR follows for that.

### What is deliberately not changed

`firebase/php-jwt` stays at 6.10.0 and remains affected by **CVE-2025-45769**
(low, CVSS 6.5, weak encryption). The advisory is only fixed in 7.0.0, and every
7.x release requires `php: ^8.0`, so it cannot be applied to a branch that
supports PHP 7.4. `master` carries v7.1.0 because it is PHP 8.3. This one has to
be accepted for the lifetime of the 10.16 line; it is called out in the changelog
entry so it is not mistaken for an oversight.

### Verification

- resolved with `composer update --no-install` under `config.platform.php = 7.4`,
  so the result is what the release build will produce
- `composer validate` passes
- all 68 production packages in the new lock re-checked against the GitHub
  Advisory Database: only the php-jwt advisory above remains
- `lib/composer` is not tracked in git, so this is lockfile-only

### Structural note

`.github/dependabot.yml` has no `target-branch`, so Dependabot only ever opens
PRs against `master`. That is why this branch drifted for a month while `master`
stayed current, and it will happen again on the next release branch unless an
entry with `target-branch: "10.16"` is added.

Refs: OC10-149

🤖 Generated with [Claude Code](https://claude.com/claude-code)
