### PR TITLE
ci: bring back Oracle database coverage in GitHub Actions [full-ci]

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -32,6 +32,15 @@ jobs:
     with:
       php-versions: '["8.3"]'
 
+  php-unit-oracle:
+    # Same display name as php-unit so both appear in one group of checks. It
+    # stays a separate job because the acceptance jobs must not need Oracle.
+    name: PHP Unit
+    uses: ./.github/workflows/php-unit.yml
+    with:
+      php-versions: '["8.3"]'
+      databases: '["oracle:23"]'
+
   calens:
     name: Changelog lint
     runs-on: ubuntu-latest

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -1,0 +1,22 @@
+name: Nightly
+
+on:
+  schedule:
+    # Scheduled workflows only run from the default branch.
+    - cron: '30 2 * * *'
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+concurrency:
+  group: nightly-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  php-unit-oracle:
+    name: PHP Unit Oracle
+    uses: ./.github/workflows/php-unit.yml
+    with:
+      php-versions: '["8.3"]'
+      databases: '["oracle:23"]'

--- a/.github/workflows/php-unit.yml
+++ b/.github/workflows/php-unit.yml
@@ -5,6 +5,11 @@ on:
         description: JSON array of PHP versions
         required: true
         type: string
+      databases:
+        description: JSON array of databases
+        required: false
+        type: string
+        default: '["sqlite","mysql:8.0","mariadb:10.6","mariadb:10.11","postgres:10.21"]'
 
 permissions:
   contents: read
@@ -17,16 +22,7 @@ jobs:
       fail-fast: false
       matrix:
         php: ${{ fromJSON(inputs.php-versions) }}
-        database: [sqlite]
-        include:
-          - php: "8.3"
-            database: "mysql:8.0"
-          - php: "8.3"
-            database: "mariadb:10.6"
-          - php: "8.3"
-            database: "mariadb:10.11"
-          - php: "8.3"
-            database: "postgres:10.21"
+        database: ${{ fromJSON(inputs.databases) }}
 
     services:
       mysql:
@@ -52,6 +48,23 @@ jobs:
           POSTGRES_PASSWORD: owncloud
         ports:
           - 5432:5432
+      oracle:
+        # Oracle Database Free 23ai. The APP_USER schema is created inside the
+        # FREEPDB1 pluggable database, so a connect string using SERVICE_NAME is
+        # required - a plain host plus database name would target the CDB root.
+        image: >-
+          ${{ startsWith(matrix.database,'oracle:') && 'gvenzl/oracle-free:23-slim-faststart' || '' }}
+        env:
+          ORACLE_PASSWORD: owncloud
+          APP_USER: owncloud
+          APP_USER_PASSWORD: owncloud
+        options: >-
+          --health-cmd healthcheck.sh
+          --health-interval=10s
+          --health-timeout=5s
+          --health-retries=30
+        ports:
+          - 1521:1521
 
     steps:
       - name: Clone owncloud/core
@@ -63,7 +76,7 @@ jobs:
         uses: shivammathur/setup-php@f3e473d116dcccaddc5834248c87452386958240 # v2.37.2
         with:
           php-version: ${{ matrix.php }}
-          extensions: curl, gd, json, xml, zip, imagick
+          extensions: curl, gd, json, xml, zip, imagick${{ startsWith(matrix.database,'oracle:') && ', oci8' || '' }}
           ini-values: "memory_limit=2048M"
 
       - name: Install ffmpeg & imagemagick
@@ -85,24 +98,34 @@ jobs:
           DB_HOST: 127.0.0.1
           DB_USERNAME: owncloud
           DB_PASSWORD: owncloud
+          ORACLE_SERVICE_NAME: FREEPDB1
 
         run: |
           DB_TYPE=${DB%:*}
           if [ $DB_TYPE == "postgres" ] ; then DB_TYPE="pgsql"; fi
           if [ $DB_TYPE == "mariadb" ] ; then DB_TYPE="mysql"; fi
+          if [ $DB_TYPE == "oracle" ] ; then DB_TYPE="oci"; fi
           install_cmd="maintenance:install -vvv \
             --database=${DB_TYPE} \
             --database-name=${DB_NAME} \
             --admin-user=${ADMIN_LOGIN} \
             --admin-pass=${ADMIN_PASSWORD} \
             --data-dir=${DATA_DIRECTORY} "
