### PR TITLE
fix: prevent arbitrary file write via unsanitized SVG/MVG bitmap previews [10.16] (OC10-164)

### DIFF
--- a/changelog/unreleased/41827
+++ b/changelog/unreleased/41827
@@ -1,0 +1,15 @@
+Security: Reject SVG/script content before it reaches ImageMagick bitmap previews
+
+Bitmap previews (PDF, Font, ...) sanitized SVG content before decoding it, but
+fell back to the original, unsanitized bytes whenever the sanitizer could not
+parse the input - which happened for any malformed SVG or non-XML payload,
+not only for genuinely broken SVG files. A crafted malformed SVG or a raw MVG
+script could therefore reach ImageMagick unsanitized and trigger an MSL
+script that reads or writes arbitrary files as the web server user.
+
+Bitmap previews no longer attempt to sanitize and fall back; they now reject
+any content that is detected as text, XML, SVG, or MVG before ImageMagick
+ever sees it, and decode through the same hardened Imagick options already
+used by the dedicated SVG preview provider.
+
+https://github.com/owncloud/core/pull/41827

--- a/changelog/unreleased/41828
+++ b/changelog/unreleased/41828
@@ -12,4 +12,4 @@ any content that is detected as text, XML, SVG, or MVG before ImageMagick
 ever sees it, and decode through the same hardened Imagick options already
 used by the dedicated SVG preview provider.
 
-https://github.com/owncloud/core/pull/41827
+https://github.com/owncloud/core/pull/41828

--- a/lib/private/Preview/Bitmap.php
+++ b/lib/private/Preview/Bitmap.php
@@ -25,6 +25,7 @@
 namespace OC\Preview;
 
 use Imagick;
+use OC\Image\ImagickFactory;
 use OC\Preview;
 use OCP\Files\File;
 use OCP\Files\FileInfo;
