### PR TITLE
chore: prepare 11.0.1

### DIFF
--- a/changelog/unreleased/41824
+++ b/changelog/unreleased/41824
@@ -1,0 +1,23 @@
+Bugfix: Ship only the app payload in the release tarballs
+
+The release bundles contained 13 bundled apps as the working tree they had been
+built in, rather than as the app's release artifact. Each of those app
+directories carried `.git/` (a shallow clone including its pack file),
+`.github/`, `tests/`, `vendor-bin/` and `build/artifacts/`, the last holding a
+second copy of the app's own tarball. That was 101.94 MB of the 441.8 MB
+uncompressed complete tarball, in 16 shipped git repositories.
+
+Three things made it more than dead weight. `files_antivirus` shipped its
+anti-virus acceptance data, so a ClamAV scan of the tarball, or of any image
+built from it, reported `Eicar-Test-Signature FOUND` and could be rejected by an
+anti-virus gate. The development files were covered by the app's
+`appinfo/signature.json`, so an administrator could not delete them without
+breaking `occ integrity:check-app`. And the shipped `.git/` carried the release
+engineer's clone metadata, including their name and e-mail address.
+
+The affected app releases have been repackaged, and the release tooling now
+refuses to build a bundle that contains a build working tree, so this cannot
+recur unnoticed. The standard tarball was affected as well, through
+`notifications`.
+
+https://github.com/owncloud/core/issues/41824

--- a/version.php
+++ b/version.php
@@ -25,10 +25,10 @@
 // We only can count up. The 4. digit is only for the internal patch-level to trigger DB upgrades
 // between betas, final and RCs. This is _not_ the public version number. Reset minor/patch-level
 // when updating major/minor version number.
-$OC_Version = [11, 0, 0, 0];
+$OC_Version = [11, 0, 1, 0];
 
 // The human-readable string
-$OC_VersionString = '11.0.0';
+$OC_VersionString = '11.0.1';
 
 $OC_VersionCanBeUpgradedFrom = [[8, 2, 11],[9, 0, 9],[9, 1]];
 


### PR DESCRIPTION
Release preparation for 11.0.1, which remediates #41824.

## What this does

- Bumps `version.php` to `11.0.1` (`$OC_Version = [11, 0, 1, 0]`).
- Adds `changelog/unreleased/41824` for the release tarball repackaging.

## Why 11.0.1 rather than rebuilding 11.0.0

Both the standard and the complete tarball change content. Reusing the version would invalidate the already-published `sha256`/`md5`/`asc` sidecars — the issue itself cites one — so this is a new version.

It is also a genuine patch release, not only a repackaging: `changelog/unreleased/` already holds **eight** queued fixes, which 11.0.1 picks up.

## The problem being fixed

11.0.0 shipped 13 bundled apps as the working tree they were built in — `101.94 MB` of the `441.8 MB` uncompressed complete tarball, across **16 shipped git repositories**. Three consequences beyond the dead weight:

1. `files_antivirus` carried its EICAR acceptance data, so a ClamAV scan of the tarball or of any image built from it reported `Eicar-Test-Signature FOUND`, and could be rejected at an anti-virus gate.
2. The files were covered by each app's `appinfo/signature.json`, so an administrator could not delete them without breaking `occ integrity:check-app`.
3. The shipped `.git/` leaked the release engineer's name and e-mail from `.git/logs/HEAD`.

The standard tarball was affected too, through `notifications` — that part is not in the original report.

Root cause was not in this repository: the app release assets had been uploaded by hand from a build checkout instead of from `build/artifacts/appstore/<app>.tar.gz`.

## Related

| what | where |
|---|---|
| repin all 14 affected apps in the 11.0.1 specs | owncloud/server-release#53 |
| fail the bundle build on a shipped build tree, and fix the same leak in the daily bundles | owncloud/server-release#54 |
| reject such an artifact at publish time | owncloud/reusable-workflows#97 |
| 12 app release PRs | linked from owncloud/server-release#53 |

## Deliberately not done here

`ocrelease changelog --version 11.0.1 --date <release date>` has **not** been run. It materialises `changelog/unreleased/` into a `changelog/11.0.1_<date>/` folder whose name embeds the release date and regenerates `CHANGELOG.md`, so it belongs immediately before tagging — otherwise it needs redoing if the release slips. Run it in this checkout, commit, then tag `v11.0.1`.

The `calens` render was checked locally: the new fragment appears correctly in both the summary and detail sections alongside the eight existing ones.

🤖 Generated with [Claude Code](https://claude.com/claude-code)