-          
-          if [[ "${DB_TYPE}" != "sqlite" ]]; then
+
+          if [[ "${DB_TYPE}" == "oci" ]]; then
+            # The database user lives in a pluggable database, so it can only be
+            # reached via a connect string carrying SERVICE_NAME. --database-host
+            # is deliberately not passed: an empty host makes the connect string
+            # take precedence over host/name.
+            install_cmd+=" --database-connection-string=(DESCRIPTION=(ADDRESS=(PROTOCOL=TCP)(HOST=${DB_HOST})(PORT=1521))(CONNECT_DATA=(SERVICE_NAME=${ORACLE_SERVICE_NAME}))) \
+              --database-user=${DB_USERNAME} \
+              --database-pass=${DB_PASSWORD}"
+          elif [[ "${DB_TYPE}" != "sqlite" ]]; then
             install_cmd+=" --database-host=${DB_HOST} \
               --database-user=${DB_USERNAME} \
               --database-pass=${DB_PASSWORD}"
           fi
-          
+
           php occ ${install_cmd}
           echo "enabling apps"
           php occ app:enable files_sharing
@@ -113,6 +136,12 @@ jobs:
           php occ app:enable federatedfilesharing
 
       - name: Run PHPUnit
+        env:
+          # test-phpunit.sh narrows the suite to --group DB whenever DB_TYPE is
+          # set to anything but sqlite. Set it for Oracle only - as drone did -
+          # because the DB group is the part worth running against Oracle. The
+          # other databases keep running the full suite, as they do today.
+          DB_TYPE: ${{ startsWith(matrix.database,'oracle:') && 'oracle' || '' }}
         run: |
           bash tests/drone/test-phpunit.sh
 

--- a/changelog/unreleased/41808
+++ b/changelog/unreleased/41808
@@ -1,0 +1,18 @@
+Change: Restore Oracle database support in the command line installer
+
+The Oracle database layer -- ConnectionFactory, OracleConnection, OracleMigrator,
+AdapterOCI8 and the OCI expression builder -- has always remained in the code
+base, but the setup class that makes it reachable had been removed, so an
+instance could no longer be installed against Oracle at all. That also meant no
+CI job could exercise that layer.
+
+The maintenance:install command accepts --database=oci again, together with the
+--database-connection-string option needed to reach a schema inside an Oracle
+pluggable database. The web installer is unchanged: Oracle is not offered there,
+because the default supportedDatabases config still lists only sqlite, mysql and
+pgsql.
+
+This restores test coverage for Oracle-specific code paths. It is not a
+statement about production support for Oracle.
+
+https://github.com/owncloud/core/pull/41808

--- a/changelog/unreleased/41808-oracle-path-hash
+++ b/changelog/unreleased/41808-oracle-path-hash
@@ -1,0 +1,12 @@
+Bugfix: Avoid a deprecation notice when hashing the file cache path on Oracle
+
+Oracle cannot store empty strings, so the file cache converts them to null
+before writing a row. For the storage root, whose path is the empty string, that
+left md5() being called with null. PHP 8 reports that as a deprecated implicit
+null to string conversion: noise in the log whenever a storage root is inserted,
+and an error under PHPUnit's strict error handling. The stored path_hash itself
+was never wrong, because md5(null) coerces to md5('').
+
+The value is now cast to a string before hashing.
+
+https://github.com/owncloud/core/pull/41808

