### PR TITLE
fix(db): only cast text and binary compare columns to char on Oracle [full-ci]

### DIFF
--- a/changelog/unreleased/41818
+++ b/changelog/unreleased/41818
@@ -1,0 +1,14 @@
+Bugfix: Restore index usage for filecache writes on Oracle
+
+On Oracle every compare column of an upsert was wrapped in to_char(). That cast
+is only needed for text and binary columns, which Oracle cannot compare
+directly, but it was applied to all of them - and to_char(column) cannot use an
+index on that column. Writes to the file cache compare storage and path_hash,
+so uploads, renames and file scans could no longer use the unique index
+fs_storage_path_hash and became very slow on large installations.
+
+Only text and binary compare columns are cast now, so every other comparison
+uses its index again.
+
+https://github.com/owncloud/core/issues/41782
+https://github.com/owncloud/core/pull/41818

--- a/lib/private/DB/Adapter.php
+++ b/lib/private/DB/Adapter.php
@@ -117,20 +117,42 @@ class Adapter {
 	}
 
 	/**
+	 * Types to pass to the expression builder for the compare columns, keyed by
+	 * column name. Only platforms that need to treat some column types
+	 * differently in a comparison return anything here - see AdapterOCI8.
+	 *
+	 * A column that is missing from the result is compared as it is, which is
+	 * what every platform except Oracle does with any type anyway, because
+	 * ExpressionBuilder::eq() ignores its type argument.
+	 *
+	 * @param string $table table name including **PREFIX**
+	 * @param string[] $compare columns that are compared to look for existing rows
+	 * @return array column name => one of \OCP\DB\QueryBuilder\IQueryBuilder::PARAM_*
+	 */
+	protected function getCompareColumnTypes($table, array $compare) {
+		return [];
+	}
+
+	/**
 	 * Inserts, or updates a row into the database. Returns the inserted or updated rows
 	 * @param $table string table name including **PREFIX**
 	 * @param $input array the key=>value pairs to insert into the db row
 	 * @param $compare array columns that should be compared to look for existing arrays
+	 *				If this is null or an empty array, all keys of $input will be compared
 	 * @return int the number of rows affected by the operation
 	 * @throws DriverException|\RuntimeException
 	 */
 	public function upsert($table, $input, $compare) {
-		$this->conn->beginTransaction();
-		$done = false;
-
 		if (empty($compare)) {
 			$compare = \array_keys($input);
 		}
+
+		// resolved before the transaction is opened, because it may query the schema
+		$compareTypes = $this->getCompareColumnTypes($table, $compare);
+		$isOracle = $this->conn->getDatabasePlatform() instanceof OraclePlatform;
+
+		$this->conn->beginTransaction();
+		$done = false;
 
 		// Construct the update query
 		$qbu = $this->conn->getQueryBuilder();
@@ -140,25 +162,19 @@ class Adapter {
 			->setParameter($col, $val);
 		}
 		foreach ($compare as $key) {
-			if ($input[$key] === null || ($input[$key] === '' && $this->conn->getDatabasePlatform() instanceof OraclePlatform)) {
+			if ($input[$key] === null || ($input[$key] === '' && $isOracle)) {
 				$qbu->andWhere($qbu->expr()->isNull($key));
 			} else {
-				if ($this->conn->getDatabasePlatform() instanceof OraclePlatform) {
-					$qbu->andWhere(
-						$qbu->expr()->eq(
-							// needs to cast to char in order to compare with char
-							$qbu->createFunction('to_char(`'.$key.'`)'), // TODO does this handle empty strings on oracle correctly
-							$qbu->expr()->literal($input[$key])
-						)
-					);
-				} else {
-					$qbu->andWhere(
-						$qbu->expr()->eq(
-							$key,
-							$qbu->expr()->literal($input[$key])
-						)
-					);
-				}
+				$qbu->andWhere(
+					$qbu->expr()->eq(
+						$key,
+						$qbu->expr()->literal($input[$key]),
+						// on Oracle a large object column has to be cast to char in
+						// order to be comparable at all - every other column must be
+						// left alone, or the comparison cannot use an index
+						$compareTypes[$key] ?? null
+					)
+				);
 			}
 		}
 

--- a/lib/private/DB/AdapterOCI8.php
+++ b/lib/private/DB/AdapterOCI8.php
@@ -24,7 +24,19 @@
 
 namespace OC\DB;
 
+use Doctrine\DBAL\Types\BlobType;
+use Doctrine\DBAL\Types\TextType;
+use OCP\DB\QueryBuilder\IQueryBuilder;
+
 class AdapterOCI8 extends Adapter {
+	/**
+	 * Large object columns per real table name, or null for a table whose
+	 * columns could not be resolved.
+	 *
+	 * @var array
+	 */
+	private $lobColumns = [];
+
 	public function lastInsertId($table) {
 		if ($table === null) {
 			throw new \InvalidArgumentException('Oracle requires a table name to be passed into lastInsertId()');
@@ -47,5 +59,96 @@ class AdapterOCI8 extends Adapter {
 		$statement = \str_ireplace('NOW()', 'CURRENT_TIMESTAMP', $statement);
 		$statement = \str_ireplace('UNIX_TIMESTAMP()', self::UNIX_TIMESTAMP_REPLACEMENT, $statement);
 		return $statement;
+	}
+
+	/**
+	 * Oracle cannot compare a CLOB or a BLOB with `=` - the attempt fails with
+	 * ORA-00932 - so those columns have to be wrapped in `to_char()`. Every
+	 * other column has to be left alone: `to_char(col) = 'x'` is not sargable,
+	 * so the comparison cannot use an index on `col` and degrades into a scan.
+	 *
+	 * If the column types cannot be resolved, all compare columns are cast.
+	 * That is the behaviour which shipped before this distinction was made -
+	 * slow, but it can never raise ORA-00932.
+	 *
+	 * @inheritdoc
+	 */
+	protected function getCompareColumnTypes($table, array $compare) {
+		$lobColumns = $this->getLobColumns($table);
+
+		$types = [];
+		foreach ($compare as $key) {
+			if ($lobColumns === null || isset($lobColumns[$key])) {
+				$types[$key] = IQueryBuilder::PARAM_STR;
+			}
+		}
+		return $types;
+	}
+
+	/**
+	 * The names of all large object columns of the given table, as keys.
+	 *
+	 * The result is memoized per connection. A schema change within the same
+	 * request is therefore not picked up, which is acceptable: the type of an
+	 * existing column does not change underneath a running upsert.
+	 *
+	 * @param string $table table name including **PREFIX**
+	 * @return array|null null if the columns could not be resolved
+	 */
+	private function getLobColumns($table) {
+		$tableName = $this->getRealTableName($table);
+		if (\array_key_exists($tableName, $this->lobColumns)) {
+			return $this->lobColumns[$tableName];
+		}
+
+		$lobColumns = null;
+		$reason = 'the table is not known to the schema manager';
+		try {
+			// the identifier has to be quoted: ownCloud creates all tables and
+			// columns quoted, hence in lower case, while Oracle folds an unquoted
+			// identifier to upper case and would not find the table at all
+			$columns = $this->conn->getSchemaManager()->listTableColumns(
+				$this->conn->quoteIdentifier($tableName)
+			);
+			if ($columns !== []) {
+				$lobColumns = [];
+				foreach ($columns as $column) {
+					$type = $column->getType();
+					if ($type instanceof TextType || $type instanceof BlobType) {
+						// getName() and not the array key, because the key keeps the
+						// quotes of a reserved word like `oc_privatedata`.`user`
+						$lobColumns[$column->getName()] = true;
+					}
+				}
+			}
+		} catch (\Exception $e) {
+			$reason = $e->getMessage();
+		}
+
+		if ($lobColumns === null) {
+			// remember the failure as well, so this is logged once per table
+			\OC::$server->getLogger()->warning(
+				'Could not determine the column types of "{table}", falling back to comparing all columns as char: {reason}',
+				['app' => 'core', 'table' => $tableName, 'reason' => $reason]
+			);
+		}
+
+		$this->lobColumns[$tableName] = $lobColumns;
+		return $lobColumns;
+	}
+
+	/**
+	 * The table name as it exists in the database, for a name as it is passed to
+	 * the query builder. Mirrors Connection::replaceTablePrefix(), which is not
+	 * reachable from here.
+	 *
+	 * @param string $table table name including **PREFIX**
+	 * @return string
+	 */
+	private function getRealTableName($table) {
+		if (\strpos($table, '*PREFIX*') === 0) {
+			$table = \substr($table, \strlen('*PREFIX*'));
+		}
+		return $this->conn->getPrefix() . $table;
 	}
 }

--- a/lib/public/IDBConnection.php
+++ b/lib/public/IDBConnection.php
@@ -140,7 +140,9 @@ interface IDBConnection {
 	 * @param array $input data that should be inserted into the table  (column name => value)
 	 * @param array|null $compare List of values that should be checked for "if not exists"
 	 *				If this is null or an empty array, all keys of $input will be compared
-	 *				Please note: text fields (clob) must not be used in the compare array
+	 *				Please note: on Oracle a text field (clob) in the compare array is
+	 *				compared as char and therefore limited to 4000 bytes, and a binary
+	 *				field (blob) cannot be compared at all
 	 * @return int number of affected rows
 	 * @throws \Doctrine\DBAL\Exception
 	 * @since 10.0.3

--- a/tests/lib/DB/AdapterTest.php
+++ b/tests/lib/DB/AdapterTest.php
@@ -343,22 +343,17 @@ class AdapterTest extends \Test\TestCase {
 		$this->assertSame(['key' => null, 'value' => IQueryBuilder::PARAM_STR], $types);
 	}
 
-	public function providesUnresolvableSchema() {
-		return [
-			'schema manager throws' => [null],
-			'table is unknown' => [[]],
-		];
-	}
-
 	/**
 	 * If the column types cannot be resolved, every compare column is cast -
 	 * the behaviour that shipped before large objects were told apart. It is
 	 * slow, but it can never raise ORA-00932.
 	 *
-	 * @dataProvider providesUnresolvableSchema
+	 * Note that this class cannot use a data provider: its constructor takes no
+	 * arguments, so PHPUnit has no way to hand a data set to an instance.
+	 *
 	 * @param array|null $columns
 	 */
-	public function testUpsertOnOracleCastsEverythingWhenSchemaIsUnavailable($columns) {
+	private function assertUpsertOnOracleCastsEverything($columns) {
 		$types = $this->captureCompareTypes(
 			AdapterOCI8::class,
 			new OraclePlatform(),
@@ -373,6 +368,14 @@ class AdapterTest extends \Test\TestCase {
 			'storage' => IQueryBuilder::PARAM_STR,
 			'path_hash' => IQueryBuilder::PARAM_STR,
 		], $types);
+	}
+
+	public function testUpsertOnOracleCastsEverythingWhenTheSchemaManagerThrows() {
+		$this->assertUpsertOnOracleCastsEverything(null);
+	}
+
+	public function testUpsertOnOracleCastsEverythingWhenTheTableIsUnknown() {
+		$this->assertUpsertOnOracleCastsEverything([]);
 	}
 
 	/**

--- a/tests/lib/DB/AdapterTest.php
+++ b/tests/lib/DB/AdapterTest.php
@@ -24,7 +24,16 @@ namespace Test\DB;
 use Doctrine\DBAL\Exception as DBALException;
 use Doctrine\DBAL\Driver\AbstractException;
 use Doctrine\DBAL\Driver\DriverException;
+use Doctrine\DBAL\Platforms\AbstractPlatform;
+use Doctrine\DBAL\Platforms\OraclePlatform;
+use Doctrine\DBAL\Platforms\SqlitePlatform;
+use Doctrine\DBAL\Schema\AbstractSchemaManager;
+use Doctrine\DBAL\Schema\Column;
+use Doctrine\DBAL\Types\Type;
+use Doctrine\DBAL\Types\Types;
 use OC\DB\Adapter;
+use OC\DB\AdapterOCI8;
+use OC\DB\Connection;
 use OCP\DB\QueryBuilder\IExpressionBuilder;
 use OCP\DB\QueryBuilder\IQueryBuilder;
 use OCP\IDBConnection;
@@ -185,5 +194,210 @@ class AdapterTest extends \Test\TestCase {
 		// Run
 		$adapter = new Adapter($mockConn);
 		$rows = $adapter->upsert('*PREFIX*appconfig', ['appid' => 'testadapter', 'configvalue' => 'test4-updated', 'configkey' => 'test4-updated'], ['appid', 'configkey']);
+	}
+
+	/**
+	 * Runs an upsert against a stubbed connection and returns the type that was
+	 * handed to the expression builder for each compare column. A column mapped
+	 * to IQueryBuilder::PARAM_STR is the one that OCIExpressionBuilder wraps in
+	 * to_char(); a column mapped to null is compared as it is.
+	 *
+	 * There is no Oracle job in CI, so the platform has to be faked here.
+	 *
+	 * @param string $adapterClass
+	 * @param AbstractPlatform $platform
+	 * @param string $table table name including *PREFIX*
+	 * @param array $input column name => value
+	 * @param array $compare columns to compare
+	 * @param array|null $columns column name as stored => doctrine type name,
+	 *				or null to make the schema lookup fail
+	 * @param string|null $expectedIdentifier the identifier the schema manager
+	 *				must be queried with, or null not to check it
+	 * @return array compare column => type
+	 */
+	private function captureCompareTypes(
+		$adapterClass,
+		AbstractPlatform $platform,
+		$table,
+		array $input,
+		array $compare,
+		$columns,
+		$expectedIdentifier
+	) {
+		$captured = [];
+
+		$expr = $this->createMock(IExpressionBuilder::class);
+		$expr->method('literal')->willReturnCallback(function ($value) {
+			return "'$value'";
+		});
+		$expr->method('eq')->willReturnCallback(function ($x, $y, $type = null) use (&$captured) {
+			$captured[$x] = $type;
+			return "$x = $y";
+		});
+
+		$qb = $this->createMock(IQueryBuilder::class);
+		$qb->method('expr')->willReturn($expr);
+		$qb->method('set')->willReturn($qb);
+		$qb->method('setValue')->willReturn($qb);
+		// pretend the update hit a row, so the insert is never attempted
+		$qb->method('execute')->willReturn(1);
+
+		$schemaManager = $this->createMock(AbstractSchemaManager::class);
+		$listTableColumns = $schemaManager->method('listTableColumns');
+		if ($expectedIdentifier !== null) {
+			$listTableColumns->with($expectedIdentifier);
+		}
+		if ($columns === null) {
+			$listTableColumns->willThrowException(new DBALException('unknown table'));
+		} else {
+			$portableColumns = [];
+			foreach ($columns as $name => $typeName) {
+				$column = new Column($name, Type::getType($typeName));
+				// this is how AbstractSchemaManager keys the result: by the quoted name
+				$portableColumns[\strtolower($column->getQuotedName($platform))] = $column;
+			}
+			$listTableColumns->willReturn($portableColumns);
+		}
+
+		$conn = $this->createMock(Connection::class);
+		$conn->method('getDatabasePlatform')->willReturn($platform);
+		$conn->method('getQueryBuilder')->willReturn($qb);
+		$conn->method('getSchemaManager')->willReturn($schemaManager);
+		$conn->method('getPrefix')->willReturn('oc_');
+		$conn->method('quoteIdentifier')->willReturnCallback(function ($name) use ($platform) {
+			return $platform->quoteIdentifier($name);
+		});
+
+		$adapter = new $adapterClass($conn);
+		$this->assertEquals(1, $adapter->upsert($table, $input, $compare));
+
+		return $captured;
+	}
+
+	/**
+	 * The regression behind SE-1776: on Oracle the compare columns of a
+	 * filecache upsert must not be wrapped in to_char(), because to_char(col)
+	 * is not sargable - the unique index fs_storage_path_hash then cannot be
+	 * used and every upload or rename degrades into an index skip scan.
+	 */
+	public function testUpsertOnOracleDoesNotCastNonLobCompareColumns() {
+		$types = $this->captureCompareTypes(
+			AdapterOCI8::class,
+			new OraclePlatform(),
+			'*PREFIX*filecache',
+			['storage' => 1, 'path' => 'files/foo.txt', 'path_hash' => \md5('files/foo.txt')],
+			['storage', 'path_hash'],
+			[
+				'storage' => Types::INTEGER,
+				'path' => Types::STRING,
+				'path_hash' => Types::STRING,
+			],
+			'"oc_filecache"'
+		);
+
+		$this->assertSame(['storage' => null, 'path_hash' => null], $types);
+	}
+
+	/**
+	 * The other half: a text column in the compare array still has to be cast,
+	 * because Oracle cannot compare a CLOB with = at all (ORA-00932).
+	 */
+	public function testUpsertOnOracleCastsLobCompareColumns() {
+		$types = $this->captureCompareTypes(
+			AdapterOCI8::class,
+			new OraclePlatform(),
+			'*PREFIX*appconfig',
+			['appid' => 'core', 'configkey' => 'installedat', 'configvalue' => '1234567890'],
+			['appid', 'configkey', 'configvalue'],
+			[
+				'appid' => Types::STRING,
+				'configkey' => Types::STRING,
+				'configvalue' => Types::TEXT,
+			],
+			'"oc_appconfig"'
+		);
+
+		$this->assertSame([
+			'appid' => null,
+			'configkey' => null,
+			'configvalue' => IQueryBuilder::PARAM_STR,
+		], $types);
+	}
+
+	/**
+	 * A column whose name is a reserved word is created quoted, and the schema
+	 * manager returns it keyed by its quoted name - the lookup must still match
+	 * the plain column name used in the compare array.
+	 */
+	public function testUpsertOnOracleCastsLobColumnWithQuotedName() {
+		$types = $this->captureCompareTypes(
+			AdapterOCI8::class,
+			new OraclePlatform(),
+			'*PREFIX*testtable',
+			['key' => 'somekey', 'value' => 'somevalue'],
+			['key', 'value'],
+			['"key"' => Types::STRING, '"value"' => Types::TEXT],
+			'"oc_testtable"'
+		);
+
+		$this->assertSame(['key' => null, 'value' => IQueryBuilder::PARAM_STR], $types);
+	}
+
+	public function providesUnresolvableSchema() {
+		return [
+			'schema manager throws' => [null],
+			'table is unknown' => [[]],
+		];
+	}
+
+	/**
+	 * If the column types cannot be resolved, every compare column is cast -
+	 * the behaviour that shipped before large objects were told apart. It is
+	 * slow, but it can never raise ORA-00932.
+	 *
+	 * @dataProvider providesUnresolvableSchema
+	 * @param array|null $columns
+	 */
+	public function testUpsertOnOracleCastsEverythingWhenSchemaIsUnavailable($columns) {
+		$types = $this->captureCompareTypes(
+			AdapterOCI8::class,
+			new OraclePlatform(),
+			'*PREFIX*filecache',
+			['storage' => 1, 'path_hash' => \md5('files/foo.txt')],
+			['storage', 'path_hash'],
+			$columns,
+			'"oc_filecache"'
+		);
+
+		$this->assertSame([
+			'storage' => IQueryBuilder::PARAM_STR,
+			'path_hash' => IQueryBuilder::PARAM_STR,
+		], $types);
+	}
+
+	/**
+	 * Every other platform compares all columns as they are, text columns
+	 * included - ExpressionBuilder::eq() ignores the type argument there.
+	 */
+	public function testUpsertDoesNotCastAnythingOnOtherPlatforms() {
+		$types = $this->captureCompareTypes(
+			Adapter::class,
+			new SqlitePlatform(),
+			'*PREFIX*appconfig',
+			['appid' => 'core', 'configkey' => 'installedat', 'configvalue' => '1234567890'],
+			['appid', 'configkey', 'configvalue'],
+			[
+				'appid' => Types::STRING,
+				'configkey' => Types::STRING,
+				'configvalue' => Types::TEXT,
+			],
+			null
+		);
+
+		$this->assertSame([
+			'appid' => null,
+			'configkey' => null,
+			'configvalue' => null,
+		], $types);
 	}
 }

--- a/tests/lib/DB/AdapterTest.php
+++ b/tests/lib/DB/AdapterTest.php
@@ -202,7 +202,9 @@ class AdapterTest extends \Test\TestCase {
 	 * to IQueryBuilder::PARAM_STR is the one that OCIExpressionBuilder wraps in
 	 * to_char(); a column mapped to null is compared as it is.
 	 *
-	 * There is no Oracle job in CI, so the platform has to be faked here.
+	 * The platform is faked, so that every platform is pinned no matter which
+	 * database the job runs against. The live Oracle behaviour is pinned by the
+	 * tests at the bottom of this class.
 	 *
 	 * @param string $adapterClass
 	 * @param AbstractPlatform $platform
@@ -402,5 +404,108 @@ class AdapterTest extends \Test\TestCase {
 			'configkey' => null,
 			'configvalue' => null,
 		], $types);
+	}
+
+	/**
+	 * An Oracle adapter for the live connection, or a skipped test everywhere
+	 * else. The adapter has to be built here: the one this class keeps is a
+	 * plain Adapter, which never casts anything on any platform.
+	 *
+	 * @return AdapterOCI8
+	 */
+	private function getOracleAdapterOrSkip() {
+		if (!$this->conn->getDatabasePlatform() instanceof OraclePlatform) {
+			$this->markTestSkipped('the live Oracle schema is only available on the Oracle job');
+		}
+		return new AdapterOCI8($this->conn);
+	}
+
+	/**
+	 * The comparison that upsert() builds for a single compare column, rendered
+	 * by the expression builder of the live connection.
+	 *
+	 * @param string $table table name without the prefix
+	 * @param string $column
+	 * @param array $types result of getCompareColumnTypes()
+	 * @return string
+	 */
+	private function buildCompareSql($table, $column, array $types) {
+		$qb = $this->conn->getQueryBuilder();
+		$qb->select($column)
+			->from($table)
+			->where(
+				$qb->expr()->eq(
+					$column,
+					$qb->expr()->literal('x'),
+					$types[$column] ?? null
+				)
+			);
+		return $qb->getSQL();
+	}
+
+	/**
+	 * The tests above fake the platform, so they cannot prove that the schema
+	 * lookup finds an ownCloud table on a live Oracle at all: the tables are
+	 * created quoted and therefore in lower case, while Oracle folds an
+	 * unquoted identifier to upper case. If the lookup came up empty, every
+	 * compare column would be cast again - which is the regression this fixes.
+	 */
+	public function testCompareColumnTypesAreResolvedFromTheLiveOracleSchema() {
+		$adapter = $this->getOracleAdapterOrSkip();
+
+		// storage is a NUMBER and path_hash a VARCHAR2, so neither is cast -
+		// otherwise the unique index fs_storage_path_hash cannot be used
+		$this->assertSame(
+			[],
+			self::invokePrivate($adapter, 'getCompareColumnTypes', ['*PREFIX*filecache', ['storage', 'path_hash']])
+		);
+
+		// configvalue is a CLOB and is the only one of the three that is cast
+		$this->assertSame(
+			['configvalue' => IQueryBuilder::PARAM_STR],
+			self::invokePrivate($adapter, 'getCompareColumnTypes', ['*PREFIX*appconfig', ['appid', 'configkey', 'configvalue']])
+		);
+	}
+
+	/**
+	 * What the resolved types amount to in the generated SQL on a live Oracle:
+	 * no to_char() around an indexed column, and still one around the CLOB.
+	 */
+	public function testUpsertSqlOnOracleDoesNotCastTheIndexedColumns() {
+		$adapter = $this->getOracleAdapterOrSkip();
+
+		$fileCacheTypes = self::invokePrivate($adapter, 'getCompareColumnTypes', ['*PREFIX*filecache', ['storage', 'path_hash']]);
+		$this->assertStringNotContainsString('to_char', $this->buildCompareSql('filecache', 'storage', $fileCacheTypes));
+		$this->assertStringNotContainsString('to_char', $this->buildCompareSql('filecache', 'path_hash', $fileCacheTypes));
+
+		$appConfigTypes = self::invokePrivate($adapter, 'getCompareColumnTypes', ['*PREFIX*appconfig', ['configvalue']]);
+		$this->assertStringContainsString('to_char', $this->buildCompareSql('appconfig', 'configvalue', $appConfigTypes));
+	}
+
+	/**
+	 * Both comparisons have to keep working against a live Oracle: an uncast
+	 * VARCHAR2 column, and a CLOB column that is still cast. A comparison that
+	 * fails to match makes upsert() fall through to the insert, so a second row
+	 * would appear - or the primary key of oc_appconfig would reject it and the
+	 * upsert would end in a RuntimeException after five attempts. Both are
+	 * caught by asserting that exactly one row is there afterwards.
+	 */
+	public function testUpsertOnOracleMatchesOnUncastAndOnCastColumns() {
+		$adapter = $this->getOracleAdapterOrSkip();
+		$input = ['appid' => 'testadapter', 'configkey' => 'test-oracle', 'configvalue' => 'v1'];
+
+		// inserts, because nothing is there yet
+		$this->assertEquals(1, $adapter->upsert('*PREFIX*appconfig', $input, ['appid', 'configkey']));
+		$this->assertRowExists('test-oracle', 'v1');
+
+		// updates, comparing two VARCHAR2 columns that are no longer cast
+		$input['configvalue'] = 'v2';
+		$this->assertEquals(1, $adapter->upsert('*PREFIX*appconfig', $input, ['appid', 'configkey']));
+		$this->assertRowExists('test-oracle', 'v2');
+
+		// updates again, this time comparing the CLOB column: the cast is what
+		// makes that possible at all, without it Oracle raises ORA-00932
+		$this->assertEquals(1, $adapter->upsert('*PREFIX*appconfig', $input, ['appid', 'configvalue']));
+		$this->assertRowExists('test-oracle', 'v2');
 	}
 }


### PR DESCRIPTION
## Description

On Oracle, `Adapter::upsert()` wrapped **every** compare column in `to_char()`. The cast is
required for CLOB and BLOB columns — Oracle refuses to compare those with `=` at all
(`ORA-00932`) — but `to_char(column) = 'literal'` is not sargable, so an index on the column
can no longer be used.

`Cache::put()` compares `storage` and `path_hash`, which is exactly the unique index
`fs_storage_path_hash`, so every upload, rename and file scan degraded from an index unique
scan into an index skip scan. On the installation where this was found the statement went
from ~0.0002 s / 8–20 buffer gets to 5.7–63.7 s / 91,000–122,000 buffer gets.

The compare column types are resolved from the schema now, and only text and binary columns
are cast:

```sql
-- before
UPDATE "oc_filecache" SET … WHERE to_char("storage") = '1' AND to_char("path_hash") = '…'
-- after
UPDATE "oc_filecache" SET … WHERE "storage" = '1' AND "path_hash" = '…'
```

Comparing a `NUMBER` column to a quoted literal is safe: Oracle converts the *literal* to a
number, so the column and its index stay usable.

## How

Rather than hand-building the cast, the per-column type is handed to the expression builder.
`OCIExpressionBuilder::eq()` already emits exactly `to_char("col")` for
`IQueryBuilder::PARAM_STR`, and the base `ExpressionBuilder::eq()` ignores its type argument
entirely, so this is a no-op on MySQL/MariaDB/PostgreSQL/SQLite — the generated SQL there is
byte-identical to before. The CLOB path on Oracle is likewise byte-identical; only non-LOB
columns change.

The resolution itself lives in `AdapterOCI8`, via a new protected
`Adapter::getCompareColumnTypes()` seam that returns nothing on every other platform. The
schema lookup passes a **quoted** identifier, because ownCloud creates all tables quoted and
therefore in lower case while Oracle folds unquoted identifiers to upper case — the same
reason `OracleConnection::tableExists()` already quotes. The result is memoized per table.

If the types cannot be resolved (unknown table, schema manager throws), every compare column
is cast, i.e. exactly the previous behaviour: slow, but it can never raise `ORA-00932`. A
warning is logged once per table.

## Tests

`tests/lib/DB/AdapterTest.php` gets six tests that fake the platform, so that every platform is
pinned no matter which database the job runs against. They cover both halves of the behaviour:

- non-LOB compare columns (`storage`, `path_hash`) are **not** cast — the regression this fixes
- a `TextType` compare column (`configvalue`) **is** still cast — the ORA-00932 case
- a LOB column whose name is a reserved word (stored quoted) is still matched
- an unresolvable schema (throws, or unknown table) casts everything
- other platforms cast nothing, text columns included

Now that #41808 has restored the Oracle job, three further tests run against a **live Oracle**
and are skipped everywhere else. They pin what the mocks cannot: that the schema lookup finds
an ownCloud table at all on Oracle, which is the one thing that decides between the fix and the
old behaviour.

- the compare column types resolved from the real `oc_filecache` and `oc_appconfig`
- the generated SQL: no `to_char()` around the indexed columns, still one around the CLOB
- an upsert that has to match on an uncast `VARCHAR2` column as well as on a cast CLOB column

The existing `AdapterTest` call-count expectations are unchanged, which confirms there is no
collateral change to the generated queries.

## Notes for the reviewer

This is the `master` forward-port of #41783, which carries the same fix for `10.16` where the
customer escalation is. `lib/private/DB/AdapterOCI8.php` is byte-identical on both branches: the
code is deliberately DBAL 2/3 agnostic. `getSchemaManager()` is deprecated on DBAL 3, but it is
what core uses everywhere else (10+ call sites, no `createSchemaManager()` usage), and
`doctrine/deprecations` stays at `TYPE_NONE` unless `DOCTRINE_DEPRECATIONS` is set, so nothing
is emitted under PHPUnit either.

Two pre-existing Oracle limitations are documented in `IDBConnection::upsert()` but
deliberately **not** changed here:

- `to_char()` on a CLOB longer than 4000 bytes raises `ORA-22835`, so comparing a long CLOB
  never worked. `OC\AllConfig` works around this with `dbms_lob.substr(configvalue, 4000, 1)`;
  adopting that changes behaviour for long values and belongs in its own PR.
- `to_char()` does not accept a BLOB, so a binary compare column has never worked either way.
  Keeping `BlobType` in the cast list preserves today's behaviour rather than changing it.

One behaviour does change on Oracle: a non-numeric string compared against a `NUMBER` column
now raises `ORA-01722` instead of silently matching no rows. No core caller does this.

Fixes #41782

🤖 Generated with [Claude Code](https://claude.com/claude-code)