@@ -85,18 +86,16 @@ abstract class Bitmap implements IProvider2 {
 	 * @return Imagick
 	 */
 	private function getResizedPreview($stream, int $maxX, int $maxY): Imagick {
-		# file content can be SVG - we need to sanitize it first
 		$content = \stream_get_contents($stream);
-		$output = SVG::sanitizeSVGContent($content);
-		# in case the content is not an SVG we use the original content
-		if ($output === '') {
-			$output = $content;
+
+		if ($this->isDangerousToDecode($content)) {
+			throw new \RuntimeException('Refusing to decode text-based content for a bitmap preview');
 		}
 
-		$bp = new Imagick();
+		$bp = ImagickFactory::create();
 
 		# setIteratorIndex(0) will make previews to be generated from the first page
-		$bp->readImageBlob($output);
+		$bp->readImageBlob($content);
 		$bp->setIteratorIndex(0);
 
 		$bp = $this->resize($bp, $maxX, $maxY);
@@ -104,6 +103,22 @@ abstract class Bitmap implements IProvider2 {
 		$bp->setImageFormat('png');
 
 		return $bp;
+	}
+
+	/**
+	 * Bitmap providers must never hand text-based content (SVG, XML, or any other
+	 * text/* type, e.g. a raw MVG script) to Imagick::readImageBlob() - ImageMagick's
+	 * text/vector coders can be abused to read and write arbitrary files.
+	 */
+	private function isDangerousToDecode(string $content): bool {
+		$mimeType = \OC::$server->getMimeTypeDetector()->detectString($content);
+		$mimeType = \strtolower(\trim(\explode(';', $mimeType, 2)[0]));
+
+		if (\strpos($mimeType, 'text/') === 0) {
+			return true;
+		}
+
+		return \in_array($mimeType, ['image/svg+xml', 'application/xml', 'image/x-mvg'], true);
 	}
 
 	/**

--- a/lib/private/Preview/Bitmap.php
+++ b/lib/private/Preview/Bitmap.php
@@ -114,11 +114,12 @@ abstract class Bitmap implements IProvider2 {
 		$mimeType = \OC::$server->getMimeTypeDetector()->detectString($content);
 		$mimeType = \strtolower(\trim(\explode(';', $mimeType, 2)[0]));
 
-		if (\strpos($mimeType, 'text/') === 0) {
+		// libmagic reports "image/svg" without the "+xml" suffix on some PHP/OS builds
+		if (\strpos($mimeType, 'text/') === 0 || \strpos($mimeType, 'image/svg') === 0) {
 			return true;
 		}
 
-		return \in_array($mimeType, ['image/svg+xml', 'application/xml', 'image/x-mvg'], true);
+		return \in_array($mimeType, ['application/xml', 'image/x-mvg'], true);
 	}
 
 	/**

--- a/lib/private/Preview/SVG.php
+++ b/lib/private/Preview/SVG.php
@@ -54,6 +54,9 @@ class SVG implements IProvider2 {
 
 			# sanitize SVG content
 			$output = self::sanitizeSVGContent($content);
+			if ($output === null) {
+				return false;
+			}
 
 			$imagick->readImageBlob($output);
 			$imagick->setImageFormat('png32');
@@ -81,7 +84,7 @@ class SVG implements IProvider2 {
 		return true;
 	}
 
-	public static function sanitizeSVGContent(string $content): string {
+	public static function sanitizeSVGContent(string $content): ?string {
 		$sanitizer = new DOMSanitizer(DOMSanitizer::SVG);
 		$sanitizer->addDisallowedTags(['image']);
 		$sanitizer->addDisallowedAttributes(['xlink:href']);
@@ -89,6 +92,10 @@ class SVG implements IProvider2 {
 
 		// XML errors are expected here if the SVG is malformed
 		\libxml_clear_errors();
+
+		if (!\is_string($sanitized_content)) {
+			return null;
+		}
 
 		return $sanitized_content;
 	}

--- a/tests/lib/Preview/SanitizeTest.php
+++ b/tests/lib/Preview/SanitizeTest.php
@@ -44,10 +44,10 @@ class SanitizeTest extends TestCase {
 		$file->method('getContent')->willReturn($svgContent);
 		$file->method('fopen')->willReturn($stream);
 
-		# create the preview
+		# create the preview - SVG/text/script-shaped content must never reach Imagick via a Bitmap provider
 		$return = $provider->getThumbnail($file, 32, 32, false);
 
-		$this->assertImage(__DIR__ . '/white-32x32.png', $return);
+		$this->assertFalse($return);
 	}
 
 	public function providesSVG(): Generator {
@@ -58,8 +58,33 @@ class SanitizeTest extends TestCase {
 </svg>
 SVG;
 
+		# malformed SVG (unclosed <image>) - the DOM sanitizer cannot parse this and
+		# used to fall back to the raw, unsanitized content
+		$malformedSvgWithMslHref = <<<SVG
+<svg xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" width="10" height="10">
+	<image xlink:href="MSL:/tmp/oc10-164-payload.msl" width="10" height="10">
+</svg>
+SVG;
+
+		$rawMvg = <<<MVG
+push graphic-context
+viewbox 0 0 64 64
+fill 'url(msl:/tmp/oc10-164-payload.msl)'
+pop graphic-context
+MVG;
+
+		$wellFormedSvg = <<<SVG
+<svg xmlns="http://www.w3.org/2000/svg" width="10" height="10"><rect width="10" height="10" fill="green"/></svg>
+SVG;
+
 		# all Bitmap based providers use the same thumbnailing logic - two is enough ....
-		yield 'PDF provider' => [$svgContent0, new PDF()];
-		yield 'Font Provider' => [$svgContent0, new Font()];
+		yield 'PDF provider - image tag' => [$svgContent0, new PDF()];
+		yield 'Font Provider - image tag' => [$svgContent0, new Font()];
+		yield 'PDF provider - malformed SVG with MSL href' => [$malformedSvgWithMslHref, new PDF()];
+		yield 'Font Provider - malformed SVG with MSL href' => [$malformedSvgWithMslHref, new Font()];
+		yield 'PDF provider - raw MVG' => [$rawMvg, new PDF()];
+		yield 'Font Provider - raw MVG' => [$rawMvg, new Font()];
+		yield 'PDF provider - well-formed SVG' => [$wellFormedSvg, new PDF()];
+		yield 'Font Provider - well-formed SVG' => [$wellFormedSvg, new Font()];
 	}
 }


### PR DESCRIPTION
## Summary

Backport of #41827 to the `10.16` maintenance line.

`Bitmap::getResizedPreview()` sanitized SVG content before handing it to `Imagick::readImageBlob()`, but fell back to the **original, unsanitized bytes** whenever the sanitizer returned an empty string. `SVG::sanitizeSVGContent()` returns `''` for *any* content libxml cannot parse, not just genuinely malformed SVG - so a malformed SVG (or any non-XML payload such as a raw MVG script) reached ImageMagick unsanitized. There, an `<image xlink:href="MSL:...">` or an MVG `fill 'url(...)'` primitive can execute an MSL script that reads and writes arbitrary files as the web user (CVSS 8.8).

- `Bitmap::getResizedPreview()` no longer sanitizes-then-falls-back. It now rejects any content whose libmagic-detected media type is `text/*`, `image/svg` (with or without the `+xml` suffix - see note below), `application/xml`, or `image/x-mvg` *before* ever calling into Imagick (`isDangerousToDecode()`), and goes through `ImagickFactory::create()` so the `svg:sanitize`/`svg:embed`/`svg:decode` hardening options apply here too.
- `SVG::sanitizeSVGContent()`'s return type changes from `string` to `?string`, returning `null` when the underlying sanitizer does not return a string, so callers can distinguish "could not sanitize" from "sanitized to an empty document". The SVG provider's own call site now bails out on `null` instead of silently passing empty content to Imagick.
- `SanitizeTest` is updated: SVG content fed to a Bitmap provider (PDF, Font) now must return `false` instead of a rendered PNG. Added regression cases for a malformed SVG with an MSL `xlink:href`, a raw MVG script, and a well-formed SVG - all must return `false` from a Bitmap provider.

Two notes specific to what surfaced while verifying this backport on PHP 7.4:
- `image/x-mvg` is in the deny-list because libmagic classifies a raw MVG script as `image/x-mvg`, not as any `text/*`/xml type.
- The SVG check matches by prefix (`image/svg`), not exact equality against `image/svg+xml`: PHP 7.4's bundled fileinfo build reports the identical SVG content as `image/svg` (no `+xml`), while PHP 8.3 reports `image/svg+xml`. An exact match would have silently passed SVG content through unblocked on this branch's PHP 7.4 target while still blocking it on master's PHP 8.3 - confirmed by running the regression suite in both a `owncloudci/php:7.4` and `owncloudci/php:8.3` container before settling on the prefix check.

Not in scope for this PR (flagging separately): `Bitmap::getThumbnail()` leaks `$stream` when `getResizedPreview()` throws - it returns at line 54 before the `fclose()` at line 57. That's a resource leak, not a security defect, and deserves its own focused PR.

## Test plan

- [x] `make test-php-style`
- [x] `make test-php-unit TEST_PHP_SUITE=tests/lib/Preview/` on `owncloudci/php:7.4` - 44 tests, 8 skipped (unrelated missing Movie/Office providers), 0 failures
- [x] Confirmed RED before the fix, GREEN after, on this branch's own PHP 7.4 target (not just carried over from the master PR)
- [x] `tests/lib/Preview/PDFTest.php` (`testimage.pdf`) and `tests/lib/Preview/BitmapTest.php` (`testimage.eps`) still produce previews