### PR TITLE
fix(composer): consume icewind deps from GitHub mirrors to survive Codeberg outages [10.16]

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -2,6 +2,10 @@
     "name": "owncloud/core",
     "description": "A safe home for all your data",
     "license": "AGPL-3.0-or-later",
+    "repositories": [
+        { "type": "vcs", "url": "https://github.com/DeepDiver1975/streams" },
+        { "type": "vcs", "url": "https://github.com/DeepDiver1975/SMB" }
+    ],
     "config" : {
         "vendor-dir": "lib/composer",
         "optimize-autoloader": true,

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "344e9958cd73533e9bdb08a414d19df0",
+    "content-hash": "68e036cb98d1342a175e02d310e0b3dc",
     "packages": [
         {
             "name": "bantu/ini-get-wrapper",
@@ -1349,8 +1349,14 @@
             "version": "v3.7.0",
             "source": {
                 "type": "git",
-                "url": "https://codeberg.org/icewind/SMB",
+                "url": "https://github.com/DeepDiver1975/SMB.git",
                 "reference": "e6904cbe75f678335092f4861c60c656b1a99e84"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/DeepDiver1975/SMB/zipball/e6904cbe75f678335092f4861c60c656b1a99e84",
+                "reference": "e6904cbe75f678335092f4861c60c656b1a99e84",
+                "shasum": ""
             },
             "require": {
                 "icewind/streams": ">=0.7.3",
@@ -1368,7 +1374,25 @@
                     "Icewind\\SMB\\": "src/"
                 }
             },
-            "notification-url": "https://packagist.org/downloads/",
+            "autoload-dev": {
+                "psr-4": {
+                    "Icewind\\SMB\\Test\\": "tests/"
+                }
+            },
+            "scripts": {
+                "lint": [
+                    "parallel-lint --exclude src --exclude vendor --exclude target --exclude build ."
+                ],
+                "cs:check": [
+                    "php-cs-fixer fix --dry-run --diff"
+                ],
+                "cs:fix": [
+                    "php-cs-fixer fix"
+                ],
+                "psalm": [
+                    "psalm.phar"
+                ]
+            },
             "license": [
                 "MIT"
             ],
@@ -1379,6 +1403,10 @@
                 }
             ],
             "description": "php wrapper for smbclient and libsmbclient-php",
+            "support": {
+                "source": "https://github.com/DeepDiver1975/SMB/tree/v3.7.0",
+                "issues": "https://github.com/DeepDiver1975/SMB/issues"
+            },
             "time": "2024-11-11T14:08:34+00:00"
         },
         {
@@ -1386,8 +1414,14 @@
             "version": "v0.7.8",
             "source": {
                 "type": "git",
-                "url": "https://codeberg.org/icewind/streams",
+                "url": "https://github.com/DeepDiver1975/streams.git",
                 "reference": "cb2bd3ed41b516efb97e06e8da35a12ef58ba48b"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/DeepDiver1975/streams/zipball/cb2bd3ed41b516efb97e06e8da35a12ef58ba48b",
+                "reference": "cb2bd3ed41b516efb97e06e8da35a12ef58ba48b",
+                "shasum": ""
             },
             "require": {
                 "php": ">=7.1"
@@ -1403,7 +1437,11 @@
                     "Icewind\\Streams\\": "src/"
                 }
             },
-            "notification-url": "https://packagist.org/downloads/",
+            "autoload-dev": {
+                "psr-4": {
+                    "Icewind\\Streams\\Tests\\": "tests/"
+                }
+            },
             "license": [
                 "MIT"
             ],
@@ -1414,6 +1452,10 @@
                 }
             ],
             "description": "A set of generic stream wrappers",
+            "support": {
+                "source": "https://github.com/DeepDiver1975/streams/tree/v0.7.8",
+                "issues": "https://github.com/DeepDiver1975/streams/issues"
+            },
             "time": "2024-12-05T14:36:22+00:00"
         },
         {


### PR DESCRIPTION
Backport of #41707 to `10.16`.

## Problem

CI on `10.16` fails whenever codeberg.org is unhealthy. Neither `icewind/streams` nor `icewind/smb` publishes a `dist` archive on Packagist, so Composer must **git-clone** them from Codeberg — and Codeberg regularly returns `503`/`504`.

Example: [run 34099036638](https://github.com/owncloud/core/actions/runs/34099036638/job/101669078066) on #41815 — the `Install Composer dependencies` step died with:

```
Failed to execute git clone --mirror -- https://codeberg.org/icewind/SMB ...
fatal: unable to access 'https://codeberg.org/icewind/SMB/': The requested URL returned error: 504
```

This is unrelated to the PR under test — any job on `10.16` that installs Composer dependencies can hit it.

## Fix

Add VCS `repositories` entries pointing at the GitHub mirrors, identical to master:

```json
"repositories": [
    { "type": "vcs", "url": "https://github.com/DeepDiver1975/streams" },
    { "type": "vcs", "url": "https://github.com/DeepDiver1975/SMB" }
]
```

GitHub serves a `dist` zipball via its API, so Composer downloads a zip and **never touches Codeberg at install time**.

## How this backport differs from master

Master locks `icewind/smb` **3.8.1**, which requires `php >= 8.2`. This branch pins `platform.php` to `7.4`, so the master lock hunk is not portable and `10.16` stays on **v3.7.0**.

Both packages are re-locked at the **exact refs already in the lock** — `smb e6904cb`, `streams cb2bd3e` — which the mirrors carry at the same tags. So this is a pure source repoint: no version bump, no dependency-tree change. Only `source.url` changes, plus the `dist` block and the metadata Composer takes from the VCS driver rather than Packagist. Constraints in `require` are untouched.

## Verification

Ran under `owncloudci/php:7.4` (matching the branch platform) with **`codeberg.org` blackholed to `127.0.0.1`**, so any attempt to reach it fails hard:

- **Before** (unpatched `10.16`): `composer install` fails — `Failed to execute git clone --mirror -- https://codeberg.org/icewind/streams ... Connection refused`. Reproduces CI exactly.
- **After** (this branch): `composer validate` reports the lock in sync, and `composer install --no-dev` completes with exit code `0`. Both `icewind/smb` and `icewind/streams` install from the GitHub zipballs; the installed `icewind/smb` declares `php: >=7.2`, confirming v3.7.0.
- `grep codeberg composer.lock` → **0 matches**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)