### PR TITLE
ci: let dependabot also target the 10.16 release branch

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -14,6 +14,25 @@ updates:
           - minor
           - patch
 
+  # Same composer dependencies, but for the maintained 10.16 release branch.
+  # Without an explicit target-branch Dependabot only ever opens PRs against the
+  # default branch, so security fixes never reach the branch that ships in the
+  # 10.16.x tarballs.
+  - package-ecosystem: composer
+    directory: "/"
+    target-branch: "10.16"
+    schedule:
+      interval: weekly
+      day: sunday
+      time: '22:00'
+      timezone: Etc/UTC
+    open-pull-requests-limit: 5
+    groups:
+      minor-and-patch:
+        update-types:
+          - minor
+          - patch
+
   - package-ecosystem: npm
     directory: "/build"
     schedule:


### PR DESCRIPTION
## Problem

`.github/dependabot.yml` declares no `target-branch`, so Dependabot only ever opens PRs against `master`. The maintained `10.16` branch has therefore received **no** dependency updates — which is the structural reason it drifted a month behind on published composer advisories and needed the hand-written backport in #41784.

## Change

Adds a second `composer` block with `target-branch: "10.16"`, otherwise identical to the existing one (same schedule, same `minor-and-patch` grouping, same PR limit).

`npm` (`/build`) and `github-actions` are deliberately left master-only: neither the build toolchain nor the workflow pins ship in the release tarball, so duplicating that churn onto a maintenance branch buys no security benefit.

## Verification

`dependabot.yml` parses and yields 4 update blocks:

```
composer (default)
composer 10.16
npm (default)
github-actions (default)
```

Related: #41784, #41785, https://kiteworks.atlassian.net/browse/OC10-149

🤖 Generated with [Claude Code](https://claude.com/claude-code)