--- a/core/Command/Maintenance/Install.php
+++ b/core/Command/Maintenance/Install.php
@@ -49,6 +49,7 @@ class Install extends Command {
 			->setName('maintenance:install')
 			->setDescription('Install ownCloud.')
 			->addOption('database', null, InputOption::VALUE_REQUIRED, 'Supported database type.', 'sqlite')
+			->addOption('database-connection-string', null, InputOption::VALUE_REQUIRED, 'Oracle specific connection string. As soon as this parameter is provided other parameters like database-host and database-name are not used and do not need to be provided')
 			->addOption('database-name', null, InputOption::VALUE_REQUIRED, 'Name of the database.')
 			->addOption('database-host', null, InputOption::VALUE_REQUIRED, 'Hostname of the database.', 'localhost')
 			->addOption('database-user', null, InputOption::VALUE_REQUIRED, 'User name to connect to the database.')
@@ -111,7 +112,13 @@ class Install extends Command {
 		$dbUser = $input->getOption('database-user');
 		$dbPass = $input->getOption('database-pass');
 		$dbName = $input->getOption('database-name');
-		$dbHost = $input->getOption('database-host');
+		$dbConnectionString = $input->getOption('database-connection-string');
+		if ($db === 'oci') {
+			// an empty hostname needs to be read from the raw parameters
+			$dbHost = $input->getParameterOption('--database-host', '');
+		} else {
+			$dbHost = $input->getOption('database-host');
+		}
 		$dbTablePrefix = 'oc_';
 		if ($input->hasParameterOption('--database-table-prefix')) {
 			$dbTablePrefix = (string) $input->getOption('database-table-prefix');
@@ -128,8 +135,8 @@ class Install extends Command {
 			if ($dbUser === null) {
 				throw new InvalidArgumentException("Database user not provided.");
 			}
-			if ($dbName === null) {
-				throw new InvalidArgumentException('Database name not provided.');
+			if ($dbName === null && $dbConnectionString === null) {
+				throw new InvalidArgumentException('Database name and connection string not provided.');
 			}
 			if ($dbPass === null) {
 				/** @var $dialog \Symfony\Component\Console\Helper\QuestionHelper */
@@ -156,6 +163,7 @@ class Install extends Command {
 			'dbpass' => $dbPass,
 			'dbname' => $dbName,
 			'dbhost' => $dbHost,
+			'dbconnectionstring' => $dbConnectionString,
 			'dbtableprefix' => $dbTablePrefix,
 			'adminlogin' => $adminLogin,
 			'adminpass' => $adminPassword,

--- a/lib/private/Files/Cache/Cache.php
+++ b/lib/private/Files/Cache/Cache.php
@@ -431,7 +431,10 @@ class Cache implements ICache {
 		foreach ($data as $name => $value) {
 			if (\array_search($name, $fields) !== false) {
 				if ($name === 'path') {
-					$params[] = \md5($value);
+					// On Oracle an empty path has been turned into null further up,
+					// so cast back: the hash of the storage root must be md5('')
+					// on every platform.
+					$params[] = \md5((string)$value);
 					$queryParts[] = '`path_hash`';
 				} elseif ($name === 'mimetype') {
 					# an unknown mimetyp will be stored as -1

--- a/lib/private/Setup.php
+++ b/lib/private/Setup.php
@@ -85,6 +85,7 @@ class Setup {
 	public static $dbSetupClasses = [
 		'mysql' => \OC\Setup\MySQL::class,
 		'pgsql' => \OC\Setup\PostgreSQL::class,
+		'oci'   => \OC\Setup\OCI::class,
 		'sqlite' => \OC\Setup\Sqlite::class,
 		'sqlite3' => \OC\Setup\Sqlite::class,
 	];
@@ -142,6 +143,11 @@ class Setup {
 				'call' => 'pg_connect',
 				'name' => 'PostgreSQL'
 			],
+			'oci' => [
+				'type' => 'function',
+				'call' => 'oci_connect',
+				'name' => 'Oracle'
+			]
 		];
 		if ($allowAllDatabases) {
 			$configuredDatabases = \array_keys($availableDatabases);

--- a/lib/private/Setup/AbstractDatabase.php
+++ b/lib/private/Setup/AbstractDatabase.php
@@ -42,6 +42,8 @@ abstract class AbstractDatabase {
 	/** @var string */
 	protected $dbHost;
 	/** @var string */
+	protected $dbConnectionString;
+	/** @var string */
 	protected $tablePrefix;
 	/** @var string */
 	protected $dbprettyname;
@@ -76,11 +78,13 @@ abstract class AbstractDatabase {
 		$dbUser = $config['dbuser'];
 		$dbPass = $config['dbpass'];
 		$dbName = $config['dbname'];
+		$dbConnectionString = $config['dbconnectionstring'] ?? '';
 		$dbHost = !empty($config['dbhost']) ? $config['dbhost'] : 'localhost';
 		$dbTablePrefix = isset($config['dbtableprefix']) ? $config['dbtableprefix'] : 'oc_';
 
 		$this->config->setSystemValues([
 			'dbname'		=> $dbName,
+			'dbconnectionstring' => $dbConnectionString,
 			'dbhost'		=> $dbHost,
 			'dbtableprefix'	=> $dbTablePrefix,
 		]);
@@ -89,6 +93,7 @@ abstract class AbstractDatabase {
 		$this->dbPassword = $dbPass;
 		$this->dbName = $dbName;
 		$this->dbHost = $dbHost;
+		$this->dbConnectionString = $dbConnectionString;
 		$this->tablePrefix = $dbTablePrefix;
 	}
 

--- a/lib/private/Setup/OCI.php
+++ b/lib/private/Setup/OCI.php
@@ -1,0 +1,160 @@
+<?php
+/**
+ * @author Andreas Fischer <bantu@owncloud.com>
+ * @author Bart Visscher <bartv@thisnet.nl>
+ * @author Joas Schilling <coding@schilljs.com>
+ * @author Jörn Friedrich Dreyer <jfd@butonic.de>
+ * @author Manish Bisht <manish.bisht490@gmail.com>
+ * @author Morris Jobke <hey@morrisjobke.de>
+ * @author Roeland Jago Douma <rullzer@owncloud.com>
+ * @author Thomas Müller <thomas.mueller@tmit.eu>
+ * @author Victor Dubiniuk <dubiniuk@owncloud.com>
+ *
+ * @copyright Copyright (c) 2018, ownCloud GmbH
+ * @license AGPL-3.0
+ *
+ * This code is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License, version 3,
+ * as published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License, version 3,
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>
+ *
+ */
+namespace OC\Setup;
+
+class OCI extends AbstractDatabase {
+	public $dbprettyname = 'Oracle';
+
+	protected $dbtablespace;
+
+	public function initialize($config) {
+		parent::initialize($config);
+		if (\array_key_exists('dbtablespace', $config)) {
+			$this->dbtablespace = $config['dbtablespace'];
+		} else {
+			$this->dbtablespace = 'USERS';
+		}
+		// allow empty hostname for oracle
+		$this->dbHost = $config['dbhost'];
+
+		$this->config->setSystemValues([
+			'dbhost'		=> $this->dbHost,
+			'dbtablespace'	=> $this->dbtablespace,
+		]);
+	}
+
+	public function validate($config) {
+		$errors = [];
+		if (empty($config['dbuser'])) {
+			$errors[] = $this->trans->t('%s enter the database username.', [$this->dbprettyname]);
+		}
+		if (empty($config['dbname']) && empty($config['dbconnectionstring'])) {
+			$errors[] = $this->trans->t('%s enter the database name or connection string.', [$this->dbprettyname]);
+		}
+		return $errors;
+	}
+
+	public function setupDatabase($username) {
+		$e_host = \addslashes($this->dbHost);
+		$e_dbname = \addslashes($this->dbName);
+		//check if the database user has admin right
+		if ($this->dbConnectionString !== null) {
+			$easy_connect_string = $this->dbConnectionString;
+		} elseif ($e_host === '') {
+			$easy_connect_string = $e_dbname; // use dbname as easy connect name
+		} else {
+			$easy_connect_string = '//'.$e_host.'/'.$e_dbname;
+		}
+		$this->logger->debug('connect string: ' . $easy_connect_string, ['app' => 'setup.oci']);
+		$connection = @\oci_connect($this->dbUser, $this->dbPassword, $easy_connect_string);
+		if (!$connection) {
+			$errorMessage = $this->getLastError();
+			if ($errorMessage) {
+				throw new \OC\DatabaseSetupException(
+					$this->trans->t('Oracle connection could not be established'),
+					$errorMessage.' Check environment: ORACLE_HOME='.\getenv('ORACLE_HOME')
+							.' ORACLE_SID='.\getenv('ORACLE_SID')
+							.' LD_LIBRARY_PATH='.\getenv('LD_LIBRARY_PATH')
+							.' NLS_LANG='.\getenv('NLS_LANG')
+							.' tnsnames.ora is '.(\is_readable(\getenv('ORACLE_HOME').'/network/admin/tnsnames.ora')?'':'not ').'readable'
+				);
+			}
+			throw new \OC\DatabaseSetupException(
+				$this->trans->t('Oracle username and/or password not valid'),
+				'Check environment: ORACLE_HOME='.\getenv('ORACLE_HOME')
+							.' ORACLE_SID='.\getenv('ORACLE_SID')
+							.' LD_LIBRARY_PATH='.\getenv('LD_LIBRARY_PATH')
+							.' NLS_LANG='.\getenv('NLS_LANG')
+							.' tnsnames.ora is '.(\is_readable(\getenv('ORACLE_HOME').'/network/admin/tnsnames.ora')?'':'not ').'readable'
+			);
+		}
+
+		$this->config->setSystemValues([
+			'dbuser'		=> $this->dbUser,
+			'dbname'		=> $this->dbName,
+			'dbpassword'	=> $this->dbPassword,
+		]);
+
+		//FIXME check tablespace exists: select * from user_tablespaces
+
+		// the connection to dbname=oracle is not needed anymore
+		\oci_close($connection);
+
+		// connect to the oracle database (schema=$this->dbuser) an check if the schema needs to be filled
+		$this->dbUser = $this->config->getSystemValue('dbuser');
+		//$this->dbname = \OC_Config::getValue('dbname');
+		$this->dbPassword = $this->config->getSystemValue('dbpassword');
+
+		$connection = @\oci_connect($this->dbUser, $this->dbPassword, $easy_connect_string);
+		if (!$connection) {
+			throw new \OC\DatabaseSetupException(
+				$this->trans->t('Oracle username and/or password not valid'),
+				$this->trans->t('You need to enter either an existing account or the administrator.')
+			);
+		}
+		$query = 'SELECT count(*) FROM user_tables WHERE table_name = :un';
+		$stmt = \oci_parse($connection, $query);
+		$un = $this->tablePrefix.'users';
+		\oci_bind_by_name($stmt, ':un', $un);
+		if (!$stmt) {
+			$entry = $this->trans->t('DB Error: "%s"', [$this->getLastError($connection)]) . '<br />';
+			$entry .= $this->trans->t('Offending command was: "%s"', [$query]) . '<br />';
+			$this->logger->warning($entry, ['app' => 'setup.oci']);
+		}
+		$result = \oci_execute($stmt);
+
+		if ($result) {
+			$row = \oci_fetch_row($stmt);
+		}
+		// the connection is not needed anymore
+		\oci_close($connection);
+
+		if (!$result || $row[0] == 0) {
+			(new \OC\DB\MDB2SchemaManager(\OC::$server->getDatabaseConnection()))->createDbFromStructure($this->dbDefinitionFile);
+		}
+	}
+
+	/**
+	 * @param resource $connection
+	 * @return string
+	 */
+	protected function getLastError($connection = null) {
+		if ($connection) {
+			$error = \oci_error($connection);
+		} else {
+			$error = \oci_error();
+		}
+		foreach (['message', 'code'] as $key) {
+			if (isset($error[$key])) {
+				return $error[$key];
+			}
+		}
+		return '';
+	}
+}

--- a/tests/lib/SetupTest.php
+++ b/tests/lib/SetupTest.php
@@ -50,14 +50,15 @@ class SetupTest extends \Test\TestCase {
 		$this->config
 			->expects($this->once())
 			->method('getSystemValue')
-			->willReturn(['sqlite', 'mysql']);
+			->willReturn(['sqlite', 'mysql', 'oci']);
 		$this->setupClass
 			->expects($this->once())
 			->method('IsClassExisting')
 			->willReturn(true);
 		$this->setupClass
-			->expects($this->never())
-			->method('is_callable');
+			->expects($this->once())
+			->method('is_callable')
+			->willReturn(false);
 		$this->setupClass
 			->expects($this->once())
 			->method('getAvailableDbDriversForPdo')
@@ -74,13 +75,13 @@ class SetupTest extends \Test\TestCase {
 		$this->config
 			->expects($this->once())
 			->method('getSystemValue')
-			->willReturn(['sqlite', 'mysql', 'pgsql']);
+			->willReturn(['sqlite', 'mysql', 'oci', 'pgsql']);
 		$this->setupClass
 			->expects($this->once())
 			->method('IsClassExisting')
 			->willReturn(false);
 		$this->setupClass
-			->expects($this->once())
+			->expects($this->exactly(2))
 			->method('is_callable')
 			->willReturn(false);
 		$this->setupClass
@@ -96,13 +97,13 @@ class SetupTest extends \Test\TestCase {
 		$this->config
 			->expects($this->once())
 			->method('getSystemValue')
-			->willReturn(['sqlite', 'mysql', 'pgsql']);
+			->willReturn(['sqlite', 'mysql', 'pgsql', 'oci']);
 		$this->setupClass
 			->expects($this->once())
 			->method('IsClassExisting')
 			->willReturn(true);
 		$this->setupClass
-			->expects($this->once())
+			->expects($this->exactly(2))
 			->method('is_callable')
 			->willReturn(true);
 		$this->setupClass
@@ -114,6 +115,7 @@ class SetupTest extends \Test\TestCase {
 			'sqlite' => 'SQLite',
 			'mysql' => 'MySQL/MariaDB',
 			'pgsql' => 'PostgreSQL',
+			'oci' => 'Oracle'
 		];
 		$this->assertSame($expectedResult, $result);
 	}


### PR DESCRIPTION
## Description

The drone → GitHub Actions migration dropped the Oracle DB pipeline, and #41555 then removed the installer-side Oracle support, so an instance can no longer be installed against Oracle at all — even though the whole Oracle *runtime* layer (`ConnectionFactory`, `OracleConnection`, `OracleMigrator`, `AdapterOCI8`, `OCIExpressionBuilder`, plus Oracle branches in `AppConfig`, `AllConfig`, `Files\Cache\Cache` and many tests) is still shipped and untested.

This restores just enough to get that layer under test again.

### 1. CLI installer (`feat:`)

A partial revert of 95e3cdec2: `OC\Setup\OCI`, its `dbSetupClasses` entry, `dbconnectionstring` handling in `AbstractDatabase`, and the `--database-connection-string` option of `maintenance:install`.

**The web installer is deliberately left unchanged** — no template or `setup.js` change, and `hasOracle` is not re-added. `getSupportedDatabases(false)` reads the `supportedDatabases` config, which still defaults to `sqlite, mysql, pgsql`, so Oracle is not offered in the UI. This exists for CI coverage of code we still ship; it is not a re-declaration of production support for Oracle.

### 2. CI job (`ci:`)

`php-unit.yml` gains a `databases` input (defaulting to today's five jobs, so nothing changes for the existing matrix) and an `oracle` service on `gvenzl/oracle-free:23-slim-faststart` (23ai), using the same "empty image string disables the service" idiom as the existing `mysql`/`postgres` services.

Notable details:

* The app user lives in the `FREEPDB1` pluggable database, so `--database-host` is **not** passed; a connect string carrying `SERVICE_NAME` is used instead, and `ConnectionFactory` then takes its `connectstring` path.
* `oci8` is only requested from `setup-php` for Oracle jobs (setup-php resolves it in ~20s, no source build).
* `DB_TYPE` is now exported to the `Run PHPUnit` step **for Oracle only**, so `test-phpunit.sh` narrows the run to `--group DB` as drone did. The other databases keep running the full suite exactly as today.

Unlike in drone (*"Note: do not run Oracle by default in PRs"*), the Oracle job runs on **every** pull request. It shares its display name with the existing `php-unit` job so all databases show up in one `PHP Unit` group of checks, but it stays a separate job because the acceptance jobs `need` `php-unit` and must not be gated on Oracle. A nightly schedule runs it as well.

### 3. One Oracle-specific bug found this way (`fix:`)

Oracle cannot store empty strings, so the file cache converts `''` → `null` before writing a row (#31692). For the storage root, whose path *is* the empty string, that left `md5(null)`, which PHP 8 reports as a deprecated implicit null-to-string conversion — log noise on every storage-root insert, and an error under PHPUnit's strict error handling. The stored `path_hash` itself was never wrong (`md5(null)` coerces to `md5('')`), so this is a cleanliness fix, not a data fix. This commit is separable if you would rather see it on its own.

## Verification

Locally, against a real `gvenzl/oracle-free:23-slim-faststart` with `oci8` 3.4.0 and PHP 8.3:

* the exact `maintenance:install` line from the workflow succeeds — 48 tables, 35 sequences, 35 triggers, 65 migrations
* `phpunit --group DB` is green: `Tests: 5421, Assertions: 35231, Skipped: 29`

The 29 skips are pre-existing platform skips, including the three Oracle ones that were already in the tree (`MDB2SchemaManagerTest::testAutoIncrement`, `MigratorTest::testDuplicateKeyUpgrade`, `ApiTest::testShareStorageMountPoint` → doctrine/dbal#4687).

CI has since confirmed the two things only a runner could show: the `oracle` service was healthy after 67s and `oci8` came from setup-php in 22s (no source build, so no extension cache is needed). The job takes 12 minutes end to end.

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [x] Technical debt

## Checklist

- [x] Code changes
- [x] Changelog items
- [ ] Documentation (not needed — no user-facing feature)
- [x] Tests

🤖 Generated with [Claude Code](https://claude.com/claude-code)

